### PR TITLE
mention that the bitwise operators also exist in two versions in modern Perl

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -21,7 +21,9 @@ two numbers for equality, and S<C<$x eq $y>> compares two strings.
 There are a few exceptions though: The operator C<x> can be either string
 repetition or list repetition, depending on the type of the left
 operand, and C<&>, C<|>, C<^> and C<~> can be either string or numeric bit
-operations.
+operations (unless C<use v5.28> or later, or L<feature/"The 'bitwise' feature">
+is in effect, in which case a different version of each operator exists
+for manipulating strings).
 
 =head2 Operator Precedence and Associativity
 X<operator, precedence> X<precedence> X<associativity>


### PR DESCRIPTION
The third paragraph of perlop says:

> There are a few exceptions though: The operator `x` can be either string repetition or list repetition, depending on the type of the left operand, and `&`, `|`, `^` and `~` can be either string or numeric bit operations.

I think it would be worth mentioning the 'bitwise' feature there, which gives the bitwise operators a numeric and a string version, making them less of an exception in modern Perl. 

@Grinnz said on IRC:

> given that use v5.28 and above enable it automatically, I think it's worth explicitly calling out the different reality in modern perl

This patch is the smallest thing I could come up with, and this PR is meant to be a conversation starter to find a better wording for this.

* This set of changes does not require a perldelta entry.
