### PR TITLE
Getopt::Std: tidy whitespace in module and test

### DIFF
--- a/lib/Getopt/Std.pm
+++ b/lib/Getopt/Std.pm
@@ -14,7 +14,7 @@ Getopt::Std - Process single-character switches with switch clustering
     use Getopt::Std;
 
     getopts('oif:');  # -o & -i are boolean flags, -f takes an argument
-		      # Sets $opt_* global variables as a side effect
+                      # Sets $opt_* global variables as a side effect
     getopts('oif:', \my %opts);  # Options as above, values in %opts
     getopt('oDI');    # -o, -D & -I take arguments
                       # Sets $opt_* global variables as a side effect
@@ -84,7 +84,7 @@ and C<version_mess()> with the switches string as an argument.
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(getopt getopts);
-our $VERSION = '1.14';
+our $VERSION = '1.15';
 # uncomment the next line to disable 1.03-backward compatibility paranoia
 # $STANDARD_HELP_VERSION = 1;
 
@@ -95,7 +95,7 @@ our $VERSION = '1.14';
 # whether there is a space between the switch and the argument.
 
 # Usage:
-#	getopt('oDI');  # -o, -D & -I take arg.  Sets opt_* as a side effect.
+#    getopt('oDI');  # -o, -D & -I take arg.  Sets opt_* as a side effect.
 
 sub getopt (;$$) {
     my ($argumentative, $hash) = @_;
@@ -105,56 +105,56 @@ sub getopt (;$$) {
     local @EXPORT;
 
     while (@ARGV && ($_ = $ARGV[0]) =~ /^-(.)(.*)/) {
-	($first, $rest) = ($1, $2);
-	if (/^--$/) {	# early exit if --
-	    shift @ARGV;
-	    last;
-	}
-	if (index($argumentative, $first) >= 0) {
-	    if ($rest ne '') {
-		shift(@ARGV);
-	    }
-	    else {
-		shift(@ARGV);
-		$rest = shift(@ARGV);
-	    }
-	    if (ref $hash) {
-	        $$hash{$first} = $rest;
-	    }
-	    else {
-            no strict 'refs';
-	        ${"opt_$first"} = $rest;
-	        push( @EXPORT, "\$opt_$first" );
-	    }
-	}
-	else {
-	    if (ref $hash) {
-	        $$hash{$first} = 1;
-	    }
-	    else {
-            no strict 'refs';
-	        ${"opt_$first"} = 1;
-	        push( @EXPORT, "\$opt_$first" );
-	    }
-	    if ($rest ne '') {
-		$ARGV[0] = "-$rest";
-	    }
-	    else {
-		shift(@ARGV);
-	    }
-	}
+        ($first, $rest) = ($1, $2);
+        if (/^--$/) {    # early exit if --
+            shift @ARGV;
+            last;
+        }
+        if (index($argumentative, $first) >= 0) {
+            if ($rest ne '') {
+                shift(@ARGV);
+            }
+            else {
+                shift(@ARGV);
+                $rest = shift(@ARGV);
+            }
+            if (ref $hash) {
+                $$hash{$first} = $rest;
+            }
+            else {
+                no strict 'refs';
+                ${"opt_$first"} = $rest;
+                push( @EXPORT, "\$opt_$first" );
+            }
+        }
+        else {
+            if (ref $hash) {
+                $$hash{$first} = 1;
+            }
+            else {
+                no strict 'refs';
+                ${"opt_$first"} = 1;
+                push( @EXPORT, "\$opt_$first" );
+            }
+            if ($rest ne '') {
+                $ARGV[0] = "-$rest";
+            }
+            else {
+                shift(@ARGV);
+            }
+        }
     }
-    unless (ref $hash) { 
-	local $Exporter::ExportLevel = 1;
-	Getopt::Std->import;
+    unless (ref $hash) {
+        local $Exporter::ExportLevel = 1;
+        Getopt::Std->import;
     }
 }
 
 our ($OUTPUT_HELP_VERSION, $STANDARD_HELP_VERSION);
 sub output_h () {
-  return $OUTPUT_HELP_VERSION if defined $OUTPUT_HELP_VERSION;
-  return \*STDOUT if $STANDARD_HELP_VERSION;
-  return \*STDERR;
+    return $OUTPUT_HELP_VERSION if defined $OUTPUT_HELP_VERSION;
+    return \*STDOUT if $STANDARD_HELP_VERSION;
+    return \*STDERR;
 }
 
 sub try_exit () {
@@ -170,15 +170,16 @@ sub version_mess ($;$) {
     my $args = shift;
     my $h = output_h;
     if (@_ and defined &main::VERSION_MESSAGE) {
-	main::VERSION_MESSAGE($h, __PACKAGE__, $VERSION, $args);
-    } else {
-	my $v = $main::VERSION;
-	$v = '[unknown]' unless defined $v;
-	my $myv = $VERSION;
-	$myv .= ' [paranoid]' unless $STANDARD_HELP_VERSION;
-	my $perlv = $];
-	$perlv = sprintf "%vd", $^V if $] >= 5.006;
-	print $h <<EOH;
+        main::VERSION_MESSAGE($h, __PACKAGE__, $VERSION, $args);
+    }
+    else {
+        my $v = $main::VERSION;
+        $v = '[unknown]' unless defined $v;
+        my $myv = $VERSION;
+        $myv .= ' [paranoid]' unless $STANDARD_HELP_VERSION;
+        my $perlv = $];
+        $perlv = sprintf "%vd", $^V if $] >= 5.006;
+        print $h <<EOH;
 $0 version $v calling Getopt::Std::getopts (version $myv),
 running under Perl version $perlv.
 EOH
@@ -189,47 +190,48 @@ sub help_mess ($;$) {
     my $args = shift;
     my $h = output_h;
     if (@_ and defined &main::HELP_MESSAGE) {
-	main::HELP_MESSAGE($h, __PACKAGE__, $VERSION, $args);
-    } else {
-	my (@witharg) = ($args =~ /(\S)\s*:/g);
-	my (@rest) = ($args =~ /([^\s:])(?!\s*:)/g);
-	my ($help, $arg) = ('', '');
-	if (@witharg) {
-	    $help .= "\n\tWith arguments: -" . join " -", @witharg;
-	    $arg = "\nSpace is not required between options and their arguments.";
-	}
-	if (@rest) {
-	    $help .= "\n\tBoolean (without arguments): -" . join " -", @rest;
-	}
-	my ($scr) = ($0 =~ m,([^/\\]+)$,);
-	print $h <<EOH if @_;			# Let the script override this
+        main::HELP_MESSAGE($h, __PACKAGE__, $VERSION, $args);
+    }
+    else {
+        my (@witharg) = ($args =~ /(\S)\s*:/g);
+        my (@rest) = ($args =~ /([^\s:])(?!\s*:)/g);
+        my ($help, $arg) = ('', '');
+        if (@witharg) {
+            $help .= "\n\tWith arguments: -" . join " -", @witharg;
+            $arg = "\nSpace is not required between options and their arguments.";
+        }
+        if (@rest) {
+            $help .= "\n\tBoolean (without arguments): -" . join " -", @rest;
+        }
+        my ($scr) = ($0 =~ m,([^/\\]+)$,);
+        print $h <<EOH if @_;            # Let the script override this
 
 Usage: $scr [-OPTIONS [-MORE_OPTIONS]] [--] [PROGRAM_ARG1 ...]
 EOH
-	print $h <<EOH;
+        print $h <<EOH;
 
 The following single-character options are accepted:$help
 
 Options may be merged together.  -- stops processing of options.$arg
 EOH
-	my $has_pod;
-	if ( defined $0 and $0 ne '-e' and -f $0 and -r $0
-	     and open my $script, '<', $0 ) {
-	    while (<$script>) {
-		$has_pod = 1, last if /^=(pod|head1)/;
-	    }
-	}
-	print $h <<EOH if $has_pod;
+        my $has_pod;
+        if ( defined $0 and $0 ne '-e' and -f $0 and -r $0
+             and open my $script, '<', $0 ) {
+            while (<$script>) {
+                $has_pod = 1, last if /^=(pod|head1)/;
+            }
+        }
+        print $h <<EOH if $has_pod;
 
 For more details run
-	perldoc -F $0
+    perldoc -F $0
 EOH
     }
 }
 
 # Usage:
-#   getopts('a:bc');	# -a takes arg. -b & -c not. Sets opt_* as a
-#			#  side effect.
+#   getopts('a:bc');    # -a takes arg. -b & -c not. Sets opt_* as a
+#            #  side effect.
 
 sub getopts ($;$) {
     my ($argumentative, $hash) = @_;
@@ -240,71 +242,72 @@ sub getopts ($;$) {
 
     @args = split( / */, $argumentative );
     while(@ARGV && ($_ = $ARGV[0]) =~ /^-(.)(.*)/s) {
-	($first, $rest) = ($1, $2);
-	if (/^--$/) {	# early exit if --
-	    shift @ARGV;
-	    last;
-	}
-	my $pos = index($argumentative, $first);
-	if ($pos >= 0) {
-	    if (defined($args[$pos+1]) and ($args[$pos+1] eq ':')) {
-		shift(@ARGV);
-		if ($rest eq '') {
-		    ++$errs unless @ARGV;
-		    $rest = shift(@ARGV);
-		}
-		if (ref $hash) {
-		    $$hash{$first} = $rest;
-		}
-		else {
-            no strict 'refs';
-		    ${"opt_$first"} = $rest;
-		    push( @EXPORT, "\$opt_$first" );
-		}
-	    }
-	    else {
-		if (ref $hash) {
-		    $$hash{$first} = 1;
-		}
-		else {
-            no strict 'refs';
-		    ${"opt_$first"} = 1;
-		    push( @EXPORT, "\$opt_$first" );
-		}
-		if ($rest eq '') {
-		    shift(@ARGV);
-		}
-		else {
-		    $ARGV[0] = "-$rest";
-		}
-	    }
-	}
-	else {
-	    if ($first eq '-' and $rest eq 'help') {
-		version_mess($argumentative, 'main');
-		help_mess($argumentative, 'main');
-		try_exit();
-		shift(@ARGV);
-		next;
-	    } elsif ($first eq '-' and $rest eq 'version') {
-		version_mess($argumentative, 'main');
-		try_exit();
-		shift(@ARGV);
-		next;
-	    }
-	    warn "Unknown option: $first\n";
-	    ++$errs;
-	    if ($rest ne '') {
-		$ARGV[0] = "-$rest";
-	    }
-	    else {
-		shift(@ARGV);
-	    }
-	}
+        ($first, $rest) = ($1, $2);
+        if (/^--$/) {    # early exit if --
+            shift @ARGV;
+            last;
+        }
+        my $pos = index($argumentative, $first);
+        if ($pos >= 0) {
+            if (defined($args[$pos+1]) and ($args[$pos+1] eq ':')) {
+                shift(@ARGV);
+                if ($rest eq '') {
+                    ++$errs unless @ARGV;
+                    $rest = shift(@ARGV);
+                }
+                if (ref $hash) {
+                    $$hash{$first} = $rest;
+                }
+                else {
+                    no strict 'refs';
+                    ${"opt_$first"} = $rest;
+                    push( @EXPORT, "\$opt_$first" );
+                }
+            }
+            else {
+                if (ref $hash) {
+                    $$hash{$first} = 1;
+                }
+                else {
+                    no strict 'refs';
+                    ${"opt_$first"} = 1;
+                    push( @EXPORT, "\$opt_$first" );
+                }
+                if ($rest eq '') {
+                    shift(@ARGV);
+                }
+                else {
+                    $ARGV[0] = "-$rest";
+                }
+            }
+        }
+        else {
+            if ($first eq '-' and $rest eq 'help') {
+                version_mess($argumentative, 'main');
+                help_mess($argumentative, 'main');
+                try_exit();
+                shift(@ARGV);
+                next;
+            }
+            elsif ($first eq '-' and $rest eq 'version') {
+                version_mess($argumentative, 'main');
+                try_exit();
+                shift(@ARGV);
+                next;
+            }
+            warn "Unknown option: $first\n";
+            ++$errs;
+            if ($rest ne '') {
+                $ARGV[0] = "-$rest";
+            }
+            else {
+                shift(@ARGV);
+            }
+        }
     }
-    unless (ref $hash) { 
-	local $Exporter::ExportLevel = 1;
-	Getopt::Std->import;
+    unless (ref $hash) {
+        local $Exporter::ExportLevel = 1;
+        Getopt::Std->import;
     }
     $errs == 0;
 }

--- a/lib/Getopt/Std.t
+++ b/lib/Getopt/Std.t
@@ -17,41 +17,41 @@ our ($warning, $opt_f, $opt_i, $opt_o, $opt_x, $opt_y, %opt);
 @ARGV = qw(-xo -f foo -y file);
 getopt('f');
 
-is( "@ARGV", 'file',		'options removed from @ARGV (1)' );
+is( "@ARGV", 'file',            'options removed from @ARGV (1)' );
 ok( $opt_x && $opt_o && $opt_y, 'options -x, -o and -y set' );
-is( $opt_f, 'foo',		q/option -f is 'foo'/ );
+is( $opt_f, 'foo',              q/option -f is 'foo'/ );
 
 @ARGV = qw(-hij k -- -l m -n);
 getopt 'il', \%opt;
 
-is( "@ARGV", 'k -- -l m -n',	'options removed from @ARGV (2)' );
-ok( $opt{h} && $opt{i} eq 'j',	'option -h and -i correctly set' );
-ok( !defined $opt{l},		'option -l not set' );
-ok( !defined $opt_i,		'$opt_i still undefined' );
+is( "@ARGV", 'k -- -l m -n',    'options removed from @ARGV (2)' );
+ok( $opt{h} && $opt{i} eq 'j',  'option -h and -i correctly set' );
+ok( !defined $opt{l},           'option -l not set' );
+ok( !defined $opt_i,            '$opt_i still undefined' );
 
 # Then we try the getopts
 $opt_o = $opt_i = $opt_f = undef;
 @ARGV = qw(-foi -i file);
 
-ok( getopts('oif:'),		'getopts succeeded (1)' );
-is( "@ARGV", 'file',		'options removed from @ARGV (3)' );
-ok( $opt_i && $opt_f eq 'oi',	'options -i and -f correctly set' );
-ok( !defined $opt_o,		'option -o not set' );
+ok( getopts('oif:'),            'getopts succeeded (1)' );
+is( "@ARGV", 'file',            'options removed from @ARGV (3)' );
+ok( $opt_i && $opt_f eq 'oi',   'options -i and -f correctly set' );
+ok( !defined $opt_o,            'option -o not set' );
 
 %opt = (); $opt_i = undef;
 @ARGV = qw(-hij -k -- -l m);
 
-ok( getopts('hi:kl', \%opt),	'getopts succeeded (2)' );
-is( "@ARGV", '-l m',		'options removed from @ARGV (4)' );
-ok( $opt{h} && $opt{k},		'options -h and -k set' );
-is( $opt{i}, 'j',		q/option -i is 'j'/ );
-ok( !defined $opt_i,		'$opt_i still undefined' );
+ok( getopts('hi:kl', \%opt),    'getopts succeeded (2)' );
+is( "@ARGV", '-l m',            'options removed from @ARGV (4)' );
+ok( $opt{h} && $opt{k},         'options -h and -k set' );
+is( $opt{i}, 'j',               q/option -i is 'j'/ );
+ok( !defined $opt_i,            '$opt_i still undefined' );
 
 # Try illegal options, but avoid printing of the error message
 $SIG{__WARN__} = sub { $warning = $_[0] };
 @ARGV = qw(-h help);
 
-ok( !getopts("xf:y"),		'getopts fails for an illegal option' );
+ok( !getopts("xf:y"),        'getopts fails for an illegal option' );
 ok( $warning eq "Unknown option: h\n", 'user warned' );
 
 # Tests for RT #41359


### PR DESCRIPTION
In the course of studying https://github.com/Perl/perl5/issues/23906, I came to the conclusion that `lib/Getopt/Std.pm` and `lib/Getopt/Std.t` would benefit from tidying whitespace.  Please review.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
