### PR TITLE
sort: correctly sort "0+" overloaded values

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5420,8 +5420,8 @@ i	|I32	|sv_i_ncmp	|NN SV * const a			\
 				|NN SV * const b
 i	|I32	|sv_i_ncmp_desc |NN SV * const a			\
 				|NN SV * const b
-i	|I32	|sv_ncmp	|NN SV * const a			\
-				|NN SV * const b
+i	|I32	|sv_ncmp	|NN SV *a				\
+				|NN SV *b
 i	|I32	|sv_ncmp_desc	|NN SV * const a			\
 				|NN SV * const b
 # if defined(USE_LOCALE_COLLATE)

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -420,7 +420,13 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+sort() optimizes common comparisons from calling the OP tree for a
+comparison block into a call to a C function.  The C function used for
+overloaded numeric comparisons did not handle the case where there was
+no comparison overload but there was a numeric ("0+") overload
+correctly, losing precision for large overloaded integer arguments that
+are not exactly representable as a Perl floating point value (NV).
+[GH #23956]
 
 =back
 

--- a/pp_sort.c
+++ b/pp_sort.c
@@ -1310,11 +1310,22 @@ S_sortcv_xsub(pTHX_ SV *const a, SV *const b)
 
 
 PERL_STATIC_FORCE_INLINE I32
-S_sv_ncmp(pTHX_ SV *const a, SV *const b)
+S_sv_ncmp(pTHX_ SV *a, SV *b)
 {
-    I32 cmp = do_ncmp(a, b);
-
     PERL_ARGS_ASSERT_SV_NCMP;
+
+    /* Numify since do_ncmp will just SvNV() non-IVs.
+
+       Even for the non-overloading case, if RVs are allocated with
+       large 64-bit addresses (only theoretically possible I think)
+       the bottom bits of the RV might be lost.
+     */
+    if (SvROK(a))
+        a = sv_2num(a);
+    if (SvROK(b))
+        b = sv_2num(b);
+
+    I32 cmp = do_ncmp(a, b);
 
     if (cmp == 2) {
         if (ckWARN(WARN_UNINITIALIZED)) report_uninit(NULL);
@@ -1359,7 +1370,7 @@ S_sv_i_ncmp_desc(pTHX_ SV *const a, SV *const b)
 #define SORT_NORMAL_RETURN_VALUE(val)  (((val) > 0) ? 1 : ((val) ? -1 : 0))
 
 PERL_STATIC_FORCE_INLINE I32
-S_amagic_ncmp(pTHX_ SV *const a, SV *const b)
+S_amagic_ncmp(pTHX_ SV *a, SV *b)
 {
     SV * const tmpsv = tryCALL_AMAGICbin(a,b,ncmp_amg);
 
@@ -1375,6 +1386,7 @@ S_amagic_ncmp(pTHX_ SV *const a, SV *const b)
             return SORT_NORMAL_RETURN_VALUE(d);
         }
      }
+
      return S_sv_ncmp(aTHX_ a, b);
 }
 

--- a/proto.h
+++ b/proto.h
@@ -8226,7 +8226,7 @@ S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b);
         assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
-S_sv_ncmp(pTHX_ SV * const a, SV * const b);
+S_sv_ncmp(pTHX_ SV *a, SV *b);
 #   define PERL_ARGS_ASSERT_SV_NCMP             \
         assert(a); assert(b)
 

--- a/t/op/sort.t
+++ b/t/op/sort.t
@@ -976,7 +976,6 @@ is("@b", "1 2 3 3 4 5 7", "comparison result as string");
         bless [ $_ ], "GH23956"
     } ~0, ~0-1;
     my @sorted = sort { $a <=> $b } @data;
-    local $::TODO = "sort amagic_ncmp is broken";
     is $sorted[0]+0, $data[1], "sort of 0+ overloaded values";
 }
 

--- a/t/op/sort.t
+++ b/t/op/sort.t
@@ -7,7 +7,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 use warnings;
-plan(tests => 205);
+plan(tests => 206);
 use Tie::Array; # we need to test sorting tied arrays
 
 # these shouldn't hang
@@ -962,6 +962,22 @@ is("@b", "1 2 3 3 4 5 7", "comparison result as string");
     is($cc, 1, 'overload compare called once');
     is("@sorted","1 2", 'overload sort result');
     is($cs, 2, 'overload string called twice');
+}
+
+{
+    # GH 23956 - amagic_ncmp didn't handle numeric conversions
+    # properly
+    package GH23956 {
+        use overload
+          fallback => 1,
+          "0+" => sub { $_[0][0] };
+    }
+    my @data = map {
+        bless [ $_ ], "GH23956"
+    } ~0, ~0-1;
+    my @sorted = sort { $a <=> $b } @data;
+    local $::TODO = "sort amagic_ncmp is broken";
+    is $sorted[0]+0, $data[1], "sort of 0+ overloaded values";
 }
 
 fresh_perl_is('sub w ($$) {my ($l, $r) = @_; my $v = \@_; undef @_; $l <=> $r}; print join q{ }, sort w 3, 1, 2, 0',


### PR DESCRIPTION
This also handles the theoretical case of large RVs, but I suspect it can't happen.

Fixes #23956 

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
