### PR TITLE
    'use 5.41' affects current line source::encoding

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -949,6 +949,7 @@ Wolfgang Laun <wolfgang.laun@alcatel.at> <wolfgang.laun@thalesgroup.com>
 Wolfgang Laun <wolfgang.laun@alcatel.at> LAUN Wolfgang <wolfgang.laun@alcatel.at>
 Wolfgang Laun <wolfgang.laun@alcatel.at> wolfgang.laun@chello.at <wolfgang.laun@chello.at>
 YAMASHINA Hio <hio@ymir.co.jp> Hio <hio@hio.jp>
+Yitzchak Scott-Thoennes <sthoenna@efn.org> Yitzchak Scott-Thoennes <sthoenna@gmail.com>
 Yitzchak Scott-Thoennes <sthoenna@efn.org> Yitzchak Scott-Thoennes <ysth@raven.shiftboard.com>
 Yuval Kogman <nothingmuch@woobling.org> nothingmuch@woobling.org <nothingmuch@woobling.org>
 Yuval Kogman <nothingmuch@woobling.org> Yuval Kojman <unknown>

--- a/lib/source/source_encoding.t
+++ b/lib/source/source_encoding.t
@@ -44,8 +44,13 @@ if (fresh_perl_like(<<~'EOT',
                     EOT
                 "",
                 { }, "source encoding can be turned off");
+    fresh_perl_like(<<~'EOT',
+                 use v5.41.0; my $var = "¶";
+                 EOT
+                qr/Use of non-ASCII character 0x[[:xdigit:]]{2} illegal/,
+                { }, ">= 'use statement affects rest of current line'");
 }
-else { # Above test depends on the previous one; if that failed, use this
+else { # Above tests depend on the previous one; if that failed, use this
        # alternate one
     fresh_perl_is(<<~'EOT',
                     use source::encoding 'ascii';

--- a/lib/source/source_encoding.t
+++ b/lib/source/source_encoding.t
@@ -34,7 +34,7 @@ if (fresh_perl_like(<<~'EOT',
                  my $var = "¶";
                  EOT
                 qr/Use of non-ASCII character 0x[[:xdigit:]]{2} illegal/,
-                { }, ">= 'use 5.39' implies use source::encoding 'ascii'")
+                { }, ">= 'use 5.41' implies use source::encoding 'ascii'")
    ) {
     fresh_perl_is(<<~'EOT',
                     use v5.41.0;

--- a/op.c
+++ b/op.c
@@ -8477,6 +8477,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         else {
             PL_hints &= ~HINT_ASCII_ENCODING;
         }
+        notify_parser_that_encoding_changed();
 
         PL_prevailing_version = shortver;
     }

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -366,7 +366,8 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+S<C<use 5.42>> now turns on S<C<use source::encoding "ascii">> for the
+remainder of the line (besides subsequent lines). [GH #23881]
 
 =back
 


### PR DESCRIPTION
 Previously it didn't take effect until subsequent lines
     
Fixes #23881

I believe this should be included in the forthcoming 5.42.1 release

* This set of changes requires a perldelta entry, and it is included.
