### PR TITLE
RMG - No more update of perlweb for BLEAD-POINT

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1379,11 +1379,12 @@ You can include the customary link to the release announcement even before your
 message reaches the web-visible archives by looking for the X-List-Archive
 header in your message after receiving it back via perl5-porters.
 
+=for checklist skip RC BLEAD-POINT
+
 =head3 Update the link to the latest perl on perlweb
 
-Submit a pull request to L<https://github.com/perlorg/perlweb>.  For a dev
-release, update the link in F<docs/dev/perl5/index.html>.  For a stable
-release, update F<docs/shared/tpl/stats.html>.
+Submit a pull request to L<https://github.com/perlorg/perlweb>. 
+Update the link in F<docs/dev/perl5/index.html> and F<docs/shared/tpl/stats.html>.
 
 =for checklist skip RC
 


### PR DESCRIPTION
Drop the dev version update of [dev.perl.org](https://dev.perl.org/perl5/).

This goes along https://github.com/perlorg/perlweb/pull/465 (merged) and removes a step for BLEAD-POINT and RC releases (since it was [generally not done for RC](https://github.com/perlorg/perlweb/pull/456#issuecomment-3016324619))

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
