### PR TITLE
pp_ctl.c: Remove code which is no longer reachable

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3310,14 +3310,6 @@ PP(pp_goto)
             else if (CxMULTICALL(cx))
                 DIE(aTHX_ "Can't goto subroutine from a sort sub (or similar callback)");
 
-            /* Check for defer { goto &...; } */
-            for(ix = cxstack_ix; ix > cxix; ix--) {
-                if(CxTYPE(&cxstack[ix]) == CXt_DEFER)
-                    /* diag_listed_as: Can't "%s" out of a "defer" block */
-                    croak("Can't \"%s\" out of a \"%s\" block",
-                            "goto", S_defer_blockname(&cxstack[ix]));
-            }
-
             /* First do some returnish stuff. */
 
             SvREFCNT_inc_simple_void(cv); /* avoid premature free during unwind */


### PR DESCRIPTION
This block was effectively superseded in abf573d165 in Nov/Dec 2022.

Fixes: GH #23958.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
