### PR TITLE
embed.pl: Tidy up embed.fnc flags error checking

### DIFF
--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3708,7 +3708,8 @@ sub generate_proto_h {
         my $func;
 
         if (! $can_ignore && $retval eq 'void') {
-            warn "It is nonsensical to require the return value of a void function ($plain_func) to be checked";
+            warn "It is nonsensical to require the return value of a void"
+               . " function ($plain_func) to be checked";
         }
 
         if ($flags =~ /[AC]/ && $flags =~ /([EX])/) {
@@ -3796,7 +3797,7 @@ sub generate_proto_h {
         if (@$args) {
             die_at_end
                     "$plain_func: n flag is contradicted by having arguments"
-                                                            if $flags =~ /n/;
+                                                             if $flags =~ /n/;
             my $n;
             my @bounded_strings;
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3668,6 +3668,8 @@ sub generate_proto_h {
                                                      if $flags =~ tr/Ii// > 1;
         die_at_end "$plain_func: S and p flags are mutually exclusive"
                                                     if $flags =~ tr/Sp// > 1;
+        die_at_end "$plain_func:, M flag requires p flag"
+                                            if $flags =~ /M/ && $flags !~ /p/;
 
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
@@ -3763,8 +3765,6 @@ sub generate_proto_h {
 
         $func = full_name($plain_func, $flags);
 
-        die_at_end "$plain_func: M flag requires p flag"
-                                            if $flags =~ /M/ && $flags !~ /p/;
         my $C_required_flags = '[pIimbs]';
         die_at_end
           "$plain_func: C flag requires one of $C_required_flags] flags"

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3666,6 +3666,8 @@ sub generate_proto_h {
 
         die_at_end "$plain_func: I and i flags are mutually exclusive"
                                                      if $flags =~ tr/Ii// > 1;
+        die_at_end "$plain_func: S and p flags are mutually exclusive"
+                                                    if $flags =~ tr/Sp// > 1;
 
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
@@ -3690,8 +3692,6 @@ sub generate_proto_h {
                      . " mutually exclusive";
         }
 
-        die_at_end "$plain_func: S and p flags are mutually exclusive"
-                                                    if $flags =~ tr/Sp// > 1;
         if ($has_mflag) {
             if ($flags =~ /([bSX])/) {
                 my $msg =

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3670,6 +3670,8 @@ sub generate_proto_h {
                                                     if $flags =~ tr/Sp// > 1;
         die_at_end "$plain_func:, M flag requires p flag"
                                             if $flags =~ /M/ && $flags !~ /p/;
+        die_at_end "$plain_func: X flag requires one of [Iip] flags"
+                                        if $flags =~ /X/ && $flags !~ /[Iip]/;
 
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
@@ -3777,8 +3779,6 @@ sub generate_proto_h {
                                                 # it's ok.
                                              && $plain_func !~ /^[Pp]erl/);
 
-        die_at_end "$plain_func: X flag requires one of [Iip] flags"
-                                        if $flags =~ /X/ && $flags !~ /[Iip]/;
         die_at_end "$plain_func: [Ii] with [ACX] requires p flag"
                     if $flags =~ /[Ii]/ && $flags =~ /[ACX]/ && $flags !~ /p/;
         die_at_end "$plain_func: b flag without M flag requires D flag"

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3664,6 +3664,9 @@ sub generate_proto_h {
             die_at_end "$plain_func: O flag forbids T flag" if $flags =~ /T/;
         }
 
+        die_at_end "$plain_func: I and i flags are mutually exclusive"
+                                                     if $flags =~ tr/Ii// > 1;
+
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
         my $has_depth = ( $flags =~ /W/ );
@@ -3780,8 +3783,6 @@ sub generate_proto_h {
                     if $flags =~ /[Ii]/ && $flags =~ /[ACX]/ && $flags !~ /p/;
         die_at_end "$plain_func: b flag without M flag requires D flag"
                         if $flags =~ /b/ && $flags !~ /M/ && $flags !~ /D/;
-        die_at_end "$plain_func: I and i flags are mutually exclusive"
-                                            if $flags =~ tr/Ii// > 1;
 
         $ret = "";
         $ret .= "$retval\n";

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3690,9 +3690,11 @@ sub generate_proto_h {
         die_at_end "$plain_func: S and p flags are mutually exclusive"
                                                     if $flags =~ tr/Sp// > 1;
         if ($has_mflag) {
-            if ($flags =~ /S/) {
-                die_at_end
-                          "$plain_func: m and S flags are mutually exclusive";
+            if ($flags =~ /([bSX])/) {
+                my $msg =
+                         "$plain_func: m and $1 flags are mutually exclusive";
+                $msg .= " (try M flag)" if $1 eq 'b';
+                die_at_end $msg;
             }
 
             # Don't generate a prototype for a macro that is not usable by the
@@ -3774,12 +3776,8 @@ sub generate_proto_h {
 
         die_at_end "$plain_func: X flag requires one of [Iip] flags"
                                         if $flags =~ /X/ && $flags !~ /[Iip]/;
-        die_at_end "$plain_func: X and m flags are mutually exclusive"
-                                            if $flags =~ /X/ && $has_mflag;
         die_at_end "$plain_func: [Ii] with [ACX] requires p flag"
                     if $flags =~ /[Ii]/ && $flags =~ /[ACX]/ && $flags !~ /p/;
-        die_at_end "$plain_func: b and m flags are mutually exclusive"
-                 . " (try M flag)" if $flags =~ /b/ && $has_mflag;
         die_at_end "$plain_func: b flag without M flag requires D flag"
                         if $flags =~ /b/ && $flags !~ /M/ && $flags !~ /D/;
         die_at_end "$plain_func: I and i flags are mutually exclusive"

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3711,10 +3711,9 @@ sub generate_proto_h {
             warn "It is nonsensical to require the return value of a void function ($plain_func) to be checked";
         }
 
-        my $has_E_or_X = $flags =~ /[EX]/;
-        if ($has_E_or_X + ($flags =~ tr/AC//) > 1) {
-            die_at_end "$plain_func: A, C, and either E or X flags are"
-                     . " mutually exclusive";
+        if ($flags =~ /[AC]/ && $flags =~ /([EX])/) {
+            die_at_end "$plain_func: $1 flag is incompatible with either A"
+                     . " or C flags";
         }
 
         if ($has_mflag) {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3666,6 +3666,8 @@ sub generate_proto_h {
 
         die_at_end "$plain_func: I and i flags are mutually exclusive"
                                                      if $flags =~ tr/Ii// > 1;
+        die_at_end "$plain_func: A, C, and S flags are all mutually exclusive"
+                                                    if $flags =~ tr/ACS// > 1;
         die_at_end "$plain_func: S and p flags are mutually exclusive"
                                                     if $flags =~ tr/Sp// > 1;
         die_at_end "$plain_func:, M flag requires p flag"

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3674,6 +3674,11 @@ sub generate_proto_h {
                                         if $flags =~ /X/ && $flags !~ /[Iip]/;
         die_at_end "$plain_func: [Ii] with [ACX] requires p flag"
                     if $flags =~ /[Ii]/ && $flags =~ /[ACX]/ && $flags !~ /p/;
+        if ($flags =~ /b/) {
+            die_at_end "$plain_func: b flag without M flag requires D flag"
+                                            if $flags !~ /M/ && $flags !~ /D/;
+        }
+
 
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
@@ -3781,8 +3786,6 @@ sub generate_proto_h {
                                                 # it's ok.
                                              && $plain_func !~ /^[Pp]erl/);
 
-        die_at_end "$plain_func: b flag without M flag requires D flag"
-                        if $flags =~ /b/ && $flags !~ /M/ && $flags !~ /D/;
 
         $ret = "";
         $ret .= "$retval\n";

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3679,6 +3679,18 @@ sub generate_proto_h {
                                             if $flags !~ /M/ && $flags !~ /D/;
         }
 
+        my $C_required_flags = '[pIimbs]';
+        die_at_end
+          "$plain_func: C flag requires one of $C_required_flags flags"
+                                             if $flags =~ /C/
+                                             && ($flags !~ /$C_required_flags/
+
+                                                # Notwithstanding the
+                                                # above, if the name won't
+                                                # clash with a user name,
+                                                # it's ok.
+                                             && $plain_func !~ /^[Pp]erl/);
+
 
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
@@ -3773,19 +3785,6 @@ sub generate_proto_h {
         }
 
         $func = full_name($plain_func, $flags);
-
-        my $C_required_flags = '[pIimbs]';
-        die_at_end
-          "$plain_func: C flag requires one of $C_required_flags] flags"
-                                             if $flags =~ /C/
-                                             && ($flags !~ /$C_required_flags/
-
-                                                # Notwithstanding the
-                                                # above, if the name won't
-                                                # clash with a user name,
-                                                # it's ok.
-                                             && $plain_func !~ /^[Pp]erl/);
-
 
         $ret = "";
         $ret .= "$retval\n";

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3716,7 +3716,7 @@ sub generate_proto_h {
         }
 
         if ($has_mflag) {
-            if ($flags =~ /([bSX])/) {
+            if ($flags =~ /([bMSX])/) {
                 my $msg =
                          "$plain_func: m and $1 flags are mutually exclusive";
                 $msg .= " (try M flag)" if $1 eq 'b';

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3703,8 +3703,7 @@ sub generate_proto_h {
             next if $flags =~ /u/;
         }
         else {
-            die_at_end "$plain_func: u flag only usable with m"
-                                                            if $flags =~ /u/;
+            die_at_end "$plain_func: u flag requires m flag" if $flags =~ /u/;
         }
 
         my ($static_flag, @extra_static_flags)= $flags =~/([SsIi])/g;
@@ -3744,7 +3743,7 @@ sub generate_proto_h {
 
             # A publicly accessible non-static element needs to have a Perl_
             # prefix available to call it with (in case of name conflicts).
-            die_at_end "'$plain_func' requires p flag because has A or C flag"
+            die_at_end "$plain_func: requires p flag because has A or C flag"
                                     if $flags !~ /p/
                                     && $flags =~ /[AC]/
                                     && $plain_func !~ /[Pp]erl/;
@@ -3759,11 +3758,11 @@ sub generate_proto_h {
 
         $func = full_name($plain_func, $flags);
 
-        die_at_end "For '$plain_func', M flag requires p flag"
+        die_at_end "$plain_func: M flag requires p flag"
                                             if $flags =~ /M/ && $flags !~ /p/;
         my $C_required_flags = '[pIimbs]';
         die_at_end
-          "For '$plain_func', C flag requires one of $C_required_flags] flags"
+          "$plain_func: C flag requires one of $C_required_flags] flags"
                                              if $flags =~ /C/
                                              && ($flags !~ /$C_required_flags/
 
@@ -3773,17 +3772,17 @@ sub generate_proto_h {
                                                 # it's ok.
                                              && $plain_func !~ /^[Pp]erl/);
 
-        die_at_end "For '$plain_func', X flag requires one of [Iip] flags"
+        die_at_end "$plain_func: X flag requires one of [Iip] flags"
                                         if $flags =~ /X/ && $flags !~ /[Iip]/;
-        die_at_end "For '$plain_func', X and m flags are mutually exclusive"
+        die_at_end "$plain_func: X and m flags are mutually exclusive"
                                             if $flags =~ /X/ && $has_mflag;
-        die_at_end "For '$plain_func', [Ii] with [ACX] requires p flag"
+        die_at_end "$plain_func: [Ii] with [ACX] requires p flag"
                     if $flags =~ /[Ii]/ && $flags =~ /[ACX]/ && $flags !~ /p/;
-        die_at_end "For '$plain_func', b and m flags are mutually exclusive"
+        die_at_end "$plain_func: b and m flags are mutually exclusive"
                  . " (try M flag)" if $flags =~ /b/ && $has_mflag;
-        die_at_end "For '$plain_func', b flag without M flag requires D flag"
+        die_at_end "$plain_func: b flag without M flag requires D flag"
                         if $flags =~ /b/ && $flags !~ /M/ && $flags !~ /D/;
-        die_at_end "For '$plain_func', I and i flags are mutually exclusive"
+        die_at_end "$plain_func: I and i flags are mutually exclusive"
                                             if $flags =~ tr/Ii// > 1;
 
         $ret = "";

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3672,6 +3672,8 @@ sub generate_proto_h {
                                             if $flags =~ /M/ && $flags !~ /p/;
         die_at_end "$plain_func: X flag requires one of [Iip] flags"
                                         if $flags =~ /X/ && $flags !~ /[Iip]/;
+        die_at_end "$plain_func: [Ii] with [ACX] requires p flag"
+                    if $flags =~ /[Ii]/ && $flags =~ /[ACX]/ && $flags !~ /p/;
 
         my @nonnull;
         my $args_assert_line = ( $flags !~ /m/ );
@@ -3779,8 +3781,6 @@ sub generate_proto_h {
                                                 # it's ok.
                                              && $plain_func !~ /^[Pp]erl/);
 
-        die_at_end "$plain_func: [Ii] with [ACX] requires p flag"
-                    if $flags =~ /[Ii]/ && $flags =~ /[ACX]/ && $flags !~ /p/;
         die_at_end "$plain_func: b flag without M flag requires D flag"
                         if $flags =~ /b/ && $flags !~ /M/ && $flags !~ /D/;
 


### PR DESCRIPTION
This series of commits mostly just moves code around and tidies things so that the error checking of flags in embed.fnc lines is more coherent.  

It adds two checks that had been omitted.  A symbol can't both be one type of macro, and another type of macro; nor public and non-public, and we don't want symbols whose names begin with `S_` to be public.  (We want `Perl_` for those.)

* This set of changes does not require a perldelta entry.
