### PR TITLE
Clear up ambiguous use of 'try block'

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2388,7 +2388,7 @@ PP_wrapped(pp_caller, MAXARG, 0)
             mPUSHs(newSVsv(cx->blk_eval.old_namesv));
             PUSHs(&PL_sv_yes);
         }
-        /* eval BLOCK (try blocks have old_namesv == 0) */
+        /* eval BLOCK (eval blocks have old_namesv == 0) */
         else {
             PUSHs(&PL_sv_undef);
             PUSHs(&PL_sv_undef);

--- a/t/op/goto.t
+++ b/t/op/goto.t
@@ -136,7 +136,7 @@ FORL2: for($y=1; 1;) {
   goto FORL2;
 }
 
-# Does goto work correctly within a try block?
+# Does goto work correctly within a eval block?
 #  (BUG ID 20000313.004) - [perl #2359]
 my $ok = 0;
 eval {
@@ -144,7 +144,7 @@ eval {
   goto LABEL20;
   LABEL20: $ok = 1 if $variable;
 };
-ok($ok, 'works correctly within a try block');
+ok($ok, 'works correctly within a eval block');
 is($@, "", '...and $@ not set');
 
 # And within an eval-string?


### PR DESCRIPTION
Way back in 2001 several tests were added to t/op/goto.t which referred to a concept called a 'try block':

    commit 9c5794fe8bd5803990d11472f5ebcdba0e7877cc
    Author:     Robin Houston <robin@cpan.org>
    AuthorDate: Wed Mar 14 01:52:51 2001 +0000
    Commit:     Jarkko Hietaniemi <jhi@iki.fi>
    CommitDate: Wed Mar 14 02:41:54 2001 +0000
    ...
    diff --git a/t/op/goto.t b/t/op/goto.t
    index 246184c56b..6f9e3493d5 100755
    --- a/t/op/goto.t
    +++ b/t/op/goto.t
    ...
    +# Does goto work correctly within a try block?

That language is still in use in two files -- but since we now have a 'try' keyword and a feature 'try', such language is now ambiguous.

Here we change 'try block' to 'eval block' in those test descriptions and comments where we're clearly speaking about 'eval BLOCK'.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
