### PR TITLE
Fix 5.42 regression with strftime() and daylight savings

### DIFF
--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -3589,7 +3589,7 @@ difftime(time1, time2)
 #     sv_setpv(TARG, ...) could be used rather than
 #     ST(0) = sv_2mortal(newSVpv(...))
 void
-strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = 0)
+strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
 	SV *		fmt
 	int		sec
 	int		min
@@ -3605,10 +3605,8 @@ strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = 0)
             PERL_UNUSED_ARG(wday);
             PERL_UNUSED_ARG(yday);
 
-            /* -isdst triggers backwards compatibility mode for non-zero
-             * 'isdst' */
             SV *sv = sv_strftime_ints(fmt, sec, min, hour, mday, mon, year,
-                                           -abs(isdst));
+                                      isdst);
 	    if (sv) {
                 sv = sv_2mortal(sv);
             }

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.24';
+our $VERSION = '2.25';
 
 require XSLoader;
 

--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -1866,49 +1866,17 @@ Identical to the string form of C<$!>, see L<perlvar/$ERRNO>.
 =item C<strftime>
 
 Convert date and time information to string based on the current
-underlying locale of the program (except for any daylight savings time).
-Returns the string.
+underlying locale of the program.
+Returns the string in a mortalized SV; set to an empty string on error.
 
-Synopsis:
-
-	strftime(fmt, sec, min, hour, mday, mon, year,
-		 wday = -1, yday = -1, isdst = 0)
-
-The month (C<mon>) begins at zero,
-I<e.g.>, January is 0, not 1.  The
-year (C<year>) is given in years since 1900, I<e.g.>, the year 1995 is 95; the
-year 2001 is 101.  Consult your system's C<strftime()> manpage for details
-about these and the other arguments.
+ my $sv = strftime(fmt, sec, min, hour, mday, mon, year,
+                   wday = -1, yday = -1, isdst = -1)
 
 The C<wday> and C<yday> parameters are both ignored.  Their values are
 always determinable from the other parameters.
 
-C<isdst> should be C<1> or C<0>, depending on whether or not daylight
-savings time is in effect for the given time or not.
-
-If you want your code to be portable, your format (C<fmt>) argument
-should use only the conversion specifiers defined by the ANSI C
-standard (C99, to play safe).  These are C<aAbBcdHIjmMpSUwWxXyYZ%>.
-But even then, the B<results> of some of the conversion specifiers are
-non-portable.  For example, the specifiers C<aAbBcpZ> change according
-to the locale settings of the user, and both how to set locales (the
-locale names) and what output to expect are non-standard.
-The specifier C<c> changes according to the timezone settings of the
-user and the timezone computation rules of the operating system.
-The C<Z> specifier is notoriously unportable since the names of
-timezones are non-standard. Sticking to the numeric specifiers is the
-safest route.
-
-The arguments, except for C<isdst>, are made consistent as though by
-calling C<mktime()> before calling your system's C<strftime()> function.
-To get correct results, you must set C<isdst> to be the proper value.
-When omitted, the function assumes daylight savings is not in effect.
-
-The string for Tuesday, December 12, 1995 in the C<C> locale.
-
-	$str = POSIX::strftime( "%A, %B %d, %Y",
-				 0, 0, 0, 12, 11, 95, 2 );
-	print "$str\n";
+More details on the behavior and the specification of the other
+parameters are described in L<perlapi/sv_strftime_ints>.
 
 =item C<strlen>
 

--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -273,7 +273,12 @@ print POSIX::strftime("ok $test # %H:%M, on %m/%d/%y\n", localtime());
 # input fields to strftime().
 sub try_strftime {
     my $expect = shift;
-    my $got = POSIX::strftime("%a %b %d %H:%M:%S %Y %j", @_);
+    my @input = @_;
+
+    # Add zeros to missing parameters.  The final 0 is for isdst, and the zero
+    # forces use of mini_mktime (unless the code changes).
+    push @input, 0 while @input < 9;
+    my $got = POSIX::strftime("%a %b %d %H:%M:%S %Y %j", @input);
     is($got, $expect, "validating mini_mktime() and strftime(): $expect");
 }
 

