### PR TITLE
Fix spelling of 'unrecognised' to en_US version

### DIFF
--- a/class.c
+++ b/class.c
@@ -238,7 +238,7 @@ XS(injected_constructor)
         while((he = hv_iternext(params)))
             sv_catpvf(paramnames, ", %" SVf, SVfARG(HeSVKEY_force(he)));
 
-        croak("Unrecognised parameters for %" HvNAMEf_QUOTEDPREFIX " constructor: %" SVf,
+        croak("Unrecognized parameters for %" HvNAMEf_QUOTEDPREFIX " constructor: %" SVf,
                 HvNAMEfARG(stash), SVfARG(paramnames));
     }
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -7544,7 +7544,7 @@ The message attempts to include the name of the called subroutine.  If
 the subroutine has been aliased, the subroutine's original name will be
 shown, regardless of what name the caller used.
 
-=item Unrecognised parameters for "%s" constructor: %s
+=item Unrecognized parameters for "%s" constructor: %s
 
 (F) You called new on a class but supplied a parameter name that
 didn't match a class field name.

--- a/t/class/construct.t
+++ b/t/class/construct.t
@@ -33,9 +33,9 @@ use builtin qw( blessed reftype );
     is($obj+0, builtin::refaddr($obj), 'numified object');
     like("$obj", qr/^Testcase1=OBJECT\(0x[[:xdigit:]]+\)$/, 'stringified object' );
 
-    ok(!eval { Testcase1->new(x => 123, y => 456); 1 }, 'Unrecognised parameter fails');
-    like($@, qr/^Unrecognised parameters for "Testcase1" constructor: y at /,
-        'Exception thrown by constructor for unrecogniser parameter');
+    ok(!eval { Testcase1->new(x => 123, y => 456); 1 }, 'Unrecognized parameter fails');
+    like($@, qr/^Unrecognized parameters for "Testcase1" constructor: y at /,
+        'Exception thrown by constructor for unrecognized parameter');
 }
 
 {


### PR DESCRIPTION
In my defence, I am British, so don't colour me an idiot please ;)

* This set of changes does not require a perldelta entry.