### PR TITLE
fix the variable name in the test comment for ${^WARNINGS_BITS}

### DIFF
--- a/t/comp/hints.t
+++ b/t/comp/hints.t
@@ -204,7 +204,7 @@ print "ok 26 - no crash when cloning a tied hint hash\n";
     print "# got: $w" if $w;
 }
 
-# Setting ${^WARNING_HINTS} to its own value should not change things.
+# Setting ${^WARNING_BITS} to its own value should not change things.
 {
     my $w;
     local $SIG{__WARN__} = sub { $w++ };


### PR DESCRIPTION
This seems to have existed since 7e4f04509c6d4e8d2ed0e31eaf59004e5c930b39 (the initial commit), so it definitely looks like a typo that wasn't spotted before.

* This set of changes does not require a perldelta entry.
