### PR TITLE
Configure: Allow LC_ALL syntax override

### DIFF
--- a/Configure
+++ b/Configure
@@ -17484,6 +17484,8 @@ $rm_try
     esac
 esac
 
+case "$perl_lc_all_separator$perl_lc_all_category_positions_init" in
+  "")
 : Check the syntax of LC_ALL when categories are set to different locales
 echo " "
 $echo "Checking the syntax of LC_ALL when categories are set to different locales..." >&4
@@ -17860,6 +17862,23 @@ $rm -f try try.*
           # and run without having to have a bunch more #ifdef's
           d_perl_lc_all_uses_name_value_pairs="$define"
 ;;
+esac
+;;
+
+  *)    # Has an lc_all definition passed-in
+     case "$perl_lc_all_separator" in
+	\"*\") ;;     # Good, enclosed in "..."
+        *) echo "Adding enclosing double quotes to perl_lc_all_separator" >&4
+           case "$perl_lc_all_separator" in
+	      \"*) perl_lc_all_separator="$perl_lc_all_separator\"" ;;
+	      *\") perl_lc_all_separator="\"$perl_lc_all_separator" ;;
+	      *)     perl_lc_all_separator="\"$perl_lc_all_separator\"" ;;
+            esac
+     esac
+     d_perl_lc_all_separator="$define"
+     d_perl_lc_all_category_positions_init="$define"
+     d_perl_lc_all_uses_name_value_pairs="$undef"
+     ;;
 esac
 
 : see if pipe2 exists

--- a/Configure
+++ b/Configure
@@ -17486,14 +17486,14 @@ esac
 
 case "$perl_lc_all_separator$perl_lc_all_category_positions_init" in
   "")
-: Check the syntax of LC_ALL when categories are set to different locales
-echo " "
-$echo "Checking the syntax of LC_ALL when categories are set to different locales..." >&4
+    : Check the syntax of LC_ALL when categories are set to different locales
+    echo " "
+    $echo "Checking the syntax of LC_ALL when categories are set to different locales..." >&4
 
-case $d_setlocale in
-    $define)
-$rm -f try try.*
-$cat >try.c <<'EOF'
+    case $d_setlocale in
+      $define)
+        $rm -f try try.*
+        $cat >try.c <<'EOF'
 #include <limits.h>
 #include <locale.h>
 #include <stdlib.h>
@@ -17823,47 +17823,47 @@ main (const int argc, const char ** argv)
 
 #endif
 EOF
-set try
-if eval $compile_ok; then
-    output=`$run ./try 2>/dev/null`
-    separator=`echo "$output" | $sed 1q`
-    case $separator in
-	"\"=;\"")
-          d_perl_lc_all_uses_name_value_pairs="$define"
-          d_perl_lc_all_separator="$undef"
-            perl_lc_all_separator=
-	  d_perl_lc_all_category_positions_init="$undef"
-	    perl_lc_all_category_positions_init=
-	    ;;
-	"") d_perl_lc_all_uses_name_value_pairs="$undef"
-            d_perl_lc_all_separator="$undef"
-              perl_lc_all_separator=
-	    d_perl_lc_all_category_positions_init="$undef"
-	      perl_lc_all_category_positions_init=
-	    ;;
-        *)  d_perl_lc_all_uses_name_value_pairs="$undef"
-            d_perl_lc_all_separator="$define"
-              perl_lc_all_separator="$separator"
-	    d_perl_lc_all_category_positions_init="$define"
-	      perl_lc_all_category_positions_init=`echo "$output" | sed -n 2p`
-	    ;;
-    esac
-else
-    $echo "Failed to compile lc_all probe" >&4
-fi
-$rm -f try try.*
-;;
-*)        d_perl_lc_all_separator="$undef"
-            perl_lc_all_separator=
-	  d_perl_lc_all_category_positions_init="$undef"
-	    perl_lc_all_category_positions_init=
+        set try
+        if eval $compile_ok; then
+            output=`$run ./try 2>/dev/null`
+            separator=`echo "$output" | $sed 1q`
+            case $separator in
+                "\"=;\"")
+                  d_perl_lc_all_uses_name_value_pairs="$define"
+                  d_perl_lc_all_separator="$undef"
+                    perl_lc_all_separator=
+                  d_perl_lc_all_category_positions_init="$undef"
+                    perl_lc_all_category_positions_init=
+                    ;;
+                "") d_perl_lc_all_uses_name_value_pairs="$undef"
+                    d_perl_lc_all_separator="$undef"
+                      perl_lc_all_separator=
+                    d_perl_lc_all_category_positions_init="$undef"
+                      perl_lc_all_category_positions_init=
+                    ;;
+                *)  d_perl_lc_all_uses_name_value_pairs="$undef"
+                    d_perl_lc_all_separator="$define"
+                      perl_lc_all_separator="$separator"
+                    d_perl_lc_all_category_positions_init="$define"
+                      perl_lc_all_category_positions_init=`echo "$output" | sed -n 2p`
+                    ;;
+            esac
+        else
+            $echo "Failed to compile lc_all probe" >&4
+        fi
+        $rm -f try try.*
+        ;;
+    *)        d_perl_lc_all_separator="$undef"
+                perl_lc_all_separator=
+              d_perl_lc_all_category_positions_init="$undef"
+                perl_lc_all_category_positions_init=
 
