### PR TITLE
don't warn on 'undef $^W'

### DIFF
--- a/mg.c
+++ b/mg.c
@@ -3152,9 +3152,8 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
     case '\027':	/* ^W & $^WARNING_BITS */
         if (*(mg->mg_ptr+1) == '\0') {
             if ( ! (PL_dowarn & G_WARN_ALL_MASK)) {
-                i = SvIV(sv);
                 PL_dowarn = (PL_dowarn & ~G_WARN_ON)
-                                | (i ? G_WARN_ON : G_WARN_OFF) ;
+                                | (SvTRUE_NN(sv) ? G_WARN_ON : G_WARN_OFF) ;
             }
         }
         else if (strEQ(mg->mg_ptr+1, "ARNING_BITS")) {

--- a/t/lib/warnings/mg
+++ b/t/lib/warnings/mg
@@ -169,3 +169,8 @@ EXPECT
 Use of uninitialized value $s in hash element at - line 13.
 Use of uninitialized value $_[0] in defined operator at - line 10.
 defined
+########
+# NAME undefined $^W shouldn't warn
+use warnings;
+undef $^W
+EXPECT

--- a/t/op/reset.t
+++ b/t/op/reset.t
@@ -197,7 +197,7 @@ SKIP:
         my $warn = '';
         local $SIG{__WARN__} = sub { $warn .= "@_\n" };
         reset "\cW";
-        like($warn, qr/uninitialized/, "magic tries to SvIV() the new value");
+        is($warn, "", 'no warnings resetting $^W');
         $warn = '';
         is($^W, 0, q"check $^W has been zeroed");
         is($warn, '', "should be no more warnings");


### PR DESCRIPTION
Ironically, this warns:

    $ perl -e'use warnings; undef $^W'
    Use of uninitialized value in undef operator at -e line 1.
    $

The magic-setting code was treating the new value of $^W as an integer. This commit makes it treat the value as a boolean.

I suppose this commit could in theory break code if that code is doing something like:

    $^W = "0 but true";

In the past that would have disabled warnings, but will now enable them. But it seems unlikely that anyone would have written such code. The variable is documented in perlvar as having a value which is interpreted as a boolean.

Note that this commit stops a test in t/op/reset.t from expecting a warning when resetting `$^W`. This test was added by issue GH #20763, and AFAIKT that ticket was concerned with 'reset $^W' not actually resetting the variable; the test for the warning was purely a side-effect of the fact that it happened to warn.

* This set of changes does not require a perldelta entry.
