### PR TITLE
run/locale.t: Skip setting to illegal locale on z/OS

### DIFF
--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -685,6 +685,8 @@ SKIP: {   # GH #20054
     skip "Even illegal locale names are accepted", 1
                     if $Config{d_setlocale_accepts_any_locale_name}
                     && $Config{d_setlocale_accepts_any_locale_name} eq 'define';
+    skip "z/OS setlocale() crashes with illegal locale names", 1
+                                                           if $^O eq 'os390';
 
     my @lc_all_locales = find_locales('LC_ALL');
     my $locale = $lc_all_locales[0];


### PR DESCRIPTION
This test gets variously an illegal instruction or segfault from within setlocale().  The default shell and bash on this system forbid the changing of LC_ALL to an illegal value, so the setlocale(3) command is insulated from getting this kind of input in actual operation.

This test was written in such a way as to get around such shell restrictions, and it turns out that the z/OS setlocale can't cope.  I haven't written a ticket to IBM because this really can't happen without a sneaky test that involves perl or something else very unlikely to happen in real life.

There is no good single-stepping debugger available I was told by an IBM person, so I tried narrowing the cause down by adding debug statements. I had to flush the buffer each time, and the results were more like going down a rabbit hole.

It turns out that when a test on the box I tested this with crashes, a human readable dump is output.  It showed that the failure is within an internal function 'locale_init()' called from setlocale(3).  That is a pretty strong indication that setlocale(3) isn't validating its input, and it isn't perl's fault.

* This set of changes does not require a perldelta entry.