-          # No setlocale(), but using this default allows our code to compile
-          # and run without having to have a bunch more #ifdef's
-          d_perl_lc_all_uses_name_value_pairs="$define"
-;;
-esac
-;;
+              # No setlocale(), but using this default allows our code to
+              # compile and run without having to have a bunch more #ifdef's
+              d_perl_lc_all_uses_name_value_pairs="$define"
+    ;;
+    esac    # case on $d_setlocale
+  ;;
 
   *)    # Has an lc_all definition passed-in
      case "$perl_lc_all_separator" in

--- a/Porting/Glossary
+++ b/Porting/Glossary
@@ -1972,8 +1972,9 @@ d_perl_lc_all_separator (disparate_lc_all.U):
 d_perl_lc_all_uses_name_value_pairs (disparate_lc_all.U):
 	This symbol, if defined, indicates that the string returned by
 	setlocale(LC_ALL, NULL) uses 'name=value;' pairs to indicate what each
-	category's locale is when they aren't all set to the same locale.
-	When not defined, the platform uses positional notation.
+	category's locale is when they aren't all set to the same locale.  Note
+	the semicolon between each pair.  When not defined, the platform uses
+	positional notation (see 'perl_lc_all_category_positions_init').
 
 d_perl_otherlibdirs (otherlibdirs.U):
 	This variable conditionally defines PERL_OTHERLIBDIRS, which

--- a/Porting/Glossary
+++ b/Porting/Glossary
@@ -4712,7 +4712,7 @@ perl_lc_all_category_positions_init (disparate_lc_all.U):
 	element [0] is the first category in the string returned by
 	setlocale(LC_ALL, NULL) when not all categories are the same, on
 	systems that use a positional notation.  After element [0] is
-	$lc_all_separator_init, then the category given by element [1], and so on.
+	$lc_all_separator, then the category given by element [1], and so on.
 
 perl_lc_all_separator (disparate_lc_all.U):
 	This symbol, when defined, gives the substring used to separate

--- a/Porting/Glossary
+++ b/Porting/Glossary
@@ -4714,12 +4714,27 @@ perl_lc_all_category_positions_init (disparate_lc_all.U):
 	setlocale(LC_ALL, NULL) when not all categories are the same, on
 	systems that use a positional notation.  After element [0] is
 	$lc_all_separator, then the category given by element [1], and so on.
+	For example, at the time this was written, the value in config.sh for
+	FreeBSD boxes is:
+            perl_lc_all_category_positions_init='{ 1, 2, 3, 4, 5, 6 }'
+	And the result of running this program
+            LC_ALL=C ./perl -Ilib -MPOSIX                               \
+                            -le 'setlocale(LC_MONETARY, "fr_FR.UTF-8"); \
+                                 print setlocale(LC_ALL)'
+	is
+            C/C/fr_FR.UTF-8/C/C/C
+	This shows that the LC_MONETARY category on FreeBSD occupies the third
+	position in the string returned by querying LC_ALL.  (See
+	perl_lc_all_separator for the source of the forward slash.)
 
 perl_lc_all_separator (disparate_lc_all.U):
-	This symbol, when defined, gives the substring used to separate
-	categories in the aggregated string returned by setlocale(LC_ALL, NULL)
-	when not all categories are in the same locale.  This is for systems
-	that use a positional notation as opposed to 'name=value' pairs.
+	This symbol, when defined, gives the substring, enclosed in double
+	quotes, used to separate categories in the aggregated string returned
+	by setlocale(LC_ALL, NULL) when not all categories are in the same
+	locale.  This is for systems that use a positional notation as opposed
+	to 'name=value' pairs.  For example, at the time this was written, the
+	value in config.sh for FreeBSD boxes is:
+            perl_lc_all_separator='"/"'
 
 PERL_PATCHLEVEL (Oldsyms.U):
 	This symbol reflects the patchlevel, if available. Will usually

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -254,7 +254,13 @@ L</Platform Support> section, instead.
 
 =item *
 
-XXX
+It is now possible to pass to F<Configure> the values dealing with POSIX
+locale categories, overriding its automatic calculation of these.  This
+enables cross-compilation to work.  The easiest way to do this is to
+extract the C program that does the calculation from F<Configure> and
+then run it on the target machine, and then pass the values it outputs
+to F<Configure> on the other machine.  F<Porting/Glossary> has examples.
+[GH #22992]
 
 =back
 


### PR DESCRIPTION
Fixes #22992

The problem here had to do with cross-compilation.  There was no way to override Perl's calculation of how LC_ALL is represented.  I had not put one in because it is hard to get it right manually.  But this doesn't work in cross-compilation; it's better to have a difficult-to-get-right way than no way at all.

I don't know where to document this.  You need to specify in a hints file:

>    
       perl_lc_all_separator="correct-value"
       perl_lc_all_category_positions_init="correct-value"

* This set of changes likely requires a perldelta entry