### PR TITLE
pp_goto: Refactor out statement used in both if and else branches

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3473,7 +3473,6 @@ PP(pp_goto)
                 PUSHMARK(mark);
                 rpp_invoke_xs(cv);
                 LEAVE;
-                goto finish;
             }
             else {
                 PADLIST * const padlist = CvPADLIST(cv);
@@ -3529,8 +3528,8 @@ PP(pp_goto)
                     }
                 }
                 retop = CvSTART(cv);
-                goto finish;
             }
+            goto finish;
         }
         else {
             /* goto EXPR */


### PR DESCRIPTION
The same (C) goto statement occurs at the end of each branch of an if-else structure.  We can move them to a single statement just after the conclusion of the else branch.


-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
