### PR TITLE
embed.fnc/group_end: correct the patend pointer decorator

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5306,7 +5306,7 @@ ST	|char	|first_symbol	|NN const char *pat			\
 RS	|const char *|get_num	|NN const char *patptr			\
 				|NN SSize_t *lenptr
 S	|const char *|group_end |SPTR const char *patptr		\
-				|EPTR const char *patend		\
+				|EPTRQ const char *patend		\
 				|char ender
 RS	|SV *	|is_an_int	|NN const char *s			\
 				|STRLEN l

--- a/proto.h
+++ b/proto.h
@@ -8090,7 +8090,7 @@ S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
 STATIC const char *
 S_group_end(pTHX_ const char *patptr, const char *patend, char ender);
 # define PERL_ARGS_ASSERT_GROUP_END             \
-        assert(patptr); assert(patend); assert(patptr < patend)
+        assert(patptr); assert(patend); assert(patptr <= patend)
 
 STATIC SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)

--- a/t/op/pack.t
+++ b/t/op/pack.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc(qw '../lib ../cpan/Math-BigInt/lib');
 }
 
-plan tests => 14724;
+plan tests => 14726;
 
 use strict;
 use warnings qw(FATAL all);
@@ -2065,4 +2065,11 @@ SKIP:
 	$x = eval { pack "[(][)]" };
 	like("$@", qr{Mismatched brackets in template},
 			"should match brackets correctly even without recursion");
+}
+
+{ # see discussion in #23980
+    ok !eval { my $x = pack "C["; 1 },
+      "pack throws with no closing ]";
+    like $@, qr/No group ending character '\]' found in template/,
+      "check the message";
 }


### PR DESCRIPTION
This was incorrectly asserting the supplied string had at least one character, which could produce an assertion instead of a useful error message for the user of pack().

Related to #23980



-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry, as it fixes a bug only introduced in previous dev release.
