### PR TITLE
Rename THING token when used for attributes

### DIFF
--- a/perly.act
+++ b/perly.act
@@ -893,7 +893,7 @@ case 2: /* @1: %empty  */
 
     break;
 
-  case 139: /* subattrlist: COLONATTR THING  */
+  case 139: /* subattrlist: COLONATTR ATTRLIST  */
 #line 1055 "perly.y"
                         {
 			  OP *attrlist = (ps[0].val.opval);
@@ -910,7 +910,7 @@ case 2: /* @1: %empty  */
 
     break;
 
-  case 141: /* attrlist: COLONATTR THING  */
+  case 141: /* attrlist: COLONATTR ATTRLIST  */
 #line 1067 "perly.y"
                         { (yyval.opval) = (ps[0].val.opval); }
 
@@ -2299,6 +2299,6 @@ case 2: /* @1: %empty  */
     
 
 /* Generated from:
- * 57cc742fa623ae44e0575b737db1c674688361cd405620798cf50de0d81cadfc perly.y
+ * 8444cada5b7e31b67a9eec8f91fdf7511e00378bd03fb2bc726dc0ff958643de perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.h
+++ b/perly.h
@@ -117,80 +117,81 @@ extern int yydebug;
     BAREWORD = 311,                /* BAREWORD  */
     METHCALL0 = 312,               /* METHCALL0  */
     METHCALL = 313,                /* METHCALL  */
-    THING = 314,                   /* THING  */
-    PMFUNC = 315,                  /* PMFUNC  */
-    PRIVATEREF = 316,              /* PRIVATEREF  */
-    QWLIST = 317,                  /* QWLIST  */
-    FUNC0OP = 318,                 /* FUNC0OP  */
-    FUNC0SUB = 319,                /* FUNC0SUB  */
-    UNIOPSUB = 320,                /* UNIOPSUB  */
-    LSTOPSUB = 321,                /* LSTOPSUB  */
-    PLUGEXPR = 322,                /* PLUGEXPR  */
-    PLUGSTMT = 323,                /* PLUGSTMT  */
-    LABEL = 324,                   /* LABEL  */
-    PROTOTYPE = 325,               /* PROTOTYPE  */
-    LOOPEX = 326,                  /* LOOPEX  */
-    DOTDOT = 327,                  /* DOTDOT  */
-    YADAYADA = 328,                /* YADAYADA  */
-    FUNC0 = 329,                   /* FUNC0  */
-    FUNC1 = 330,                   /* FUNC1  */
-    FUNC = 331,                    /* FUNC  */
-    UNIOP = 332,                   /* UNIOP  */
-    LSTOP = 333,                   /* LSTOP  */
-    BLKLSTOP = 334,                /* BLKLSTOP  */
-    POWOP = 335,                   /* POWOP  */
-    MULOP = 336,                   /* MULOP  */
-    ADDOP = 337,                   /* ADDOP  */
-    DOLSHARP = 338,                /* DOLSHARP  */
-    HASHBRACK = 339,               /* HASHBRACK  */
-    NOAMP = 340,                   /* NOAMP  */
-    COLONATTR = 341,               /* COLONATTR  */
-    FORMLBRACK = 342,              /* FORMLBRACK  */
-    FORMRBRACK = 343,              /* FORMRBRACK  */
-    SUBLEXSTART = 344,             /* SUBLEXSTART  */
-    SUBLEXEND = 345,               /* SUBLEXEND  */
-    PHASER = 346,                  /* PHASER  */
-    PREC_LOW = 347,                /* PREC_LOW  */
-    PLUGIN_LOW_OP = 348,           /* PLUGIN_LOW_OP  */
-    OROP = 349,                    /* OROP  */
-    PLUGIN_LOGICAL_OR_LOW_OP = 350, /* PLUGIN_LOGICAL_OR_LOW_OP  */
-    ANDOP = 351,                   /* ANDOP  */
-    PLUGIN_LOGICAL_AND_LOW_OP = 352, /* PLUGIN_LOGICAL_AND_LOW_OP  */
-    NOTOP = 353,                   /* NOTOP  */
-    ASSIGNOP = 354,                /* ASSIGNOP  */
-    PLUGIN_ASSIGN_OP = 355,        /* PLUGIN_ASSIGN_OP  */
-    PERLY_QUESTION_MARK = 356,     /* PERLY_QUESTION_MARK  */
-    PERLY_COLON = 357,             /* PERLY_COLON  */
-    OROR = 358,                    /* OROR  */
-    DORDOR = 359,                  /* DORDOR  */
-    PLUGIN_LOGICAL_OR_OP = 360,    /* PLUGIN_LOGICAL_OR_OP  */
-    ANDAND = 361,                  /* ANDAND  */
-    PLUGIN_LOGICAL_AND_OP = 362,   /* PLUGIN_LOGICAL_AND_OP  */
-    BITOROP = 363,                 /* BITOROP  */
-    BITANDOP = 364,                /* BITANDOP  */
-    CHEQOP = 365,                  /* CHEQOP  */
-    NCEQOP = 366,                  /* NCEQOP  */
-    CHRELOP = 367,                 /* CHRELOP  */
-    NCRELOP = 368,                 /* NCRELOP  */
-    PLUGIN_REL_OP = 369,           /* PLUGIN_REL_OP  */
-    SHIFTOP = 370,                 /* SHIFTOP  */
-    PLUGIN_ADD_OP = 371,           /* PLUGIN_ADD_OP  */
-    PLUGIN_MUL_OP = 372,           /* PLUGIN_MUL_OP  */
-    MATCHOP = 373,                 /* MATCHOP  */
-    PERLY_EXCLAMATION_MARK = 374,  /* PERLY_EXCLAMATION_MARK  */
-    PERLY_TILDE = 375,             /* PERLY_TILDE  */
-    UMINUS = 376,                  /* UMINUS  */
-    REFGEN = 377,                  /* REFGEN  */
-    PLUGIN_POW_OP = 378,           /* PLUGIN_POW_OP  */
-    PREINC = 379,                  /* PREINC  */
-    PREDEC = 380,                  /* PREDEC  */
-    POSTINC = 381,                 /* POSTINC  */
-    POSTDEC = 382,                 /* POSTDEC  */
-    POSTJOIN = 383,                /* POSTJOIN  */
-    PLUGIN_HIGH_OP = 384,          /* PLUGIN_HIGH_OP  */
-    ARROW = 385,                   /* ARROW  */
-    PERLY_PAREN_CLOSE = 386,       /* PERLY_PAREN_CLOSE  */
-    PERLY_PAREN_OPEN = 387         /* PERLY_PAREN_OPEN  */
+    ATTRLIST = 314,                /* ATTRLIST  */
+    THING = 315,                   /* THING  */
+    PMFUNC = 316,                  /* PMFUNC  */
+    PRIVATEREF = 317,              /* PRIVATEREF  */
+    QWLIST = 318,                  /* QWLIST  */
+    FUNC0OP = 319,                 /* FUNC0OP  */
+    FUNC0SUB = 320,                /* FUNC0SUB  */
+    UNIOPSUB = 321,                /* UNIOPSUB  */
+    LSTOPSUB = 322,                /* LSTOPSUB  */
+    PLUGEXPR = 323,                /* PLUGEXPR  */
+    PLUGSTMT = 324,                /* PLUGSTMT  */
+    LABEL = 325,                   /* LABEL  */
+    PROTOTYPE = 326,               /* PROTOTYPE  */
+    LOOPEX = 327,                  /* LOOPEX  */
+    DOTDOT = 328,                  /* DOTDOT  */
+    YADAYADA = 329,                /* YADAYADA  */
+    FUNC0 = 330,                   /* FUNC0  */
+    FUNC1 = 331,                   /* FUNC1  */
+    FUNC = 332,                    /* FUNC  */
+    UNIOP = 333,                   /* UNIOP  */
+    LSTOP = 334,                   /* LSTOP  */
+    BLKLSTOP = 335,                /* BLKLSTOP  */
+    POWOP = 336,                   /* POWOP  */
+    MULOP = 337,                   /* MULOP  */
+    ADDOP = 338,                   /* ADDOP  */
+    DOLSHARP = 339,                /* DOLSHARP  */
+    HASHBRACK = 340,               /* HASHBRACK  */
+    NOAMP = 341,                   /* NOAMP  */
+    COLONATTR = 342,               /* COLONATTR  */
+    FORMLBRACK = 343,              /* FORMLBRACK  */
+    FORMRBRACK = 344,              /* FORMRBRACK  */
+    SUBLEXSTART = 345,             /* SUBLEXSTART  */
+    SUBLEXEND = 346,               /* SUBLEXEND  */
+    PHASER = 347,                  /* PHASER  */
+    PREC_LOW = 348,                /* PREC_LOW  */
+    PLUGIN_LOW_OP = 349,           /* PLUGIN_LOW_OP  */
+    OROP = 350,                    /* OROP  */
+    PLUGIN_LOGICAL_OR_LOW_OP = 351, /* PLUGIN_LOGICAL_OR_LOW_OP  */
+    ANDOP = 352,                   /* ANDOP  */
+    PLUGIN_LOGICAL_AND_LOW_OP = 353, /* PLUGIN_LOGICAL_AND_LOW_OP  */
+    NOTOP = 354,                   /* NOTOP  */
+    ASSIGNOP = 355,                /* ASSIGNOP  */
+    PLUGIN_ASSIGN_OP = 356,        /* PLUGIN_ASSIGN_OP  */
+    PERLY_QUESTION_MARK = 357,     /* PERLY_QUESTION_MARK  */
+    PERLY_COLON = 358,             /* PERLY_COLON  */
+    OROR = 359,                    /* OROR  */
+    DORDOR = 360,                  /* DORDOR  */
+    PLUGIN_LOGICAL_OR_OP = 361,    /* PLUGIN_LOGICAL_OR_OP  */
+    ANDAND = 362,                  /* ANDAND  */
+    PLUGIN_LOGICAL_AND_OP = 363,   /* PLUGIN_LOGICAL_AND_OP  */
+    BITOROP = 364,                 /* BITOROP  */
+    BITANDOP = 365,                /* BITANDOP  */
+    CHEQOP = 366,                  /* CHEQOP  */
+    NCEQOP = 367,                  /* NCEQOP  */
+    CHRELOP = 368,                 /* CHRELOP  */
+    NCRELOP = 369,                 /* NCRELOP  */
+    PLUGIN_REL_OP = 370,           /* PLUGIN_REL_OP  */
+    SHIFTOP = 371,                 /* SHIFTOP  */
+    PLUGIN_ADD_OP = 372,           /* PLUGIN_ADD_OP  */
+    PLUGIN_MUL_OP = 373,           /* PLUGIN_MUL_OP  */
+    MATCHOP = 374,                 /* MATCHOP  */
+    PERLY_EXCLAMATION_MARK = 375,  /* PERLY_EXCLAMATION_MARK  */
+    PERLY_TILDE = 376,             /* PERLY_TILDE  */
+    UMINUS = 377,                  /* UMINUS  */
+    REFGEN = 378,                  /* REFGEN  */
+    PLUGIN_POW_OP = 379,           /* PLUGIN_POW_OP  */
+    PREINC = 380,                  /* PREINC  */
+    PREDEC = 381,                  /* PREDEC  */
+    POSTINC = 382,                 /* POSTINC  */
+    POSTDEC = 383,                 /* POSTDEC  */
+    POSTJOIN = 384,                /* POSTJOIN  */
+    PLUGIN_HIGH_OP = 385,          /* PLUGIN_HIGH_OP  */
+    ARROW = 386,                   /* ARROW  */
+    PERLY_PAREN_CLOSE = 387,       /* PERLY_PAREN_CLOSE  */
+    PERLY_PAREN_OPEN = 388         /* PERLY_PAREN_OPEN  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -200,6 +201,7 @@ extern int yydebug;
 static bool
 S_is_opval_token(int type) {
     switch (type) {
+    case ATTRLIST:
     case BAREWORD:
     case FUNC0OP:
     case FUNC0SUB:
@@ -246,6 +248,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * 57cc742fa623ae44e0575b737db1c674688361cd405620798cf50de0d81cadfc perly.y
+ * 8444cada5b7e31b67a9eec8f91fdf7511e00378bd03fb2bc726dc0ff958643de perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.tab
+++ b/perly.tab
@@ -67,219 +67,220 @@ enum yysymbol_kind_t
   YYSYMBOL_BAREWORD = 56,                  /* BAREWORD  */
   YYSYMBOL_METHCALL0 = 57,                 /* METHCALL0  */
   YYSYMBOL_METHCALL = 58,                  /* METHCALL  */
-  YYSYMBOL_THING = 59,                     /* THING  */
-  YYSYMBOL_PMFUNC = 60,                    /* PMFUNC  */
-  YYSYMBOL_PRIVATEREF = 61,                /* PRIVATEREF  */
-  YYSYMBOL_QWLIST = 62,                    /* QWLIST  */
-  YYSYMBOL_FUNC0OP = 63,                   /* FUNC0OP  */
-  YYSYMBOL_FUNC0SUB = 64,                  /* FUNC0SUB  */
-  YYSYMBOL_UNIOPSUB = 65,                  /* UNIOPSUB  */
-  YYSYMBOL_LSTOPSUB = 66,                  /* LSTOPSUB  */
-  YYSYMBOL_PLUGEXPR = 67,                  /* PLUGEXPR  */
-  YYSYMBOL_PLUGSTMT = 68,                  /* PLUGSTMT  */
-  YYSYMBOL_LABEL = 69,                     /* LABEL  */
-  YYSYMBOL_PROTOTYPE = 70,                 /* PROTOTYPE  */
-  YYSYMBOL_LOOPEX = 71,                    /* LOOPEX  */
-  YYSYMBOL_DOTDOT = 72,                    /* DOTDOT  */
-  YYSYMBOL_YADAYADA = 73,                  /* YADAYADA  */
-  YYSYMBOL_FUNC0 = 74,                     /* FUNC0  */
-  YYSYMBOL_FUNC1 = 75,                     /* FUNC1  */
-  YYSYMBOL_FUNC = 76,                      /* FUNC  */
-  YYSYMBOL_UNIOP = 77,                     /* UNIOP  */
-  YYSYMBOL_LSTOP = 78,                     /* LSTOP  */
-  YYSYMBOL_BLKLSTOP = 79,                  /* BLKLSTOP  */
-  YYSYMBOL_POWOP = 80,                     /* POWOP  */
-  YYSYMBOL_MULOP = 81,                     /* MULOP  */
-  YYSYMBOL_ADDOP = 82,                     /* ADDOP  */
-  YYSYMBOL_DOLSHARP = 83,                  /* DOLSHARP  */
-  YYSYMBOL_HASHBRACK = 84,                 /* HASHBRACK  */
-  YYSYMBOL_NOAMP = 85,                     /* NOAMP  */
-  YYSYMBOL_COLONATTR = 86,                 /* COLONATTR  */
-  YYSYMBOL_FORMLBRACK = 87,                /* FORMLBRACK  */
-  YYSYMBOL_FORMRBRACK = 88,                /* FORMRBRACK  */
-  YYSYMBOL_SUBLEXSTART = 89,               /* SUBLEXSTART  */
-  YYSYMBOL_SUBLEXEND = 90,                 /* SUBLEXEND  */
-  YYSYMBOL_PHASER = 91,                    /* PHASER  */
-  YYSYMBOL_PREC_LOW = 92,                  /* PREC_LOW  */
-  YYSYMBOL_PLUGIN_LOW_OP = 93,             /* PLUGIN_LOW_OP  */
-  YYSYMBOL_OROP = 94,                      /* OROP  */
-  YYSYMBOL_PLUGIN_LOGICAL_OR_LOW_OP = 95,  /* PLUGIN_LOGICAL_OR_LOW_OP  */
-  YYSYMBOL_ANDOP = 96,                     /* ANDOP  */
-  YYSYMBOL_PLUGIN_LOGICAL_AND_LOW_OP = 97, /* PLUGIN_LOGICAL_AND_LOW_OP  */
-  YYSYMBOL_NOTOP = 98,                     /* NOTOP  */
-  YYSYMBOL_ASSIGNOP = 99,                  /* ASSIGNOP  */
-  YYSYMBOL_PLUGIN_ASSIGN_OP = 100,         /* PLUGIN_ASSIGN_OP  */
-  YYSYMBOL_PERLY_QUESTION_MARK = 101,      /* PERLY_QUESTION_MARK  */
-  YYSYMBOL_PERLY_COLON = 102,              /* PERLY_COLON  */
-  YYSYMBOL_OROR = 103,                     /* OROR  */
-  YYSYMBOL_DORDOR = 104,                   /* DORDOR  */
-  YYSYMBOL_PLUGIN_LOGICAL_OR_OP = 105,     /* PLUGIN_LOGICAL_OR_OP  */
-  YYSYMBOL_ANDAND = 106,                   /* ANDAND  */
-  YYSYMBOL_PLUGIN_LOGICAL_AND_OP = 107,    /* PLUGIN_LOGICAL_AND_OP  */
-  YYSYMBOL_BITOROP = 108,                  /* BITOROP  */
-  YYSYMBOL_BITANDOP = 109,                 /* BITANDOP  */
-  YYSYMBOL_CHEQOP = 110,                   /* CHEQOP  */
-  YYSYMBOL_NCEQOP = 111,                   /* NCEQOP  */
-  YYSYMBOL_CHRELOP = 112,                  /* CHRELOP  */
-  YYSYMBOL_NCRELOP = 113,                  /* NCRELOP  */
-  YYSYMBOL_PLUGIN_REL_OP = 114,            /* PLUGIN_REL_OP  */
-  YYSYMBOL_SHIFTOP = 115,                  /* SHIFTOP  */
-  YYSYMBOL_PLUGIN_ADD_OP = 116,            /* PLUGIN_ADD_OP  */
-  YYSYMBOL_PLUGIN_MUL_OP = 117,            /* PLUGIN_MUL_OP  */
-  YYSYMBOL_MATCHOP = 118,                  /* MATCHOP  */
-  YYSYMBOL_PERLY_EXCLAMATION_MARK = 119,   /* PERLY_EXCLAMATION_MARK  */
-  YYSYMBOL_PERLY_TILDE = 120,              /* PERLY_TILDE  */
-  YYSYMBOL_UMINUS = 121,                   /* UMINUS  */
-  YYSYMBOL_REFGEN = 122,                   /* REFGEN  */
-  YYSYMBOL_PLUGIN_POW_OP = 123,            /* PLUGIN_POW_OP  */
-  YYSYMBOL_PREINC = 124,                   /* PREINC  */
-  YYSYMBOL_PREDEC = 125,                   /* PREDEC  */
-  YYSYMBOL_POSTINC = 126,                  /* POSTINC  */
-  YYSYMBOL_POSTDEC = 127,                  /* POSTDEC  */
-  YYSYMBOL_POSTJOIN = 128,                 /* POSTJOIN  */
-  YYSYMBOL_PLUGIN_HIGH_OP = 129,           /* PLUGIN_HIGH_OP  */
-  YYSYMBOL_ARROW = 130,                    /* ARROW  */
-  YYSYMBOL_PERLY_PAREN_CLOSE = 131,        /* PERLY_PAREN_CLOSE  */
-  YYSYMBOL_PERLY_PAREN_OPEN = 132,         /* PERLY_PAREN_OPEN  */
-  YYSYMBOL_YYACCEPT = 133,                 /* $accept  */
-  YYSYMBOL_grammar = 134,                  /* grammar  */
-  YYSYMBOL_135_1 = 135,                    /* @1  */
-  YYSYMBOL_136_2 = 136,                    /* @2  */
-  YYSYMBOL_137_3 = 137,                    /* @3  */
-  YYSYMBOL_138_4 = 138,                    /* @4  */
-  YYSYMBOL_139_5 = 139,                    /* @5  */
-  YYSYMBOL_140_6 = 140,                    /* @6  */
-  YYSYMBOL_141_7 = 141,                    /* @7  */
-  YYSYMBOL_bare_statement_block = 142,     /* bare_statement_block  */
-  YYSYMBOL_bare_statement_class_declaration = 143, /* bare_statement_class_declaration  */
-  YYSYMBOL_bare_statement_class_definition = 144, /* bare_statement_class_definition  */
-  YYSYMBOL_145_8 = 145,                    /* $@8  */
-  YYSYMBOL_bare_statement_default = 146,   /* bare_statement_default  */
-  YYSYMBOL_bare_statement_defer = 147,     /* bare_statement_defer  */
-  YYSYMBOL_bare_statement_expression = 148, /* bare_statement_expression  */
-  YYSYMBOL_bare_statement_field_declaration = 149, /* bare_statement_field_declaration  */
-  YYSYMBOL_bare_statement_for = 150,       /* bare_statement_for  */
-  YYSYMBOL_151_9 = 151,                    /* $@9  */
-  YYSYMBOL_152_10 = 152,                   /* $@10  */
-  YYSYMBOL_153_11 = 153,                   /* @11  */
-  YYSYMBOL_bare_statement_format = 154,    /* bare_statement_format  */
-  YYSYMBOL_bare_statement_given = 155,     /* bare_statement_given  */
-  YYSYMBOL_bare_statement_if = 156,        /* bare_statement_if  */
-  YYSYMBOL_bare_statement_null = 157,      /* bare_statement_null  */
-  YYSYMBOL_bare_statement_package_declaration = 158, /* bare_statement_package_declaration  */
-  YYSYMBOL_bare_statement_package_definition = 159, /* bare_statement_package_definition  */
-  YYSYMBOL_160_12 = 160,                   /* $@12  */
-  YYSYMBOL_bare_statement_phaser = 161,    /* bare_statement_phaser  */
-  YYSYMBOL_162_13 = 162,                   /* $@13  */
-  YYSYMBOL_bare_statement_sub_signature = 163, /* bare_statement_sub_signature  */
-  YYSYMBOL_164_14 = 164,                   /* $@14  */
-  YYSYMBOL_bare_statement_sub_traditional = 165, /* bare_statement_sub_traditional  */
-  YYSYMBOL_166_15 = 166,                   /* $@15  */
-  YYSYMBOL_bare_statement_try_catch = 167, /* bare_statement_try_catch  */
-  YYSYMBOL_168_16 = 168,                   /* $@16  */
-  YYSYMBOL_bare_statement_unless = 169,    /* bare_statement_unless  */
-  YYSYMBOL_bare_statement_until = 170,     /* bare_statement_until  */
-  YYSYMBOL_bare_statement_utilize = 171,   /* bare_statement_utilize  */
-  YYSYMBOL_172_17 = 172,                   /* $@17  */
-  YYSYMBOL_bare_statement_when = 173,      /* bare_statement_when  */
-  YYSYMBOL_bare_statement_while = 174,     /* bare_statement_while  */
-  YYSYMBOL_bare_statement_yadayada = 175,  /* bare_statement_yadayada  */
-  YYSYMBOL_sigsub_or_method_named = 176,   /* sigsub_or_method_named  */
-  YYSYMBOL_block = 177,                    /* block  */
-  YYSYMBOL_empty = 178,                    /* empty  */
-  YYSYMBOL_formblock = 179,                /* formblock  */
-  YYSYMBOL_remember = 180,                 /* remember  */
-  YYSYMBOL_mblock = 181,                   /* mblock  */
-  YYSYMBOL_mremember = 182,                /* mremember  */
-  YYSYMBOL_catch_paren = 183,              /* catch_paren  */
-  YYSYMBOL_184_18 = 184,                   /* $@18  */
-  YYSYMBOL_185_19 = 185,                   /* $@19  */
-  YYSYMBOL_stmtseq = 186,                  /* stmtseq  */
-  YYSYMBOL_formstmtseq = 187,              /* formstmtseq  */
-  YYSYMBOL_fullstmt = 188,                 /* fullstmt  */
-  YYSYMBOL_labfullstmt = 189,              /* labfullstmt  */
-  YYSYMBOL_barestmt = 190,                 /* barestmt  */
-  YYSYMBOL_formline = 191,                 /* formline  */
-  YYSYMBOL_formarg = 192,                  /* formarg  */
-  YYSYMBOL_condition = 193,                /* condition  */
-  YYSYMBOL_sideff = 194,                   /* sideff  */
-  YYSYMBOL_else = 195,                     /* else  */
-  YYSYMBOL_cont = 196,                     /* cont  */
-  YYSYMBOL_finally = 197,                  /* finally  */
-  YYSYMBOL_mintro = 198,                   /* mintro  */
-  YYSYMBOL_nexpr = 199,                    /* nexpr  */
-  YYSYMBOL_texpr = 200,                    /* texpr  */
-  YYSYMBOL_iexpr = 201,                    /* iexpr  */
-  YYSYMBOL_mexpr = 202,                    /* mexpr  */
-  YYSYMBOL_mnexpr = 203,                   /* mnexpr  */
-  YYSYMBOL_formname = 204,                 /* formname  */
-  YYSYMBOL_startsub = 205,                 /* startsub  */
-  YYSYMBOL_startanonsub = 206,             /* startanonsub  */
-  YYSYMBOL_startanonmethod = 207,          /* startanonmethod  */
-  YYSYMBOL_startformsub = 208,             /* startformsub  */
-  YYSYMBOL_subname = 209,                  /* subname  */
-  YYSYMBOL_proto = 210,                    /* proto  */
-  YYSYMBOL_subattrlist = 211,              /* subattrlist  */
-  YYSYMBOL_attrlist = 212,                 /* attrlist  */
-  YYSYMBOL_optattrlist = 213,              /* optattrlist  */
-  YYSYMBOL_sigvar = 214,                   /* sigvar  */
-  YYSYMBOL_sigslurpsigil = 215,            /* sigslurpsigil  */
-  YYSYMBOL_sigslurpelem = 216,             /* sigslurpelem  */
-  YYSYMBOL_optcolon = 217,                 /* optcolon  */
-  YYSYMBOL_sigscalarelem = 218,            /* sigscalarelem  */
-  YYSYMBOL_optsigscalardefault = 219,      /* optsigscalardefault  */
-  YYSYMBOL_sigelem = 220,                  /* sigelem  */
-  YYSYMBOL_siglist = 221,                  /* siglist  */
-  YYSYMBOL_optsiglist = 222,               /* optsiglist  */
-  YYSYMBOL_optsubsignature = 223,          /* optsubsignature  */
-  YYSYMBOL_subsignature = 224,             /* subsignature  */
-  YYSYMBOL_subsigguts = 225,               /* subsigguts  */
-  YYSYMBOL_226_20 = 226,                   /* $@20  */
-  YYSYMBOL_optsubbody = 227,               /* optsubbody  */
-  YYSYMBOL_subbody = 228,                  /* subbody  */
-  YYSYMBOL_optsigsubbody = 229,            /* optsigsubbody  */
-  YYSYMBOL_sigsubbody = 230,               /* sigsubbody  */
-  YYSYMBOL_231_21 = 231,                   /* $@21  */
-  YYSYMBOL_expr = 232,                     /* expr  */
-  YYSYMBOL_listexpr = 233,                 /* listexpr  */
-  YYSYMBOL_listop = 234,                   /* listop  */
-  YYSYMBOL_235_22 = 235,                   /* @22  */
-  YYSYMBOL_methodname = 236,               /* methodname  */
-  YYSYMBOL_subscripted = 237,              /* subscripted  */
-  YYSYMBOL_termbinop = 238,                /* termbinop  */
-  YYSYMBOL_termrelop = 239,                /* termrelop  */
-  YYSYMBOL_relopchain = 240,               /* relopchain  */
-  YYSYMBOL_termeqop = 241,                 /* termeqop  */
-  YYSYMBOL_eqopchain = 242,                /* eqopchain  */
-  YYSYMBOL_termunop = 243,                 /* termunop  */
-  YYSYMBOL_anonymous = 244,                /* anonymous  */
-  YYSYMBOL_termdo = 245,                   /* termdo  */
-  YYSYMBOL_term = 246,                     /* term  */
-  YYSYMBOL_247_23 = 247,                   /* @23  */
-  YYSYMBOL_myattrterm = 248,               /* myattrterm  */
-  YYSYMBOL_myterm = 249,                   /* myterm  */
-  YYSYMBOL_fieldvar = 250,                 /* fieldvar  */
-  YYSYMBOL_fielddecl = 251,                /* fielddecl  */
-  YYSYMBOL_252_24 = 252,                   /* $@24  */
-  YYSYMBOL_optlistexpr = 253,              /* optlistexpr  */
-  YYSYMBOL_optexpr = 254,                  /* optexpr  */
-  YYSYMBOL_optrepl = 255,                  /* optrepl  */
-  YYSYMBOL_my_scalar = 256,                /* my_scalar  */
-  YYSYMBOL_list_of_scalars = 257,          /* list_of_scalars  */
-  YYSYMBOL_my_list_of_scalars = 258,       /* my_list_of_scalars  */
-  YYSYMBOL_my_var = 259,                   /* my_var  */
-  YYSYMBOL_refgen_topic = 260,             /* refgen_topic  */
-  YYSYMBOL_my_refgen = 261,                /* my_refgen  */
-  YYSYMBOL_amper = 262,                    /* amper  */
-  YYSYMBOL_scalar = 263,                   /* scalar  */
-  YYSYMBOL_ary = 264,                      /* ary  */
-  YYSYMBOL_hsh = 265,                      /* hsh  */
-  YYSYMBOL_arylen = 266,                   /* arylen  */
-  YYSYMBOL_star = 267,                     /* star  */
-  YYSYMBOL_sliceme = 268,                  /* sliceme  */
-  YYSYMBOL_kvslice = 269,                  /* kvslice  */
-  YYSYMBOL_gelem = 270,                    /* gelem  */
-  YYSYMBOL_indirob = 271                   /* indirob  */
+  YYSYMBOL_ATTRLIST = 59,                  /* ATTRLIST  */
+  YYSYMBOL_THING = 60,                     /* THING  */
+  YYSYMBOL_PMFUNC = 61,                    /* PMFUNC  */
+  YYSYMBOL_PRIVATEREF = 62,                /* PRIVATEREF  */
+  YYSYMBOL_QWLIST = 63,                    /* QWLIST  */
+  YYSYMBOL_FUNC0OP = 64,                   /* FUNC0OP  */
+  YYSYMBOL_FUNC0SUB = 65,                  /* FUNC0SUB  */
+  YYSYMBOL_UNIOPSUB = 66,                  /* UNIOPSUB  */
+  YYSYMBOL_LSTOPSUB = 67,                  /* LSTOPSUB  */
+  YYSYMBOL_PLUGEXPR = 68,                  /* PLUGEXPR  */
+  YYSYMBOL_PLUGSTMT = 69,                  /* PLUGSTMT  */
+  YYSYMBOL_LABEL = 70,                     /* LABEL  */
+  YYSYMBOL_PROTOTYPE = 71,                 /* PROTOTYPE  */
+  YYSYMBOL_LOOPEX = 72,                    /* LOOPEX  */
+  YYSYMBOL_DOTDOT = 73,                    /* DOTDOT  */
+  YYSYMBOL_YADAYADA = 74,                  /* YADAYADA  */
+  YYSYMBOL_FUNC0 = 75,                     /* FUNC0  */
+  YYSYMBOL_FUNC1 = 76,                     /* FUNC1  */
+  YYSYMBOL_FUNC = 77,                      /* FUNC  */
+  YYSYMBOL_UNIOP = 78,                     /* UNIOP  */
+  YYSYMBOL_LSTOP = 79,                     /* LSTOP  */
+  YYSYMBOL_BLKLSTOP = 80,                  /* BLKLSTOP  */
+  YYSYMBOL_POWOP = 81,                     /* POWOP  */
+  YYSYMBOL_MULOP = 82,                     /* MULOP  */
+  YYSYMBOL_ADDOP = 83,                     /* ADDOP  */
+  YYSYMBOL_DOLSHARP = 84,                  /* DOLSHARP  */
+  YYSYMBOL_HASHBRACK = 85,                 /* HASHBRACK  */
+  YYSYMBOL_NOAMP = 86,                     /* NOAMP  */
+  YYSYMBOL_COLONATTR = 87,                 /* COLONATTR  */
+  YYSYMBOL_FORMLBRACK = 88,                /* FORMLBRACK  */
+  YYSYMBOL_FORMRBRACK = 89,                /* FORMRBRACK  */
+  YYSYMBOL_SUBLEXSTART = 90,               /* SUBLEXSTART  */
+  YYSYMBOL_SUBLEXEND = 91,                 /* SUBLEXEND  */
+  YYSYMBOL_PHASER = 92,                    /* PHASER  */
+  YYSYMBOL_PREC_LOW = 93,                  /* PREC_LOW  */
+  YYSYMBOL_PLUGIN_LOW_OP = 94,             /* PLUGIN_LOW_OP  */
+  YYSYMBOL_OROP = 95,                      /* OROP  */
+  YYSYMBOL_PLUGIN_LOGICAL_OR_LOW_OP = 96,  /* PLUGIN_LOGICAL_OR_LOW_OP  */
+  YYSYMBOL_ANDOP = 97,                     /* ANDOP  */
+  YYSYMBOL_PLUGIN_LOGICAL_AND_LOW_OP = 98, /* PLUGIN_LOGICAL_AND_LOW_OP  */
+  YYSYMBOL_NOTOP = 99,                     /* NOTOP  */
+  YYSYMBOL_ASSIGNOP = 100,                 /* ASSIGNOP  */
+  YYSYMBOL_PLUGIN_ASSIGN_OP = 101,         /* PLUGIN_ASSIGN_OP  */
+  YYSYMBOL_PERLY_QUESTION_MARK = 102,      /* PERLY_QUESTION_MARK  */
+  YYSYMBOL_PERLY_COLON = 103,              /* PERLY_COLON  */
+  YYSYMBOL_OROR = 104,                     /* OROR  */
+  YYSYMBOL_DORDOR = 105,                   /* DORDOR  */
+  YYSYMBOL_PLUGIN_LOGICAL_OR_OP = 106,     /* PLUGIN_LOGICAL_OR_OP  */
+  YYSYMBOL_ANDAND = 107,                   /* ANDAND  */
+  YYSYMBOL_PLUGIN_LOGICAL_AND_OP = 108,    /* PLUGIN_LOGICAL_AND_OP  */
+  YYSYMBOL_BITOROP = 109,                  /* BITOROP  */
+  YYSYMBOL_BITANDOP = 110,                 /* BITANDOP  */
+  YYSYMBOL_CHEQOP = 111,                   /* CHEQOP  */
+  YYSYMBOL_NCEQOP = 112,                   /* NCEQOP  */
+  YYSYMBOL_CHRELOP = 113,                  /* CHRELOP  */
+  YYSYMBOL_NCRELOP = 114,                  /* NCRELOP  */
+  YYSYMBOL_PLUGIN_REL_OP = 115,            /* PLUGIN_REL_OP  */
+  YYSYMBOL_SHIFTOP = 116,                  /* SHIFTOP  */
+  YYSYMBOL_PLUGIN_ADD_OP = 117,            /* PLUGIN_ADD_OP  */
+  YYSYMBOL_PLUGIN_MUL_OP = 118,            /* PLUGIN_MUL_OP  */
+  YYSYMBOL_MATCHOP = 119,                  /* MATCHOP  */
+  YYSYMBOL_PERLY_EXCLAMATION_MARK = 120,   /* PERLY_EXCLAMATION_MARK  */
+  YYSYMBOL_PERLY_TILDE = 121,              /* PERLY_TILDE  */
+  YYSYMBOL_UMINUS = 122,                   /* UMINUS  */
+  YYSYMBOL_REFGEN = 123,                   /* REFGEN  */
+  YYSYMBOL_PLUGIN_POW_OP = 124,            /* PLUGIN_POW_OP  */
+  YYSYMBOL_PREINC = 125,                   /* PREINC  */
+  YYSYMBOL_PREDEC = 126,                   /* PREDEC  */
+  YYSYMBOL_POSTINC = 127,                  /* POSTINC  */
+  YYSYMBOL_POSTDEC = 128,                  /* POSTDEC  */
+  YYSYMBOL_POSTJOIN = 129,                 /* POSTJOIN  */
+  YYSYMBOL_PLUGIN_HIGH_OP = 130,           /* PLUGIN_HIGH_OP  */
+  YYSYMBOL_ARROW = 131,                    /* ARROW  */
+  YYSYMBOL_PERLY_PAREN_CLOSE = 132,        /* PERLY_PAREN_CLOSE  */
+  YYSYMBOL_PERLY_PAREN_OPEN = 133,         /* PERLY_PAREN_OPEN  */
+  YYSYMBOL_YYACCEPT = 134,                 /* $accept  */
+  YYSYMBOL_grammar = 135,                  /* grammar  */
+  YYSYMBOL_136_1 = 136,                    /* @1  */
+  YYSYMBOL_137_2 = 137,                    /* @2  */
+  YYSYMBOL_138_3 = 138,                    /* @3  */
+  YYSYMBOL_139_4 = 139,                    /* @4  */
+  YYSYMBOL_140_5 = 140,                    /* @5  */
+  YYSYMBOL_141_6 = 141,                    /* @6  */
+  YYSYMBOL_142_7 = 142,                    /* @7  */
+  YYSYMBOL_bare_statement_block = 143,     /* bare_statement_block  */
+  YYSYMBOL_bare_statement_class_declaration = 144, /* bare_statement_class_declaration  */
+  YYSYMBOL_bare_statement_class_definition = 145, /* bare_statement_class_definition  */
+  YYSYMBOL_146_8 = 146,                    /* $@8  */
+  YYSYMBOL_bare_statement_default = 147,   /* bare_statement_default  */
+  YYSYMBOL_bare_statement_defer = 148,     /* bare_statement_defer  */
+  YYSYMBOL_bare_statement_expression = 149, /* bare_statement_expression  */
+  YYSYMBOL_bare_statement_field_declaration = 150, /* bare_statement_field_declaration  */
+  YYSYMBOL_bare_statement_for = 151,       /* bare_statement_for  */
+  YYSYMBOL_152_9 = 152,                    /* $@9  */
+  YYSYMBOL_153_10 = 153,                   /* $@10  */
+  YYSYMBOL_154_11 = 154,                   /* @11  */
+  YYSYMBOL_bare_statement_format = 155,    /* bare_statement_format  */
+  YYSYMBOL_bare_statement_given = 156,     /* bare_statement_given  */
+  YYSYMBOL_bare_statement_if = 157,        /* bare_statement_if  */
+  YYSYMBOL_bare_statement_null = 158,      /* bare_statement_null  */
+  YYSYMBOL_bare_statement_package_declaration = 159, /* bare_statement_package_declaration  */
+  YYSYMBOL_bare_statement_package_definition = 160, /* bare_statement_package_definition  */
+  YYSYMBOL_161_12 = 161,                   /* $@12  */
+  YYSYMBOL_bare_statement_phaser = 162,    /* bare_statement_phaser  */
+  YYSYMBOL_163_13 = 163,                   /* $@13  */
+  YYSYMBOL_bare_statement_sub_signature = 164, /* bare_statement_sub_signature  */
+  YYSYMBOL_165_14 = 165,                   /* $@14  */
+  YYSYMBOL_bare_statement_sub_traditional = 166, /* bare_statement_sub_traditional  */
+  YYSYMBOL_167_15 = 167,                   /* $@15  */
+  YYSYMBOL_bare_statement_try_catch = 168, /* bare_statement_try_catch  */
+  YYSYMBOL_169_16 = 169,                   /* $@16  */
+  YYSYMBOL_bare_statement_unless = 170,    /* bare_statement_unless  */
+  YYSYMBOL_bare_statement_until = 171,     /* bare_statement_until  */
+  YYSYMBOL_bare_statement_utilize = 172,   /* bare_statement_utilize  */
+  YYSYMBOL_173_17 = 173,                   /* $@17  */
+  YYSYMBOL_bare_statement_when = 174,      /* bare_statement_when  */
+  YYSYMBOL_bare_statement_while = 175,     /* bare_statement_while  */
+  YYSYMBOL_bare_statement_yadayada = 176,  /* bare_statement_yadayada  */
+  YYSYMBOL_sigsub_or_method_named = 177,   /* sigsub_or_method_named  */
+  YYSYMBOL_block = 178,                    /* block  */
+  YYSYMBOL_empty = 179,                    /* empty  */
+  YYSYMBOL_formblock = 180,                /* formblock  */
+  YYSYMBOL_remember = 181,                 /* remember  */
+  YYSYMBOL_mblock = 182,                   /* mblock  */
+  YYSYMBOL_mremember = 183,                /* mremember  */
+  YYSYMBOL_catch_paren = 184,              /* catch_paren  */
+  YYSYMBOL_185_18 = 185,                   /* $@18  */
+  YYSYMBOL_186_19 = 186,                   /* $@19  */
+  YYSYMBOL_stmtseq = 187,                  /* stmtseq  */
+  YYSYMBOL_formstmtseq = 188,              /* formstmtseq  */
+  YYSYMBOL_fullstmt = 189,                 /* fullstmt  */
+  YYSYMBOL_labfullstmt = 190,              /* labfullstmt  */
+  YYSYMBOL_barestmt = 191,                 /* barestmt  */
+  YYSYMBOL_formline = 192,                 /* formline  */
+  YYSYMBOL_formarg = 193,                  /* formarg  */
+  YYSYMBOL_condition = 194,                /* condition  */
+  YYSYMBOL_sideff = 195,                   /* sideff  */
+  YYSYMBOL_else = 196,                     /* else  */
+  YYSYMBOL_cont = 197,                     /* cont  */
+  YYSYMBOL_finally = 198,                  /* finally  */
+  YYSYMBOL_mintro = 199,                   /* mintro  */
+  YYSYMBOL_nexpr = 200,                    /* nexpr  */
+  YYSYMBOL_texpr = 201,                    /* texpr  */
+  YYSYMBOL_iexpr = 202,                    /* iexpr  */
+  YYSYMBOL_mexpr = 203,                    /* mexpr  */
+  YYSYMBOL_mnexpr = 204,                   /* mnexpr  */
+  YYSYMBOL_formname = 205,                 /* formname  */
+  YYSYMBOL_startsub = 206,                 /* startsub  */
+  YYSYMBOL_startanonsub = 207,             /* startanonsub  */
+  YYSYMBOL_startanonmethod = 208,          /* startanonmethod  */
+  YYSYMBOL_startformsub = 209,             /* startformsub  */
+  YYSYMBOL_subname = 210,                  /* subname  */
+  YYSYMBOL_proto = 211,                    /* proto  */
+  YYSYMBOL_subattrlist = 212,              /* subattrlist  */
+  YYSYMBOL_attrlist = 213,                 /* attrlist  */
+  YYSYMBOL_optattrlist = 214,              /* optattrlist  */
+  YYSYMBOL_sigvar = 215,                   /* sigvar  */
+  YYSYMBOL_sigslurpsigil = 216,            /* sigslurpsigil  */
+  YYSYMBOL_sigslurpelem = 217,             /* sigslurpelem  */
+  YYSYMBOL_optcolon = 218,                 /* optcolon  */
+  YYSYMBOL_sigscalarelem = 219,            /* sigscalarelem  */
+  YYSYMBOL_optsigscalardefault = 220,      /* optsigscalardefault  */
+  YYSYMBOL_sigelem = 221,                  /* sigelem  */
+  YYSYMBOL_siglist = 222,                  /* siglist  */
+  YYSYMBOL_optsiglist = 223,               /* optsiglist  */
+  YYSYMBOL_optsubsignature = 224,          /* optsubsignature  */
+  YYSYMBOL_subsignature = 225,             /* subsignature  */
+  YYSYMBOL_subsigguts = 226,               /* subsigguts  */
+  YYSYMBOL_227_20 = 227,                   /* $@20  */
+  YYSYMBOL_optsubbody = 228,               /* optsubbody  */
+  YYSYMBOL_subbody = 229,                  /* subbody  */
+  YYSYMBOL_optsigsubbody = 230,            /* optsigsubbody  */
+  YYSYMBOL_sigsubbody = 231,               /* sigsubbody  */
+  YYSYMBOL_232_21 = 232,                   /* $@21  */
+  YYSYMBOL_expr = 233,                     /* expr  */
+  YYSYMBOL_listexpr = 234,                 /* listexpr  */
+  YYSYMBOL_listop = 235,                   /* listop  */
+  YYSYMBOL_236_22 = 236,                   /* @22  */
+  YYSYMBOL_methodname = 237,               /* methodname  */
+  YYSYMBOL_subscripted = 238,              /* subscripted  */
+  YYSYMBOL_termbinop = 239,                /* termbinop  */
+  YYSYMBOL_termrelop = 240,                /* termrelop  */
+  YYSYMBOL_relopchain = 241,               /* relopchain  */
+  YYSYMBOL_termeqop = 242,                 /* termeqop  */
+  YYSYMBOL_eqopchain = 243,                /* eqopchain  */
+  YYSYMBOL_termunop = 244,                 /* termunop  */
+  YYSYMBOL_anonymous = 245,                /* anonymous  */
+  YYSYMBOL_termdo = 246,                   /* termdo  */
+  YYSYMBOL_term = 247,                     /* term  */
+  YYSYMBOL_248_23 = 248,                   /* @23  */
+  YYSYMBOL_myattrterm = 249,               /* myattrterm  */
+  YYSYMBOL_myterm = 250,                   /* myterm  */
+  YYSYMBOL_fieldvar = 251,                 /* fieldvar  */
+  YYSYMBOL_fielddecl = 252,                /* fielddecl  */
+  YYSYMBOL_253_24 = 253,                   /* $@24  */
+  YYSYMBOL_optlistexpr = 254,              /* optlistexpr  */
+  YYSYMBOL_optexpr = 255,                  /* optexpr  */
+  YYSYMBOL_optrepl = 256,                  /* optrepl  */
+  YYSYMBOL_my_scalar = 257,                /* my_scalar  */
+  YYSYMBOL_list_of_scalars = 258,          /* list_of_scalars  */
+  YYSYMBOL_my_list_of_scalars = 259,       /* my_list_of_scalars  */
+  YYSYMBOL_my_var = 260,                   /* my_var  */
+  YYSYMBOL_refgen_topic = 261,             /* refgen_topic  */
+  YYSYMBOL_my_refgen = 262,                /* my_refgen  */
+  YYSYMBOL_amper = 263,                    /* amper  */
+  YYSYMBOL_scalar = 264,                   /* scalar  */
+  YYSYMBOL_ary = 265,                      /* ary  */
+  YYSYMBOL_hsh = 266,                      /* hsh  */
+  YYSYMBOL_arylen = 267,                   /* arylen  */
+  YYSYMBOL_star = 268,                     /* star  */
+  YYSYMBOL_sliceme = 269,                  /* sliceme  */
+  YYSYMBOL_kvslice = 270,                  /* kvslice  */
+  YYSYMBOL_gelem = 271,                    /* gelem  */
+  YYSYMBOL_indirob = 272                   /* indirob  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -288,10 +289,10 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 #define YYFINAL  16
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   3753
+#define YYLAST   3780
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  133
+#define YYNTOKENS  134
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  139
 /* YYNRULES -- Number of rules.  */
@@ -300,7 +301,7 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 #define YYNSTATES  702
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   387
+#define YYMAXUTOK   388
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -352,7 +353,7 @@ static const yytype_uint8 yytranslate[] =
       95,    96,    97,    98,    99,   100,   101,   102,   103,   104,
      105,   106,   107,   108,   109,   110,   111,   112,   113,   114,
      115,   116,   117,   118,   119,   120,   121,   122,   123,   124,
-     125,   126,   127,   128,   129,   130,   131,   132
+     125,   126,   127,   128,   129,   130,   131,   132,   133
 };
 
 #if YYDEBUG
