### PR TITLE
Don't warn about jumping into a construct if we're DIE-ing

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3250,6 +3250,7 @@ PP(pp_goto)
     I32 ix;
     PERL_CONTEXT *cx;
     OP *enterops[GOTO_DEPTH];
+    bool into_construct = FALSE;
     const char *label = NULL;
     STRLEN label_len = 0;
     U32 label_flags = 0;
@@ -3652,9 +3653,7 @@ PP(pp_goto)
                     ? 2
                     : 1;
             if (enterops[i])
-                deprecate_fatal_in(WARN_DEPRECATED__GOTO_CONSTRUCT,
-                        "5.42",
-                        "Use of \"goto\" to jump into a construct");
+                into_construct = TRUE;
         }
 
         /* pop unwanted frames */
@@ -3685,6 +3684,12 @@ PP(pp_goto)
             PL_op = oldop;
         }
     }
+
+    if (into_construct)
+        deprecate_fatal_in(WARN_DEPRECATED__GOTO_CONSTRUCT,
+                "5.42",
+                "Use of \"goto\" to jump into a construct");
+
 
     if (do_dump) {
 #ifdef VMS

--- a/t/lib/croak/pp_ctl
+++ b/t/lib/croak/pp_ctl
@@ -1,45 +1,40 @@
 __END__
 # NAME goto into foreach
-no warnings 'deprecated';
 goto f;
 foreach(1){f:}
 EXPECT
-Can't "goto" into the middle of a foreach loop at - line 3.
+Can't "goto" into the middle of a foreach loop at - line 2.
 ########
 # NAME goto into given
-no warnings 'deprecated';
 goto f;
 CORE::given(1){f:}
 EXPECT
-Can't "goto" into a "given" block at - line 3.
-########
-# NAME goto from given topic expression
-no warnings 'deprecated';
-CORE::given(goto f){f:}
-EXPECT
 Can't "goto" into a "given" block at - line 2.
 ########
+# NAME goto from given topic expression
+CORE::given(goto f){f:}
+EXPECT
+Can't "goto" into a "given" block at - line 1.
+########
 # NAME goto into expression
-no warnings 'deprecated';
 eval { goto a; 1 + do { a: } }; warn $@;
 eval { goto b; meth { b: }   }; warn $@;
 eval { goto c; map { c: } () }; warn $@;
 eval { goto d; f(do { d: })  }; die  $@;
 EXPECT
+Can't "goto" into a binary or list expression at - line 1.
 Can't "goto" into a binary or list expression at - line 2.
 Can't "goto" into a binary or list expression at - line 3.
 Can't "goto" into a binary or list expression at - line 4.
-Can't "goto" into a binary or list expression at - line 5.
 ########
 # NAME dump with computed label
-no warnings 'deprecated';
 my $label = "foo";
 CORE::dump $label;
 EXPECT
-Can't find label foo at - line 3.
+Can't find label foo at - line 2.
 ########
 # NAME when outside given
-use 5.01; no warnings 'deprecated';
+use 5.01;
 when(undef){}
 EXPECT
 Can't "when" outside a topicalizer at - line 2.


### PR DESCRIPTION
There are many cases where we throw exceptions if you attempt to goto somewhere you have no business going. We'd *also* throw a deprecation warning in these cases, which just seems silly. Deprecated means "this will stop working eventually", so there's no need to throw that when we're just going to die right now.

This probably warrants a changelog entry.

IMO, this could (should) be merged, and then https://github.com/Perl/perl5/pull/23782 could be built on this, changing the `deprecate_fatal_in` to a DIE() to match the other goto exceptions...

