### PR TITLE
AHOCORASICK - Reduce heap allocation overhead

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -3258,29 +3258,40 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             const char *real_start = s;
 #endif
             STRLEN maxlen = trie->maxlen;
-            SV *sv_points;
             U8 **points; /* map of where we were in the input string
                             when reading a given char. For ASCII this
                             is unnecessary overhead as the relationship
                             is always 1:1, but for Unicode, especially
                             case folded Unicode this is not true. */
+
+            /* For a shorter maxlen, points are stored in a stack buffer. */
+            /* The choice of STACK_POINTS_MAX here is rather arbitrary.
+             * When building perl and running test_harness, maxlen rarely
+             * goes above 8, but presumbaly there are good business cases
+             * where a somewhat larger value is common. */
+            enum { STACK_POINTS_MAX = 32 };
+            U8 *points_stack[STACK_POINTS_MAX];
+            /* Otherwise, a more costly heap allocation is used. */
+            bool used_heap = false;
+
             U8 foldbuf[ UTF8_MAXBYTES_CASE + 1 ];
             U8 *bitmap = NULL;
-
+            U8 **points_heap = NULL;
 
             DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-            /* We can't just allocate points here. We need to wrap it in
-             * an SV so it gets freed properly if there is a croak while
-             * running the match */
-            ENTER;
-            SAVETMPS;
-            sv_points = newSV(maxlen * sizeof(U8 *));
-            SvCUR_set(sv_points,
-                maxlen * sizeof(U8 *));
-            SvPOK_on(sv_points);
-            sv_2mortal(sv_points);
-            points = (U8**)SvPV_nolen(sv_points );
+            if (maxlen <= STACK_POINTS_MAX) {
+                points = points_stack;
+            } else {
+                used_heap = true;
+                /* In case of a die event, the allocation will be freed
+                   as the savestack is unwound. */
+                ENTER;
+                Newx(points_heap, maxlen, U8*);
+                SAVEFREEPV(points_heap);
+                points = points_heap;
+            }
+
             if ( trie_type != trie_utf8_fold
                  && (trie->bitmap || OP(c)==AHOCORASICKC) )
             {
@@ -3464,8 +3475,9 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         );
                     });
                     if (reginfo->intuit || regtry(reginfo, &s)) {
-                        FREETMPS;
-                        LEAVE;
+                        if (used_heap) {
+                            LEAVE;
+                        }
                         goto got_it;
                     }
                     if (s < reginfo->strend) {
@@ -3482,8 +3494,9 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                     break;
                 }
             }
-            FREETMPS;
-            LEAVE;
+            if (used_heap) {
+                LEAVE;
+            }
         }
         break;
 


### PR DESCRIPTION
A `U8*` structure is used to track character positions during Aho-Corasick string searching. This used to always be allocated from the heap, and wrapped in a mortal SV to avoid leakage. However, that incurs overhead.

Following this commit:
* A stack buffer is used if `maxlen` is small enough.
* Otherwise, the heap allocation is saved directly to the savestack for freeing during stack unwinding.
* Since a mortal SV is no longer used, there is no need to `SAVETMPS` and `FREETMPS` at scope entry/exit.

`./perl -e 'my $x = "x" x 100_000_000; 1 while $x =~ /xx|ab/aag;'` was used to measure performance.

Blead:
```
          6,620.36 msec task-clock                       #    0.999 CPUs utilized             
    28,654,412,324      cycles                           #    4.328 GHz                       
       911,721,108      stalled-cycles-frontend          #    3.18% frontend cycles idle      
   108,774,373,701      instructions                     #    3.80  insn per cycle            
    22,155,300,318      branches                         #    3.347 G/sec
```
`sv_points` -> `points_heap`:
```
          5,980.47 msec task-clock                       #    0.999 CPUs utilized             
    26,034,479,632      cycles                           #    4.353 GHz                       
       268,382,711      stalled-cycles-frontend          #    1.03% frontend cycles idle      
   101,423,701,030      instructions                     #    3.90  insn per cycle            
    20,205,140,413      branches                         #    3.379 G/sec
```
Add `points_stack`:
```
          5,498.05 msec task-clock                       #    0.999 CPUs utilized             
    24,193,996,840      cycles                           #    4.400 GHz                       
        82,342,305      stalled-cycles-frontend          #    0.34% frontend cycles idle      
    91,772,992,857      instructions                     #    3.79  insn per cycle            
    18,054,971,288      branches                         #    3.284 G/sec
```
Mandatory -> conditional ENTER/LEAVE:
```
          5,141.42 msec task-clock                       #    0.999 CPUs utilized             
    23,185,766,525      cycles                           #    4.510 GHz                       
       131,930,496      stalled-cycles-frontend          #    0.57% frontend cycles idle      
    86,972,184,973      instructions                     #    3.75  insn per cycle            
    17,254,785,144      branches                         #    3.356 G/sec
```

I'm not sure what the optimum stack size should be. For reference, these were the
`maxlen` values observed and the counts of each when building Perl and running
the test harness:

```
          '2' => 35534,
          '1' => 14188,
          '8' => 8568,
          '5' => 3271,
          '6' => 2996,
          '3' => 641,
          '12' => 408,
          '7' => 358,
          '4' => 241,
          '10' => 172,
          '22' => 147,
          '16' => 67,
          '9' => 10,
          '31' => 5,
          '11' => 3,
          '35' => 3
          '47' => 1,
          '33' => 1,
          '18' => 1,
``` 

-------------------------------------------------------------------------------

* This set of changes may require a perldelta entry and I can add one if so.