@@ -424,23 +425,23 @@ static const char *const yytname[] =
   "KW_GIVEN", "KW_WHEN", "KW_DEFAULT", "KW_TRY", "KW_CATCH", "KW_FINALLY",
   "KW_DEFER", "KW_REQUIRE", "KW_DO", "KW_USE_or_NO", "KW_SUB_named",
   "KW_SUB_named_sig", "KW_SUB_anon", "KW_SUB_anon_sig", "KW_METHOD_named",
-  "KW_METHOD_anon", "BAREWORD", "METHCALL0", "METHCALL", "THING", "PMFUNC",
-  "PRIVATEREF", "QWLIST", "FUNC0OP", "FUNC0SUB", "UNIOPSUB", "LSTOPSUB",
-  "PLUGEXPR", "PLUGSTMT", "LABEL", "PROTOTYPE", "LOOPEX", "DOTDOT",
-  "YADAYADA", "FUNC0", "FUNC1", "FUNC", "UNIOP", "LSTOP", "BLKLSTOP",
-  "POWOP", "MULOP", "ADDOP", "DOLSHARP", "HASHBRACK", "NOAMP", "COLONATTR",
-  "FORMLBRACK", "FORMRBRACK", "SUBLEXSTART", "SUBLEXEND", "PHASER",
-  "PREC_LOW", "PLUGIN_LOW_OP", "OROP", "PLUGIN_LOGICAL_OR_LOW_OP", "ANDOP",
-  "PLUGIN_LOGICAL_AND_LOW_OP", "NOTOP", "ASSIGNOP", "PLUGIN_ASSIGN_OP",
-  "PERLY_QUESTION_MARK", "PERLY_COLON", "OROR", "DORDOR",
-  "PLUGIN_LOGICAL_OR_OP", "ANDAND", "PLUGIN_LOGICAL_AND_OP", "BITOROP",
-  "BITANDOP", "CHEQOP", "NCEQOP", "CHRELOP", "NCRELOP", "PLUGIN_REL_OP",
-  "SHIFTOP", "PLUGIN_ADD_OP", "PLUGIN_MUL_OP", "MATCHOP",
-  "PERLY_EXCLAMATION_MARK", "PERLY_TILDE", "UMINUS", "REFGEN",
-  "PLUGIN_POW_OP", "PREINC", "PREDEC", "POSTINC", "POSTDEC", "POSTJOIN",
-  "PLUGIN_HIGH_OP", "ARROW", "PERLY_PAREN_CLOSE", "PERLY_PAREN_OPEN",
-  "$accept", "grammar", "@1", "@2", "@3", "@4", "@5", "@6", "@7",
-  "bare_statement_block", "bare_statement_class_declaration",
+  "KW_METHOD_anon", "BAREWORD", "METHCALL0", "METHCALL", "ATTRLIST",
+  "THING", "PMFUNC", "PRIVATEREF", "QWLIST", "FUNC0OP", "FUNC0SUB",
+  "UNIOPSUB", "LSTOPSUB", "PLUGEXPR", "PLUGSTMT", "LABEL", "PROTOTYPE",
+  "LOOPEX", "DOTDOT", "YADAYADA", "FUNC0", "FUNC1", "FUNC", "UNIOP",
+  "LSTOP", "BLKLSTOP", "POWOP", "MULOP", "ADDOP", "DOLSHARP", "HASHBRACK",
+  "NOAMP", "COLONATTR", "FORMLBRACK", "FORMRBRACK", "SUBLEXSTART",
+  "SUBLEXEND", "PHASER", "PREC_LOW", "PLUGIN_LOW_OP", "OROP",
+  "PLUGIN_LOGICAL_OR_LOW_OP", "ANDOP", "PLUGIN_LOGICAL_AND_LOW_OP",
+  "NOTOP", "ASSIGNOP", "PLUGIN_ASSIGN_OP", "PERLY_QUESTION_MARK",
+  "PERLY_COLON", "OROR", "DORDOR", "PLUGIN_LOGICAL_OR_OP", "ANDAND",
+  "PLUGIN_LOGICAL_AND_OP", "BITOROP", "BITANDOP", "CHEQOP", "NCEQOP",
+  "CHRELOP", "NCRELOP", "PLUGIN_REL_OP", "SHIFTOP", "PLUGIN_ADD_OP",
+  "PLUGIN_MUL_OP", "MATCHOP", "PERLY_EXCLAMATION_MARK", "PERLY_TILDE",
+  "UMINUS", "REFGEN", "PLUGIN_POW_OP", "PREINC", "PREDEC", "POSTINC",
+  "POSTDEC", "POSTJOIN", "PLUGIN_HIGH_OP", "ARROW", "PERLY_PAREN_CLOSE",
+  "PERLY_PAREN_OPEN", "$accept", "grammar", "@1", "@2", "@3", "@4", "@5",
+  "@6", "@7", "bare_statement_block", "bare_statement_class_declaration",
   "bare_statement_class_definition", "$@8", "bare_statement_default",
   "bare_statement_defer", "bare_statement_expression",
   "bare_statement_field_declaration", "bare_statement_for", "$@9", "$@10",
