### PR TITLE
Migrate more signatures warn/croak tests to t/lib/*

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6198,6 +6198,7 @@ t/lib/warnings/pp_sys			Tests for pp_sys.c for warnings.t
 t/lib/warnings/regcomp			Tests for regcomp.c for warnings.t
 t/lib/warnings/regexec			Tests for regexec.c for warnings.t
 t/lib/warnings/run			Tests for run.c for warnings.t
+t/lib/warnings/signatures		Tests for signatures-related warnings for warnings.t
 t/lib/warnings/sv			Tests for sv.c for warnings.t
 t/lib/warnings/taint			Tests for taint.c for warnings.t
 t/lib/warnings/toke			Tests for toke.c for warnings.t

--- a/t/lib/croak/signatures
+++ b/t/lib/croak/signatures
@@ -209,6 +209,11 @@ EXPECT
 Illegal character following sigil in a subroutine signature at - line 2, near "($"
 syntax error at - line 2, near "$$) "
 ########
+# NAME global $_ in signature
+sub t101 ($_) { }
+EXPECT
+Can't use global $_ in subroutine signature at - line 2, near "($_"
+########
 # NAME global @_ in signature
 sub t101 (@_) { }
 EXPECT
@@ -218,4 +223,8 @@ Can't use global @_ in subroutine signature at - line 2, near "(@_"
 sub t102 (%_) { }
 EXPECT
 Can't use global %_ in subroutine signature at - line 2, near "(%_"
-
+########
+# NAME global $1 in signature
+sub t101 ($1) { }
+EXPECT
+Illegal operator following parameter in a subroutine signature at - line 2, near "($1"

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2039,13 +2039,6 @@ sub dont_warn_48 { $a //= return $b; }
 sub dont_warn_49 { $a &&= exit $b; }
 EXPECT
 ########
-use feature "signatures";
-sub aaa { 2 }
-sub bbb ($a) { 4 }
-$aaa = sub { 2 };
-$bbb = sub ($a) { 4 };
-EXPECT
-########
 use warnings 'numeric';
 my $c = -4.5;
 my $a = "y" x $c;

--- a/t/lib/warnings/signatures
+++ b/t/lib/warnings/signatures
@@ -1,0 +1,26 @@
+# PREAMBLE use warnings;
+# PREAMBLE use feature 'signatures';
+__END__
+########
+# NAME simple usage does not provoke warnings
+sub aaa { 2 }
+sub bbb ($a) { 4 }
+$aaa = sub { 2 };
+$bbb = sub ($a) { 4 };
+EXPECT
+########
+# NAME warnings from default expressions come from the correct line
+sub multiline1 (
+    $a,
+    $b = $a + 1,
+    $c = $a + 1)
+{
+    my $d = $a + 1;
+    my $e = $a + 1;
+}
+multiline1(undef);
+EXPECT
+Use of uninitialized value $a in addition (+) at - line 5.
+Use of uninitialized value $a in addition (+) at - line 6.
+Use of uninitialized value $a in addition (+) at - line 8.
+Use of uninitialized value $a in addition (+) at - line 9.

--- a/t/op/signatures.t
+++ b/t/op/signatures.t
@@ -1386,42 +1386,6 @@ while(<$kh>) {
         "RT 132760 err 0";
 }
 
-# check that warnings come from the correct line
-
-{
-    my @warn;
-    local $SIG{__WARN__} = sub { push @warn, @_};
-    eval q{
-        sub multiline1 (
-            $a,
-            $b = $a + 1,
-            $c = $a + 1)
-        {
-            my $d = $a + 1;
-            my $e = $a + 1;
-        }
-    };
-    multiline1(undef);
-    like $warn[0], qr/line 4,/, 'multiline1: $b';
-    like $warn[1], qr/line 5,/, 'multiline1: $c';
-    like $warn[2], qr/line 7,/, 'multiline1: $d';
-    like $warn[3], qr/line 8,/, 'multiline1: $e';
-}
-
-# check errors for using global vars as params
-
-{
-    eval q{ sub ($_) {} };
-    like $@, qr/Can't use global \$_ in subroutine signature/, 'f($_)';
-    eval q{ sub (@_) {} };
-    like $@, qr/Can't use global \@_ in subroutine signature/, 'f(@_)';
-    eval q{ sub (%_) {} };
-    like $@, qr/Can't use global \%_ in subroutine signature/, 'f(%_)';
-    eval q{ sub ($1) {} };
-    like $@, qr/Illegal operator following parameter in a subroutine signature/,
-            'f($1)';
-}
-
 # check that various uses of @_ inside signatured subs causes "experimental"
 # warnings at compiletime
 {


### PR DESCRIPTION
Recently I moved a few of the custom ad-hoc tests of compile-time failures out of `t/op/signatures.t` into the dedicated infrastructure of `t/lib/croak`. Here's a few more movements, and also some warnings tests as well.

This is a prerequisite for my `signature-named-params` branch.

* This set of changes does not require a perldelta entry.
