### PR TITLE
perlguts: the types are struct Perl_OpDumpContext * and const OP *

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -3938,10 +3938,11 @@ I<oldop> is the previous OP optimized, whose C<op_next> points to I<o>.
 =item xop_dump
 
 This member is a pointer to a function of type
-C<void (pTHX_ OP *, struct OpDumpContext *)>. If set, this function is called
-by C<op_dump()> when dumping a custom operator of this type, after the op's
-basic fields have been printed. This function may make use of
-C<opdump_printf()> to emit additional output that may be useful for debugging.
+C<void (pTHX_ const OP *, struct Perl_OpDumpContext *)>. If set, this
+function is called by C<op_dump()> when dumping a custom operator of this
+type, after the op's basic fields have been printed. This function may make
+use of C<opdump_printf()> to emit additional output that may be useful for
+debugging.
 
 The opaque structure pointer passed in as its final argument should be passed
 directly into C<opdump_printf()>.


### PR DESCRIPTION
which I missed in the review of #22572 but found when I tried to use it.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
