### PR TITLE
perly - simplify non-terminal bare_statement_for

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6451,6 +6451,8 @@ t/op/filetest_stack_ok.t		See if file tests leave their argument on the stack
 t/op/filetest_t.t			See if -t file test works
 t/op/flip.t				See if range operator works
 t/op/for.t				See if for loops work
+t/op/for-cstyle-scope.t			See if scope of for-cstyle variable(s) works
+t/op/for-itervars-scope.t		See if scope of for-itervars variable(s) works
 t/op/for-many.t				See if n-at-a-time for loops work
 t/op/fork.t				See if fork works
 t/op/fresh_perl_utf8.t			UTF8 tests for pads and gvs

--- a/perly.y
+++ b/perly.y
@@ -121,6 +121,7 @@
 %type <opval> bare_statement_when
 %type <opval> bare_statement_while
 %type <opval> bare_statement_yadayada
+%type <opval> clause_mexpr
 %type <opval> subscript_index
 %type <opval> subscript_keys
 %type <opval> subscriptable_reference
@@ -395,9 +396,7 @@ bare_statement_for_itervars
 		remember
 		KW_MY
 		my_scalar
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
@@ -410,9 +409,7 @@ bare_statement_for_itervars
 		PERLY_PAREN_OPEN
 		my_list_of_itervars
 		PERLY_PAREN_CLOSE
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
@@ -426,9 +423,7 @@ bare_statement_for_itervars
 	|	KW_FOR
 		remember
 		scalar
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
@@ -443,9 +438,7 @@ bare_statement_for_itervars
 			parser->in_my = 0;
 			$<opval>$ = my($my_var);
 		}[variable]
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
@@ -468,9 +461,7 @@ bare_statement_for_itervars
 		remember
 		REFGEN
 		refgen_topic
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
@@ -488,9 +479,7 @@ bare_statement_for_itervars
 		}
 	|	KW_FOR
 		remember
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
@@ -518,9 +507,7 @@ bare_statement_format
 bare_statement_given
 	:	KW_GIVEN
 		remember
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		{
 			$$ = block_end($remember, newGIVENOP($mexpr, op_scope($mblock), 0));
@@ -531,9 +518,7 @@ bare_statement_given
 bare_statement_if
 	:	KW_IF
 		remember
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		else
 		{
@@ -698,9 +683,7 @@ bare_statement_try_catch
 bare_statement_unless
 	:	KW_UNLESS
 		remember
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		else
 		{
@@ -746,9 +729,7 @@ bare_statement_utilize
 bare_statement_when
 	:	KW_WHEN
 		remember
-		PERLY_PAREN_OPEN
-		mexpr
-		PERLY_PAREN_CLOSE
+		clause_mexpr[mexpr]
 		mblock
 		{
 			$$ = block_end($remember, newWHENOP($mexpr, op_scope($mblock)));
@@ -775,6 +756,15 @@ bare_statement_yadayada
 		{
 			/* diag_listed_as: Unimplemented */
 			$$ = newLISTOP(OP_DIE, 0, newOP(OP_PUSHMARK, 0), newSVOP(OP_CONST, 0, newSVpvs("Unimplemented")));
+		}
+	;
+
+clause_mexpr
+	:	PERLY_PAREN_OPEN
+		mexpr
+		PERLY_PAREN_CLOSE
+		{
+			$$ = $mexpr;
 		}
 	;
 
@@ -1012,7 +1002,7 @@ else
 			  ($mblock)->op_flags |= OPf_PARENS;
 			  $$ = op_scope($mblock);
 			}
-	|	KW_ELSIF PERLY_PAREN_OPEN mexpr PERLY_PAREN_CLOSE mblock else[else.recurse]
+	|	KW_ELSIF clause_mexpr[mexpr] mblock else[else.recurse]
 			{ parser->copline = (line_t)$KW_ELSIF;
 			    $$ = newCONDOP(OPpSTATEMENT<<8,
 				newSTATEOP(OPf_SPECIAL,NULL,$mexpr),

--- a/perly.y
+++ b/perly.y
@@ -349,8 +349,8 @@ bare_statement_field_declaration
 
 bare_statement_for
 	:	KW_FOR
-		PERLY_PAREN_OPEN
 		remember
+		PERLY_PAREN_OPEN
 		mnexpr[init_mnexpr]
 		PERLY_SEMICOLON
 		{
@@ -380,8 +380,8 @@ bare_statement_for
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
-		KW_MY
 		remember
+		KW_MY
 		my_scalar
 		PERLY_PAREN_OPEN
 		mexpr
@@ -393,8 +393,8 @@ bare_statement_for
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
-		KW_MY
 		remember
+		KW_MY
 		PERLY_PAREN_OPEN
 		my_list_of_itervars
 		PERLY_PAREN_CLOSE
@@ -412,9 +412,9 @@ bare_statement_for
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
+		remember
 		scalar
 		PERLY_PAREN_OPEN
-		remember
 		mexpr
 		PERLY_PAREN_CLOSE
 		mblock
@@ -424,8 +424,8 @@ bare_statement_for
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
-		my_refgen
 		remember
+		my_refgen
 		my_var
 		{
 			parser->in_my = 0;
@@ -453,10 +453,10 @@ bare_statement_for
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
+		remember
 		REFGEN
 		refgen_topic
 		PERLY_PAREN_OPEN
-		remember
 		mexpr
 		PERLY_PAREN_CLOSE
 		mblock
@@ -475,8 +475,8 @@ bare_statement_for
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
-		PERLY_PAREN_OPEN
 		remember
+		PERLY_PAREN_OPEN
 		mexpr
 		PERLY_PAREN_CLOSE
 		mblock
@@ -505,8 +505,8 @@ bare_statement_format
 
 bare_statement_given
 	:	KW_GIVEN
-		PERLY_PAREN_OPEN
 		remember
+		PERLY_PAREN_OPEN
 		mexpr
 		PERLY_PAREN_CLOSE
 		mblock
@@ -518,8 +518,8 @@ bare_statement_given
 
 bare_statement_if
 	:	KW_IF
-		PERLY_PAREN_OPEN
 		remember
+		PERLY_PAREN_OPEN
 		mexpr
 		PERLY_PAREN_CLOSE
 		mblock
@@ -685,8 +685,8 @@ bare_statement_try_catch
 
 bare_statement_unless
 	:	KW_UNLESS
-		PERLY_PAREN_OPEN
 		remember
+		PERLY_PAREN_OPEN
 		mexpr
 		PERLY_PAREN_CLOSE
 		mblock
@@ -733,8 +733,8 @@ bare_statement_utilize
 
 bare_statement_when
 	:	KW_WHEN
-		PERLY_PAREN_OPEN
 		remember
+		PERLY_PAREN_OPEN
 		mexpr
 		PERLY_PAREN_CLOSE
 		mblock

--- a/perly.y
+++ b/perly.y
@@ -395,39 +395,44 @@ bare_statement_for_itervars
 	:	KW_FOR
 		remember
 		KW_MY
-		my_scalar
+		my_scalar[itervars]
 		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
-			$$ = block_end($remember, newFOROP(0, $my_scalar, $mexpr, $mblock, $cont));
+			$$ = block_end($remember, newFOROP(0, $itervars, $mexpr, $mblock, $cont));
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
 		remember
 		KW_MY
 		PERLY_PAREN_OPEN
-		my_list_of_itervars
+		my_list_of_itervars[itervars]
+    	{
+			if ($itervars->op_type == OP_PADSV)
+				/* degenerate case of 1 var: for my ($x) ....
+				   Flag it so it can be special-cased in newFOROP */
+				$itervars->op_flags |= OPf_PARENS;
+        }
 		PERLY_PAREN_CLOSE
 		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
-			if ($my_list_of_itervars->op_type == OP_PADSV)
-				/* degenerate case of 1 var: for my ($x) ....
-				   Flag it so it can be special-cased in newFOROP */
-				$my_list_of_itervars->op_flags |= OPf_PARENS;
-			$$ = block_end($remember, newFOROP(0, $my_list_of_itervars, $mexpr, $mblock, $cont));
+			$$ = block_end($remember, newFOROP(0, $itervars, $mexpr, $mblock, $cont));
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
 		remember
 		scalar
+		{
+			$<opval>$ = op_lvalue ($scalar, OP_ENTERLOOP);
+		}[itervars]
 		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
-			$$ = block_end($remember, newFOROP(0, op_lvalue($scalar, OP_ENTERLOOP), $mexpr, $mblock, $cont));
+			$$ = block_end($remember, newFOROP(0, $<opval>itervars, $mexpr, $mblock, $cont));
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
@@ -436,45 +441,30 @@ bare_statement_for_itervars
 		my_var
 		{
 			parser->in_my = 0;
-			$<opval>$ = my($my_var);
-		}[variable]
+			$<opval>$ = op_lvalue(
+				newUNOP(OP_REFGEN, 0, my ($my_var)),
+				OP_ENTERLOOP
+			);
+		}[itervars]
 		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
-			$$ = block_end(
-				$remember,
-				newFOROP(
-					0,
-					op_lvalue(
-						newUNOP(OP_REFGEN, 0, $<opval>variable),
-						OP_ENTERLOOP
-					),
-					$mexpr,
-					$mblock,
-					$cont
-				)
-			);
+			$$ = block_end($remember, newFOROP(0, $<opval>itervars, $mexpr, $mblock, $cont));
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
 		remember
 		REFGEN
 		refgen_topic
+		{
+			$<opval>$ = op_lvalue (newUNOP(OP_REFGEN, 0, $refgen_topic), OP_ENTERLOOP);
+		}[itervars]
 		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
-			$$ = block_end (
-				$remember,
-				newFOROP (
-					0,
-					op_lvalue (newUNOP(OP_REFGEN, 0, $refgen_topic), OP_ENTERLOOP),
-					$mexpr,
-					$mblock,
-					$cont
-				)
-			);
+			$$ = block_end($remember, newFOROP(0, $<opval>itervars, $mexpr, $mblock, $cont));
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR

--- a/perly.y
+++ b/perly.y
@@ -121,6 +121,7 @@
 %type <opval> bare_statement_when
 %type <opval> bare_statement_while
 %type <opval> bare_statement_yadayada
+%type <opval> clause_itervars
 %type <opval> clause_mexpr
 %type <opval> subscript_index
 %type <opval> subscript_keys
@@ -394,77 +395,12 @@ bare_statement_for_itervars
 	/* for loop iterating over list using iterate variables */
 	:	KW_FOR
 		remember
-		KW_MY
-		my_scalar[itervars]
+		clause_itervars[itervars]
 		clause_mexpr[mexpr]
 		mblock
 		cont
 		{
 			$$ = block_end($remember, newFOROP(0, $itervars, $mexpr, $mblock, $cont));
-			parser->copline = (line_t)$KW_FOR;
-		}
-	|	KW_FOR
-		remember
-		KW_MY
-		PERLY_PAREN_OPEN
-		my_list_of_itervars[itervars]
-    	{
-			if ($itervars->op_type == OP_PADSV)
-				/* degenerate case of 1 var: for my ($x) ....
-				   Flag it so it can be special-cased in newFOROP */
-				$itervars->op_flags |= OPf_PARENS;
-        }
-		PERLY_PAREN_CLOSE
-		clause_mexpr[mexpr]
-		mblock
-		cont
-		{
-			$$ = block_end($remember, newFOROP(0, $itervars, $mexpr, $mblock, $cont));
-			parser->copline = (line_t)$KW_FOR;
-		}
-	|	KW_FOR
-		remember
-		scalar
-		{
-			$<opval>$ = op_lvalue ($scalar, OP_ENTERLOOP);
-		}[itervars]
-		clause_mexpr[mexpr]
-		mblock
-		cont
-		{
-			$$ = block_end($remember, newFOROP(0, $<opval>itervars, $mexpr, $mblock, $cont));
-			parser->copline = (line_t)$KW_FOR;
-		}
-	|	KW_FOR
-		remember
-		my_refgen
-		my_var
-		{
-			parser->in_my = 0;
-			$<opval>$ = op_lvalue(
-				newUNOP(OP_REFGEN, 0, my ($my_var)),
-				OP_ENTERLOOP
-			);
-		}[itervars]
-		clause_mexpr[mexpr]
-		mblock
-		cont
-		{
-			$$ = block_end($remember, newFOROP(0, $<opval>itervars, $mexpr, $mblock, $cont));
-			parser->copline = (line_t)$KW_FOR;
-		}
-	|	KW_FOR
-		remember
-		REFGEN
-		refgen_topic
-		{
-			$<opval>$ = op_lvalue (newUNOP(OP_REFGEN, 0, $refgen_topic), OP_ENTERLOOP);
-		}[itervars]
-		clause_mexpr[mexpr]
-		mblock
-		cont
-		{
-			$$ = block_end($remember, newFOROP(0, $<opval>itervars, $mexpr, $mblock, $cont));
 			parser->copline = (line_t)$KW_FOR;
 		}
 	|	KW_FOR
@@ -746,6 +682,49 @@ bare_statement_yadayada
 		{
 			/* diag_listed_as: Unimplemented */
 			$$ = newLISTOP(OP_DIE, 0, newOP(OP_PUSHMARK, 0), newSVOP(OP_CONST, 0, newSVpvs("Unimplemented")));
+		}
+	;
+
+clause_itervars
+	/* read as: (clause)_(for_itervars)_(itervars)
+	 * part of `for_itervars` statement which declares `itervars`
+	 */
+	:	scalar
+		{
+			$$ = op_lvalue ($scalar, OP_ENTERLOOP);
+		}
+	|	KW_MY
+		my_scalar
+		{
+			$$ = $my_scalar;
+		}
+	|	KW_MY
+		PERLY_PAREN_OPEN
+		my_list_of_itervars
+		PERLY_PAREN_CLOSE
+		{
+			if ($my_list_of_itervars->op_type == OP_PADSV)
+				/* degenerate case of 1 var: for my ($x) ....
+				   Flag it so it can be special-cased in newFOROP */
+				$my_list_of_itervars->op_flags |= OPf_PARENS;
+			$$ = $my_list_of_itervars;
+		}
+	|	my_refgen
+		my_var
+		{
+			parser->in_my = 0;
+			$$ = op_lvalue (
+				newUNOP (OP_REFGEN, 0, my ($my_var)),
+				OP_ENTERLOOP
+			);
+		}
+	|	REFGEN
+		refgen_topic
+		{
+			$$ = op_lvalue (
+				newUNOP (OP_REFGEN, 0, $refgen_topic),
+				OP_ENTERLOOP
+			);
 		}
 	;
 

--- a/perly.y
+++ b/perly.y
@@ -103,6 +103,8 @@
 %type <opval> bare_statement_expression
 %type <opval> bare_statement_field_declaration
 %type <opval> bare_statement_for
+%type <opval> bare_statement_for_cstyle
+%type <opval> bare_statement_for_itervars
 %type <opval> bare_statement_format
 %type <opval> bare_statement_given
 %type <opval> bare_statement_if
@@ -348,6 +350,12 @@ bare_statement_field_declaration
 	;
 
 bare_statement_for
+	:	bare_statement_for_cstyle
+	|	bare_statement_for_itervars
+	;
+
+bare_statement_for_cstyle
+	/* C-style for loop: for ( initialize; condition; iterate ) { ... } */
 	:	KW_FOR
 		remember
 		PERLY_PAREN_OPEN
@@ -379,7 +387,11 @@ bare_statement_for
 			$$ = block_end($remember, forop);
 			parser->copline = (line_t)$KW_FOR;
 		}
-	|	KW_FOR
+	;
+
+bare_statement_for_itervars
+	/* for loop iterating over list using iterate variables */
+	:	KW_FOR
 		remember
 		KW_MY
 		my_scalar

--- a/t/op/for-cstyle-scope.t
+++ b/t/op/for-cstyle-scope.t
@@ -1,0 +1,74 @@
+#!./perl
+
+# Test lexical scope of `for` statement, variant: `for (init; control condition; post iterate)`
+
+BEGIN {
+	chdir 't' if -d 't';
+	require "./test.pl";
+	set_up_inc('../lib');
+}
+
+use v5.38;
+
+assume q ([for-cstyle] modifies global variable)
+	=> expect => q (3)
+	=> eval   => eval_this_code q {
+		no strict;
+		no warnings;
+
+		for ($control_global = 1; $control_global < 3; ++$control_global) { }
+
+		$control_global // q (undef);
+	};
+
+assume q ([for-cstyle] `my` variable is restricted into `for`'s lexical scope)
+	=> expect => q (42)
+	=> eval   => eval_this_code q {
+		use strict;
+		use warnings FATAL => q (all);
+
+		my $control_my = 42;
+
+		for (my $control_my = 1; $control_my < 3; ++$control_my) { }
+
+		$control_my;
+	};
+
+assume q ([for-cstyle] `our` variable declared inside `for` scope isn't visible outside)
+	=> throws => qr (^Variable ".control_our" is not imported)
+	=> eval   => eval_this_code q {
+		use strict;
+		use warnings FATAL => q (all);
+
+		for (our $control_our = 1; $control_our < 3; ++$control_our) { }
+
+		$control_our;
+	};
+
+assume q ([for-cstyle] `our` variable inside `for` scope redeclares outer variable)
+	=> throws => qr (^"our" variable .control_redeclared redeclared)
+	=> eval   => eval_this_code q {
+		use strict;
+		use warnings FATAL => q (all);
+
+		our $control_redeclared = 42;
+
+		for (our $control_redeclared = 1; $control_redeclared < 3; ++$control_redeclared) { }
+
+		$control_redeclared;
+	};
+
+assume q ([for-cstyle] `local` localizes variable )
+	=> expect => q (3)
+	=> eval   => eval_this_code q {
+		use strict;
+		use warnings FATAL => q (all);
+
+		our $control_local = 42;
+
+		for (local $control_local = 1; $control_local < 3; ++$control_local) { }
+
+		$control_local;
+	};
+
+done_testing;

--- a/t/op/for-itervars-scope.t
+++ b/t/op/for-itervars-scope.t
@@ -1,0 +1,163 @@
+#!./perl
+
+# Test lexical scope of `for` statement, variant: `for $var (@array)` (foreach)
+# Tested behaviour:
+# - capability to declare / use given cursor
+# - visibility of given cursor in both for-block and continue-block
+# - behaviour of cursor after for-loop (exists? what value?)
+
+BEGIN {
+	chdir 't' if -d 't';
+	require "./test.pl";
+	set_up_inc('../lib');
+}
+
+use v5.38;
+
+assume q ([for-itervars] global cursor is visible in `continue` block and its original value is preserved)
+	=> expect => q (/Foo.Foo=42)
+	=> eval   => q {
+		my $cursor_global = 42;
+
+		for $cursor_global (qw (Foo)) {
+			$result .= q (/) . $cursor_global;
+		} continue {
+			$result .= q (.) . $cursor_global;
+		}
+
+		$result .= q (=) . ($cursor_global // q ([undef]));
+	};
+
+assume q ([for-itervars] `our` cursor is visible in continue block)
+	=> expect => q (/Foo.Foo)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+
+		for our $cursor_our_continue (qw (Foo)) {
+			$result .= q (/) . $cursor_our_continue;
+		} continue {
+			$result .= q (.) . $cursor_our_continue;
+		}
+
+		$result;
+	};
+
+assume q ([for-itervars] `our` cursor is not visible after `for` loop)
+	=> throws => qr (^Variable "\$cursor_our_after" is not imported)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+
+		for our $cursor_our_after (qw (Foo)) {
+		}
+
+		$result .= $cursor_our_after;
+	};
+
+assume q ([for-itervars] `our` cursor redeclares already declared global variable)
+	=> throws => qr (^"our" variable .cursor_redeclared redeclared)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+
+		our $cursor_redeclared = 42;
+
+		for our $cursor_redeclared () {
+		}
+	};
+
+assume q ([for-itervars] `my` cursor is visible in `continue` block)
+	=> expect => q (/Foo.Foo)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+
+		for my $cursor_my (q (Foo)) {
+			$result .= q (/) . $cursor_my;
+		} continue {
+			$result .= q (.) . $cursor_my;
+		}
+
+		$result;
+	};
+
+assume q ([for-itervars] `my` cursor is not visible after `for` loop)
+	=> throws => qr (^Global symbol "\$cursor_my_after" requires explicit package name)
+	=> eval   => q {
+		use strict;
+		use warnings;
+
+		for my $cursor_my_after (q (Foo)) {
+		}
+
+		$cursor_my_after;
+	};
+
+assume q ([for-itervars] `my` multi-cursors are visible in `continue` block)
+	=> expect => q (/FooBar.FooBar)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+
+		for my ($cursor_multi_1, $cursor_multi_2) (qw (Foo Bar)) {
+			$result .= q (/) . $cursor_multi_1 . $cursor_multi_2;
+		} continue {
+			$result .= q (.) . $cursor_multi_1 . $cursor_multi_2;
+		}
+
+		$result;
+	};
+
+assume q ([for-itervars] `my` multi-cursors are not visible after `for` loop)
+	=> throws => qr (^Global symbol "\$cursor_my_multi_1" requires explicit package name)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+
+		for my ($cursor_my_multi_1, $cursor_my_multi_2) (qw (Foo Bar)) {
+		} continue {
+		}
+
+		$cursor_my_multi_1;
+	};
+
+assume q ([for-itervars] `refaliasing` global cursor preserves it's original value)
+	=> expect => q (/Foo.Foo=42)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+		use experimental qw (refaliasing);
+
+		my $cursor_refalias = 42;
+
+		for \ $cursor_refalias (\ qw (Foo)) {
+			$result .= q (/) . $cursor_refalias;
+		} continue {
+			$result .= q (.) . $cursor_refalias;
+		}
+
+		$result . q (=) . $cursor_refalias;
+	};
+
+assume q ([for-itervars] `declared_refs` is visible in continue block)
+	=> expect => q (/Foo.Foo)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+		use experimental qw (declared_refs);
+
+		for my \ $cursor_refs (\ qw (Foo)) {
+			$result .= q (/) . $cursor_refs;
+		} continue {
+			$result .= q (.) . $cursor_refs;
+		}
+
+		$result;
+	};
+
+assume q ([for-itervars] `declared_refs` is not visible after loop)
+	=> throws => qr (^Global symbol "\$cursor_refs_after" requires explicit package name)
+	=> eval   => q {
+		use warnings FATAL => q (all);
+		use experimental qw (declared_refs);
+
+		for my \ $cursor_refs_after (\ qw (Foo)) {
+		}
+
+		$cursor_refs_after;
+	};
+
+done_testing;

--- a/t/test.pl
+++ b/t/test.pl
@@ -41,6 +41,11 @@ our $TODO = 0;
 our $NO_ENDING = 0;
 our $Tests_Are_Passing = 1;
 
+sub diag;
+sub fail;
+sub is;
+sub like;
+
 # Use this instead of print to avoid interference while testing globals.
 sub _print {
     local($\, $", $,) = (undef, ' ', '');
@@ -50,6 +55,88 @@ sub _print {
 sub _print_stderr {
     local($\, $", $,) = (undef, ' ', '');
     print STDERR @_;
+}
+
+sub assume {
+	my ($message, %args) = @_;
+
+    local $Level = $Level + 1;
+
+	# Single assert function which:
+	# - detects whether code should successed or faile
+	# - detect comparison method: `is` / `like`
+
+	# Accept named arguments:
+	#
+	# diag => scalar
+	# - additional diagnostic message
+	#
+	# eval => code
+	# - code to evaluate
+	# - code is evaluated with known and initialized variable: `my $result = q ()`
+	#
+	# expect => string / regex
+	# - when specified it expects evaluated code to not fail and validates result
+	# - when not specified it just expect evaluated to not fail
+	# - accepts string (acting as `is`) or regex (acting as `like`)
+	#
+	# throws => string / regex
+	# - when specified it expects evaluated code to fail and validates failure ($@)
+	# - accepts string (acting as `is`) or regex (acting as `like`)
+
+	my $got;
+	my $lives = eval qq {
+		do {
+			use strict;
+			use warnings;
+			my \$result = q ();
+			\$got = do {\n$args{eval}; };
+		};
+		1;
+	};
+	my $error = $@;
+
+	if (exists $args{throws}) {
+		if ($lives) {
+			fail $message;
+			diag q (Expected to fail but it lives);
+			diag $args{diag}
+				if exists $args{diag}
+				;
+			return 0;
+		}
+
+		return ref $args{throws}
+			? like $@, $args{throws}, $message
+			: is   $@, $args{throws}, $message
+			;
+	}
+
+	unless ($lives) {
+		fail $message;
+
+		diag q (Expected to live but it died:);
+		diag $args{diag}
+			if exists $args{diag}
+			;
+		diag $error =~ s (^) (  )rmg;
+
+		return 0;
+	}
+
+	return ref $args{expect}
+		? like $got, $args{expect}, $message
+		: is   $got, $args{expect}, $message
+		;
+}
+
+sub eval_this_code {
+    my (undef, $filename, $lineno) = caller;
+
+    return (
+		qq (\n#line $lineno "$filename"\n) . shift,
+		@_,
+	);
 }
 
 sub plan {

--- a/t/test_pl.pod
+++ b/t/test_pl.pod
@@ -208,6 +208,55 @@ tests are produced:
 
 =over
 
+=item assume $message, %arguments
+
+    assume q (the answer to life, the universe, and everything)
+        => expect => q (42)
+        => eval   => eval_code q {
+            42
+        };
+
+    assume q (it fails to calculate the ultimate question)
+        => throws => qr (^ 42 \b)x
+        => eval   => eval_code q {
+            die 42
+        };
+
+A smart assertion that combines code evaluation with value comparison.
+
+The assertion evaluates code, verifies the evaluation status, and checks
+the expected value in a single call.
+
+The expected evaluation status is determined by the presence of the
+named argument C<throws>.
+
+When the expected value is a scalar, the assertion acts like C<it>;
+otherwise, it behaves like C<like>.
+
+Named arguments:
+
+=over
+
+=item diag
+
+When specified, the assertion uses this value as an additional diagnostic message.
+
+=item eval
+
+The string to be evaluated. Within this string, the variable C<$result> is available
+and is initialised to an empty string.
+
+=item expect
+
+When provided, this value is used for comparison if the code evaluates without error.
+
+=item throws
+
+When provided, the evaluation is expected to fail, and C<$@> is used for the
+value comparison.
+
+=back
+
 =item within($got, $expected, $range, $name)
 
 Check C<$got> is within a numeric range.
@@ -378,6 +427,26 @@ Return or set the current test number.
 This can be used when dealing with forked processes to ensure child
 and parent test numbers are sequential.  See F<t/io/socket.t> for an
 example.
+
+=item eval_this_code
+
+Takes the first argument as a string to be evaluated and prepends it with the
+C<#line> pragma. This ensures that reports contain the file and line number
+relative to the test file itself.
+
+Returns the modified string and the remainder of its arguments.
+
+The reported location will be relative to where C<eval_this_code> is called.
+While this may differ slightly from the exact line, it provides a better
+approximation than a standard C<eval>.
+
+Instead of:
+
+    foo at (eval 10) line 11.
+
+The output will be:
+
+    foo at t/some-file.t line 17.
 
 =item todo_skip($reason, $count);
 


### PR DESCRIPTION
By extracting various declarations of cursor variable(s) into dedicated non-terminal
for statement now contains only 3 branches:
- `for (;;)`
- `for ()`
- `for cursor ()`

with LALR(1) parser `cursor` cannot be empty -> it will produce conflict with `for (;;)` form.

* This set of changes does not require a perldelta entry.
