### PR TITLE
fix the variable name in the doc for ${^MAX_NESTED_EVAL_BEGIN_BLOCKS}

### DIFF
--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -643,8 +643,8 @@ fact the above code is equivalent to
     BEGIN { $n+=2 }
     BEGIN { $n+=1 }
 
-which makes it obvious why a ${^MAX_EVAL_BEGIN_DEPTH} of 1 would not
-block this code.
+which makes it obvious why a ${^MAX_NESTED_EVAL_BEGIN_BLOCKS} of 1
+would not block this code.
 
 Only C<BEGIN>'s executed inside of an C<eval> or C<require> (possibly via
 C<use>) are affected.


### PR DESCRIPTION
This seems to have existed since 741a5c7396a0ca90a22ea8d8e0761c70c14b0a77 (the initial commit), so it definitely looks like a typo that wasn't spotted before.

* This set of changes does not require a perldelta entry.
