### PR TITLE
Revert "handy.h: Add void * casts to memEQ, memNE"

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -683,8 +683,8 @@ based on the underlying C library functions):
 #define strnNE(s1,s2,l) (strncmp(s1,s2,l) != 0)
 #define strnEQ(s1,s2,l) (strncmp(s1,s2,l) == 0)
 
-#define memEQ(s1,s2,l) (memcmp(((const void *) (s1)), ((const void *) (s2)), l) == 0)
-#define memNE(s1,s2,l) (! memEQ(s1,s2,l))
+#define memNE(s1,s2,l) (memcmp(s1,s2,l) != 0)
+#define memEQ(s1,s2,l) (memcmp(s1,s2,l) == 0)
 
 /* memEQ and memNE where second comparand is a string constant */
 #define memEQs(s1, l, s2) \


### PR DESCRIPTION
This reverts commit 9d3980bc229750e6c07726fe529f02bf4dc6a5a5.

It can create problems to add casts to macros; potentially hiding real issues.  These casts caused Tony Cook some lost time recently; whatever the cause for this commit isn't showing up on my box; so I'll try reverting it to see if something shows up on some other platform.


* This set of changes does not require a perldelta entry.
