### PR TITLE
S_parse_ident: Apply flag only to first loop iteration

### DIFF
--- a/t/comp/parser.t
+++ b/t/comp/parser.t
@@ -8,7 +8,7 @@ BEGIN {
     chdir 't' if -d 't';
 }
 
-print "1..191\n";
+print "1..192\n";
 
 sub failed {
     my ($got, $expected, $name) = @_;
@@ -666,6 +666,11 @@ is $@, "", 'substr keys assignment';
     eval 'm(@{if(0){sub d{]]])}return';
     like $@, qr/^syntax error at \(eval \d+\) line 1, near "\{\]"/,
         'RT #130815: null pointer deref';
+}
+
+{   # GH #23861
+    eval 'my @foo = keys %SWISH::3::;';
+    is ($@, "", "Handles all numeric package component after ::");
 }
 
 # Add new tests HERE (above this line)

--- a/toke.c
+++ b/toke.c
@@ -10557,7 +10557,7 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      *    of ASCII \w characters.  As a special case of this, it can
      *    optionally stop parsing at the first non-digit, returning just the
      *    initial digits.  */
-    const bool stop_at_first_non_digit = flags & STOP_AT_FIRST_NON_DIGIT;
+    bool stop_at_first_non_digit = flags & STOP_AT_FIRST_NON_DIGIT;
 
      /*    This type of identifier can be completely prohibited, so that
       *    anything that doesn't match type 1) is not considered to be an
@@ -10657,6 +10657,9 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
                 croak(ident_var_zero_multi_digit);
             }
 
+            /* This option only applies to the first component in a
+             * multi-component package variable name.  So quit the loop before
+             * trying to find a package separator */
             break;
         }
         else if (! idfirst_only && isWORDCHAR_A(*s) ) {
@@ -10690,6 +10693,13 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
             *(*d)++ = ':';
             *(*d)++ = ':';
             s += (*s == ':') ? 2 : 1;
+
+            /* This option only applies to the first component in a
+             * multi-component package variable name.  For example, in
+             * "SWISH::3::", the '3' is not the first component, and so the
+             * option needs to be turned off before the next loop iteration
+             * parses it. */
+            stop_at_first_non_digit = false;
         }
         else    /* None of the above means have come to the end of any
                    identifier*/


### PR DESCRIPTION
Fixes #23861

This special case of an all numeric identifier doesn't apply to a multi-component package variable.  In "Swish::3::", the 3 is not the first component, and so should not be special cased.  Therefore turn off the special handling before looping for a subsequent component.

In d2a0fb8c48c5baf9b54f467909b3ff0c824cf26e, I moved some code into a called function, adding a flag for the function to specially treat this case as the caller had done.  It was my intent that there be no change in behavior.  But, the called function differs from the original, in that it can loop, gathering each component of a package variable.  I overlooked that possibility, and our test suite lacked a test for this situation.

The called function is not an exact fit with what the caller did; hence the new flag.  But it had enough overlap that it avoided some duplication of code; and allowed for the caller to be simplified.  And there is another case in the caller that repeated nearly duplicate code so that a later commit changed to use this function, further simplifying things.


* This set of changes does not require a perldelta entry.
