### PR TITLE
Remove unnecessary initializer in Perl_grok_bin_oct_hex()

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -487,12 +487,9 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
           break;
     }
 
-    /* How many real digits have been processed */
-    STRLEN bytes_so_far = s - s0;
-
     /* In overflows, this keeps track of how much to multiply the overflowed NV
      * by as we continue to parse the remaining digits */
-    NV factor = shift << bytes_so_far;
+    NV factor = 0.0;
 
     bool overflowed = FALSE;
     NV value_nv = 0;

--- a/t/op/oct.t
+++ b/t/op/oct.t
@@ -5,8 +5,9 @@
 chdir 't' if -d 't';
 require './test.pl';
 use strict;
+no warnings 'overflow';
 
-plan(tests => 79);
+plan(tests => 81);
 
 foreach(['0b1_0101', 0b101_01],
 	['0b10_101', 0_2_5],
@@ -58,6 +59,8 @@ foreach(['0b1_0101', 0b101_01],
         # Additional syntax for octals
         ["0o7_654_321", 2054353],
         ["O4567", 0o4_567],
+        # Overflow approximation
+        ["52" x 32, 4184734490257787175890526282138444277401570296309356341930],
        ) {
     my ($string, $value) = @$_;
     my $result = oct $string;
@@ -95,6 +98,8 @@ foreach(['01_234', 0b_1001000110100],
 	# Allow uppercase base markers (#76296)
 	["0XCAFE",   0xCAFE],
 	["XCAFE",    0xCAFE],
+        # Overflow approximation
+        ["5" x 48, 2092367245128893587945263141069222138700785148154678170965],
        ) {
     my ($string, $value) = @$_;
     my $result = hex $string;


### PR DESCRIPTION
I've found that in `Perl_grok_bin_oct_hex` the initial value of `factor`, `shift << bytes_so_far`, is effectively not used, as it will be only used in multiplication with zero (initial value of `value_nv`) on first overflow. Moreover, this original initializer expression might cause undefined behavior as `bytes_so_far` (= s - s0) might become too large for shift amount if the string had many leading zeros.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
