### PR TITLE
RMG generate the correct commands for blead-point releases

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1121,11 +1121,19 @@ paths.
 Note that the results may be different without a F<.git/> directory,
 which is why you should test from the tarball.
 
+=for checklist skip BLEAD-POINT
+
 =head4 Run the Installation Verification Procedure utility
 
  $ bin/perlivp
+ ...
+ All tests successful.
+ $
 
- # Or, perhaps:
+=for checklist skip RC MAINT BLEAD-FINAL
+
+=head4 Run the Installation Verification Procedure utility
+
  $ bin/perlivp5.X.Y
  ...
  All tests successful.

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1161,13 +1161,20 @@ performing these actions:
 
  $ unset PERL5LIB PERL_MB_OPT PERL_LOCAL_LIB_ROOT PERL_MM_OPT
 
+=for checklist skip BLEAD-POINT
+
 =head4 Bootstrap the CPAN client
 
 Bootstrap the CPAN client on the clean install:
 
  $ bin/cpan
 
- # Or, perhaps:
+=for checklist skip RC MAINT BLEAD-FINAL
+
+=head4 Bootstrap the CPAN client
+
+Bootstrap the CPAN client on the clean install:
+
  $ bin/cpan5.X.Y
 
 =head4 Install the Inline module with CPAN and test it

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1177,6 +1177,8 @@ Bootstrap the CPAN client on the clean install:
 
  $ bin/cpan5.X.Y
 
+=for checklist skip BLEAD-POINT
+
 =head4 Install the Inline module with CPAN and test it
 
 Try installing a popular CPAN module that's reasonably complex and that
@@ -1189,13 +1191,50 @@ Check that your perl can run this:
 
  $ bin/perl -lwe "use Inline C => q[int f() { return 42;}]; print f"
  42
- $
+
+=for checklist skip RC MAINT BLEAD-FINAL
+
+=head4 Install the Inline module with CPAN and test it
+
+Try installing a popular CPAN module that's reasonably complex and that
+has dependencies; for example:
+
+ CPAN> install Inline::C
+ CPAN> quit
+
+Check that your perl can run this:
+
+ $ bin/perl5.X.Y -lwe "use Inline C => q[int f() { return 42;}]; print f"
+ 42
+
+=for checklist skip BLEAD-POINT
 
 =head4 Make sure that perlbug works
 
 Test L<perlbug> with the following:
 
  $ bin/perlbug
+ ...
+ Subject: test bug report
+ Local perl administrator [yourself]:
+ Editor [vi]:
+ Module:
+ Category [core]:
+ Severity [low]:
+ (edit report)
+ Action (Send/Display/Edit/Subject/Save to File): f
+ Name of file to save message in [perlbug.rep]:
+
+Then carefully examine the output (in F<perlbug.rep]>), especially
+the "Locally applied patches" section.
+
+=for checklist skip RC MAINT BLEAD-FINAL
+
+=head4 Make sure that perlbug works
+
+Test L<perlbug> with the following:
+
+ $ bin/perlbug5.X.Y
  ...
  Subject: test bug report
  Local perl administrator [yourself]:


### PR DESCRIPTION
Blead point releases install with commands of the format `bin/perl5.X.Y` and this allows the generated guide to provide the correct instruction to the release manager in both BLEAD-POINT and other types of releases (RC MAINT BLEAD-FINAL).

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