--- a/ext/POSIX/t/time.t
+++ b/ext/POSIX/t/time.t
@@ -16,14 +16,15 @@ use Test::More tests => 31;
 # Those with a working tzset() should be able to use the TZ below.
 $ENV{TZ} = "EST5EDT";
 
+# It looks like POSIX.xs claims that only VMS and Mac OS traditional
+# don't have tzset().  Win32 works to call the function, but it doesn't
+# actually do anything.  Cygwin works in some places, but not others.  The
+# other Win32's below are guesses.
+my $has_tzset = $^O ne "VMS" && $^O ne "cygwin"
+             && $^O ne "MSWin32" && $^O ne "interix";
+
 SKIP: {
-    # It looks like POSIX.xs claims that only VMS and Mac OS traditional
-    # don't have tzset().  Win32 works to call the function, but it doesn't
-    # actually do anything.  Cygwin works in some places, but not others.  The
-    # other Win32's below are guesses.
-    skip "No tzset()", 1
-       if $^O eq "VMS" || $^O eq "cygwin" ||
-          $^O eq "MSWin32" || $^O eq "interix";
+    skip "No tzset()", 1 unless $has_tzset;
     tzset();
     SKIP: {
         my @tzname = tzname();
@@ -42,9 +43,7 @@ SKIP: {
 $ENV{TZ} = "UTC0UTC";
 
 SKIP: {
-    skip "No tzset()", 2
-       if $^O eq "VMS" || $^O eq "cygwin" ||
-          $^O eq "MSWin32" || $^O eq "interix";
+    skip "No tzset()", 2 unless $has_tzset;
     tzset();
     my @tzname = tzname();
     like($tzname[0], qr/(GMT|UTC)/i, "tzset() to GMT/UTC");

--- a/ext/POSIX/t/time.t
+++ b/ext/POSIX/t/time.t
@@ -17,11 +17,12 @@ use Test::More tests => 31;
 $ENV{TZ} = "EST5EDT";
 
 # It looks like POSIX.xs claims that only VMS and Mac OS traditional
-# don't have tzset().  Win32 works to call the function, but it doesn't
-# actually do anything.  Cygwin works in some places, but not others.  The
-# other Win32's below are guesses.
+# don't have tzset().  MingW doesn't work.  Cygwin works in some places, but
+# not others.  The other Win32's below are guesses.
 my $has_tzset = $^O ne "VMS" && $^O ne "cygwin"
-             && $^O ne "MSWin32" && $^O ne "interix";
+             && ($^O ne "MSWin32" || (   $^O eq "MSWin32"
+                                      && $Config{make} eq 'nmake'))
+             && $^O ne "interix";
 
 SKIP: {
     skip "No tzset()", 1 unless $has_tzset;

--- a/ext/POSIX/t/time.t
+++ b/ext/POSIX/t/time.t
@@ -9,7 +9,7 @@ use strict;
 
 use Config;
 use POSIX;
-use Test::More tests => 31;
+use Test::More tests => 49;
 
 # For the first go to UTC to avoid DST issues around the world when testing.  SUS3 says that
 # null should get you UTC, but some environments want the explicit names.
@@ -205,7 +205,7 @@ SKIP: {
     is(mktime(CORE::localtime($time)), $time, "mktime()");
     is(mktime(POSIX::localtime($time)), $time, "mktime()");
 }
- 
+
 SKIP: {
     skip "'%s' not implemented in strftime", 1 if $^O eq "VMS"
                                                || $^O eq "MSWin32"
@@ -225,4 +225,123 @@ SKIP: {
     local $SIG{__WARN__} = sub { $warnings .= $_[0] };
     is(strftime(undef, CORE::localtime), '', "strftime() works if format is undef");
     like($warnings, qr/^Use of uninitialized value in subroutine entry /, "strftime(undef, ...) produces expected warning");
+}
+
+# Now check the transitioning between standard and daylight savings times.  To
+# do this requires setting a timezone.  Unfortunately, timezone specification
+# syntax differs incompatibly between systems.  The older PST8PDT style
+# prevails on Windows, but is being supplanted by "Europe/Paris" style
+# elsewhere.  Debian in particular requires a special package to be installed
+# to correctly work with the old style.  Worse, without the package, it still
+# can recognize the syntax and correctly get right times that aren't at the
+# edge of the transitions.  khw tried the 2004 and 2025 spring forward times,
+# and Debian sans-package was exactly 6 hours off the correct values.
+# (The older style was U.S. centric, assuming everyone in the world with the
+# same longitude obeyed the same rules; the new style can tailor the rules to
+# the specific region affected.)
+
+# Tue 01 Jul 2025 05:01:01 PM GMT.  This is chosen as being in the middle of
+# Daylight Savings Time.  Below, we set locales, and verify that these
+# actually worked by checking that the hour returned is the expected value.
+my $reference_time = 1751389261;
+
+my $new_names_all_passed = 0;
+my $some_new_name_passed = 0;
+
+SKIP: {   # GH #23878; test that dst fall back works properly
+    my $skip_count = 9;
+    skip "No mktime()", $skip_count if $Config{d_mktime} ne 'define';
+
+    # Doing this ensures that Windows is expecting a different timezone than
+    # the one in the test.  Hence, if the new-style name isn't recognized, the
+    # tests will be skipped.  Otherwise, if the test happens to being run on a
+    # platform located in the Paris timezone, the check will happen to
+    # succeed even though the timezone change failed.
+    $ENV{TZ} = "PST8PDT";
+    tzset() if $has_tzset;
+
+    my $locale = "Europe/Paris";
+    $ENV{TZ} = $locale;
+    tzset() if $has_tzset;
+
+    skip "'$locale' not understood", $skip_count
+                   if POSIX::strftime("%H", localtime($reference_time)) != 19;
+
+    my $t = 1761436800;     # an hour before time should have changed
+    my @fall = (
+                 [   -1, "2025-10-26 01:59:59+0200", "Chg -1 hr, 1 sec" ],
+                 [    0, "2025-10-26 02:00:00+0200", "Chg -1 hr, 0 sec" ],
+                 [    1, "2025-10-26 02:00:01+0200", "Chg -59 min, 59 sec" ],
+                 [ 3599, "2025-10-26 02:59:59+0200", "Chg -1 sec" ],
+                 [ 3600, "2025-10-26 02:00:00+0100", "At Paris DST fallback" ],
+                 [ 3601, "2025-10-26 02:00:01+0100", "Chg +1 sec" ],
+                 [ 7199, "2025-10-26 02:59:59+0100", "Chg +1 hr, 59m, 59s" ],
+                 [ 7200, "2025-10-26 03:00:00+0100", "Chg +1 hr" ],
+                 [ 7201, "2025-10-26 03:00:01+0100", "Chg +1 hr, 1 sec" ],
+               );
+    my $had_failure = 0;
+    for (my $i = 0; $i < @fall; $i++) {
+        if (is(POSIX::strftime("%F %T%z", localtime $t + $fall[$i][0]),
+               $fall[$i][1], $fall[$i][2]))
+        {
+            $some_new_name_passed = 1;
+        }
+        else {
+            $had_failure = 1
+        }
+    }
+
+    $new_names_all_passed = ! $had_failure;
+}
+
+SKIP: {   # GH #23878: test that dst spring forward works properly.
+    my $skip_count = 9;
+    skip "No mktime()", $skip_count if $Config{d_mktime} ne 'define';
+
+    my $locale;
+
+    # For this group of tests, we use the old-style timezone names on systems
+    # that don't understand the new ones, and use the new ones on systems that
+    # do; this finesses the problem of some systems needing special packages
+    # to handle old names properly.
+
+    # The group of tests just before this one set this variable.  If 'false'
+    # it means no new name worked, likely because they aren't understood, but
+    # also could be because of bugs.
+    if ($some_new_name_passed) {
+        skip "DST fall back didn't work; spring forward not tested",
+                                     $skip_count unless $new_names_all_passed;
+        $locale = "America/Los_Angeles";
+    }
+    else {
+
+        # Use a locale that MS narcissism should be able to handle
+        $locale = "PST8PDT";
+    }
+
+    $ENV{TZ} = $locale;
+    tzset() if $has_tzset;
+
+    # $reference_time is in the middle of summer, dst should be in effect.
+    skip "'$locale' not understood", $skip_count if
+                POSIX::strftime("%H", localtime($reference_time)) != 10;
+
+    my $t = 1741510800;     # an hour before time should have changed
+
+    my @spring = (
+                  [   -1, "2025-03-09 00:59:59-0800", "Chg -1 hr,-1 sec" ],
+                  [    0, "2025-03-09 01:00:00-0800", "Chg -1 hr, 0 sec" ],
+                  [    1, "2025-03-09 01:00:01-0800", "Chg -59 min,-59 sec" ],
+                  [ 3599, "2025-03-09 01:59:59-0800", "Chg -1 sec" ],
+                  [ 3600, "2025-03-09 03:00:00-0700",
+                                            "At Redmond DST spring forward" ],
+                  [  3601, "2025-03-09 03:00:01-0700", "Chg +1 sec" ],
+                  [  7199, "2025-03-09 03:59:59-0700", "Chg +1 hr, 59m,59s" ],
+                  [  7200, "2025-03-09 04:00:00-0700", "Chg +1 hr" ],
+                  [  7201, "2025-03-09 04:00:01-0700", "Chg +1 hr, 1 sec" ],
+            );
+    for (my $i = 0; $i < @spring; $i++) {
+        is(POSIX::strftime("%F %T%z", localtime $t + $spring[$i][0]),
+           $spring[$i][1], $spring[$i][2]);
+    }
 }

--- a/locale.c
+++ b/locale.c
@@ -8271,15 +8271,8 @@ Perl_sv_strftime_ints(pTHX_ SV * fmt, int sec, int min, int hour,
     const char * locale = "C";
 #endif
 
-    /* A negative 'isdst' triggers backwards compatibility mode for
-     * POSIX::strftime(), in which 0 is always passed to ints_to_tm() so that
-     * the possibility of daylight savings time is never considered,  But, a 1
-     * is eventually passed to libc strftime() so that it returns the results
-     * it always has for a non-zero 'isdst'.  See GH #22351 */
     struct tm  mytm;
-    ints_to_tm(&mytm, locale, sec, min, hour, mday, mon, year,
-                              MAX(0, isdst));
-    mytm.tm_isdst = MIN(1, abs(isdst));
+    ints_to_tm(&mytm, locale, sec, min, hour, mday, mon, year, isdst);
     return sv_strftime_common(fmt, locale, &mytm);
 }
 
@@ -8387,30 +8380,35 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
     if (isdst == 0) {
         mini_mktime(mytm);
 
-#  ifndef ALWAYS_RUN_MKTIME
+#  ifdef ALWAYS_RUN_MKTIME
 
-    /* When we don't always need libc mktime(), we call it only when we didn't
-     * call mini_mktime() */
-    } else {
-
-#  else
         /* Here will have to run libc mktime() in order to get the values of
          * some fields that mini_mktime doesn't populate.  We don't want
-         * mktime's side effect of looking for dst, so we have to have a
-         * separate tm structure from which we copy just those fields into the
-         * returned structure.  Initialize its values.  mytm should now be a
-         * normalized version of the input. */
+         * mktime's side effect of looking for dst (because isdst==0), so we
+         * have to have a separate tm structure from which we copy just those
+         * fields into the structure we return.  Initialize its values, which
+         * have now been normalized by mini_mktime. */
         aux_tm = *mytm;
-        aux_tm.tm_isdst = isdst;
         which_tm = &aux_tm;
+
+#  endif
+
+    }
+
+#  ifndef ALWAYS_RUN_MKTIME
+
+    else {  /* Don't run libc mktime if both:
+                1) we ran mini_mktime above; and
+                2) we don't have to always run libc mktime */
 
 #  endif
 
         /* Here, we need to run libc mktime(), either because we want to take
          * dst into consideration, or because it calculates one or two fields
-         * that we need that mini_mktime() doesn't handle.
-         *
-         * Unlike mini_mktime(), it does consider the locale, so have to switch
+         * that we need that mini_mktime() doesn't handle. */
+        which_tm->tm_isdst = isdst;
+
+        /* Unlike mini_mktime(), it does consider the locale, so have to switch
          * to the correct one. */
         const char * orig_TIME_locale = toggle_locale_c(LC_TIME, locale);
         MKTIME_LOCK;
@@ -8422,9 +8420,12 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
 
         MKTIME_UNLOCK;
         restore_toggled_locale_c(LC_TIME, orig_TIME_locale);
+
+#  ifndef ALWAYS_RUN_MKTIME
+
     }
 
-#  if defined(HAS_TM_TM_GMTOFF) || defined(HAS_TM_TM_ZONE)
+#  else
 
     /* And use the saved libc values for tm_gmtoff and tm_zone if we used an
      * auxiliary struct to get them */

--- a/locale.c
+++ b/locale.c
@@ -8242,7 +8242,6 @@ Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour,
     PERL_ARGS_ASSERT_MY_STRFTIME;
     PERL_UNUSED_ARG(wday);
     PERL_UNUSED_ARG(yday);
-    PERL_UNUSED_ARG(isdst);
 
 #ifdef USE_LOCALE_TIME
     const char * locale = querylocale_c(LC_TIME);
@@ -8251,7 +8250,7 @@ Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour,
 #endif
 
     struct tm  mytm;
-    ints_to_tm(&mytm, locale, sec, min, hour, mday, mon, year, 0);
+    ints_to_tm(&mytm, locale, sec, min, hour, mday, mon, year, isdst);
     if (! strftime_tm(fmt, PL_scratch_langinfo, locale, &mytm)) {
         return NULL;
     }

--- a/locale.c
+++ b/locale.c
@@ -8415,7 +8415,7 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
         const char * orig_TIME_locale = toggle_locale_c(LC_TIME, locale);
         MKTIME_LOCK;
 
-        /* which_tm points to an auxiliary copy if we ran mini_mktime().
+        /* 'which_tm' points to an auxiliary copy if we ran mini_mktime().
          * Otherwise it points to the passed-in one which now gets populated
          * directly. */
         (void) mktime(which_tm);

--- a/locale.c
+++ b/locale.c
@@ -8154,11 +8154,12 @@ S_maybe_override_codeset(pTHX_ const char * codeset,
 
 /*
 =for apidoc_section $time
-=for apidoc      sv_strftime_tm
-=for apidoc_item sv_strftime_ints
+=for apidoc      sv_strftime_ints
+=for apidoc_item sv_strftime_tm
 =for apidoc_item my_strftime
 
-These implement the libc strftime().
+These implement libc strftime(), overcoming various deficiencies it has; you
+will come to regret sooner or later using it directly instead of these.
 
 On failure, they return NULL, and set C<errno> to C<EINVAL>.
 
@@ -8167,70 +8168,154 @@ handle the UTF-8ness of the current locale, the input C<fmt>, and the returned
 result.  Only if the current C<LC_TIME> locale is a UTF-8 one (and S<C<use
 bytes>> is not in effect) will the result be marked as UTF-8.
 
+For these, the caller assumes ownership of the returned SV with a reference
+count of 1.
+
 C<my_strftime> is kept for backwards compatibility.  Knowing if its result
 should be considered UTF-8 or not requires significant extra logic.
 
 Note that all three functions are always executed in the underlying
 C<LC_TIME> locale of the program, giving results based on that locale.
 
+The stringified C<fmt> parameter in all is the same as the system libc
+C<strftime>.  The available conversion specifications vary by platform.  These
+days, every specification listed in the ANSI C99 standard should be usable
+everywhere.  These are C<a A b B c d H I j m M p S U w W x X y Y Z %>. 
+
+But note that the B<results> of some of the conversion specifiers are
+non-portable.  For example, the specifiers C<a A b B c p Z> change according
+to the locale settings of the user, and both how to set locales (the
+locale names) and what output to expect are not standardized.
+The specifier C<c> changes according to the timezone settings of the
+user and the timezone computation rules of the operating system.
+The C<Z> specifier is notoriously unportable since the names of
+timezones are not standardized. Sticking to the numeric specifiers is the
+safest route.
+
+At the time of this writing, for example, C<%s> is not available on
+Windows-like systems.
+
 The functions differ as follows:
 
-C<sv_strftime_tm> takes a pointer to a filled-in S<C<struct tm>> parameter.  It
-ignores the values of the C<wday> and C<yday> fields in it.  The other fields
-give enough information to accurately calculate these values, and are used for
-that purpose.
-
-The caller assumes ownership of the returned SV with a reference count of 1.
-
-C<sv_strftime_ints> takes a bunch of integer parameters that together
-completely define a given time.  It calculates the S<C<struct tm>> to pass to
-libc strftime(), and calls that function.
-
-The value of C<isdst> is used as follows:
-
 =over
 
-=item 0
+=item *
 
-No daylight savings time is in effect
-
-=item E<gt>0
-
-Check if daylight savings time is in effect, and adjust the results
-accordingly.
-
-=item E<lt>0
-
-This value is reserved for internal use by the L<POSIX> module for backwards
-compatibility purposes.
-
-=back
-
-The caller assumes ownership of the returned SV with a reference count of 1.
-
-C<my_strftime> is like C<sv_strftime_ints> except that:
-
-=over
-
-=item The C<fmt> parameter and the return are S<C<char *>> instead of
-S<C<SV *>>.
-
-This means the UTF-8ness of the result is unspecified.  The result MUST be
+The C<fmt> parameter and the return from C<my_strftime> are S<C<char *>>
+instead of the S<C<SV *>> in the other two functions.  This means the
+UTF-8ness of the format and result are unspecified.  The result MUST be
 arranged to be FREED BY THE CALLER).
 
-=item The C<is_dst> parameter is ignored.
+=item *
 
-Daylight savings time is never considered to be in effect.
+C<sv_strftime_ints> and C<my_strftime> take a bunch of integer parameters that
+together completely define a given time.  They calculate the S<C<struct tm>>
+to pass to libc strftime(), and call that function.  See below for the meaning
+of the parameters.
 
-=item It has extra parameters C<yday> and C<wday> that are ignored.
+C<sv_strftime_tm> takes a pointer to an already filled-in S<C<struct tm>>
+parameter, so avoids that calculation.
 
-These exist only for historical reasons; the values for the corresponding
-fields in S<C<struct tm>> are calculated from the other arguments.
+=item *
+
+C<my_strftime> takes two extra parameters that are ignored, being kept only
+for historical reasons.  These are C<wday> and C<yday>.
 
 =back
 
-Note that all three functions are always executed in the underlying C<LC_TIME>
-locale of the program, giving results based on that locale.
+The C99 Standard calls for S<C<struct tm>> to contain at least these fields:
+
+ int tm_sec;    // seconds after the minute — [0, 60]
+ int tm_min;    // minutes after the hour — [0, 59]
+ int tm_hour;   // hours since midnight — [0, 23]
+ int tm_mday;   // day of the month — [1, 31]
+ int tm_mon;    // months since January — [0, 11]
+ int tm_year;   // years since 1900
+ int tm_wday;   // days since Sunday — [0, 6]
+ int tm_yday;   // days since January 1 — [0, 365]
+ int tm_isdst;  // Daylight Saving Time flag
+
+C<tm_wday> and C<tm_yday> are output only; the other fields give enough
+information to accurately calculate these, and are internally used for that
+purpose.
+
+The numbers enclosed in the square brackets above give the maximum legal
+ranges for values in the corresponding field.  Those ranges are restricted for
+some inputs. For example, not all months have 31 days, but all hours have 60
+minutes.  If you set a number that is outside the corresponding range, perl
+and the libc functions will automatically normalize it to be inside the range,
+adjusting other values as necessary.  For example, specifying February 29, is
+the same as saying March 1 for non-leap years; and using a minute value of 60
+will instead change that to a 0, and increment the hour, which in turn, if the
+hour was 23, will roll it over to 0 it and increment the day, and so on.
+
+Each parameter to C<sv_strftime_ints> and C<my_strftime> populates the
+similarly-named field in this structure.
+
+A value of 60 is legal for C<tm_sec>, but only for those moments when an
+official leap second has been declared.  It is undefined behavior to use them
+otherwise, and the behavior does vary depending on the implementation.
+Some implementations take your word for it that this is a leap second, leaving
+it as the 61st second of the given minute; some roll it over to be the 0th
+second of the following minute; some treat it as 0.  Some non-conforming
+implementations always roll it over to the next minute, regardless of whether
+an actual leap second is occurring or not.  (And yes, it is a real problem
+that different computers have a different conception of what the current time
+is; you can search the internet for details.)
+
+There is no limit (outside the size of C<int>) for the value of C<tm_year>,
+but sufficiently negative values (for earlier than 1900) may have different
+results on different systems and locales.  Some libc implementations may know
+when a given locale adopted the Greorian calendar, and adjust for that.
+Others will not.  (And some countries didn't adopt the Gregorian calendar
+until after 1900.)  Probably all implementations assume modern time zones go
+back forever, before they were actually invented, starting in the last half of
+the 19th century.
+
+The treatment of the C<isdst> field has varied over previous Perl versions,
+and has been buggy (both by perl and by some libc implementations), but is now
+aligned, as best we can, with the POSIX Standard, as follows:
+
+=over
+
+=item C<is_dist> is 0
+
+The function is to assume that daylight savings time is not in effect.  This
+should now always work properly, as perl uses its own implementation in this
+case, avoiding non-conforming libc ones.
+
+=item C<is_dist> is E<gt>0
+
+The function is to assume that daylight savings time is in effect, though some
+underlying libc implementations treat this as a hint instead of a mandate.
+
+=item C<is_dist> is E<lt>0
+
+The function is to itself try to calculate if daylight savings time is in
+effect.  More recent libc implementations are better at this than earlier
+ones.
+
+=back
+
+Some libc implementations have extra fields in S<C<struct tm>>.  The two that
+perl handles are:
+
+  int tm_gmtoff;            // Seconds East of UTC [%z]
+  const char * tm_zone;     // Timezone abbreviation [%Z]
+
+These are both output only.  Using the respective conversion specifications
+(enclosed in the square brackets) in the C<fmt> parameter is a portable way to
+gain access to these values, working both on systems that have and don't have
+these fields.
+
+Example, in the C<C> locale:
+
+ my_strftime( "%A, %B %d, %Y", 0, 0, 0, 12, 11, 95, 0, 0, -1 );
+
+returns
+
+ "Tuesday, December 12, 1995"
+
 =cut
  */
 

--- a/locale.c
+++ b/locale.c
@@ -8363,20 +8363,22 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
     mytm->tm_year = year;
 
     struct tm * which_tm = mytm;
-    struct tm aux_tm;
 
 #ifndef HAS_MKTIME
 
     mini_mktime(mytm);
 
 #else
+#  if defined(HAS_TM_TM_GMTOFF) || defined(HAS_TM_TM_ZONE)
+#    define ALWAYS_RUN_MKTIME
+
+    struct tm aux_tm;
+
+#  endif
 
     /* On platforms that have either of these two fields, we have to run the
      * libc mktime() in order to set them, as mini_mktime() doesn't deal with
      * them.  [perl #18238] */
-#  if defined(HAS_TM_TM_GMTOFF) || defined(HAS_TM_TM_ZONE)
-#    define ALWAYS_RUN_MKTIME
-#  endif
 
     /* When isdst is 0, it means to consider daylight savings time as never
      * being in effect.  Many libc implementations of mktime() do not allow

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -376,6 +376,16 @@ used to be parsed incorrectly.
 
 XXX
 
+=item *
+
+Perl 5.42.0 does not handle the transition to/from daylight savings time
+properly.  The time and/or timezone can be off by an hour in the
+intervals surrounding such transitions.  This is a regression from
+earlier releases, and is now fixed.  This bug was evident from perl
+space in the L<POSIX/strftime> function, and in XS code with any of
+L<perlapi/my_strftime>, L<perlapi/sv_strftime_ints>, or
+L<perlapi/sv_strftime_tm>.
+
 =back
 
 =head1 Known Problems


### PR DESCRIPTION
tl;dr:

Fixes  #23878

I botched this in Perl 5.42.  These conditional compilation statements in locale.c were just plain wrong, causing code to be skipped that should have been compiled.  It only affected the few hours of the year when daylight savings time is removed, so that the hour value is repeated.  We didn't have a good test for that.

gory details:

libc uses 'struct tm' to hold information about a given instant in time, containing fields for things like the year, month, hour, etc.  The libc function mktime() is used to normalize the structure, adjusting, say, an input Nov 31 to be Dec 01.

One of the fields in the structure, 'is_dst', indicates if daylight savings is in effect, or whether that fact is unknown.  If unknown, mktime() is supposed to calculate the answer and to change 'is_dst' accordingly.  Some implementations appear to always do this calculation even when the input value says the result is known.  Others appear to honor it.

Some libc implementations have extra fields in 'struct tm'.

Perl has a stripped down version of mktime(), called mini_mktime(), written by Larry Wall a long time ago.  I don't know why.  This crippled version ignores locale and daylight time.  It also doesn't know about the extra fields in 'struct tm' that some implementations have.  Nor can it be extended to know about those fields, as they are dependent on timezone and daylight time, which it deliberately doesn't consider.

The botched #ifdef's were supposed to compensate for both the extra fields in the struct and that some libc implementations always recalculate 'is_dst'.

On systems with these fields, the botched #if's caused only mini_mktime() to be called.  This meant that these extra fields didn't get populated, and daylight time is never considered to be in effect.  And 'is_dst' does not get changed from the input.

On systems without these fields, the regular libc mktime() would be called appropriately.

The bottom line is that for the portion of the year when daylight savings is not in effect, things mostly worked properly.  The two extra fields would not be populated, so if some code were to read them, it would only get the proper values by chance.  We got no failure reports of this.  I attribute that to the fact that the use of these is not portable, so code wouldn't tend to use them.  There are portable ways to access the information they contain.

Tests were failing for the portions of the year when daylight savings is in effect; see GH #22351.  The code looked correct just reading it (not seeing the flaw in the #ifdef's), so I assumed that it was an issue in the libc implementations and instituted a workaround.  (I can't now think of a platform where there hasn't been a problem with a libc with something regarding locales, so that was a reasonable assumption.)

Among other things that workaround overrode the 'is_dst' field after the call to mini_mktime(), so that the value actually passed to libc strftime() indicated that daylight is in effect.

What happens next depends on the libc strftime() implementation.  It could conceivably itself call mktime() which might choose to override is_dst to be the correct value, and everything would always work.  The more likely possibility is that it just takes the values in the struct as-is.  Remember that those values on systems with the extra fields were calculated as if daylight savings wasn't in effect, but now we're telling strftime() to use those values as if it were in effect.  This is a discrepancy.  I'd have to trace through some libc implementations to understand why this discrepancy seems to not matter except at the transition time.

But the bottom line is this p.r removes that discrepancy, and causes mktime() to be called appropriately on systems where it wasn't, so strftime() should now function properly.  And the workarounds are also removed.

This regression fix should go into a maintenance release.

* This set of changes requires a perldelta entry, and it is included.
