### PR TITLE
Remove "no warnings 'deprecated';" where no longer needed

### DIFF
--- a/t/lib/croak/pp_ctl
+++ b/t/lib/croak/pp_ctl
@@ -20,26 +20,24 @@ EXPECT
 Can't "goto" into a "given" block at - line 2.
 ########
 # NAME goto into expression
-no warnings 'deprecated';
 eval { goto a; 1 + do { a: } }; warn $@;
 eval { goto b; meth { b: }   }; warn $@;
 eval { goto c; map { c: } () }; warn $@;
 eval { goto d; f(do { d: })  }; die  $@;
 EXPECT
+Can't "goto" into a binary or list expression at - line 1.
 Can't "goto" into a binary or list expression at - line 2.
 Can't "goto" into a binary or list expression at - line 3.
 Can't "goto" into a binary or list expression at - line 4.
-Can't "goto" into a binary or list expression at - line 5.
 ########
 # NAME dump with computed label
-no warnings 'deprecated';
 my $label = "foo";
 CORE::dump $label;
 EXPECT
-Can't find label foo at - line 3.
+Can't find label foo at - line 2.
 ########
 # NAME when outside given
-use 5.01; no warnings 'deprecated';
+use 5.01;
 when(undef){}
 EXPECT
 Can't "when" outside a topicalizer at - line 2.


### PR DESCRIPTION
These 3 unit tests (which run during t/lib/croak.t):

        ok 98 - goto into expression
        ok 99 - dump with computed label
        ok 100 - when outside given

... no longer need "no warnings 'deprecated';" because they no longer generate 'deprecated'-class warnings.

Inside pp_ctl.c we have a 'deprecated'-class warning at line 3655, which falls within function PP(pp_goto).  Let's take the 3 unit tests above in turn.

"goto into expression"

The exception which generates "Can't "goto" into a binary or list expression" occurs at +3234 pp_ctl.c, inside function S_check_op_type. This function is called at +3646 pp_ctl.c and at +3680 pp_ctl.c, both of which are inside function PP(pp_goto).  Experimentation indicates that the invocation at +3646 pp_ctl.c. is the triggering invocation.  Hence control passes to S_check_op_type before the deprecate_fatal warning at +3655 can be reached.

"dump with computed label"

The exception which generates "Can't find label" occurs at +3635 pp_ctl.c -- 20 lines before the 'deprecated'-class warning.

"when outside given"

The exception which generates "Can't "when" outside a topicalizer" occurs at +6398 pp_ctl.c, inside function PP(pp_leavewhen).  It appears that in older perls "No warnings 'deprecated';" was needed here because of the (now apparently abandoned) deprecation of given/when.

**Note:** This p.r. should be considered for merging into blead *before* https://github.com/Perl/perl5/pull/23922 or https://github.com/Perl/perl5/pull/23782.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
