### PR TITLE
Revert "win32/perllib.c: Omit unused formal parameter name

### DIFF
--- a/win32/perllib.c
+++ b/win32/perllib.c
@@ -261,8 +261,10 @@ EXTERN_C		/* GCC in C++ mode mangles the name, otherwise */
 BOOL APIENTRY
 DllMain(HINSTANCE hModule,	/* DLL module handle */
         DWORD fdwReason,	/* reason called */
-        LPVOID)                 /* reserved */
+        LPVOID lpvReserved)	/* reserved */
 { 
+    PERL_UNUSED_ARG(lpvReserved);
+
     switch (fdwReason) {
         /* The DLL is attaching to a process due to process
          * initialization or a call to LoadLibrary.


### PR DESCRIPTION
This reverts commit 6fb21d69a83e1c194e85e936ab62dea5c142a51d and changes to use PERL_UNUSED_ARG

Fixes #23952.


* This set of changes does not require a perldelta entry.