@@ -480,7 +481,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-583)
+#define YYPACT_NINF (-584)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
@@ -494,77 +495,77 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-     599,  -583,  -583,  -583,  -583,  -583,  -583,  -583,    53,  -583,
-    3065,    46,  2007,  1890,  -583,  -583,  -583,  -583,   182,  3065,
-     182,  3065,   182,  3065,   182,   182,  3065,    87,  3065,  2336,
-    -583,  -583,  -583,  -583,   182,   182,  -583,  -583,    56,   -34,
-    -583,  3065,  -583,  -583,  3065,   -30,   -24,   -40,  2336,  2255,
-      46,   182,  3065,     6,  3065,  3065,  3065,  3065,  3065,  3065,
-    2417,  -583,   530,   103,  -583,    37,  -583,   -47,    45,   -28,
-      62,  -583,  -583,  -583,  3257,  -583,  -583,    59,   114,   176,
-     200,  -583,   117,   207,   269,   177,  -583,  -583,  -583,  -583,
-    -583,   156,   173,   267,   105,   112,    13,   118,   124,   125,
-     130,    46,   257,   257,  -583,     6,  -583,  -583,  -583,   255,
-    -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,
-    -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,
-    -583,  -583,  -583,  -583,  -583,     6,   242,  -583,   262,   432,
-     264,  1890,  -583,  -583,  -583,  -583,   686,  -583,    35,   883,
-    -583,  -583,  -583,  -583,  -583,   275,  -583,   366,  -583,   366,
-    -583,  -583,  3623,  3146,  2498,   212,  -583,  -583,  -583,  3623,
-    -583,  3623,   246,   238,   238,  3065,   196,   243,  3065,   211,
-    3623,    46,  3257,   213,  2579,  3065,  2255,  -583,  3623,  3227,
-    -583,   103,  -583,  2660,  3065,  3065,  -583,   308,  -583,  -583,
-    3065,   103,   366,   366,   366,   224,   224,   330,   241,  3065,
-    3065,  3065,  3065,  3065,  3065,  3065,  2741,  -583,  -583,  3065,
-    -583,  -583,  3065,  3065,  3065,  3065,  3065,  3065,  3065,  3065,
-    3065,  3065,  3065,  3065,  3065,  3065,  3065,  3065,  3065,  3065,
-    3065,  3065,  3065,  3065,  3065,  3065,  3065,  3065,  -583,  -583,
-    -583,  3065,   309,  2822,  3065,  3065,  3065,  3065,  3065,  3065,
-    3065,  -583,   302,   305,   307,   212,  -583,  -583,  -583,  -583,
-    -583,   249,   397,  -583,  -583,   228,  -583,  -583,  -583,  -583,
-    -583,  -583,   321,  -583,  -583,  -583,  -583,  -583,  -583,    46,
-    -583,  -583,  -583,  3065,  3065,  3065,  3065,  3065,  3065,  -583,
-    -583,  -583,  -583,  -583,  -583,  -583,  -583,   323,  -583,   369,
-    -583,  -583,   376,  -583,  -583,  2903,   366,   212,    82,    99,
-     168,  -583,   251,   338,  -583,  -583,  -583,   238,   343,  -583,
-       1,     1,  -583,  3065,  3065,    20,  -583,  -583,  -583,  -583,
-     403,   316,   278,  3065,   103,   103,   399,  -583,  3065,   401,
-     100,   100,  -583,  -583,  3361,   273,    26,  -583,   415,  3544,
-    3584,  3465,   366,   358,  3431,  3309,  3361,  3361,  1034,   713,
-     713,   713,  3504,  3504,  3526,  3565,  3584,  3584,  3544,  3544,
-    3604,  1049,  3431,   358,   366,   366,    74,    63,  3065,  3065,
-      80,   390,   395,   410,  -583,   411,  2984,   290,  -583,  -583,
-     436,   284,    64,   293,   120,   299,   139,   304,  1000,  -583,
-    -583,   406,   162,   212,  -583,  -583,   329,  3065,  3065,  -583,
-       7,  -583,  -583,   310,  -583,  -583,  -583,  -583,  2093,   267,
-    -583,  3065,  3065,  3065,  3065,  -583,  -583,   381,  -583,   417,
-    -583,  -583,  -583,   530,  -583,  -583,  -583,   530,  -583,  -583,
-    -583,   341,   323,    35,    68,   460,  -583,  -583,  -583,   434,
-    -583,   311,  -583,  -583,   327,    18,  -583,  3065,  -583,  -583,
-    -583,   469,  -583,   152,  3065,   440,  -583,  -583,  3065,  -583,
-     322,   335,   164,  -583,  -583,  -583,  -583,  -583,  -583,   485,
-    3065,  -583,   448,  -583,   449,  -583,   451,  -583,   454,  -583,
-    -583,  -583,  -583,  -583,   199,  -583,   340,   530,   346,   456,
-     342,  -583,  -583,  -583,  -583,  -583,   347,   457,   111,  -583,
-    3065,   352,   360,   530,   372,   373,  1188,   375,   462,   246,
-    -583,   494,  -583,  -583,   238,  3065,   414,  -583,    88,  -583,
-    -583,  -583,   505,  -583,  -583,  3065,  -583,   430,  -583,  -583,
-    -583,   169,  -583,  3413,  3065,   509,  -583,  -583,   391,  -583,
-    -583,  -583,  -583,   515,  -583,  -583,  -583,  3065,   257,   257,
-     523,   409,  -583,  3065,  3065,   257,  -583,   418,   420,  -583,
-    -583,   257,   257,  -583,  -583,  -583,  -583,  3065,   238,  -583,
-     519,  3257,  3065,   421,  -583,   530,  -583,  -583,   427,  -583,
-    -583,   471,  -583,  -583,  3257,   190,   190,   456,   428,   431,
-     438,   242,  3065,  3065,   257,   257,   257,  -583,  -583,   456,
-     257,   520,   417,  1305,  -583,  -583,  -583,  -583,  3257,  -583,
-    -583,  -583,  -583,  1422,  -583,   257,   439,  -583,  -583,  -583,
-    -583,  3065,   257,   257,  -583,   550,   443,   242,   242,   242,
-    -583,   538,  -583,  -583,  -583,  1539,  -583,     5,  -583,  1656,
-    -583,  3065,   453,   242,   242,  -583,   257,  -583,  -583,  -583,
-     461,    46,  -583,  -583,   568,   500,  -583,  -583,   463,   257,
-    -583,  -583,  -583,   242,  -583,  -583,  -583,  -583,  -583,  -583,
-     257,   242,  2174,  -583,  1773,   190,  -583,   466,  -583,  -583,
-     257,  -583
+     643,  -584,  -584,  -584,  -584,  -584,  -584,  -584,    50,  -584,
+    3028,    67,  1957,  1839,  -584,  -584,  -584,  -584,   167,  3028,
+     167,  3028,   167,  3028,   167,   167,  3028,   121,  3028,  2290,
+    -584,  -584,  -584,  -584,   167,   167,  -584,  -584,    21,   -52,
+    -584,  3028,  -584,  -584,  3028,   -28,   -18,   -50,  2290,  2208,
+      67,   167,  3028,    26,  3028,  3028,  3028,  3028,  3028,  3028,
+    2372,  -584,   123,   120,  -584,    40,  -584,   -48,     8,    86,
+      28,  -584,  -584,  -584,  3222,  -584,  -584,    19,   136,   148,
+     168,  -584,   149,   174,   178,   157,  -584,  -584,  -584,  -584,
+    -584,   118,   132,    98,    72,    75,    13,    80,    91,   105,
+     113,    67,   182,   182,  -584,    26,  -584,  -584,  -584,   236,
+    -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,
+    -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,
+    -584,  -584,  -584,  -584,  -584,    26,   225,  -584,   244,   431,
+     246,  1839,  -584,  -584,  -584,  -584,   686,  -584,   103,   883,
+    -584,  -584,  -584,  -584,  -584,   272,  -584,   364,  -584,   364,
+    -584,  -584,  3630,  3110,  2454,   109,  -584,  -584,  -584,  3630,
+    -584,  3630,   220,   208,   208,  3028,   165,   213,  3028,   184,
+    3630,    67,  3222,   194,  2536,  3028,  2208,  -584,  3630,  3192,
+    -584,   120,  -584,  2618,  3028,  3028,  -584,   284,  -584,  -584,
+    3028,   120,   364,   364,   364,   254,   254,   319,   279,  3028,
+    3028,  3028,  3028,  3028,  3028,  3028,  2700,  -584,  -584,  3028,
+    -584,  -584,  3028,  3028,  3028,  3028,  3028,  3028,  3028,  3028,
+    3028,  3028,  3028,  3028,  3028,  3028,  3028,  3028,  3028,  3028,
+    3028,  3028,  3028,  3028,  3028,  3028,  3028,  3028,  -584,  -584,
+    -584,  3028,   100,  2782,  3028,  3028,  3028,  3028,  3028,  3028,
+    3028,  -584,   287,   292,   299,   109,  -584,  -584,  -584,  -584,
+    -584,   264,   587,  -584,  -584,   259,  -584,  -584,  -584,  -584,
+    -584,  -584,   325,  -584,  -584,  -584,  -584,  -584,  -584,    67,
+    -584,  -584,  -584,  3028,  3028,  3028,  3028,  3028,  3028,  -584,
+    -584,  -584,  -584,  -584,  -584,  -584,  -584,   331,  -584,   380,
+    -584,  -584,   386,  -584,  -584,  2864,   364,   109,    56,    82,
+      85,  -584,   345,   343,  -584,  -584,  -584,   208,   347,  -584,
+       1,     1,  -584,  3028,  3028,   114,  -584,  -584,  -584,  -584,
+     388,   316,   277,  3028,   120,   120,   403,  -584,  3028,   400,
+     106,   106,  -584,  -584,  3326,   185,   119,  -584,   401,  3591,
+    3571,  3430,   364,   206,  3156,  3274,  3326,  3326,   722,  3469,
+    3469,  3469,  3492,  3492,  3531,  3552,  3571,  3571,  3591,  3591,
+    3610,  3649,  3156,   206,   364,   364,   112,    30,  3028,  3028,
+      92,   392,   395,   396,  -584,   399,  2946,   298,  -584,  -584,
+     414,   255,   139,   293,   152,   302,   243,   332,  1001,  -584,
+    -584,   417,    37,   109,  -584,  -584,   346,  3028,  3028,  -584,
+      25,  -584,  -584,   321,  -584,  -584,  -584,  -584,  2044,    98,
+    -584,  3028,  3028,  3028,  3028,  -584,  -584,   376,  -584,   430,
+    -584,  -584,  -584,   123,  -584,  -584,  -584,   123,  -584,  -584,
+    -584,   358,   331,   103,    14,   459,  -584,  -584,  -584,   449,
+    -584,   328,  -584,  -584,   338,    34,  -584,  3028,  -584,  -584,
+    -584,   468,  -584,   249,  3028,   452,  -584,  -584,  3028,  -584,
+     340,   341,   270,  -584,  -584,  -584,  -584,  -584,  -584,   484,
+    3028,  -584,   462,  -584,   464,  -584,   466,  -584,   467,  -584,
+    -584,  -584,  -584,  -584,    53,  -584,   339,   123,   349,   471,
+     356,  -584,  -584,  -584,  -584,  -584,   368,   481,   224,  -584,
+    3028,   372,   373,   123,   375,   381,  1131,   383,   465,   220,
+    -584,   507,  -584,  -584,   208,  3028,   422,  -584,    20,  -584,
+    -584,  -584,   519,  -584,  -584,  3028,  -584,   440,  -584,  -584,
+    -584,   275,  -584,  3378,  3028,   520,  -584,  -584,   402,  -584,
+    -584,  -584,  -584,   515,  -584,  -584,  -584,  3028,   182,   182,
+     523,   408,  -584,  3028,  3028,   182,  -584,   409,   418,  -584,
+    -584,   182,   182,  -584,  -584,  -584,  -584,  3028,   208,  -584,
+     529,  3222,  3028,   420,  -584,   123,  -584,  -584,   426,  -584,
+    -584,   470,  -584,  -584,  3222,   295,   295,   471,   427,   435,
+     437,   225,  3028,  3028,   182,   182,   182,  -584,  -584,   471,
+     182,   540,   430,  1249,  -584,  -584,  -584,  -584,  3222,  -584,
+    -584,  -584,  -584,  1367,  -584,   182,   438,  -584,  -584,  -584,
+    -584,  3028,   182,   182,  -584,   550,   442,   225,   225,   225,
+    -584,   496,  -584,  -584,  -584,  1485,  -584,     2,  -584,  1603,
+    -584,  3028,   451,   225,   225,  -584,   182,  -584,  -584,  -584,
+     453,    67,  -584,  -584,   567,   499,  -584,  -584,   460,   182,
+    -584,  -584,  -584,   225,  -584,  -584,  -584,  -584,  -584,  -584,
+     182,   225,  2126,  -584,  1721,   295,  -584,   461,  -584,  -584,
+     182,  -584
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -648,20 +649,20 @@ static const yytype_int16 yydefact[] =
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,
-    -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,
-    -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,
-    -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,
-    -583,  -583,  -583,  -583,    -4,   -10,  -583,    23,   -67,  -583,
-    -583,  -583,  -583,   -16,  -583,   580,   468,    -1,  -583,  -583,
-      79,  -425,  -582,  -308,  -583,  -552,  -583,   -14,   179,  -334,
-     -81,  -583,   -93,    44,  -583,  -583,   -83,    84,  -172,  -150,
-     202,   165,  -583,  -583,  -583,  -583,  -583,   166,  -583,  -583,
-    -583,  -583,    81,  -583,    -2,   171,  -583,  -312,  -583,    16,
-     -44,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,  -583,
-    -583,  -583,  -583,   635,  -583,  -583,   472,  -583,  -583,  -583,
-    -162,   -15,  -583,  -583,  -583,  -583,   203,  -583,  -583,   359,
-      36,   -21,   -19,  -583,  -583,  -583,  -583,  -583,    55
+    -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,
+    -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,
+    -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,
+    -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,
+    -584,  -584,  -584,  -584,    -4,   -10,  -584,    23,   -67,  -584,
+    -584,  -584,  -584,   -16,  -584,   581,   457,    -1,  -584,  -584,
+      63,  -425,  -583,  -269,  -584,  -552,  -584,    -8,   171,  -334,
+     -87,  -584,   -93,    60,  -584,  -584,   -83,    77,  -172,  -150,
+     195,   158,  -584,  -584,  -584,  -584,  -584,   156,  -584,  -584,
+    -584,  -584,    73,  -584,    -7,   160,  -584,  -312,  -584,    16,
+     -44,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,  -584,
+    -584,  -584,  -584,   635,  -584,  -584,   458,  -584,  -584,  -584,
+    -162,   -15,  -584,  -584,  -584,  -584,   191,  -584,  -584,   352,
+      36,   -21,   -19,  -584,  -584,  -584,  -584,  -584,    55
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
@@ -690,70 +691,70 @@ static const yytype_int16 yytable[] =
 {
       61,   149,   331,   514,   155,   191,   167,    87,   168,    61,
      201,   137,   -61,   332,   152,   324,   152,   287,   152,   463,
-     152,   152,   285,    20,   639,   170,    62,   674,   616,    20,
-     152,   152,    17,   213,   466,    62,   283,   197,   347,   190,
-     476,   545,    61,   271,   187,   152,   195,   152,   214,   185,
-     215,  -152,   288,    16,   153,   303,   153,    86,   153,   304,
-     153,   153,   198,   166,   675,   217,   218,   199,    62,   178,
-     153,   153,   267,   154,   268,   173,   208,   158,   493,   160,
-     161,   348,   220,   221,   508,   193,   181,   153,   479,   175,
-     176,    86,   186,   254,   516,   255,    20,   280,   179,   524,
-     525,   474,   183,    20,   194,   483,   196,    22,   184,   261,
-    -362,    24,  -362,   699,   209,   210,   211,   212,   213,   198,
-     209,   210,   211,   212,   199,   254,   290,   255,  -366,   266,
-     692,   191,   275,   -61,   495,   272,   150,   305,   306,   509,
-     301,   151,   319,   293,   320,   273,   294,   295,   296,   297,
-     344,   345,   298,   497,  -327,   459,   191,   219,   209,   210,
-     211,   212,   326,   329,   329,   190,   550,   456,  -328,   216,
-     341,   342,   222,   502,  -326,    61,    61,   337,   556,  -364,
-     322,  -364,   152,   597,   503,  -330,   578,  -362,   260,  -362,
-     190,   253,   438,    86,   335,   440,   211,   212,    20,   318,
-     340,    62,    62,  -370,   252,   209,   210,   211,   212,   163,
-     565,  -364,   263,  -364,   209,   210,   211,   212,   256,   164,
-     257,   566,   193,   635,   636,   350,   351,   352,   353,   264,
-     355,   356,   358,   209,   210,   211,   212,   269,   150,   609,
-     610,   343,  -126,   151,   270,   408,   209,   210,   211,   212,
-     276,   426,   410,   427,  -329,   414,   277,   278,   209,   210,
-     211,   212,   279,   209,   210,   211,   212,   514,   281,   400,
-     401,   402,   403,   404,   405,   406,   407,   286,   626,   646,
-     258,   289,   259,    20,   292,   441,   299,    22,   398,   314,
-     465,    24,   417,   418,   420,   475,   428,   429,   323,   431,
-     432,   433,   434,   644,   480,   548,   492,   662,   425,   443,
-     443,   443,   447,   443,   443,   494,   325,   329,   464,   387,
-     388,   496,   389,    61,   328,   390,   498,   678,   333,   391,
-     346,   455,   334,   392,   393,   209,   210,   211,   212,   667,
-     668,   669,   336,   348,   338,   209,   210,   211,   212,    62,
-    -370,  -370,  -370,   251,   252,   680,   681,   555,   409,   471,
-     430,   412,   590,   413,   473,   436,   394,   209,   210,   211,
-     212,   419,   349,   444,   445,   693,   448,   449,   209,   210,
-     211,   212,   457,   696,   450,   452,   152,   209,   210,   211,
-     212,   453,   395,   209,   210,   211,   212,   458,   209,   210,
-     211,   212,   460,   414,   481,   482,   469,    18,   426,   470,
-     427,   472,   489,    20,   474,   484,   622,    22,   513,   526,
-     485,    24,   490,   191,   500,   621,   153,   421,   505,   209,
-     210,   211,   212,   507,   507,   486,   487,   528,   224,   530,
-     535,   396,   512,   540,   518,   -61,   224,   447,   523,   507,
-     507,   541,   552,   520,   554,   546,   511,   190,   544,   527,
-     559,   560,   531,   561,   293,   425,   562,   294,   295,   296,
-     297,   568,    20,   298,   573,   558,   246,   569,   575,   576,
-      61,   247,   531,   579,   248,   249,   250,   251,   252,   247,
-     551,   580,   248,   249,   250,   251,   252,   209,   210,   211,
-     212,   605,   606,   581,   582,   589,    62,   584,   611,   209,
-     210,   211,   212,   592,   617,   618,   594,   585,   587,   326,
-     596,   599,   600,   563,   329,   564,   209,   210,   211,   212,
-     209,   210,   211,   212,   468,   574,   507,   601,   607,   598,
-     608,   624,   652,   191,    61,   572,   477,   647,   648,   649,
-     613,   614,   629,   651,   209,   210,   211,   212,   631,   632,
-     641,   595,   642,   209,   210,   211,   212,   491,   660,   643,
+     152,   152,   285,   639,   674,   170,    62,   348,   616,    20,
+     152,   152,    17,   474,   178,    62,   283,   197,   347,   190,
+     185,    20,    61,   271,   187,   152,   195,   152,   502,   213,
+      16,   214,   288,   215,   153,   479,   153,   545,   153,   503,
+     153,   153,   675,   166,   565,   217,   218,   254,    62,   255,
+     153,   153,   267,   154,   268,   566,   208,   158,    86,   160,
+     161,   179,   198,   186,   508,   193,   198,   153,   199,   175,
+     176,   173,   199,  -362,   516,  -362,  -364,   280,  -364,   524,
+     525,  -327,   181,    86,   194,   183,   196,  -326,    20,   261,
+     387,   388,   699,   389,    20,   184,   390,   483,    22,  -152,
+     391,   219,    24,   303,   392,   393,   290,   304,   466,   266,
+     692,   191,   275,   476,   -61,   213,   272,    20,   306,   222,
+     301,    22,   319,  -328,   320,    24,   273,   254,   150,   255,
+     344,   345,   253,   493,   151,   459,   191,   394,   509,  -362,
+    -366,  -362,   326,   329,   329,   190,   495,   456,   260,  -330,
+     341,   342,  -329,   216,   263,    61,    61,   337,    86,  -364,
+     322,  -364,   152,    20,   395,   256,   578,   257,   264,   258,
+     190,   259,   438,   281,   335,   440,   323,   220,   221,   318,
+     340,    62,    62,   211,   212,   269,   305,   475,   270,   209,
+     210,   211,   212,   276,   209,   210,   211,   212,   209,   210,
+     211,   212,   193,   150,   277,   350,   351,   352,   353,   151,
+     355,   356,   358,   396,   209,   210,   211,   212,   278,   609,
+     610,   343,  -370,   252,   163,   408,   279,   209,   210,   211,
+     212,   426,   410,   427,   164,   414,   293,   497,   286,   294,
+     295,   296,   297,   550,   289,   298,   292,   514,   299,   400,
+     401,   402,   403,   404,   405,   406,   407,   492,   626,   646,
+     209,   210,   211,   212,   556,   441,   314,   224,   398,   597,
+     465,   325,   417,   418,   420,   328,   428,   429,   333,   431,
+     432,   433,   434,   334,   480,   548,   346,   662,   425,   443,
+     443,   443,   447,   443,   443,   494,   336,   329,   464,   209,
+     210,   211,   212,    61,   496,   246,   338,   678,   635,   636,
+     247,   455,   348,   248,   249,   250,   251,   252,   209,   210,
+     211,   212,   644,   409,   209,   210,   211,   212,   412,    62,
+     209,   210,   211,   212,   498,   413,  -126,   444,   445,   471,
+     448,   449,   590,   555,   473,   209,   210,   211,   212,   436,
+     209,   210,   211,   212,   209,   210,   211,   212,   667,   668,
+     669,  -370,  -370,  -370,   251,   252,   152,   419,   209,   210,
+     211,   212,   430,   450,   680,   681,   452,   209,   210,   211,
+     212,   453,   458,   414,   481,   482,   460,   469,   426,   470,
+     427,   349,   489,   474,   693,   472,   622,   484,   513,   526,
+     485,   486,   696,   191,   487,   621,   153,   209,   210,   211,
+     212,   490,   528,   507,   507,   500,   209,   210,   211,   212,
+     209,   210,   211,   212,   518,   224,   505,   447,   523,   507,
+     507,   541,   530,   520,   512,   546,   511,   190,   535,   527,
+     -61,   540,   531,   293,   552,   425,   294,   295,   296,   297,
+     544,   568,   298,   554,   559,   558,   560,   457,   561,   562,
+      61,   569,   531,   209,   210,   211,   212,    20,   247,   573,
+     551,   248,   249,   250,   251,   252,   209,   210,   211,   212,
+     575,   605,   606,   576,   579,   580,    62,   581,   611,   209,
+     210,   211,   212,   582,   617,   618,   584,   585,   589,   326,
+     468,   587,   592,   563,   329,   564,   209,   210,   211,   212,
+     594,   596,   599,   477,   600,   574,   507,   601,   607,   598,
+     608,   671,   613,   191,    61,   572,   491,   647,   648,   649,
+     614,   624,   629,   651,   209,   210,   211,   212,   631,   632,
+     641,   595,   652,   209,   210,   211,   212,   642,   660,   643,
       62,   661,   665,   623,   666,   663,   664,   190,   329,   209,
-     210,   211,   212,   671,   679,   686,   633,   687,   603,   507,
-     507,   538,   684,   142,   690,   637,   637,   700,   645,   683,
-     549,   290,     1,     2,     3,     4,     5,     6,     7,   300,
-     521,   697,   691,   588,   655,   504,   557,   536,   659,   537,
-     653,   593,   656,   695,   209,   210,   211,   212,   523,   507,
-     539,   424,   519,   701,     0,   317,     0,   290,   290,   290,
-       0,     0,     0,   640,     0,   531,     0,     0,     0,     0,
-       0,     0,     0,   290,   290,   650,   157,   507,   159,     0,
+     210,   211,   212,   679,   686,   684,   633,   687,   603,   507,
+     507,   538,   690,   700,   142,   637,   637,    18,   300,   683,
+     549,   290,   521,    20,   645,   697,   588,    22,   504,   537,
+     536,    24,   691,   593,   655,   653,   557,   421,   659,   539,
+     519,   317,   656,   695,   424,     0,     0,     0,   523,   507,
+       0,     0,     0,   701,     0,     0,     0,   290,   290,   290,
+       0,     0,     0,   640,     0,   531,     1,     2,     3,     4,
+       5,     6,     7,   290,   290,   650,   157,   507,   159,     0,
        0,   162,     0,   169,   171,   688,     0,   685,     0,     0,
        0,   694,     0,   290,     0,     0,   180,   507,     0,   182,
        0,   290,   513,   188,     0,   637,   -13,    88,     0,     0,
@@ -762,18 +763,18 @@ static const yytype_int16 yytable[] =
       24,    25,    90,    91,    92,    26,    27,    93,    94,     0,
        0,    95,    96,    97,    98,     0,    99,   100,   101,   102,
        0,     0,   103,    28,    29,   104,   105,   106,    30,    31,
-     107,    32,    33,    34,    35,    36,    37,     0,    38,    39,
-      40,    41,    42,    43,   108,   141,     0,    44,     0,   109,
-      45,    46,    47,    48,    49,    50,     0,     0,     0,    51,
-      52,    53,     0,     0,     0,     0,     0,   110,     0,     0,
-       0,     0,     0,     0,    54,     0,     0,     0,     0,     0,
-       0,     0,     0,   224,   225,   226,     0,     0,   316,     0,
-       0,     0,     0,     0,     0,    55,    56,     0,    57,     0,
-      58,    59,     0,     0,     0,     0,     0,     0,    60,   234,
+     107,    32,    33,    34,    35,     0,    36,    37,     0,    38,
+      39,    40,    41,    42,    43,   108,   141,     0,    44,     0,
+     109,    45,    46,    47,    48,    49,    50,     0,     0,     0,
+      51,    52,    53,     0,     0,     0,     0,     0,   110,     0,
+       0,     0,     0,     0,     0,    54,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   223,     0,     0,   316,     0,
+       0,     0,     0,   224,   225,   226,    55,    56,     0,    57,
+       0,    58,    59,     0,     0,     0,   227,     0,     0,    60,
+       0,     0,   228,   229,   230,   478,   231,   232,   233,   234,
      235,   236,   237,   238,   239,   240,   241,   242,   243,   244,
-     245,   246,     0,     0,     0,     0,   247,     0,     0,   248,
-     249,   250,   251,   252,     0,     0,     0,     0,   354,     0,
-       0,     0,     0,     0,   359,     0,     0,   360,   361,   362,
+     245,   246,     0,     0,     0,     0,   247,     0,   354,   248,
+     249,   250,   251,   252,   359,     0,     0,   360,   361,   362,
      363,   364,   365,   366,   367,   368,   369,   370,   371,   372,
      373,   374,   375,   376,   377,   378,   379,   380,   381,   382,
      383,   384,   385,    -3,    88,     0,   386,     0,     0,     0,
@@ -782,107 +783,102 @@ static const yytype_int16 yytable[] =
       91,    92,    26,    27,    93,    94,     0,     0,    95,    96,
       97,    98,     0,    99,   100,   101,   102,     0,     0,   103,
       28,    29,   104,   105,   106,    30,    31,   107,    32,    33,
-      34,    35,    36,    37,     0,    38,    39,    40,    41,    42,
-      43,   108,   141,     0,    44,     0,   109,    45,    46,    47,
-      48,    49,    50,     0,     0,     0,    51,    52,    53,     0,
-       0,     0,     0,     0,   110,     0,     0,     0,     0,     0,
-       0,    54,     0,     0,     0,     0,     0,     0,     0,     0,
+      34,    35,     0,    36,    37,     0,    38,    39,    40,    41,
+      42,    43,   108,   141,     0,    44,     0,   109,    45,    46,
+      47,    48,    49,    50,     0,     0,     0,    51,    52,    53,
+       0,     0,     0,     0,     0,   110,     0,     0,     0,     0,
+       0,     0,    54,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    88,    55,    56,     0,    57,     0,    58,    59,     0,
-      18,    86,   499,    19,     0,    60,    20,     0,     0,    21,
-      22,    23,    89,     0,    24,    25,    90,    91,    92,    26,
-      27,    93,    94,     0,     0,    95,    96,    97,    98,     0,
-      99,   100,   101,   102,     0,     0,   103,    28,    29,   104,
-     105,   106,    30,    31,   107,    32,    33,    34,    35,    36,
+       0,     0,    88,    55,    56,     0,    57,     0,    58,    59,
+       0,    18,    86,   499,    19,     0,    60,    20,     0,     0,
+      21,    22,    23,    89,     0,    24,    25,    90,    91,    92,
+      26,    27,    93,    94,     0,     0,    95,    96,    97,    98,
+       0,    99,   100,   101,   102,     0,     0,   103,    28,    29,
+     104,   105,   106,    30,    31,   107,    32,    33,    34,    35,
+       0,    36,    37,     0,    38,    39,    40,    41,    42,    43,
+     108,   141,     0,    44,     0,   109,    45,    46,    47,    48,
+      49,    50,     0,     0,     0,    51,    52,    53,     0,     0,
+       0,     0,     0,   110,     0,     0,     0,     0,     0,     0,
+      54,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   553,     0,     0,     0,     0,     0,     0,
+       0,    55,    56,     0,    57,     0,    58,    59,     0,     0,
+       0,     0,    88,     0,    60,     0,     0,     0,     0,     0,
+       0,    18,    86,   583,    19,     0,     0,    20,     0,     0,
+      21,    22,    23,    89,     0,    24,    25,    90,    91,    92,
+      26,    27,    93,    94,     0,     0,    95,    96,    97,    98,
+     591,    99,   100,   101,   102,     0,     0,   103,    28,    29,
+     104,   105,   106,    30,    31,   107,    32,    33,    34,    35,
+       0,    36,    37,     0,    38,    39,    40,    41,    42,    43,
+     108,   141,   604,    44,     0,   109,    45,    46,    47,    48,
+      49,    50,     0,     0,     0,    51,    52,    53,     0,     0,
+       0,     0,     0,   110,     0,     0,     0,   628,     0,     0,
+      54,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      88,    55,    56,     0,    57,     0,    58,    59,     0,    18,
+      86,   654,    19,     0,    60,    20,     0,     0,    21,    22,
+      23,    89,     0,    24,    25,    90,    91,    92,    26,    27,
+      93,    94,     0,     0,    95,    96,    97,    98,     0,    99,
+     100,   101,   102,     0,     0,   103,    28,    29,   104,   105,
+     106,    30,    31,   107,    32,    33,    34,    35,     0,    36,
       37,     0,    38,    39,    40,    41,    42,    43,   108,   141,
        0,    44,     0,   109,    45,    46,    47,    48,    49,    50,
        0,     0,     0,    51,    52,    53,     0,     0,     0,     0,
        0,   110,     0,     0,     0,     0,     0,     0,    54,     0,
-       0,     0,     0,     0,     0,     0,   223,     0,     0,     0,
-       0,     0,     0,   553,   224,   225,   226,     0,     0,    55,
-      56,     0,    57,     0,    58,    59,     0,   227,     0,   224,
-     225,   226,    60,   228,   229,   230,   478,   231,   232,   233,
-     234,   235,   236,   237,   238,   239,   240,   241,   242,   243,
-     244,   245,   246,     0,     0,     0,     0,   247,     0,     0,
-     248,   249,   250,   251,   252,   244,   245,   246,     0,     0,
-     591,     0,   247,     0,     0,   248,   249,   250,   251,   252,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    88,
-       0,     0,     0,     0,     0,     0,     0,     0,    18,    86,
-     583,    19,   604,     0,    20,     0,     0,    21,    22,    23,
-      89,     0,    24,    25,    90,    91,    92,    26,    27,    93,
-      94,     0,     0,    95,    96,    97,    98,   628,    99,   100,
-     101,   102,     0,     0,   103,    28,    29,   104,   105,   106,
-      30,    31,   107,    32,    33,    34,    35,    36,    37,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    88,    55,
+      56,     0,    57,     0,    58,    59,     0,    18,    86,   658,
+      19,     0,    60,    20,     0,     0,    21,    22,    23,    89,
+       0,    24,    25,    90,    91,    92,    26,    27,    93,    94,
+       0,     0,    95,    96,    97,    98,     0,    99,   100,   101,
+     102,     0,     0,   103,    28,    29,   104,   105,   106,    30,
+      31,   107,    32,    33,    34,    35,     0,    36,    37,     0,
       38,    39,    40,    41,    42,    43,   108,   141,     0,    44,
        0,   109,    45,    46,    47,    48,    49,    50,     0,     0,
        0,    51,    52,    53,     0,     0,     0,     0,     0,   110,
        0,     0,     0,     0,     0,     0,    54,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,    88,    55,    56,     0,
-      57,     0,    58,    59,     0,    18,    86,   654,    19,     0,
+      57,     0,    58,    59,     0,    18,    86,   673,    19,     0,
       60,    20,     0,     0,    21,    22,    23,    89,     0,    24,
       25,    90,    91,    92,    26,    27,    93,    94,     0,     0,
       95,    96,    97,    98,     0,    99,   100,   101,   102,     0,
        0,   103,    28,    29,   104,   105,   106,    30,    31,   107,
-      32,    33,    34,    35,    36,    37,     0,    38,    39,    40,
-      41,    42,    43,   108,   141,     0,    44,     0,   109,    45,
-      46,    47,    48,    49,    50,     0,     0,     0,    51,    52,
-      53,     0,     0,     0,     0,     0,   110,     0,     0,     0,
-       0,     0,     0,    54,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    88,    55,    56,     0,    57,     0,    58,
-      59,     0,    18,    86,   658,    19,     0,    60,    20,     0,
-       0,    21,    22,    23,    89,     0,    24,    25,    90,    91,
-      92,    26,    27,    93,    94,     0,     0,    95,    96,    97,
-      98,     0,    99,   100,   101,   102,     0,     0,   103,    28,
-      29,   104,   105,   106,    30,    31,   107,    32,    33,    34,
-      35,    36,    37,     0,    38,    39,    40,    41,    42,    43,
-     108,   141,     0,    44,     0,   109,    45,    46,    47,    48,
-      49,    50,     0,     0,     0,    51,    52,    53,     0,     0,
-       0,     0,     0,   110,     0,     0,     0,     0,     0,     0,
-      54,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-      88,    55,    56,     0,    57,     0,    58,    59,     0,    18,
-      86,   673,    19,     0,    60,    20,     0,     0,    21,    22,
-      23,    89,     0,    24,    25,    90,    91,    92,    26,    27,
-      93,    94,     0,     0,    95,    96,    97,    98,     0,    99,
-     100,   101,   102,     0,     0,   103,    28,    29,   104,   105,
-     106,    30,    31,   107,    32,    33,    34,    35,    36,    37,
-       0,    38,    39,    40,    41,    42,    43,   108,   141,     0,
-      44,     0,   109,    45,    46,    47,    48,    49,    50,     0,
-       0,     0,    51,    52,    53,     0,     0,     0,     0,     0,
-     110,     0,     0,     0,     0,     0,     0,    54,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    88,    55,    56,
-       0,    57,     0,    58,    59,     0,    18,    86,   677,    19,
-       0,    60,    20,     0,     0,    21,    22,    23,    89,     0,
-      24,    25,    90,    91,    92,    26,    27,    93,    94,     0,
-       0,    95,    96,    97,    98,     0,    99,   100,   101,   102,
-       0,     0,   103,    28,    29,   104,   105,   106,    30,    31,
-     107,    32,    33,    34,    35,    36,    37,     0,    38,    39,
+      32,    33,    34,    35,     0,    36,    37,     0,    38,    39,
       40,    41,    42,    43,   108,   141,     0,    44,     0,   109,
       45,    46,    47,    48,    49,    50,     0,     0,     0,    51,
       52,    53,     0,     0,     0,     0,     0,   110,     0,     0,
        0,     0,     0,     0,    54,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,    88,    55,    56,     0,    57,     0,
-      58,    59,     0,    18,    86,     0,    19,     0,    60,    20,
+      58,    59,     0,    18,    86,   677,    19,     0,    60,    20,
        0,     0,    21,    22,    23,    89,     0,    24,    25,    90,
       91,    92,    26,    27,    93,    94,     0,     0,    95,    96,
       97,    98,     0,    99,   100,   101,   102,     0,     0,   103,
       28,    29,   104,   105,   106,    30,    31,   107,    32,    33,
-      34,    35,    36,    37,     0,    38,    39,    40,    41,    42,
-      43,   108,   141,     0,    44,     0,   109,    45,    46,    47,
-      48,    49,    50,     0,     0,     0,    51,    52,    53,     0,
-       0,   698,     0,     0,   110,     0,     0,     0,     0,     0,
-       0,    54,     0,     0,     0,     0,     0,     0,     0,     0,
+      34,    35,     0,    36,    37,     0,    38,    39,    40,    41,
+      42,    43,   108,   141,     0,    44,     0,   109,    45,    46,
+      47,    48,    49,    50,     0,     0,     0,    51,    52,    53,
+       0,     0,     0,     0,     0,   110,     0,     0,     0,     0,
+       0,     0,    54,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    88,    55,    56,     0,    57,     0,    58,    59,     0,
-      18,    86,     0,    19,     0,    60,    20,     0,     0,    21,
-      22,    23,    89,     0,    24,    25,    90,    91,    92,    26,
-      27,    93,    94,     0,     0,    95,    96,    97,    98,     0,
-      99,   100,   101,   102,     0,     0,   103,    28,    29,   104,
-     105,   106,    30,    31,   107,    32,    33,    34,    35,    36,
+       0,     0,    88,    55,    56,     0,    57,     0,    58,    59,
+       0,    18,    86,     0,    19,     0,    60,    20,     0,     0,
+      21,    22,    23,    89,     0,    24,    25,    90,    91,    92,
+      26,    27,    93,    94,     0,     0,    95,    96,    97,    98,
+       0,    99,   100,   101,   102,     0,     0,   103,    28,    29,
+     104,   105,   106,    30,    31,   107,    32,    33,    34,    35,
+       0,    36,    37,     0,    38,    39,    40,    41,    42,    43,
+     108,   141,     0,    44,     0,   109,    45,    46,    47,    48,
+      49,    50,     0,     0,     0,    51,    52,    53,     0,     0,
+     698,     0,     0,   110,     0,     0,     0,     0,     0,     0,
+      54,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      88,    55,    56,     0,    57,     0,    58,    59,     0,    18,
+      86,     0,    19,     0,    60,    20,     0,     0,    21,    22,
+      23,    89,     0,    24,    25,    90,    91,    92,    26,    27,
+      93,    94,     0,     0,    95,    96,    97,    98,     0,    99,
+     100,   101,   102,     0,     0,   103,    28,    29,   104,   105,
+     106,    30,    31,   107,    32,    33,    34,    35,     0,    36,
       37,     0,    38,    39,    40,    41,    42,    43,   108,   141,
        0,    44,     0,   109,    45,    46,    47,    48,    49,    50,
        0,     0,     0,    51,    52,    53,     0,     0,     0,     0,
@@ -894,80 +890,81 @@ static const yytype_int16 yytable[] =
        0,    24,    25,    90,    91,    92,    26,    27,    93,    94,
        0,     0,    95,    96,    97,    98,     0,    99,   100,   101,
      102,     0,     0,   103,    28,    29,   104,   105,   106,    30,
-      31,   107,    32,    33,    34,    35,    36,    37,     0,    38,
-      39,    40,    41,    42,    43,   108,     0,     0,    44,     0,
-     109,    45,    46,    47,    48,    49,    50,     0,     0,     0,
-      51,    52,    53,     0,    88,     0,     0,     0,   110,     0,
-       0,     0,     0,    18,     0,    54,    19,     0,     0,    20,
-       0,     0,    21,    22,    23,   -59,     0,    24,    25,     0,
-       0,     0,    26,    27,     0,     0,    55,    56,     0,    57,
-       0,    58,    59,     0,     0,     0,     0,     0,     0,    60,
-      28,    29,     0,     0,     0,    30,    31,     0,    32,    33,
-      34,    35,    36,    37,     0,    38,    39,    40,    41,    42,
-      43,     0,     0,     0,    44,     0,     0,    45,    46,    47,
-      48,    49,    50,     0,     0,    88,    51,    52,    53,     0,
-       0,     0,     0,     0,    18,     0,     0,    19,     0,     0,
-      20,    54,     0,    21,    22,    23,     0,     0,    24,    25,
-       0,     0,     0,    26,    27,     0,     0,     0,     0,     0,
-       0,     0,    55,    56,     0,    57,     0,    58,    59,     0,
-       0,    28,    29,     0,     0,    60,    30,    31,     0,    32,
-      33,    34,    35,    36,    37,     0,    38,    39,    40,    41,
-      42,    43,     0,     0,     0,    44,     0,     0,    45,    46,
-      47,    48,    49,    50,     0,     0,     0,    51,    52,    53,
-       0,     0,     0,     0,     0,    18,    86,     0,    19,     0,
-       0,    20,    54,     0,    21,    22,    23,     0,     0,    24,
-      25,     0,     0,     0,    26,    27,     0,     0,     0,     0,
-       0,     0,     0,    55,    56,     0,    57,     0,    58,    59,
-       0,     0,    28,    29,     0,   -59,    60,    30,    31,     0,
-      32,   189,    34,    35,    36,    37,   151,    38,    39,    40,
+      31,   107,    32,    33,    34,    35,     0,    36,    37,     0,
+      38,    39,    40,    41,    42,    43,   108,     0,     0,    44,
+       0,   109,    45,    46,    47,    48,    49,    50,     0,     0,
+       0,    51,    52,    53,     0,    88,     0,     0,     0,   110,
+       0,     0,     0,     0,    18,     0,    54,    19,     0,     0,
+      20,     0,     0,    21,    22,    23,   -59,     0,    24,    25,
+       0,     0,     0,    26,    27,     0,     0,    55,    56,     0,
+      57,     0,    58,    59,     0,     0,     0,     0,     0,     0,
+      60,    28,    29,     0,     0,     0,    30,    31,     0,    32,
+      33,    34,    35,     0,    36,    37,     0,    38,    39,    40,
       41,    42,    43,     0,     0,     0,    44,     0,     0,    45,
-      46,    47,    48,    49,    50,     0,     0,     0,    51,    52,
-      53,     0,     0,     0,     0,     0,    18,    86,     0,    19,
+      46,    47,    48,    49,    50,     0,     0,    88,    51,    52,
+      53,     0,     0,     0,     0,     0,    18,     0,     0,    19,
        0,     0,    20,    54,     0,    21,    22,    23,     0,     0,
       24,    25,     0,     0,     0,    26,    27,     0,     0,     0,
        0,     0,     0,     0,    55,    56,     0,    57,     0,    58,
       59,     0,     0,    28,    29,     0,     0,    60,    30,    31,
-       0,    32,    33,    34,    35,    36,    37,     0,    38,    39,
-      40,    41,    42,    43,     0,     0,     0,    44,     0,     0,
-      45,    46,    47,    48,    49,    50,     0,     0,     0,    51,
-      52,    53,     0,     0,     0,     0,     0,    18,     0,     0,
-      19,     0,     0,    20,    54,     0,    21,    22,    23,     0,
-       0,    24,    25,     0,     0,     0,    26,    27,     0,     0,
-       0,     0,     0,     0,     0,    55,    56,     0,    57,     0,
-      58,    59,     0,     0,    28,    29,     0,     0,    60,    30,
-      31,     0,    32,    33,    34,    35,    36,    37,     0,    38,
+       0,    32,    33,    34,    35,     0,    36,    37,     0,    38,
       39,    40,    41,    42,    43,     0,     0,     0,    44,     0,
        0,    45,    46,    47,    48,    49,    50,     0,     0,     0,
-      51,    52,    53,     0,     0,     0,     0,     0,    18,     0,
+      51,    52,    53,     0,     0,     0,     0,     0,    18,    86,
        0,    19,     0,     0,    20,    54,     0,    21,    22,    23,
        0,     0,    24,    25,     0,     0,     0,    26,    27,     0,
        0,     0,     0,     0,     0,     0,    55,    56,     0,    57,
-       0,    58,    59,     0,     0,    28,    29,     0,   207,    60,
-      30,    31,     0,    32,    33,    34,    35,    36,    37,     0,
-      38,    39,    40,    41,    42,    43,     0,     0,     0,    44,
-       0,     0,    45,    46,    47,    48,    49,    50,     0,     0,
-       0,    51,    52,    53,     0,     0,     0,     0,     0,    18,
-       0,     0,    19,     0,     0,    20,    54,     0,    21,    22,
-      23,     0,     0,    24,    25,     0,     0,     0,    26,    27,
-       0,     0,     0,     0,     0,     0,     0,    55,    56,     0,
-      57,     0,    58,    59,     0,     0,    28,    29,     0,   321,
-      60,    30,    31,     0,    32,    33,    34,    35,    36,    37,
-       0,    38,    39,    40,    41,    42,    43,     0,     0,     0,
+       0,    58,    59,     0,     0,    28,    29,     0,   -59,    60,
+      30,    31,     0,    32,   189,    34,    35,     0,    36,    37,
+     151,    38,    39,    40,    41,    42,    43,     0,     0,     0,
       44,     0,     0,    45,    46,    47,    48,    49,    50,     0,
        0,     0,    51,    52,    53,     0,     0,     0,     0,     0,
-    -369,   254,     0,   255,     0,     0,  -369,    54,     0,  -369,
-    -369,  -369,     0,     0,  -369,  -369,     0,     0,     0,  -369,
-    -369,     0,     0,     0,     0,     0,     0,     0,    55,    56,
-       0,    57,     0,    58,    59,     0,     0,  -369,  -369,     0,
-     339,    60,  -369,  -369,     0,  -369,  -369,  -369,  -369,  -369,
-    -369,     0,  -369,  -369,  -369,  -369,  -369,  -369,     0,     0,
-       0,  -369,     0,     0,  -369,  -369,  -369,  -369,  -369,  -369,
-       0,     0,     0,  -369,  -369,  -369,     0,     0,     0,     0,
-       0,    18,     0,     0,    19,     0,     0,    20,  -369,     0,
-      21,    22,    23,     0,     0,    24,    25,     0,     0,     0,
-      26,    27,     0,     0,     0,     0,     0,     0,     0,  -369,
-    -369,     0,  -369,     0,  -369,  -369,     0,     0,    28,    29,
-       0,     0,  -369,    30,    31,     0,    32,    33,    34,    35,
+      18,    86,     0,    19,     0,     0,    20,    54,     0,    21,
+      22,    23,     0,     0,    24,    25,     0,     0,     0,    26,
+      27,     0,     0,     0,     0,     0,     0,     0,    55,    56,
+       0,    57,     0,    58,    59,     0,     0,    28,    29,     0,
+       0,    60,    30,    31,     0,    32,    33,    34,    35,     0,
+      36,    37,     0,    38,    39,    40,    41,    42,    43,     0,
+       0,     0,    44,     0,     0,    45,    46,    47,    48,    49,
+      50,     0,     0,     0,    51,    52,    53,     0,     0,     0,
+       0,     0,    18,     0,     0,    19,     0,     0,    20,    54,
+       0,    21,    22,    23,     0,     0,    24,    25,     0,     0,
+       0,    26,    27,     0,     0,     0,     0,     0,     0,     0,
+      55,    56,     0,    57,     0,    58,    59,     0,     0,    28,
+      29,     0,     0,    60,    30,    31,     0,    32,    33,    34,
+      35,     0,    36,    37,     0,    38,    39,    40,    41,    42,
+      43,     0,     0,     0,    44,     0,     0,    45,    46,    47,
+      48,    49,    50,     0,     0,     0,    51,    52,    53,     0,
+       0,     0,     0,     0,    18,     0,     0,    19,     0,     0,
+      20,    54,     0,    21,    22,    23,     0,     0,    24,    25,
+       0,     0,     0,    26,    27,     0,     0,     0,     0,     0,
+       0,     0,    55,    56,     0,    57,     0,    58,    59,     0,
+       0,    28,    29,     0,   207,    60,    30,    31,     0,    32,
+      33,    34,    35,     0,    36,    37,     0,    38,    39,    40,
+      41,    42,    43,     0,     0,     0,    44,     0,     0,    45,
+      46,    47,    48,    49,    50,     0,     0,     0,    51,    52,
+      53,     0,     0,     0,     0,     0,    18,     0,     0,    19,
+       0,     0,    20,    54,     0,    21,    22,    23,     0,     0,
+      24,    25,     0,     0,     0,    26,    27,     0,     0,     0,
+       0,     0,     0,     0,    55,    56,     0,    57,     0,    58,
+      59,     0,     0,    28,    29,     0,   321,    60,    30,    31,
+       0,    32,    33,    34,    35,     0,    36,    37,     0,    38,
+      39,    40,    41,    42,    43,     0,     0,     0,    44,     0,
+       0,    45,    46,    47,    48,    49,    50,     0,     0,     0,
+      51,    52,    53,     0,     0,     0,     0,     0,  -369,   254,
+       0,   255,     0,     0,  -369,    54,     0,  -369,  -369,  -369,
+       0,     0,  -369,  -369,     0,     0,     0,  -369,  -369,     0,
+       0,     0,     0,     0,     0,     0,    55,    56,     0,    57,
+       0,    58,    59,     0,     0,  -369,  -369,     0,   339,    60,
+    -369,  -369,     0,  -369,  -369,  -369,  -369,     0,  -369,  -369,
+       0,  -369,  -369,  -369,  -369,  -369,  -369,     0,     0,     0,
+    -369,     0,     0,  -369,  -369,  -369,  -369,  -369,  -369,     0,
+       0,     0,  -369,  -369,  -369,     0,     0,     0,     0,     0,
+      18,     0,     0,    19,     0,     0,    20,  -369,     0,    21,
+      22,    23,     0,     0,    24,    25,     0,     0,     0,    26,
+      27,     0,     0,     0,     0,     0,     0,     0,  -369,  -369,
+       0,  -369,     0,  -369,  -369,     0,     0,    28,    29,     0,
+       0,  -369,    30,    31,     0,    32,    33,    34,    35,     0,
       36,    37,     0,    38,    39,    40,    41,    42,    43,     0,
        0,     0,    44,     0,     0,    45,    46,    47,    48,    49,
       50,     0,     0,     0,    51,    52,    53,     0,     0,     0,
@@ -976,164 +973,171 @@ static const yytype_int16 yytable[] =
        0,    26,    27,     0,     0,     0,     0,     0,     0,     0,
       55,    56,     0,    57,     0,    58,    59,     0,     0,    28,
       29,     0,   357,    60,    30,    31,     0,    32,    33,    34,
-      35,    36,    37,     0,    38,    39,    40,    41,    42,    43,
-       0,     0,     0,    44,     0,     0,    45,    46,    47,    48,
-      49,    50,     0,     0,     0,    51,    52,    53,     0,     0,
-       0,     0,     0,    18,     0,     0,    19,     0,     0,    20,
-      54,     0,    21,    22,    23,     0,     0,    24,    25,     0,
-       0,     0,    26,    27,     0,     0,     0,     0,     0,     0,
-       0,    55,    56,     0,    57,     0,    58,    59,     0,     0,
-      28,    29,     0,   399,    60,    30,    31,     0,    32,    33,
-      34,    35,    36,    37,     0,    38,    39,    40,    41,    42,
+      35,     0,    36,    37,     0,    38,    39,    40,    41,    42,
       43,     0,     0,     0,    44,     0,     0,    45,    46,    47,
       48,    49,    50,     0,     0,     0,    51,    52,    53,     0,
        0,     0,     0,     0,    18,     0,     0,    19,     0,     0,
       20,    54,     0,    21,    22,    23,     0,     0,    24,    25,
        0,     0,     0,    26,    27,     0,     0,     0,     0,     0,
        0,     0,    55,    56,     0,    57,     0,    58,    59,     0,
-       0,    28,    29,     0,   454,    60,    30,    31,     0,    32,
-      33,    34,    35,    36,    37,     0,    38,    39,    40,    41,
-      42,    43,     0,     0,     0,    44,     0,     0,    45,    46,
-      47,    48,    49,    50,     0,     0,     0,    51,    52,    53,
-       0,     0,     0,     0,     0,    18,     0,     0,    19,     0,
-       0,    20,    54,     0,    21,    22,    23,     0,     0,    24,
-      25,     0,     0,     0,    26,    27,     0,     0,     0,     0,
-       0,     0,     0,    55,    56,     0,    57,     0,    58,    59,
-       0,     0,    28,    29,     0,   488,    60,    30,    31,     0,
-      32,    33,    34,    35,    36,    37,     0,    38,    39,    40,
+       0,    28,    29,     0,   399,    60,    30,    31,     0,    32,
+      33,    34,    35,     0,    36,    37,     0,    38,    39,    40,
       41,    42,    43,     0,     0,     0,    44,     0,     0,    45,
       46,    47,    48,    49,    50,     0,     0,     0,    51,    52,
       53,     0,     0,     0,     0,     0,    18,     0,     0,    19,
        0,     0,    20,    54,     0,    21,    22,    23,     0,     0,
       24,    25,     0,     0,     0,    26,    27,     0,     0,     0,
        0,     0,     0,     0,    55,    56,     0,    57,     0,    58,
-      59,     0,     0,    28,    29,     0,     0,    60,    30,    31,
-       0,    32,    33,    34,    35,    36,    37,     0,    38,    39,
-      40,    41,    42,    43,     0,     0,     0,    44,     0,     0,
-      45,    46,    47,    48,    49,    50,     0,     0,     0,    51,
-      52,    53,     0,     0,     0,     0,     0,  -368,     0,     0,
-    -368,     0,     0,  -368,    54,     0,  -368,  -368,  -368,     0,
-       0,  -368,  -368,     0,     0,     0,  -368,  -368,     0,     0,
-       0,     0,     0,     0,     0,    55,    56,     0,    57,     0,
-      58,    59,     0,     0,  -368,  -368,     0,     0,   315,  -368,
-    -368,     0,  -368,  -368,  -368,  -368,  -368,  -368,     0,  -368,
-    -368,  -368,  -368,  -368,  -368,     0,     0,     0,  -368,     0,
-       0,  -368,  -368,  -368,  -368,  -368,  -368,     0,     0,     0,
-    -368,  -368,  -368,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,  -368,     0,     0,     0,   223,
-       0,     0,     0,     0,     0,     0,     0,   224,   225,   226,
-       0,     0,     0,     0,     0,     0,  -368,  -368,     0,  -368,
-     227,  -368,  -368,     0,     0,     0,   228,   229,   230,  -368,
+      59,     0,     0,    28,    29,     0,   454,    60,    30,    31,
+       0,    32,    33,    34,    35,     0,    36,    37,     0,    38,
+      39,    40,    41,    42,    43,     0,     0,     0,    44,     0,
+       0,    45,    46,    47,    48,    49,    50,     0,     0,     0,
+      51,    52,    53,     0,     0,     0,     0,     0,    18,     0,
+       0,    19,     0,     0,    20,    54,     0,    21,    22,    23,
+       0,     0,    24,    25,     0,     0,     0,    26,    27,     0,
+       0,     0,     0,     0,     0,     0,    55,    56,     0,    57,
+       0,    58,    59,     0,     0,    28,    29,     0,   488,    60,
+      30,    31,     0,    32,    33,    34,    35,     0,    36,    37,
+       0,    38,    39,    40,    41,    42,    43,     0,     0,     0,
+      44,     0,     0,    45,    46,    47,    48,    49,    50,     0,
+       0,     0,    51,    52,    53,     0,     0,     0,     0,     0,
+      18,     0,     0,    19,     0,     0,    20,    54,     0,    21,
+      22,    23,     0,     0,    24,    25,     0,     0,     0,    26,
+      27,     0,     0,     0,     0,     0,     0,     0,    55,    56,
+       0,    57,     0,    58,    59,     0,     0,    28,    29,     0,
+       0,    60,    30,    31,     0,    32,    33,    34,    35,     0,
+      36,    37,     0,    38,    39,    40,    41,    42,    43,     0,
+       0,     0,    44,     0,     0,    45,    46,    47,    48,    49,
+      50,     0,     0,     0,    51,    52,    53,     0,     0,     0,
+       0,     0,  -368,     0,     0,  -368,     0,     0,  -368,    54,
+       0,  -368,  -368,  -368,     0,     0,  -368,  -368,     0,     0,
+       0,  -368,  -368,     0,     0,     0,     0,     0,     0,     0,
+      55,    56,     0,    57,     0,    58,    59,   224,   225,  -368,
+    -368,     0,     0,   315,  -368,  -368,     0,  -368,  -368,  -368,
+    -368,     0,  -368,  -368,     0,  -368,  -368,  -368,  -368,  -368,
+    -368,     0,     0,     0,  -368,     0,     0,  -368,  -368,  -368,
+    -368,  -368,  -368,     0,   245,   246,  -368,  -368,  -368,     0,
+     247,     0,     0,   248,   249,   250,   251,   252,     0,     0,
+       0,  -368,     0,     0,     0,   223,     0,     0,     0,     0,
+       0,     0,     0,   224,   225,   226,     0,     0,     0,     0,
+       0,     0,  -368,  -368,     0,  -368,   227,  -368,  -368,     0,
+       0,     0,   228,   229,   230,  -368,   231,   232,   233,   234,
+     235,   236,   237,   238,   239,   240,   241,   242,   243,   244,
+     245,   246,     0,     0,     0,     0,   247,   223,     0,   248,
+     249,   250,   251,   252,     0,   224,   225,   226,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,  -370,     0,
+       0,     0,     0,     0,   228,   229,   230,     0,   231,   232,
+     233,   234,   235,   236,   237,   238,   239,   240,   241,   242,
+     243,   244,   245,   246,     0,     0,     0,     0,   247,   223,
+       0,   248,   249,   250,   251,   252,     0,   224,   225,   226,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   228,   229,   230,     0,
      231,   232,   233,   234,   235,   236,   237,   238,   239,   240,
      241,   242,   243,   244,   245,   246,     0,     0,     0,     0,
      247,   223,     0,   248,   249,   250,   251,   252,     0,   224,
      225,   226,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,  -370,     0,     0,     0,     0,     0,   228,   229,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
      230,     0,   231,   232,   233,   234,   235,   236,   237,   238,
      239,   240,   241,   242,   243,   244,   245,   246,     0,     0,
-       0,     0,   247,   223,     0,   248,   249,   250,   251,   252,
+       0,     0,   247,  -370,     0,   248,   249,   250,   251,   252,
        0,   224,   225,   226,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     228,   229,   230,     0,   231,   232,   233,   234,   235,   236,
+       0,     0,     0,     0,   231,   232,   233,   234,   235,   236,
      237,   238,   239,   240,   241,   242,   243,   244,   245,   246,
-       0,     0,     0,     0,   247,   223,     0,   248,   249,   250,
-     251,   252,     0,   224,   225,   226,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   224,   225,     0,   230,     0,   231,   232,   233,   234,
-     235,   236,   237,   238,   239,   240,   241,   242,   243,   244,
-     245,   246,     0,     0,     0,     0,   247,  -370,     0,   248,
-     249,   250,   251,   252,     0,   224,   225,   226,   245,   246,
+     224,   225,   226,     0,   247,     0,     0,   248,   249,   250,
+     251,   252,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   224,   225,   226,   234,   235,   236,   237,
+     238,   239,   240,   241,   242,   243,   244,   245,   246,     0,
+       0,     0,     0,   247,     0,     0,   248,   249,   250,   251,
+     252,   236,   237,   238,   239,   240,   241,   242,   243,   244,
+     245,   246,   224,   225,   226,     0,   247,     0,     0,   248,
+     249,   250,   251,   252,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   224,   225,   226,     0,     0,     0,     0,
+       0,   237,   238,   239,   240,   241,   242,   243,   244,   245,
+     246,     0,   224,   225,   226,   247,     0,     0,   248,   249,
+     250,   251,   252,   238,   239,   240,   241,   242,   243,   244,
+     245,   246,   224,   225,   226,     0,   247,     0,     0,   248,
+     249,   250,   251,   252,   240,   241,   242,   243,   244,   245,
+     246,   224,   225,   226,     0,   247,     0,     0,   248,   249,
+     250,   251,   252,     0,     0,     0,   242,   243,   244,   245,
+     246,   224,   225,   226,     0,   247,     0,     0,   248,   249,
+     250,   251,   252,     0,     0,  -370,   243,   244,   245,   246,
+     224,   225,   226,     0,   247,     0,     0,   248,   249,   250,
+     251,   252,     0,     0,     0,     0,   243,   244,   245,   246,
        0,     0,     0,     0,   247,     0,     0,   248,   249,   250,
-     251,   252,     0,     0,     0,     0,     0,     0,   231,   232,
-     233,   234,   235,   236,   237,   238,   239,   240,   241,   242,
-     243,   244,   245,   246,   224,   225,   226,     0,   247,     0,
-       0,   248,   249,   250,   251,   252,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   224,   225,   226,     0,
-       0,     0,   236,   237,   238,   239,   240,   241,   242,   243,
-     244,   245,   246,     0,   224,   225,   226,   247,     0,     0,
-     248,   249,   250,   251,   252,   237,   238,   239,   240,   241,
-     242,   243,   244,   245,   246,   224,   225,   226,     0,   247,
-       0,     0,   248,   249,   250,   251,   252,     0,   242,   243,
-     244,   245,   246,     0,   224,   225,   226,   247,     0,     0,
-     248,   249,   250,   251,   252,   238,   239,   240,   241,   242,
-     243,   244,   245,   246,   224,   225,   226,     0,   247,     0,
-       0,   248,   249,   250,   251,   252,   240,   241,   242,   243,
-     244,   245,   246,   224,   225,   226,     0,   247,     0,     0,
-     248,   249,   250,   251,   252,     0,     0,     0,  -370,   243,
-     244,   245,   246,     0,     0,     0,     0,   247,     0,     0,
-     248,   249,   250,   251,   252,     0,     0,     0,   243,   244,
-     245,   246,     0,     0,     0,     0,   247,     0,     0,   248,
-     249,   250,   251,   252
+     251,   252,     0,     0,     0,     0,   244,   245,   246,     0,
+       0,     0,     0,   247,     0,     0,   248,   249,   250,   251,
+     252
 };
 
 static const yytype_int16 yycheck[] =
 {
       10,    17,   174,   428,    19,    49,    27,    11,    27,    19,
       54,    12,    11,   175,    18,   165,    20,   110,    22,   331,
-      24,    25,   105,    16,   606,    29,    10,    22,   580,    16,
-      34,    35,     9,    15,    14,    19,   103,    52,   200,    49,
-      14,    23,    52,    30,    48,    49,    50,    51,    11,    89,
-      13,    16,   135,     0,    18,    20,    20,    11,    22,    24,
-      24,    25,    56,    27,    59,   112,   113,    61,    52,    13,
-      34,    35,    93,    18,    93,    31,    60,    22,    14,    24,
-      25,    13,   110,   111,   418,    49,    42,    51,    25,    34,
-      35,    11,   132,    11,   428,    13,    16,   101,   132,   433,
-     434,    13,   132,    16,    49,    25,    51,    20,   132,    86,
-      11,    24,    13,   695,    94,    95,    96,    97,    15,    56,
-      94,    95,    96,    97,    61,    11,   136,    13,    11,    93,
-     682,   175,    96,   132,    14,   122,    56,   102,   148,   132,
-     141,    61,   163,    32,   163,   132,    35,    36,    37,    38,
-     194,   195,    41,    14,    86,   327,   200,   112,    94,    95,
-      96,    97,   172,   173,   174,   175,    14,   317,    86,   132,
-     185,   186,   110,    11,    86,   185,   186,   181,    14,    11,
-     164,    13,   186,    14,    22,    86,   520,    11,    11,    13,
-     200,   132,   285,    11,   178,   288,    96,    97,    16,   163,
-     184,   185,   186,   129,   130,    94,    95,    96,    97,   122,
-      11,    11,    56,    13,    94,    95,    96,    97,    11,   132,
-      13,    22,   186,    33,    34,   209,   210,   211,   212,    56,
-     214,   215,   216,    94,    95,    96,    97,   132,    56,   573,
-     574,   186,   131,    61,   132,   261,    94,    95,    96,    97,
-     132,   272,   262,   272,    86,   265,   132,   132,    94,    95,
-      96,    97,   132,    94,    95,    96,    97,   692,    11,   253,
+      24,    25,   105,   606,    22,    29,    10,    13,   580,    16,
+      34,    35,     9,    13,    13,    19,   103,    52,   200,    49,
+      90,    16,    52,    30,    48,    49,    50,    51,    11,    15,
+       0,    11,   135,    13,    18,    25,    20,    23,    22,    22,
+      24,    25,    60,    27,    11,   113,   114,    11,    52,    13,
+      34,    35,    93,    18,    93,    22,    60,    22,    11,    24,
+      25,   133,    56,   133,   418,    49,    56,    51,    62,    34,
+      35,    31,    62,    11,   428,    13,    11,   101,    13,   433,
+     434,    87,    42,    11,    49,   133,    51,    87,    16,    86,
+      10,    11,   695,    13,    16,   133,    16,    25,    20,    16,
+      20,   113,    24,    20,    24,    25,   136,    24,    14,    93,
+     682,   175,    96,    14,   133,    15,   123,    16,   148,   111,
+     141,    20,   163,    87,   163,    24,   133,    11,    56,    13,
+     194,   195,   133,    14,    62,   327,   200,    57,   133,    11,
+      11,    13,   172,   173,   174,   175,    14,   317,    11,    87,
+     185,   186,    87,   133,    56,   185,   186,   181,    11,    11,
+     164,    13,   186,    16,    84,    11,   520,    13,    56,    11,
+     200,    13,   285,    11,   178,   288,    87,   111,   112,   163,
+     184,   185,   186,    97,    98,   133,   103,    22,   133,    95,
+      96,    97,    98,   133,    95,    96,    97,    98,    95,    96,
+      97,    98,   186,    56,   133,   209,   210,   211,   212,    62,
+     214,   215,   216,   133,    95,    96,    97,    98,   133,   573,
+     574,   186,   130,   131,   123,   261,   133,    95,    96,    97,
+      98,   272,   262,   272,   133,   265,    32,    14,    22,    35,
+      36,    37,    38,    14,    39,    41,    22,   692,    22,   253,
      254,   255,   256,   257,   258,   259,   260,    22,   590,   613,
-      11,    39,    13,    16,    22,   289,    22,    20,   252,    14,
-     334,    24,   269,   270,   271,    22,   273,   274,    86,   276,
-     277,   278,   279,   611,   387,   467,    22,   641,   272,   293,
-     294,   295,   296,   297,   298,    22,    70,   327,   333,    10,
-      11,    22,    13,   333,    86,    16,    22,   661,   132,    20,
-      22,   315,    89,    24,    25,    94,    95,    96,    97,   647,
-     648,   649,   131,    13,   131,    94,    95,    96,    97,   333,
-     126,   127,   128,   129,   130,   663,   664,    22,    56,   343,
-     132,    56,   534,    56,   348,    44,    57,    94,    95,    96,
-      97,   122,   131,   294,   295,   683,   297,   298,    94,    95,
-      96,    97,   131,   691,    61,    16,   390,    94,    95,    96,
-      97,    15,    83,    94,    95,    96,    97,    59,    94,    95,
-      96,    97,    59,   413,   388,   389,    90,    10,   429,   131,
-     429,    12,   396,    16,    13,    25,   588,    20,   428,   435,
-      25,    24,   132,   467,    18,   587,   390,    30,    99,    94,
-      95,    96,    97,   417,   418,    25,    25,    56,    80,    22,
-      99,   132,   132,   132,   428,    11,    80,   431,   432,   433,
-     434,   461,    12,   430,   132,   465,   420,   467,   131,   436,
-      12,    12,   439,    12,    32,   429,    12,    35,    36,    37,
-      38,   131,    16,    41,   132,   490,   118,   131,   131,    22,
-     490,   123,   459,   131,   126,   127,   128,   129,   130,   123,
-     474,   131,   126,   127,   128,   129,   130,    94,    95,    96,
-      97,   568,   569,   131,   131,    11,   490,   132,   575,    94,
-      95,    96,    97,    99,   581,   582,    11,   527,    56,   529,
-      90,    12,   131,   500,   534,   502,    94,    95,    96,    97,
-      94,    95,    96,    97,   131,   512,   520,    22,    15,   554,
-     131,    22,    22,   587,   554,   509,   131,   614,   615,   616,
-     132,   131,   131,   620,    94,    95,    96,    97,   131,    88,
-     132,   545,   131,    94,    95,    96,    97,   131,   635,   131,
-     554,   132,    22,   589,   131,   642,   643,   587,   588,    94,
-      95,    96,    97,    45,   131,    17,   602,    87,   565,   573,
-     574,   131,   131,    13,   131,   605,   606,   131,   612,   666,
-     131,   611,     3,     4,     5,     6,     7,     8,     9,   141,
-     431,   692,   679,   529,   630,   413,   131,   452,   634,   453,
-     622,   540,   632,   690,    94,    95,    96,    97,   612,   613,
-     459,   272,   429,   700,    -1,   163,    -1,   647,   648,   649,
-      -1,    -1,    -1,   607,    -1,   622,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   663,   664,   619,    21,   641,    23,    -1,
+      95,    96,    97,    98,    14,   289,    14,    81,   252,    14,
+     334,    71,   269,   270,   271,    87,   273,   274,   133,   276,
+     277,   278,   279,    90,   387,   467,    22,   641,   272,   293,
+     294,   295,   296,   297,   298,    22,   132,   327,   333,    95,
+      96,    97,    98,   333,    22,   119,   132,   661,    33,    34,
+     124,   315,    13,   127,   128,   129,   130,   131,    95,    96,
+      97,    98,   611,    56,    95,    96,    97,    98,    56,   333,
+      95,    96,    97,    98,    22,    56,   132,   294,   295,   343,
+     297,   298,   534,    22,   348,    95,    96,    97,    98,    44,
+      95,    96,    97,    98,    95,    96,    97,    98,   647,   648,
+     649,   127,   128,   129,   130,   131,   390,   123,    95,    96,
+      97,    98,   133,    62,   663,   664,    16,    95,    96,    97,
+      98,    15,    59,   413,   388,   389,    59,    91,   429,   132,
+     429,   132,   396,    13,   683,    12,   588,    25,   428,   435,
+      25,    25,   691,   467,    25,   587,   390,    95,    96,    97,
+      98,   133,    56,   417,   418,    18,    95,    96,    97,    98,
+      95,    96,    97,    98,   428,    81,   100,   431,   432,   433,
+     434,   461,    22,   430,   133,   465,   420,   467,   100,   436,
+      11,   133,   439,    32,    12,   429,    35,    36,    37,    38,
+     132,   132,    41,   133,    12,   490,    12,   132,    12,    12,
+     490,   132,   459,    95,    96,    97,    98,    16,   124,   133,
+     474,   127,   128,   129,   130,   131,    95,    96,    97,    98,
+     132,   568,   569,    22,   132,   132,   490,   132,   575,    95,
+      96,    97,    98,   132,   581,   582,   133,   527,    11,   529,
+     132,    56,   100,   500,   534,   502,    95,    96,    97,    98,
+      11,    91,    12,   132,   132,   512,   520,    22,    15,   554,
+     132,    45,   133,   587,   554,   509,   132,   614,   615,   616,
+     132,    22,   132,   620,    95,    96,    97,    98,   132,    89,
+     133,   545,    22,    95,    96,    97,    98,   132,   635,   132,
+     554,   133,    22,   589,   132,   642,   643,   587,   588,    95,
+      96,    97,    98,   132,    17,   132,   602,    88,   565,   573,
+     574,   132,   132,   132,    13,   605,   606,    10,   141,   666,
+     132,   611,   431,    16,   612,   692,   529,    20,   413,   453,
+     452,    24,   679,   540,   630,   622,   132,    30,   634,   459,
+     429,   163,   632,   690,   272,    -1,    -1,    -1,   612,   613,
+      -1,    -1,    -1,   700,    -1,    -1,    -1,   647,   648,   649,
+      -1,    -1,    -1,   607,    -1,   622,     3,     4,     5,     6,
+       7,     8,     9,   663,   664,   619,    21,   641,    23,    -1,
       -1,    26,    -1,    28,    29,   675,    -1,   671,    -1,    -1,
       -1,   687,    -1,   683,    -1,    -1,    41,   661,    -1,    44,
       -1,   691,   692,    48,    -1,   695,     0,     1,    -1,    -1,
@@ -1142,18 +1146,18 @@ static const yytype_int16 yycheck[] =
       24,    25,    26,    27,    28,    29,    30,    31,    32,    -1,
       -1,    35,    36,    37,    38,    -1,    40,    41,    42,    43,
       -1,    -1,    46,    47,    48,    49,    50,    51,    52,    53,
-      54,    55,    56,    57,    58,    59,    60,    -1,    62,    63,
-      64,    65,    66,    67,    68,    69,    -1,    71,    -1,    73,
-      74,    75,    76,    77,    78,    79,    -1,    -1,    -1,    83,
-      84,    85,    -1,    -1,    -1,    -1,    -1,    91,    -1,    -1,
-      -1,    -1,    -1,    -1,    98,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    80,    81,    82,    -1,    -1,   163,    -1,
-      -1,    -1,    -1,    -1,    -1,   119,   120,    -1,   122,    -1,
-     124,   125,    -1,    -1,    -1,    -1,    -1,    -1,   132,   106,
-     107,   108,   109,   110,   111,   112,   113,   114,   115,   116,
-     117,   118,    -1,    -1,    -1,    -1,   123,    -1,    -1,   126,
-     127,   128,   129,   130,    -1,    -1,    -1,    -1,   213,    -1,
-      -1,    -1,    -1,    -1,   219,    -1,    -1,   222,   223,   224,
+      54,    55,    56,    57,    58,    -1,    60,    61,    -1,    63,
+      64,    65,    66,    67,    68,    69,    70,    -1,    72,    -1,
+      74,    75,    76,    77,    78,    79,    80,    -1,    -1,    -1,
+      84,    85,    86,    -1,    -1,    -1,    -1,    -1,    92,    -1,
+      -1,    -1,    -1,    -1,    -1,    99,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    73,    -1,    -1,   163,    -1,
+      -1,    -1,    -1,    81,    82,    83,   120,   121,    -1,   123,
+      -1,   125,   126,    -1,    -1,    -1,    94,    -1,    -1,   133,
+      -1,    -1,   100,   101,   102,   103,   104,   105,   106,   107,
+     108,   109,   110,   111,   112,   113,   114,   115,   116,   117,
+     118,   119,    -1,    -1,    -1,    -1,   124,    -1,   213,   127,
+     128,   129,   130,   131,   219,    -1,    -1,   222,   223,   224,
      225,   226,   227,   228,   229,   230,   231,   232,   233,   234,
      235,   236,   237,   238,   239,   240,   241,   242,   243,   244,
      245,   246,   247,     0,     1,    -1,   251,    -1,    -1,    -1,
@@ -1162,408 +1166,411 @@ static const yytype_int16 yycheck[] =
       27,    28,    29,    30,    31,    32,    -1,    -1,    35,    36,
       37,    38,    -1,    40,    41,    42,    43,    -1,    -1,    46,
       47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      57,    58,    59,    60,    -1,    62,    63,    64,    65,    66,
-      67,    68,    69,    -1,    71,    -1,    73,    74,    75,    76,
-      77,    78,    79,    -1,    -1,    -1,    83,    84,    85,    -1,
-      -1,    -1,    -1,    -1,    91,    -1,    -1,    -1,    -1,    -1,
-      -1,    98,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      57,    58,    -1,    60,    61,    -1,    63,    64,    65,    66,
+      67,    68,    69,    70,    -1,    72,    -1,    74,    75,    76,
+      77,    78,    79,    80,    -1,    -1,    -1,    84,    85,    86,
+      -1,    -1,    -1,    -1,    -1,    92,    -1,    -1,    -1,    -1,
+      -1,    -1,    99,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,     1,   119,   120,    -1,   122,    -1,   124,   125,    -1,
-      10,    11,    12,    13,    -1,   132,    16,    -1,    -1,    19,
-      20,    21,    22,    -1,    24,    25,    26,    27,    28,    29,
-      30,    31,    32,    -1,    -1,    35,    36,    37,    38,    -1,
-      40,    41,    42,    43,    -1,    -1,    46,    47,    48,    49,
-      50,    51,    52,    53,    54,    55,    56,    57,    58,    59,
-      60,    -1,    62,    63,    64,    65,    66,    67,    68,    69,
-      -1,    71,    -1,    73,    74,    75,    76,    77,    78,    79,
-      -1,    -1,    -1,    83,    84,    85,    -1,    -1,    -1,    -1,
-      -1,    91,    -1,    -1,    -1,    -1,    -1,    -1,    98,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    72,    -1,    -1,    -1,
-      -1,    -1,    -1,   478,    80,    81,    82,    -1,    -1,   119,
-     120,    -1,   122,    -1,   124,   125,    -1,    93,    -1,    80,
-      81,    82,   132,    99,   100,   101,   102,   103,   104,   105,
-     106,   107,   108,   109,   110,   111,   112,   113,   114,   115,
-     116,   117,   118,    -1,    -1,    -1,    -1,   123,    -1,    -1,
-     126,   127,   128,   129,   130,   116,   117,   118,    -1,    -1,
-     535,    -1,   123,    -1,    -1,   126,   127,   128,   129,   130,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    10,    11,
-      12,    13,   567,    -1,    16,    -1,    -1,    19,    20,    21,
-      22,    -1,    24,    25,    26,    27,    28,    29,    30,    31,
-      32,    -1,    -1,    35,    36,    37,    38,   592,    40,    41,
-      42,    43,    -1,    -1,    46,    47,    48,    49,    50,    51,
-      52,    53,    54,    55,    56,    57,    58,    59,    60,    -1,
-      62,    63,    64,    65,    66,    67,    68,    69,    -1,    71,
-      -1,    73,    74,    75,    76,    77,    78,    79,    -1,    -1,
-      -1,    83,    84,    85,    -1,    -1,    -1,    -1,    -1,    91,
-      -1,    -1,    -1,    -1,    -1,    -1,    98,    -1,    -1,    -1,
+      -1,    -1,     1,   120,   121,    -1,   123,    -1,   125,   126,
+      -1,    10,    11,    12,    13,    -1,   133,    16,    -1,    -1,
+      19,    20,    21,    22,    -1,    24,    25,    26,    27,    28,
+      29,    30,    31,    32,    -1,    -1,    35,    36,    37,    38,
+      -1,    40,    41,    42,    43,    -1,    -1,    46,    47,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    58,
+      -1,    60,    61,    -1,    63,    64,    65,    66,    67,    68,
+      69,    70,    -1,    72,    -1,    74,    75,    76,    77,    78,
+      79,    80,    -1,    -1,    -1,    84,    85,    86,    -1,    -1,
+      -1,    -1,    -1,    92,    -1,    -1,    -1,    -1,    -1,    -1,
+      99,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,   478,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,   120,   121,    -1,   123,    -1,   125,   126,    -1,    -1,
+      -1,    -1,     1,    -1,   133,    -1,    -1,    -1,    -1,    -1,
+      -1,    10,    11,    12,    13,    -1,    -1,    16,    -1,    -1,
+      19,    20,    21,    22,    -1,    24,    25,    26,    27,    28,
+      29,    30,    31,    32,    -1,    -1,    35,    36,    37,    38,
+     535,    40,    41,    42,    43,    -1,    -1,    46,    47,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    58,
+      -1,    60,    61,    -1,    63,    64,    65,    66,    67,    68,
+      69,    70,   567,    72,    -1,    74,    75,    76,    77,    78,
+      79,    80,    -1,    -1,    -1,    84,    85,    86,    -1,    -1,
+      -1,    -1,    -1,    92,    -1,    -1,    -1,   592,    -1,    -1,
+      99,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,     1,   119,   120,    -1,
-     122,    -1,   124,   125,    -1,    10,    11,    12,    13,    -1,
-     132,    16,    -1,    -1,    19,    20,    21,    22,    -1,    24,
-      25,    26,    27,    28,    29,    30,    31,    32,    -1,    -1,
-      35,    36,    37,    38,    -1,    40,    41,    42,    43,    -1,
-      -1,    46,    47,    48,    49,    50,    51,    52,    53,    54,
-      55,    56,    57,    58,    59,    60,    -1,    62,    63,    64,
-      65,    66,    67,    68,    69,    -1,    71,    -1,    73,    74,
-      75,    76,    77,    78,    79,    -1,    -1,    -1,    83,    84,
-      85,    -1,    -1,    -1,    -1,    -1,    91,    -1,    -1,    -1,
-      -1,    -1,    -1,    98,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,     1,   119,   120,    -1,   122,    -1,   124,
-     125,    -1,    10,    11,    12,    13,    -1,   132,    16,    -1,
-      -1,    19,    20,    21,    22,    -1,    24,    25,    26,    27,
-      28,    29,    30,    31,    32,    -1,    -1,    35,    36,    37,
-      38,    -1,    40,    41,    42,    43,    -1,    -1,    46,    47,
-      48,    49,    50,    51,    52,    53,    54,    55,    56,    57,
-      58,    59,    60,    -1,    62,    63,    64,    65,    66,    67,
-      68,    69,    -1,    71,    -1,    73,    74,    75,    76,    77,
-      78,    79,    -1,    -1,    -1,    83,    84,    85,    -1,    -1,
-      -1,    -1,    -1,    91,    -1,    -1,    -1,    -1,    -1,    -1,
-      98,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-       1,   119,   120,    -1,   122,    -1,   124,   125,    -1,    10,
-      11,    12,    13,    -1,   132,    16,    -1,    -1,    19,    20,
+       1,   120,   121,    -1,   123,    -1,   125,   126,    -1,    10,
+      11,    12,    13,    -1,   133,    16,    -1,    -1,    19,    20,
       21,    22,    -1,    24,    25,    26,    27,    28,    29,    30,
       31,    32,    -1,    -1,    35,    36,    37,    38,    -1,    40,
       41,    42,    43,    -1,    -1,    46,    47,    48,    49,    50,
-      51,    52,    53,    54,    55,    56,    57,    58,    59,    60,
-      -1,    62,    63,    64,    65,    66,    67,    68,    69,    -1,
-      71,    -1,    73,    74,    75,    76,    77,    78,    79,    -1,
-      -1,    -1,    83,    84,    85,    -1,    -1,    -1,    -1,    -1,
-      91,    -1,    -1,    -1,    -1,    -1,    -1,    98,    -1,    -1,
+      51,    52,    53,    54,    55,    56,    57,    58,    -1,    60,
+      61,    -1,    63,    64,    65,    66,    67,    68,    69,    70,
+      -1,    72,    -1,    74,    75,    76,    77,    78,    79,    80,
+      -1,    -1,    -1,    84,    85,    86,    -1,    -1,    -1,    -1,
+      -1,    92,    -1,    -1,    -1,    -1,    -1,    -1,    99,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,   119,   120,
-      -1,   122,    -1,   124,   125,    -1,    10,    11,    12,    13,
-      -1,   132,    16,    -1,    -1,    19,    20,    21,    22,    -1,
-      24,    25,    26,    27,    28,    29,    30,    31,    32,    -1,
-      -1,    35,    36,    37,    38,    -1,    40,    41,    42,    43,
-      -1,    -1,    46,    47,    48,    49,    50,    51,    52,    53,
-      54,    55,    56,    57,    58,    59,    60,    -1,    62,    63,
-      64,    65,    66,    67,    68,    69,    -1,    71,    -1,    73,
-      74,    75,    76,    77,    78,    79,    -1,    -1,    -1,    83,
-      84,    85,    -1,    -1,    -1,    -1,    -1,    91,    -1,    -1,
-      -1,    -1,    -1,    -1,    98,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,   120,
+     121,    -1,   123,    -1,   125,   126,    -1,    10,    11,    12,
+      13,    -1,   133,    16,    -1,    -1,    19,    20,    21,    22,
+      -1,    24,    25,    26,    27,    28,    29,    30,    31,    32,
+      -1,    -1,    35,    36,    37,    38,    -1,    40,    41,    42,
+      43,    -1,    -1,    46,    47,    48,    49,    50,    51,    52,
+      53,    54,    55,    56,    57,    58,    -1,    60,    61,    -1,
+      63,    64,    65,    66,    67,    68,    69,    70,    -1,    72,
+      -1,    74,    75,    76,    77,    78,    79,    80,    -1,    -1,
+      -1,    84,    85,    86,    -1,    -1,    -1,    -1,    -1,    92,
+      -1,    -1,    -1,    -1,    -1,    -1,    99,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,     1,   119,   120,    -1,   122,    -1,
-     124,   125,    -1,    10,    11,    -1,    13,    -1,   132,    16,
+      -1,    -1,    -1,    -1,    -1,    -1,     1,   120,   121,    -1,
+     123,    -1,   125,   126,    -1,    10,    11,    12,    13,    -1,
+     133,    16,    -1,    -1,    19,    20,    21,    22,    -1,    24,
+      25,    26,    27,    28,    29,    30,    31,    32,    -1,    -1,
+      35,    36,    37,    38,    -1,    40,    41,    42,    43,    -1,
+      -1,    46,    47,    48,    49,    50,    51,    52,    53,    54,
+      55,    56,    57,    58,    -1,    60,    61,    -1,    63,    64,
+      65,    66,    67,    68,    69,    70,    -1,    72,    -1,    74,
+      75,    76,    77,    78,    79,    80,    -1,    -1,    -1,    84,
+      85,    86,    -1,    -1,    -1,    -1,    -1,    92,    -1,    -1,
+      -1,    -1,    -1,    -1,    99,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,     1,   120,   121,    -1,   123,    -1,
+     125,   126,    -1,    10,    11,    12,    13,    -1,   133,    16,
       -1,    -1,    19,    20,    21,    22,    -1,    24,    25,    26,
       27,    28,    29,    30,    31,    32,    -1,    -1,    35,    36,
       37,    38,    -1,    40,    41,    42,    43,    -1,    -1,    46,
       47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      57,    58,    59,    60,    -1,    62,    63,    64,    65,    66,
-      67,    68,    69,    -1,    71,    -1,    73,    74,    75,    76,
-      77,    78,    79,    -1,    -1,    -1,    83,    84,    85,    -1,
-      -1,    88,    -1,    -1,    91,    -1,    -1,    -1,    -1,    -1,
-      -1,    98,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      57,    58,    -1,    60,    61,    -1,    63,    64,    65,    66,
+      67,    68,    69,    70,    -1,    72,    -1,    74,    75,    76,
+      77,    78,    79,    80,    -1,    -1,    -1,    84,    85,    86,
+      -1,    -1,    -1,    -1,    -1,    92,    -1,    -1,    -1,    -1,
+      -1,    -1,    99,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,     1,   119,   120,    -1,   122,    -1,   124,   125,    -1,
-      10,    11,    -1,    13,    -1,   132,    16,    -1,    -1,    19,
-      20,    21,    22,    -1,    24,    25,    26,    27,    28,    29,
-      30,    31,    32,    -1,    -1,    35,    36,    37,    38,    -1,
-      40,    41,    42,    43,    -1,    -1,    46,    47,    48,    49,
-      50,    51,    52,    53,    54,    55,    56,    57,    58,    59,
-      60,    -1,    62,    63,    64,    65,    66,    67,    68,    69,
-      -1,    71,    -1,    73,    74,    75,    76,    77,    78,    79,
-      -1,    -1,    -1,    83,    84,    85,    -1,    -1,    -1,    -1,
-      -1,    91,    -1,    -1,    -1,    -1,    -1,    -1,    98,    -1,
+      -1,    -1,     1,   120,   121,    -1,   123,    -1,   125,   126,
+      -1,    10,    11,    -1,    13,    -1,   133,    16,    -1,    -1,
+      19,    20,    21,    22,    -1,    24,    25,    26,    27,    28,
+      29,    30,    31,    32,    -1,    -1,    35,    36,    37,    38,
+      -1,    40,    41,    42,    43,    -1,    -1,    46,    47,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    58,
+      -1,    60,    61,    -1,    63,    64,    65,    66,    67,    68,
+      69,    70,    -1,    72,    -1,    74,    75,    76,    77,    78,
+      79,    80,    -1,    -1,    -1,    84,    85,    86,    -1,    -1,
+      89,    -1,    -1,    92,    -1,    -1,    -1,    -1,    -1,    -1,
+      99,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,   119,
-     120,    -1,   122,    -1,   124,   125,    -1,    10,    11,    -1,
-      13,    -1,   132,    16,    -1,    -1,    19,    20,    21,    22,
+       1,   120,   121,    -1,   123,    -1,   125,   126,    -1,    10,
+      11,    -1,    13,    -1,   133,    16,    -1,    -1,    19,    20,
+      21,    22,    -1,    24,    25,    26,    27,    28,    29,    30,
+      31,    32,    -1,    -1,    35,    36,    37,    38,    -1,    40,
+      41,    42,    43,    -1,    -1,    46,    47,    48,    49,    50,
+      51,    52,    53,    54,    55,    56,    57,    58,    -1,    60,
+      61,    -1,    63,    64,    65,    66,    67,    68,    69,    70,
+      -1,    72,    -1,    74,    75,    76,    77,    78,    79,    80,
+      -1,    -1,    -1,    84,    85,    86,    -1,    -1,    -1,    -1,
+      -1,    92,    -1,    -1,    -1,    -1,    -1,    -1,    99,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,   120,
+     121,    -1,   123,    -1,   125,   126,    -1,    10,    11,    -1,
+      13,    -1,   133,    16,    -1,    -1,    19,    20,    21,    22,
       -1,    24,    25,    26,    27,    28,    29,    30,    31,    32,
       -1,    -1,    35,    36,    37,    38,    -1,    40,    41,    42,
       43,    -1,    -1,    46,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    57,    58,    59,    60,    -1,    62,
-      63,    64,    65,    66,    67,    68,    -1,    -1,    71,    -1,
-      73,    74,    75,    76,    77,    78,    79,    -1,    -1,    -1,
-      83,    84,    85,    -1,     1,    -1,    -1,    -1,    91,    -1,
-      -1,    -1,    -1,    10,    -1,    98,    13,    -1,    -1,    16,
-      -1,    -1,    19,    20,    21,    22,    -1,    24,    25,    -1,
-      -1,    -1,    29,    30,    -1,    -1,   119,   120,    -1,   122,
-      -1,   124,   125,    -1,    -1,    -1,    -1,    -1,    -1,   132,
-      47,    48,    -1,    -1,    -1,    52,    53,    -1,    55,    56,
-      57,    58,    59,    60,    -1,    62,    63,    64,    65,    66,
-      67,    -1,    -1,    -1,    71,    -1,    -1,    74,    75,    76,
-      77,    78,    79,    -1,    -1,     1,    83,    84,    85,    -1,
-      -1,    -1,    -1,    -1,    10,    -1,    -1,    13,    -1,    -1,
-      16,    98,    -1,    19,    20,    21,    -1,    -1,    24,    25,
-      -1,    -1,    -1,    29,    30,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   119,   120,    -1,   122,    -1,   124,   125,    -1,
-      -1,    47,    48,    -1,    -1,   132,    52,    53,    -1,    55,
-      56,    57,    58,    59,    60,    -1,    62,    63,    64,    65,
-      66,    67,    -1,    -1,    -1,    71,    -1,    -1,    74,    75,
-      76,    77,    78,    79,    -1,    -1,    -1,    83,    84,    85,
-      -1,    -1,    -1,    -1,    -1,    10,    11,    -1,    13,    -1,
-      -1,    16,    98,    -1,    19,    20,    21,    -1,    -1,    24,
-      25,    -1,    -1,    -1,    29,    30,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   119,   120,    -1,   122,    -1,   124,   125,
-      -1,    -1,    47,    48,    -1,   131,   132,    52,    53,    -1,
-      55,    56,    57,    58,    59,    60,    61,    62,    63,    64,
-      65,    66,    67,    -1,    -1,    -1,    71,    -1,    -1,    74,
-      75,    76,    77,    78,    79,    -1,    -1,    -1,    83,    84,
-      85,    -1,    -1,    -1,    -1,    -1,    10,    11,    -1,    13,
-      -1,    -1,    16,    98,    -1,    19,    20,    21,    -1,    -1,
+      53,    54,    55,    56,    57,    58,    -1,    60,    61,    -1,
+      63,    64,    65,    66,    67,    68,    69,    -1,    -1,    72,
+      -1,    74,    75,    76,    77,    78,    79,    80,    -1,    -1,
+      -1,    84,    85,    86,    -1,     1,    -1,    -1,    -1,    92,
+      -1,    -1,    -1,    -1,    10,    -1,    99,    13,    -1,    -1,
+      16,    -1,    -1,    19,    20,    21,    22,    -1,    24,    25,
+      -1,    -1,    -1,    29,    30,    -1,    -1,   120,   121,    -1,
+     123,    -1,   125,   126,    -1,    -1,    -1,    -1,    -1,    -1,
+     133,    47,    48,    -1,    -1,    -1,    52,    53,    -1,    55,
+      56,    57,    58,    -1,    60,    61,    -1,    63,    64,    65,
+      66,    67,    68,    -1,    -1,    -1,    72,    -1,    -1,    75,
+      76,    77,    78,    79,    80,    -1,    -1,     1,    84,    85,
+      86,    -1,    -1,    -1,    -1,    -1,    10,    -1,    -1,    13,
+      -1,    -1,    16,    99,    -1,    19,    20,    21,    -1,    -1,
       24,    25,    -1,    -1,    -1,    29,    30,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   119,   120,    -1,   122,    -1,   124,
-     125,    -1,    -1,    47,    48,    -1,    -1,   132,    52,    53,
-      -1,    55,    56,    57,    58,    59,    60,    -1,    62,    63,
-      64,    65,    66,    67,    -1,    -1,    -1,    71,    -1,    -1,
-      74,    75,    76,    77,    78,    79,    -1,    -1,    -1,    83,
-      84,    85,    -1,    -1,    -1,    -1,    -1,    10,    -1,    -1,
-      13,    -1,    -1,    16,    98,    -1,    19,    20,    21,    -1,
-      -1,    24,    25,    -1,    -1,    -1,    29,    30,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   119,   120,    -1,   122,    -1,
-     124,   125,    -1,    -1,    47,    48,    -1,    -1,   132,    52,
-      53,    -1,    55,    56,    57,    58,    59,    60,    -1,    62,
-      63,    64,    65,    66,    67,    -1,    -1,    -1,    71,    -1,
-      -1,    74,    75,    76,    77,    78,    79,    -1,    -1,    -1,
-      83,    84,    85,    -1,    -1,    -1,    -1,    -1,    10,    -1,
-      -1,    13,    -1,    -1,    16,    98,    -1,    19,    20,    21,
+      -1,    -1,    -1,    -1,   120,   121,    -1,   123,    -1,   125,
+     126,    -1,    -1,    47,    48,    -1,    -1,   133,    52,    53,
+      -1,    55,    56,    57,    58,    -1,    60,    61,    -1,    63,
+      64,    65,    66,    67,    68,    -1,    -1,    -1,    72,    -1,
+      -1,    75,    76,    77,    78,    79,    80,    -1,    -1,    -1,
+      84,    85,    86,    -1,    -1,    -1,    -1,    -1,    10,    11,
+      -1,    13,    -1,    -1,    16,    99,    -1,    19,    20,    21,
       -1,    -1,    24,    25,    -1,    -1,    -1,    29,    30,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,   119,   120,    -1,   122,
-      -1,   124,   125,    -1,    -1,    47,    48,    -1,   131,   132,
-      52,    53,    -1,    55,    56,    57,    58,    59,    60,    -1,
-      62,    63,    64,    65,    66,    67,    -1,    -1,    -1,    71,
-      -1,    -1,    74,    75,    76,    77,    78,    79,    -1,    -1,
-      -1,    83,    84,    85,    -1,    -1,    -1,    -1,    -1,    10,
-      -1,    -1,    13,    -1,    -1,    16,    98,    -1,    19,    20,
-      21,    -1,    -1,    24,    25,    -1,    -1,    -1,    29,    30,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,   119,   120,    -1,
-     122,    -1,   124,   125,    -1,    -1,    47,    48,    -1,   131,
-     132,    52,    53,    -1,    55,    56,    57,    58,    59,    60,
-      -1,    62,    63,    64,    65,    66,    67,    -1,    -1,    -1,
-      71,    -1,    -1,    74,    75,    76,    77,    78,    79,    -1,
-      -1,    -1,    83,    84,    85,    -1,    -1,    -1,    -1,    -1,
-      10,    11,    -1,    13,    -1,    -1,    16,    98,    -1,    19,
+      -1,    -1,    -1,    -1,    -1,    -1,   120,   121,    -1,   123,
+      -1,   125,   126,    -1,    -1,    47,    48,    -1,   132,   133,
+      52,    53,    -1,    55,    56,    57,    58,    -1,    60,    61,
+      62,    63,    64,    65,    66,    67,    68,    -1,    -1,    -1,
+      72,    -1,    -1,    75,    76,    77,    78,    79,    80,    -1,
+      -1,    -1,    84,    85,    86,    -1,    -1,    -1,    -1,    -1,
+      10,    11,    -1,    13,    -1,    -1,    16,    99,    -1,    19,
       20,    21,    -1,    -1,    24,    25,    -1,    -1,    -1,    29,
-      30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   119,   120,
-      -1,   122,    -1,   124,   125,    -1,    -1,    47,    48,    -1,
-     131,   132,    52,    53,    -1,    55,    56,    57,    58,    59,
-      60,    -1,    62,    63,    64,    65,    66,    67,    -1,    -1,
-      -1,    71,    -1,    -1,    74,    75,    76,    77,    78,    79,
-      -1,    -1,    -1,    83,    84,    85,    -1,    -1,    -1,    -1,
-      -1,    10,    -1,    -1,    13,    -1,    -1,    16,    98,    -1,
-      19,    20,    21,    -1,    -1,    24,    25,    -1,    -1,    -1,
-      29,    30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   119,
-     120,    -1,   122,    -1,   124,   125,    -1,    -1,    47,    48,
-      -1,    -1,   132,    52,    53,    -1,    55,    56,    57,    58,
-      59,    60,    -1,    62,    63,    64,    65,    66,    67,    -1,
-      -1,    -1,    71,    -1,    -1,    74,    75,    76,    77,    78,
-      79,    -1,    -1,    -1,    83,    84,    85,    -1,    -1,    -1,
-      -1,    -1,    10,    -1,    -1,    13,    -1,    -1,    16,    98,
+      30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   120,   121,
+      -1,   123,    -1,   125,   126,    -1,    -1,    47,    48,    -1,
+      -1,   133,    52,    53,    -1,    55,    56,    57,    58,    -1,
+      60,    61,    -1,    63,    64,    65,    66,    67,    68,    -1,
+      -1,    -1,    72,    -1,    -1,    75,    76,    77,    78,    79,
+      80,    -1,    -1,    -1,    84,    85,    86,    -1,    -1,    -1,
+      -1,    -1,    10,    -1,    -1,    13,    -1,    -1,    16,    99,
       -1,    19,    20,    21,    -1,    -1,    24,    25,    -1,    -1,
       -1,    29,    30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     119,   120,    -1,   122,    -1,   124,   125,    -1,    -1,    47,
-      48,    -1,   131,   132,    52,    53,    -1,    55,    56,    57,
-      58,    59,    60,    -1,    62,    63,    64,    65,    66,    67,
-      -1,    -1,    -1,    71,    -1,    -1,    74,    75,    76,    77,
-      78,    79,    -1,    -1,    -1,    83,    84,    85,    -1,    -1,
-      -1,    -1,    -1,    10,    -1,    -1,    13,    -1,    -1,    16,
-      98,    -1,    19,    20,    21,    -1,    -1,    24,    25,    -1,
-      -1,    -1,    29,    30,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   119,   120,    -1,   122,    -1,   124,   125,    -1,    -1,
-      47,    48,    -1,   131,   132,    52,    53,    -1,    55,    56,
-      57,    58,    59,    60,    -1,    62,    63,    64,    65,    66,
-      67,    -1,    -1,    -1,    71,    -1,    -1,    74,    75,    76,
-      77,    78,    79,    -1,    -1,    -1,    83,    84,    85,    -1,
+     120,   121,    -1,   123,    -1,   125,   126,    -1,    -1,    47,
+      48,    -1,    -1,   133,    52,    53,    -1,    55,    56,    57,
+      58,    -1,    60,    61,    -1,    63,    64,    65,    66,    67,
+      68,    -1,    -1,    -1,    72,    -1,    -1,    75,    76,    77,
+      78,    79,    80,    -1,    -1,    -1,    84,    85,    86,    -1,
       -1,    -1,    -1,    -1,    10,    -1,    -1,    13,    -1,    -1,
-      16,    98,    -1,    19,    20,    21,    -1,    -1,    24,    25,
+      16,    99,    -1,    19,    20,    21,    -1,    -1,    24,    25,
       -1,    -1,    -1,    29,    30,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,   119,   120,    -1,   122,    -1,   124,   125,    -1,
-      -1,    47,    48,    -1,   131,   132,    52,    53,    -1,    55,
-      56,    57,    58,    59,    60,    -1,    62,    63,    64,    65,
-      66,    67,    -1,    -1,    -1,    71,    -1,    -1,    74,    75,
-      76,    77,    78,    79,    -1,    -1,    -1,    83,    84,    85,
-      -1,    -1,    -1,    -1,    -1,    10,    -1,    -1,    13,    -1,
-      -1,    16,    98,    -1,    19,    20,    21,    -1,    -1,    24,
-      25,    -1,    -1,    -1,    29,    30,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,   119,   120,    -1,   122,    -1,   124,   125,
-      -1,    -1,    47,    48,    -1,   131,   132,    52,    53,    -1,
-      55,    56,    57,    58,    59,    60,    -1,    62,    63,    64,
-      65,    66,    67,    -1,    -1,    -1,    71,    -1,    -1,    74,
-      75,    76,    77,    78,    79,    -1,    -1,    -1,    83,    84,
-      85,    -1,    -1,    -1,    -1,    -1,    10,    -1,    -1,    13,
-      -1,    -1,    16,    98,    -1,    19,    20,    21,    -1,    -1,
+      -1,    -1,   120,   121,    -1,   123,    -1,   125,   126,    -1,
+      -1,    47,    48,    -1,   132,   133,    52,    53,    -1,    55,
+      56,    57,    58,    -1,    60,    61,    -1,    63,    64,    65,
+      66,    67,    68,    -1,    -1,    -1,    72,    -1,    -1,    75,
+      76,    77,    78,    79,    80,    -1,    -1,    -1,    84,    85,
+      86,    -1,    -1,    -1,    -1,    -1,    10,    -1,    -1,    13,
+      -1,    -1,    16,    99,    -1,    19,    20,    21,    -1,    -1,
       24,    25,    -1,    -1,    -1,    29,    30,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,   119,   120,    -1,   122,    -1,   124,
-     125,    -1,    -1,    47,    48,    -1,    -1,   132,    52,    53,
-      -1,    55,    56,    57,    58,    59,    60,    -1,    62,    63,
-      64,    65,    66,    67,    -1,    -1,    -1,    71,    -1,    -1,
-      74,    75,    76,    77,    78,    79,    -1,    -1,    -1,    83,
-      84,    85,    -1,    -1,    -1,    -1,    -1,    10,    -1,    -1,
-      13,    -1,    -1,    16,    98,    -1,    19,    20,    21,    -1,
-      -1,    24,    25,    -1,    -1,    -1,    29,    30,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,   119,   120,    -1,   122,    -1,
-     124,   125,    -1,    -1,    47,    48,    -1,    -1,   132,    52,
-      53,    -1,    55,    56,    57,    58,    59,    60,    -1,    62,
-      63,    64,    65,    66,    67,    -1,    -1,    -1,    71,    -1,
-      -1,    74,    75,    76,    77,    78,    79,    -1,    -1,    -1,
-      83,    84,    85,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    98,    -1,    -1,    -1,    72,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    80,    81,    82,
-      -1,    -1,    -1,    -1,    -1,    -1,   119,   120,    -1,   122,
-      93,   124,   125,    -1,    -1,    -1,    99,   100,   101,   132,
-     103,   104,   105,   106,   107,   108,   109,   110,   111,   112,
-     113,   114,   115,   116,   117,   118,    -1,    -1,    -1,    -1,
-     123,    72,    -1,   126,   127,   128,   129,   130,    -1,    80,
-      81,    82,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    93,    -1,    -1,    -1,    -1,    -1,    99,   100,
-     101,    -1,   103,   104,   105,   106,   107,   108,   109,   110,
-     111,   112,   113,   114,   115,   116,   117,   118,    -1,    -1,
-      -1,    -1,   123,    72,    -1,   126,   127,   128,   129,   130,
-      -1,    80,    81,    82,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   120,   121,    -1,   123,    -1,   125,
+     126,    -1,    -1,    47,    48,    -1,   132,   133,    52,    53,
+      -1,    55,    56,    57,    58,    -1,    60,    61,    -1,    63,
+      64,    65,    66,    67,    68,    -1,    -1,    -1,    72,    -1,
+      -1,    75,    76,    77,    78,    79,    80,    -1,    -1,    -1,
+      84,    85,    86,    -1,    -1,    -1,    -1,    -1,    10,    11,
+      -1,    13,    -1,    -1,    16,    99,    -1,    19,    20,    21,
+      -1,    -1,    24,    25,    -1,    -1,    -1,    29,    30,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   120,   121,    -1,   123,
+      -1,   125,   126,    -1,    -1,    47,    48,    -1,   132,   133,
+      52,    53,    -1,    55,    56,    57,    58,    -1,    60,    61,
+      -1,    63,    64,    65,    66,    67,    68,    -1,    -1,    -1,
+      72,    -1,    -1,    75,    76,    77,    78,    79,    80,    -1,
+      -1,    -1,    84,    85,    86,    -1,    -1,    -1,    -1,    -1,
+      10,    -1,    -1,    13,    -1,    -1,    16,    99,    -1,    19,
+      20,    21,    -1,    -1,    24,    25,    -1,    -1,    -1,    29,
+      30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   120,   121,
+      -1,   123,    -1,   125,   126,    -1,    -1,    47,    48,    -1,
+      -1,   133,    52,    53,    -1,    55,    56,    57,    58,    -1,
+      60,    61,    -1,    63,    64,    65,    66,    67,    68,    -1,
+      -1,    -1,    72,    -1,    -1,    75,    76,    77,    78,    79,
+      80,    -1,    -1,    -1,    84,    85,    86,    -1,    -1,    -1,
+      -1,    -1,    10,    -1,    -1,    13,    -1,    -1,    16,    99,
+      -1,    19,    20,    21,    -1,    -1,    24,    25,    -1,    -1,
+      -1,    29,    30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     120,   121,    -1,   123,    -1,   125,   126,    -1,    -1,    47,
+      48,    -1,   132,   133,    52,    53,    -1,    55,    56,    57,
+      58,    -1,    60,    61,    -1,    63,    64,    65,    66,    67,
+      68,    -1,    -1,    -1,    72,    -1,    -1,    75,    76,    77,
+      78,    79,    80,    -1,    -1,    -1,    84,    85,    86,    -1,
+      -1,    -1,    -1,    -1,    10,    -1,    -1,    13,    -1,    -1,
+      16,    99,    -1,    19,    20,    21,    -1,    -1,    24,    25,
+      -1,    -1,    -1,    29,    30,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,   120,   121,    -1,   123,    -1,   125,   126,    -1,
+      -1,    47,    48,    -1,   132,   133,    52,    53,    -1,    55,
+      56,    57,    58,    -1,    60,    61,    -1,    63,    64,    65,
+      66,    67,    68,    -1,    -1,    -1,    72,    -1,    -1,    75,
+      76,    77,    78,    79,    80,    -1,    -1,    -1,    84,    85,
+      86,    -1,    -1,    -1,    -1,    -1,    10,    -1,    -1,    13,
+      -1,    -1,    16,    99,    -1,    19,    20,    21,    -1,    -1,
+      24,    25,    -1,    -1,    -1,    29,    30,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   120,   121,    -1,   123,    -1,   125,
+     126,    -1,    -1,    47,    48,    -1,   132,   133,    52,    53,
+      -1,    55,    56,    57,    58,    -1,    60,    61,    -1,    63,
+      64,    65,    66,    67,    68,    -1,    -1,    -1,    72,    -1,
+      -1,    75,    76,    77,    78,    79,    80,    -1,    -1,    -1,
+      84,    85,    86,    -1,    -1,    -1,    -1,    -1,    10,    -1,
+      -1,    13,    -1,    -1,    16,    99,    -1,    19,    20,    21,
+      -1,    -1,    24,    25,    -1,    -1,    -1,    29,    30,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   120,   121,    -1,   123,
+      -1,   125,   126,    -1,    -1,    47,    48,    -1,   132,   133,
+      52,    53,    -1,    55,    56,    57,    58,    -1,    60,    61,
+      -1,    63,    64,    65,    66,    67,    68,    -1,    -1,    -1,
+      72,    -1,    -1,    75,    76,    77,    78,    79,    80,    -1,
+      -1,    -1,    84,    85,    86,    -1,    -1,    -1,    -1,    -1,
+      10,    -1,    -1,    13,    -1,    -1,    16,    99,    -1,    19,
+      20,    21,    -1,    -1,    24,    25,    -1,    -1,    -1,    29,
+      30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   120,   121,
+      -1,   123,    -1,   125,   126,    -1,    -1,    47,    48,    -1,
+      -1,   133,    52,    53,    -1,    55,    56,    57,    58,    -1,
+      60,    61,    -1,    63,    64,    65,    66,    67,    68,    -1,
+      -1,    -1,    72,    -1,    -1,    75,    76,    77,    78,    79,
+      80,    -1,    -1,    -1,    84,    85,    86,    -1,    -1,    -1,
+      -1,    -1,    10,    -1,    -1,    13,    -1,    -1,    16,    99,
+      -1,    19,    20,    21,    -1,    -1,    24,    25,    -1,    -1,
+      -1,    29,    30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+     120,   121,    -1,   123,    -1,   125,   126,    81,    82,    47,
+      48,    -1,    -1,   133,    52,    53,    -1,    55,    56,    57,
+      58,    -1,    60,    61,    -1,    63,    64,    65,    66,    67,
+      68,    -1,    -1,    -1,    72,    -1,    -1,    75,    76,    77,
+      78,    79,    80,    -1,   118,   119,    84,    85,    86,    -1,
+     124,    -1,    -1,   127,   128,   129,   130,   131,    -1,    -1,
+      -1,    99,    -1,    -1,    -1,    73,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    81,    82,    83,    -1,    -1,    -1,    -1,
+      -1,    -1,   120,   121,    -1,   123,    94,   125,   126,    -1,
+      -1,    -1,   100,   101,   102,   133,   104,   105,   106,   107,
+     108,   109,   110,   111,   112,   113,   114,   115,   116,   117,
+     118,   119,    -1,    -1,    -1,    -1,   124,    73,    -1,   127,
+     128,   129,   130,   131,    -1,    81,    82,    83,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    94,    -1,
+      -1,    -1,    -1,    -1,   100,   101,   102,    -1,   104,   105,
+     106,   107,   108,   109,   110,   111,   112,   113,   114,   115,
+     116,   117,   118,   119,    -1,    -1,    -1,    -1,   124,    73,
+      -1,   127,   128,   129,   130,   131,    -1,    81,    82,    83,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      99,   100,   101,    -1,   103,   104,   105,   106,   107,   108,
-     109,   110,   111,   112,   113,   114,   115,   116,   117,   118,
-      -1,    -1,    -1,    -1,   123,    72,    -1,   126,   127,   128,
-     129,   130,    -1,    80,    81,    82,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,   100,   101,   102,    -1,
+     104,   105,   106,   107,   108,   109,   110,   111,   112,   113,
+     114,   115,   116,   117,   118,   119,    -1,    -1,    -1,    -1,
+     124,    73,    -1,   127,   128,   129,   130,   131,    -1,    81,
+      82,    83,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    80,    81,    -1,   101,    -1,   103,   104,   105,   106,
-     107,   108,   109,   110,   111,   112,   113,   114,   115,   116,
-     117,   118,    -1,    -1,    -1,    -1,   123,    72,    -1,   126,
-     127,   128,   129,   130,    -1,    80,    81,    82,   117,   118,
-      -1,    -1,    -1,    -1,   123,    -1,    -1,   126,   127,   128,
-     129,   130,    -1,    -1,    -1,    -1,    -1,    -1,   103,   104,
-     105,   106,   107,   108,   109,   110,   111,   112,   113,   114,
-     115,   116,   117,   118,    80,    81,    82,    -1,   123,    -1,
-      -1,   126,   127,   128,   129,   130,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    80,    81,    82,    -1,
-      -1,    -1,   108,   109,   110,   111,   112,   113,   114,   115,
-     116,   117,   118,    -1,    80,    81,    82,   123,    -1,    -1,
-     126,   127,   128,   129,   130,   109,   110,   111,   112,   113,
-     114,   115,   116,   117,   118,    80,    81,    82,    -1,   123,
-      -1,    -1,   126,   127,   128,   129,   130,    -1,   114,   115,
-     116,   117,   118,    -1,    80,    81,    82,   123,    -1,    -1,
-     126,   127,   128,   129,   130,   110,   111,   112,   113,   114,
-     115,   116,   117,   118,    80,    81,    82,    -1,   123,    -1,
-      -1,   126,   127,   128,   129,   130,   112,   113,   114,   115,
-     116,   117,   118,    80,    81,    82,    -1,   123,    -1,    -1,
-     126,   127,   128,   129,   130,    -1,    -1,    -1,   114,   115,
-     116,   117,   118,    -1,    -1,    -1,    -1,   123,    -1,    -1,
-     126,   127,   128,   129,   130,    -1,    -1,    -1,   115,   116,
-     117,   118,    -1,    -1,    -1,    -1,   123,    -1,    -1,   126,
-     127,   128,   129,   130
+     102,    -1,   104,   105,   106,   107,   108,   109,   110,   111,
+     112,   113,   114,   115,   116,   117,   118,   119,    -1,    -1,
+      -1,    -1,   124,    73,    -1,   127,   128,   129,   130,   131,
+      -1,    81,    82,    83,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,   104,   105,   106,   107,   108,   109,
+     110,   111,   112,   113,   114,   115,   116,   117,   118,   119,
+      81,    82,    83,    -1,   124,    -1,    -1,   127,   128,   129,
+     130,   131,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    81,    82,    83,   107,   108,   109,   110,
+     111,   112,   113,   114,   115,   116,   117,   118,   119,    -1,
+      -1,    -1,    -1,   124,    -1,    -1,   127,   128,   129,   130,
+     131,   109,   110,   111,   112,   113,   114,   115,   116,   117,
+     118,   119,    81,    82,    83,    -1,   124,    -1,    -1,   127,
+     128,   129,   130,   131,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    81,    82,    83,    -1,    -1,    -1,    -1,
+      -1,   110,   111,   112,   113,   114,   115,   116,   117,   118,
+     119,    -1,    81,    82,    83,   124,    -1,    -1,   127,   128,
+     129,   130,   131,   111,   112,   113,   114,   115,   116,   117,
+     118,   119,    81,    82,    83,    -1,   124,    -1,    -1,   127,
+     128,   129,   130,   131,   113,   114,   115,   116,   117,   118,
+     119,    81,    82,    83,    -1,   124,    -1,    -1,   127,   128,
+     129,   130,   131,    -1,    -1,    -1,   115,   116,   117,   118,
+     119,    81,    82,    83,    -1,   124,    -1,    -1,   127,   128,
+     129,   130,   131,    -1,    -1,   115,   116,   117,   118,   119,
+      81,    82,    83,    -1,   124,    -1,    -1,   127,   128,   129,
+     130,   131,    -1,    -1,    -1,    -1,   116,   117,   118,   119,
+      -1,    -1,    -1,    -1,   124,    -1,    -1,   127,   128,   129,
+     130,   131,    -1,    -1,    -1,    -1,   117,   118,   119,    -1,
+      -1,    -1,    -1,   124,    -1,    -1,   127,   128,   129,   130,
+     131
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_int16 yystos[] =
 {
-       0,     3,     4,     5,     6,     7,     8,     9,   134,   135,
-     136,   137,   138,   139,   140,   141,     0,   180,    10,    13,
+       0,     3,     4,     5,     6,     7,     8,     9,   135,   136,
+     137,   138,   139,   140,   141,   142,     0,   181,    10,    13,
       16,    19,    20,    21,    24,    25,    29,    30,    47,    48,
-      52,    53,    55,    56,    57,    58,    59,    60,    62,    63,
-      64,    65,    66,    67,    71,    74,    75,    76,    77,    78,
-      79,    83,    84,    85,    98,   119,   120,   122,   124,   125,
-     132,   178,   232,   233,   234,   237,   238,   239,   240,   241,
-     242,   243,   244,   245,   246,   248,   254,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,    11,   177,     1,    22,
+      52,    53,    55,    56,    57,    58,    60,    61,    63,    64,
+      65,    66,    67,    68,    72,    75,    76,    77,    78,    79,
+      80,    84,    85,    86,    99,   120,   121,   123,   125,   126,
+     133,   179,   233,   234,   235,   238,   239,   240,   241,   242,
+     243,   244,   245,   246,   247,   249,   255,   263,   264,   265,
+     266,   267,   268,   269,   270,   271,    11,   178,     1,    22,
       26,    27,    28,    31,    32,    35,    36,    37,    38,    40,
-      41,    42,    43,    46,    49,    50,    51,    54,    68,    73,
-      91,   142,   143,   144,   146,   147,   148,   149,   150,   154,
-     155,   156,   157,   158,   159,   161,   163,   165,   167,   169,
-     170,   171,   173,   174,   175,   176,   177,   190,   194,   232,
-     251,    69,   188,   189,   190,   178,   186,   225,   226,   186,
-      56,    61,   177,   263,   271,   254,   271,   246,   271,   246,
-     271,   271,   246,   122,   132,   249,   263,   264,   265,   246,
-     177,   246,   206,   206,   207,   271,   271,   247,    13,   132,
-     246,   206,   246,   132,   132,    89,   132,   177,   246,    56,
-     178,   233,   253,   263,   271,   177,   271,   254,    56,    61,
-     209,   233,   246,   246,   246,   246,   246,   131,   232,    94,
-      95,    96,    97,    15,    11,    13,   132,   112,   113,   112,
-     110,   111,   110,    72,    80,    81,    82,    93,    99,   100,
-     101,   103,   104,   105,   106,   107,   108,   109,   110,   111,
-     112,   113,   114,   115,   116,   117,   118,   123,   126,   127,
-     128,   129,   130,   132,    11,    13,    11,    13,    11,    13,
-      11,   180,   208,    56,    56,   250,   263,   264,   265,   132,
-     132,    30,   122,   132,   261,   263,   132,   132,   132,   132,
-     177,    11,   181,   181,   205,   209,    22,   205,   209,    39,
-     178,   196,    22,    32,    35,    36,    37,    38,    41,    22,
-     189,   190,   188,    20,    24,   102,   178,   215,   216,   217,
-     218,   220,   221,   222,    14,   132,   246,   249,   263,   264,
-     265,   131,   232,    86,   212,    70,   178,   210,    86,   178,
-     211,   211,   253,   132,    89,   232,   131,   177,   131,   131,
-     232,   254,   254,   271,   233,   233,    22,   253,    13,   131,
-     232,   232,   232,   232,   246,   232,   232,   131,   232,   246,
-     246,   246,   246,   246,   246,   246,   246,   246,   246,   246,
-     246,   246,   246,   246,   246,   246,   246,   246,   246,   246,
-     246,   246,   246,   246,   246,   246,   246,    10,    11,    13,
-      16,    20,    24,    25,    57,    83,   132,   236,   263,   131,
-     232,   232,   232,   232,   232,   232,   232,   232,   186,    56,
-     178,   204,    56,    56,   178,   212,   213,   180,   180,   122,
-     180,    30,   259,   260,   262,   263,   264,   265,   180,   180,
-     132,   180,   180,   180,   180,   182,    44,   172,   205,   162,
-     205,   177,   193,   232,   193,   193,   201,   232,   193,   193,
-      61,   214,    16,    15,   131,   232,   212,   131,    59,   211,
-      59,   180,   230,   230,   254,   233,    14,   235,   131,    90,
-     131,   232,    12,   232,    13,    22,    14,   131,   102,    25,
-     209,   232,   232,    25,    25,    25,    25,    25,   131,   232,
-     132,   131,    22,    14,    22,    14,    22,    14,    22,    12,
-      18,   179,    11,    22,   213,    99,   202,   232,   202,   132,
-     256,   263,   132,   178,   194,   199,   202,   203,   232,   259,
-     180,   201,   200,   232,   202,   202,   186,   180,    56,   166,
-      22,   180,   227,   228,   164,    99,   214,   220,   131,   228,
-     132,   178,   223,   224,   131,    23,   178,   255,   253,   131,
-      14,   232,    12,   246,   132,    22,    14,   131,   254,    12,
-      12,    12,    12,   180,   180,    11,    22,   252,   131,   131,
-     257,   258,   263,   132,   180,   131,    22,   153,   202,   131,
-     131,   131,   131,    12,   132,   178,   183,    56,   210,    11,
-     211,   246,    99,   225,    11,   232,    90,    14,   254,    12,
-     131,    22,   160,   180,   246,   181,   181,    15,   131,   202,
-     202,   181,   151,   132,   131,   198,   198,   181,   181,   184,
-     168,   253,   211,   186,    22,   229,   230,   219,   246,   131,
-     231,   131,    88,   186,   145,    33,    34,   178,   195,   195,
-     263,   132,   131,   131,   196,   200,   202,   181,   181,   181,
-     263,   181,    22,   227,    12,   186,   178,   187,    12,   186,
-     181,   132,   202,   181,   181,    22,   131,   196,   196,   196,
-     185,    45,   197,    12,    22,    59,   191,    12,   202,   131,
-     196,   196,   152,   181,   131,   177,    17,    87,   178,   192,
-     131,   181,   198,   196,   186,   181,   196,   203,    88,   195,
-     131,   181
+      41,    42,    43,    46,    49,    50,    51,    54,    69,    74,
+      92,   143,   144,   145,   147,   148,   149,   150,   151,   155,
+     156,   157,   158,   159,   160,   162,   164,   166,   168,   170,
+     171,   172,   174,   175,   176,   177,   178,   191,   195,   233,
+     252,    70,   189,   190,   191,   179,   187,   226,   227,   187,
+      56,    62,   178,   264,   272,   255,   272,   247,   272,   247,
+     272,   272,   247,   123,   133,   250,   264,   265,   266,   247,
+     178,   247,   207,   207,   208,   272,   272,   248,    13,   133,
+     247,   207,   247,   133,   133,    90,   133,   178,   247,    56,
+     179,   234,   254,   264,   272,   178,   272,   255,    56,    62,
+     210,   234,   247,   247,   247,   247,   247,   132,   233,    95,
+      96,    97,    98,    15,    11,    13,   133,   113,   114,   113,
+     111,   112,   111,    73,    81,    82,    83,    94,   100,   101,
+     102,   104,   105,   106,   107,   108,   109,   110,   111,   112,
+     113,   114,   115,   116,   117,   118,   119,   124,   127,   128,
+     129,   130,   131,   133,    11,    13,    11,    13,    11,    13,
+      11,   181,   209,    56,    56,   251,   264,   265,   266,   133,
+     133,    30,   123,   133,   262,   264,   133,   133,   133,   133,
+     178,    11,   182,   182,   206,   210,    22,   206,   210,    39,
+     179,   197,    22,    32,    35,    36,    37,    38,    41,    22,
+     190,   191,   189,    20,    24,   103,   179,   216,   217,   218,
+     219,   221,   222,   223,    14,   133,   247,   250,   264,   265,
+     266,   132,   233,    87,   213,    71,   179,   211,    87,   179,
+     212,   212,   254,   133,    90,   233,   132,   178,   132,   132,
+     233,   255,   255,   272,   234,   234,    22,   254,    13,   132,
+     233,   233,   233,   233,   247,   233,   233,   132,   233,   247,
+     247,   247,   247,   247,   247,   247,   247,   247,   247,   247,
+     247,   247,   247,   247,   247,   247,   247,   247,   247,   247,
+     247,   247,   247,   247,   247,   247,   247,    10,    11,    13,
+      16,    20,    24,    25,    57,    84,   133,   237,   264,   132,
+     233,   233,   233,   233,   233,   233,   233,   233,   187,    56,
+     179,   205,    56,    56,   179,   213,   214,   181,   181,   123,
+     181,    30,   260,   261,   263,   264,   265,   266,   181,   181,
+     133,   181,   181,   181,   181,   183,    44,   173,   206,   163,
+     206,   178,   194,   233,   194,   194,   202,   233,   194,   194,
+      62,   215,    16,    15,   132,   233,   213,   132,    59,   212,
+      59,   181,   231,   231,   255,   234,    14,   236,   132,    91,
+     132,   233,    12,   233,    13,    22,    14,   132,   103,    25,
+     210,   233,   233,    25,    25,    25,    25,    25,   132,   233,
+     133,   132,    22,    14,    22,    14,    22,    14,    22,    12,
+      18,   180,    11,    22,   214,   100,   203,   233,   203,   133,
+     257,   264,   133,   179,   195,   200,   203,   204,   233,   260,
+     181,   202,   201,   233,   203,   203,   187,   181,    56,   167,
+      22,   181,   228,   229,   165,   100,   215,   221,   132,   229,
+     133,   179,   224,   225,   132,    23,   179,   256,   254,   132,
+      14,   233,    12,   247,   133,    22,    14,   132,   255,    12,
+      12,    12,    12,   181,   181,    11,    22,   253,   132,   132,
+     258,   259,   264,   133,   181,   132,    22,   154,   203,   132,
+     132,   132,   132,    12,   133,   179,   184,    56,   211,    11,
+     212,   247,   100,   226,    11,   233,    91,    14,   255,    12,
+     132,    22,   161,   181,   247,   182,   182,    15,   132,   203,
+     203,   182,   152,   133,   132,   199,   199,   182,   182,   185,
+     169,   254,   212,   187,    22,   230,   231,   220,   247,   132,
+     232,   132,    89,   187,   146,    33,    34,   179,   196,   196,
+     264,   133,   132,   132,   197,   201,   203,   182,   182,   182,
+     264,   182,    22,   228,    12,   187,   179,   188,    12,   187,
+     182,   133,   203,   182,   182,    22,   132,   197,   197,   197,
+     186,    45,   198,    12,    22,    60,   192,    12,   203,   132,
+     197,   197,   153,   182,   132,   178,    17,    88,   179,   193,
+     132,   182,   199,   197,   187,   182,   197,   204,    89,   196,
+     132,   182
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int16 yyr1[] =
 {
-       0,   133,   135,   134,   136,   134,   137,   134,   138,   134,
-     139,   134,   140,   134,   141,   134,   142,   143,   145,   144,
-     146,   147,   148,   149,   151,   152,   150,   150,   150,   150,
-     153,   150,   150,   150,   154,   155,   156,   157,   158,   160,
-     159,   162,   161,   164,   163,   166,   165,   168,   167,   169,
-     170,   172,   171,   173,   174,   175,   176,   176,   177,   178,
-     179,   180,   181,   182,   183,   184,   185,   183,   186,   186,
-     187,   187,   188,   188,   189,   189,   190,   190,   190,   190,
-     190,   190,   190,   190,   190,   190,   190,   190,   190,   190,
-     190,   190,   190,   190,   190,   190,   190,   190,   190,   190,
-     190,   191,   192,   192,   193,   194,   194,   194,   194,   194,
-     194,   194,   194,   195,   195,   195,   196,   196,   197,   197,
-     198,   199,   199,   200,   200,   201,   202,   203,   204,   204,
-     205,   206,   207,   208,   209,   209,   210,   210,   211,   211,
-     211,   212,   212,   213,   213,   214,   214,   215,   215,   216,
-     216,   216,   217,   217,   218,   218,   219,   219,   220,   220,
-     221,   221,   221,   222,   222,   223,   223,   224,   226,   225,
-     227,   227,   228,   229,   229,   231,   230,   232,   232,   232,
-     232,   232,   233,   233,   233,   234,   234,   234,   234,   234,
-     234,   234,   234,   234,   234,   234,   234,   235,   234,   236,
-     236,   237,   237,   237,   237,   237,   237,   237,   237,   237,
-     237,   237,   237,   237,   237,   238,   238,   238,   238,   238,
-     238,   238,   238,   238,   238,   238,   238,   238,   238,   238,
-     238,   238,   238,   238,   238,   238,   238,   239,   239,   239,
-     239,   239,   240,   240,   241,   241,   241,   241,   242,   242,
-     243,   243,   243,   243,   243,   243,   243,   243,   243,   244,
-     244,   244,   244,   244,   244,   244,   244,   245,   245,   246,
-     246,   246,   246,   246,   246,   246,   246,   246,   246,   246,
-     246,   246,   246,   246,   246,   246,   246,   246,   246,   246,
-     246,   246,   246,   246,   246,   246,   246,   246,   246,   246,
-     246,   246,   246,   246,   246,   246,   246,   246,   246,   246,
-     246,   246,   246,   246,   246,   246,   246,   247,   246,   246,
-     246,   246,   248,   248,   248,   248,   249,   249,   249,   249,
-     249,   250,   250,   250,   251,   252,   251,   253,   253,   254,
-     254,   255,   255,   256,   257,   257,   257,   258,   259,   259,
-     259,   260,   260,   261,   261,   262,   263,   264,   265,   266,
-     266,   267,   268,   268,   269,   269,   270,   270,   271,   271,
-     271,   271
+       0,   134,   136,   135,   137,   135,   138,   135,   139,   135,
+     140,   135,   141,   135,   142,   135,   143,   144,   146,   145,
+     147,   148,   149,   150,   152,   153,   151,   151,   151,   151,
+     154,   151,   151,   151,   155,   156,   157,   158,   159,   161,
+     160,   163,   162,   165,   164,   167,   166,   169,   168,   170,
+     171,   173,   172,   174,   175,   176,   177,   177,   178,   179,
+     180,   181,   182,   183,   184,   185,   186,   184,   187,   187,
+     188,   188,   189,   189,   190,   190,   191,   191,   191,   191,
+     191,   191,   191,   191,   191,   191,   191,   191,   191,   191,
+     191,   191,   191,   191,   191,   191,   191,   191,   191,   191,
+     191,   192,   193,   193,   194,   195,   195,   195,   195,   195,
+     195,   195,   195,   196,   196,   196,   197,   197,   198,   198,
+     199,   200,   200,   201,   201,   202,   203,   204,   205,   205,
+     206,   207,   208,   209,   210,   210,   211,   211,   212,   212,
+     212,   213,   213,   214,   214,   215,   215,   216,   216,   217,
+     217,   217,   218,   218,   219,   219,   220,   220,   221,   221,
+     222,   222,   222,   223,   223,   224,   224,   225,   227,   226,
+     228,   228,   229,   230,   230,   232,   231,   233,   233,   233,
+     233,   233,   234,   234,   234,   235,   235,   235,   235,   235,
+     235,   235,   235,   235,   235,   235,   235,   236,   235,   237,
+     237,   238,   238,   238,   238,   238,   238,   238,   238,   238,
+     238,   238,   238,   238,   238,   239,   239,   239,   239,   239,
+     239,   239,   239,   239,   239,   239,   239,   239,   239,   239,
+     239,   239,   239,   239,   239,   239,   239,   240,   240,   240,
+     240,   240,   241,   241,   242,   242,   242,   242,   243,   243,
+     244,   244,   244,   244,   244,   244,   244,   244,   244,   245,
+     245,   245,   245,   245,   245,   245,   245,   246,   246,   247,
+     247,   247,   247,   247,   247,   247,   247,   247,   247,   247,
+     247,   247,   247,   247,   247,   247,   247,   247,   247,   247,
+     247,   247,   247,   247,   247,   247,   247,   247,   247,   247,
+     247,   247,   247,   247,   247,   247,   247,   247,   247,   247,
+     247,   247,   247,   247,   247,   247,   247,   248,   247,   247,
+     247,   247,   249,   249,   249,   249,   250,   250,   250,   250,
+     250,   251,   251,   251,   252,   253,   252,   254,   254,   255,
+     255,   256,   256,   257,   258,   258,   258,   259,   260,   260,
+     260,   261,   261,   262,   262,   263,   264,   265,   266,   267,
+     267,   268,   269,   269,   270,   270,   271,   271,   272,   272,
+     272,   272
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -1628,23 +1635,23 @@ static const toketypes yy_type_tab[] =
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
+  toketype_ival, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
-  toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_ival, toketype_ival,
+  toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval, toketype_opval,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival,
   toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
-  toketype_opval, toketype_opval,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival, toketype_ival,
+  toketype_ival, toketype_ival, toketype_opval, toketype_opval,
   toketype_opval, toketype_ival, toketype_opval,
   toketype_opval, toketype_opval,
   toketype_opval, toketype_opval, toketype_ival, toketype_ival,
@@ -1678,6 +1685,6 @@ static const toketypes yy_type_tab[] =
 };
 
 /* Generated from:
- * 57cc742fa623ae44e0575b737db1c674688361cd405620798cf50de0d81cadfc perly.y
+ * 8444cada5b7e31b67a9eec8f91fdf7511e00378bd03fb2bc726dc0ff958643de perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.y
+++ b/perly.y
@@ -81,7 +81,7 @@
 %token <ival> KW_METHOD_named KW_METHOD_anon
 
 /* Tokens emitted in other situations */
-%token <opval> BAREWORD METHCALL0 METHCALL THING PMFUNC PRIVATEREF QWLIST
+%token <opval> BAREWORD METHCALL0 METHCALL ATTRLIST THING PMFUNC PRIVATEREF QWLIST
 %token <opval> FUNC0OP FUNC0SUB UNIOPSUB LSTOPSUB
 %token <opval> PLUGEXPR PLUGSTMT
 %token <opval> LABEL PROTOTYPE
@@ -1051,9 +1051,9 @@ proto
 /* Optional list of subroutine attributes */
 subattrlist
 	:	empty
-	|	COLONATTR THING
+	|	COLONATTR ATTRLIST
 			{
-			  OP *attrlist = $THING;
+			  OP *attrlist = $ATTRLIST;
 			  if(attrlist && !PL_parser->sig_seen)
 			      attrlist = apply_builtin_cv_attributes(PL_compcv, attrlist);
 			  $$ = attrlist;
@@ -1063,8 +1063,8 @@ subattrlist
 	;
 
 /* List of attributes for some other kind of declaration (variables, classes) */
-attrlist:	COLONATTR THING
-			{ $$ = $THING; }
+attrlist:	COLONATTR ATTRLIST
+			{ $$ = $ATTRLIST; }
 	|	COLONATTR
 			{ $$ = NULL; }
 	;

--- a/toke.c
+++ b/toke.c
@@ -442,6 +442,7 @@ static struct debug_tokens {
     DEBUG_TOKEN (NONE,  ANDOP),
     DEBUG_TOKEN (NONE,  ARROW),
     DEBUG_TOKEN (OPNUM, ASSIGNOP),
+    DEBUG_TOKEN (OPVAL, ATTRLIST),
     DEBUG_TOKEN (OPNUM, BITANDOP),
     DEBUG_TOKEN (OPNUM, BITOROP),
     DEBUG_TOKEN (OPNUM, BLKLSTOP),
@@ -6523,7 +6524,7 @@ yyl_colon(pTHX_ char *s)
         }
         if (attrs) {
             NEXTVAL_NEXTTOKE.opval = attrs;
-            force_next(THING);
+            force_next(ATTRLIST);
         }
         TOKEN(COLONATTR);
     }


### PR DESCRIPTION
Prior to this, toke.c and perly.y used the token name `THING` for a number of apparently totally unrelated reasons. While I haven't attempted to fix most of them, I did find that the one used for attribute lists is unrelated to the others, so I have renamed that to something more sensible and meaningful.

I intend that this change should have no visible effects on anything as it should just be internal neatening and renaming. I'm relatively confident this use of `THING` was isolated from the others due to the unique appearance of the `COLONATTR` that goes with it. But the complexities of tokenization and parsing mean I'm not 100% sure there isn't some weird twisty cornercase that I haven't noticed, and might break somewhere. We should keep an eye on CPAN test reports post-merge on this one.

* This set of changes may require a perldelta if we think there's a risk it is CPAN-visible