### PR TITLE
named signatures: fix crash when slurping and tainting

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -8021,12 +8021,12 @@ PP(pp_multiparam)
                 SV **padentry = &PAD_SVl(padix);
                 save_clearsv(padentry);
 
+                if(!val)
+                    val = &PL_sv_undef;
+
                 assert(TAINTING_get || !TAINT_get);
                 if (UNLIKELY(TAINT_get) && !SvTAINTED(val))
                     TAINT_NOT;
-
-                if(!val)
-                    val = &PL_sv_undef;
 
                 SvPADSTALE_off(*padentry);
                 SvSetMagicSV(*padentry, val);

--- a/t/op/signatures.t
+++ b/t/op/signatures.t
@@ -1589,6 +1589,25 @@ EOPERL
         'thread cloning during signature parse does not crash');
 }
 
+SKIP:
+{
+    skip "No taint support", 1
+      if exists $Config{taint_support} && !$Config{taint_support};
+    # https://github.com/Perl/perl5/pull/23871#discussion_r2488103875
+    $ENV{BAD} = "x";
+    fresh_perl_is(<<'CODE', "ok\n",
+no warnings "experimental::signature_named_parameters";
+use feature "signatures";
+sub foo (:$x, @y) {
+    print "ok\n";
+}
+foo("$ENV{BAD}");
+CODE
+                  {
+                   switches => [ "-t" ],
+                  }, "crash in named parameter handling");
+}
+
 done_testing;
 
 1;


### PR DESCRIPTION
Only try to dereference a parameter pointer after we ensure it is valid.

CID 638315

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
This fixes an unreleased feature.
