### PR TITLE
Exercise one exception in pp_goto()

### DIFF
--- a/t/op/defer.t
+++ b/t/op/defer.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan 32;
+plan 33;
 
 use feature 'defer';
 no warnings 'experimental::defer';
@@ -323,5 +323,24 @@ no warnings 'experimental::defer';
         $err,
         qr/Can't "last" out of a "defer" block at \(eval \d+\) line 1\./,
         "Got expected exception: last out of defer block");
+}
+
+# [GH #23964]
+{
+    use warnings;
+    no warnings 'experimental::defer';
+    use feature 'say';
+
+    eval {
+        sub f { goto FOO; }
+        sub g { defer { f() } }
+        g();
+        goto BAR;
+        FOO: say "FOO";
+        BAR: say "BAR";
+    };
+    like($@,
+        qr/Can't \"goto\" out of a \"defer\" block/,
+        "Got expected exception: can't goto out of defer block");
 }
 


### PR DESCRIPTION
Reworked from recommendation by Tony Cook in GH #23964.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
