### PR TITLE
Add Karen Etheridge to the list of VICTIMS

### DIFF
--- a/Porting/release_schedule.pod
+++ b/Porting/release_schedule.pod
@@ -76,6 +76,7 @@ consent of the Steering Council.)
   Florian Ragwitz <rafl@debian.org>
   Jesse Luehrs <doy@cpan.org>
   Jesse Vincent <jesse@cpan.org>
+  Karen Etheridge <ether@cpan.org>
   Leon Brocard <acme@astray.com>
   Matt Trout <mst@shadowcat.co.uk>
   Matthew Horsfall <wolfsage@gmail.com>


### PR DESCRIPTION
As discussed some time ago, add @karenetheridge to the list of "VICTIMS"

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
