### PR TITLE
pp_ctl.c: Comment on 2 exceptions in pp_goto()

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3290,6 +3290,8 @@ PP(pp_goto)
                     gv_efullname3(tmpstr, gv, NULL);
                     DIE(aTHX_ "Goto undefined subroutine &%" SVf, SVfARG(tmpstr));
                 }
+                /* GH-23969: This exception should be retained because it can
+                 * be reached from XS code. */
                 DIE(aTHX_ "Goto undefined subroutine");
             }
 
@@ -3369,6 +3371,8 @@ PP(pp_goto)
                     DIE(aTHX_ "Goto undefined subroutine &%" SVf,
                                SVfARG(tmpstr));
                 }
+                /* GH-23969: This exception should be retained because it can
+                 * be reached from XS code. */
                 DIE(aTHX_ "Goto undefined subroutine");
             }
 


### PR DESCRIPTION
Per discussion in GH #23969, neither of these two exceptions can be reached from our test suite. The exceptions address the possibility of a subroutine without a name, which is unlikely except possibly from XS code.

The exceptions immediately preceding each of the two upon which we are commenting have messages composed to include a subroutine's name.  These exceptions can be reached from our test suite and are covered as of the time of this commit.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
