### PR TITLE
Refactor Perl_av_fetch: remove goto, reduce the number of branches

### DIFF
--- a/av.c
+++ b/av.c
@@ -266,9 +266,6 @@ S_adjust_index(pTHX_ AV *av, const MAGIC *mg, SSize_t *keyp)
 SV**
 Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
 {
-    SSize_t neg;
-    SSize_t size;
-
     PERL_ARGS_ASSERT_AV_FETCH;
 
     if (UNLIKELY(SvRMAGICAL(av))) {
@@ -291,24 +288,23 @@ Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
         }
     }
 
-    neg  = (key < 0);
-    size = AvFILLp(av) + 1;
-    key += neg * size; /* handle negative index without using branch */
+    /* recalculating key early helps branch prediction */
+    SSize_t neg = key < 0;
+    SSize_t size = AvFILLp(av) + 1;
+    key += neg * size;
 
     /* the cast from SSize_t to Size_t allows both (key < 0) and (key >= size)
      * to be tested as a single condition */
-    if ((Size_t)key >= (Size_t)size) {
-        if (UNLIKELY(neg))
-            return NULL;
-        goto emptiness;
-    }
+    if ((Size_t)key >= (Size_t)size)
+        /* Only non-negative out of bounds keys are eligible for lvalue
+         * treatment, so adjust lval by setting value to 0 if the key was
+         * negative */
+        lval *= !neg;
+    else if (AvARRAY(av)[key])
+        return &AvARRAY(av)[key];
 
-    if (!AvARRAY(av)[key]) {
-      emptiness:
-        return lval ? av_store(av,key,newSV_type(SVt_NULL)) : NULL;
-    }
-
-    return &AvARRAY(av)[key];
+    /* value does not exist in the array */
+    return lval ? av_store(av, key, newSV_type(SVt_NULL)) : NULL;
 }
 
 /*


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
This change refactors Perl_av_fetch function and moves the re-calculation of key, so that it happens only if the key is not found in range between 0 and max_index. Fetching existing non-negative elements should be much more common than the alternatives, and this change should reduce the number of instructions needed to achieve that.

I've run Porting/bench.pl script against all tests that start with `expr::array`, here are the average results:
```
       hacked  blead
       ------ ------
    Ir 100.00  97.63
    Dr 100.00 100.00
    Dw 100.00  97.14
  COND 100.00 101.30
   IND 100.00 100.00

COND_m 100.00 100.00
 IND_m 100.00  98.36

 Ir_m1 100.00 102.22
 Dr_m1 100.00 100.00
 Dw_m1 100.00 100.00

 Ir_mm 100.00 100.00
 Dr_mm 100.00 100.00
 Dw_mm 100.00 100.00
```
Tests which contributed to `COND` being higher were `expr::array::pkg_1const_m1` and `expr::array::lex_1const_m1` - not unexpected. Single L1 cache miss comes from `expr::arrayhash::lex_3var` test, and surprisingly, the pkg version of the same test did not miss the cache.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
