### PR TITLE
t/run/exit.t: Fix syntax of 'my'

### DIFF
--- a/t/run/exit.t
+++ b/t/run/exit.t
@@ -45,7 +45,7 @@ plan(tests => $numtests);
 my $native_success = 0;
    $native_success = 1 if $^O eq 'VMS';
 
-my $exit, $exit_arg;
+my ($exit, $exit_arg);
 
 $exit = run('exit');
 is( $exit >> 8, 0,              'Normal exit' );


### PR DESCRIPTION
I found this by code reading
  
* This set of changes does not require a perldelta entry.
