### PR TITLE
Fix Perl_av_store off by one error in key comparison

### DIFF
--- a/av.c
+++ b/av.c
@@ -361,7 +361,7 @@ Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
             return NULL;
     }
 
-    if (SvREADONLY(av) && key >= AvFILL(av))
+    if (SvREADONLY(av) && key > AvFILL(av))
         croak_no_modify();
 
     if (!AvREAL(av) && AvREIFY(av))

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('.', '../lib');
 }
 
-plan (198);
+plan (199);
 
 #
 # @foo, @bar, and @ary are also used from tie-stdarray after tie-ing them
@@ -734,3 +734,15 @@ fresh_perl_is('my @x;$x[0] = 1;shift @x;$x[22] = 1;$x[25] = 1;','',
     is($arr[1], 3,
        'Array element within array range created at correct index from subroutine @_ alias; GH 16364');
 }
+
+# regression test for GH #24006
+{
+    use feature qw(refaliasing);
+    no warnings 'experimental::refaliasing';
+    my @arr = (1, 2);
+    Internals::SvREADONLY(@arr, 1);
+
+    eval { \$arr[1] = \42 };
+    ok !$@, "Last element's contents of a readonly array can be modified";
+}
+


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
This change addresses a long-standing but rather uncommon bug in checking for replacing scalars in a readonly array. In rare cases, modifying the last scalar in a readonly array will croak with `Modification of a read-only value attempted`. This happens because the comparison treats the last index of the array as if it was array size.

Here is a script which reproduces this bug:
```
use feature qw(refaliasing);
my @xs = qw(a b c);
Internals::SvREADONLY(@xs, 1);

\$xs[1] = \42;
\$xs[2] = \42;
```
Prints:
```
Aliasing via reference is experimental at test.pl line 5.
Aliasing via reference is experimental at test.pl line 6.
Modification of a read-only value attempted at test.pl line 6.
```

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
