### PR TITLE
amagic_call: don't invoke DB::sub for overloads called from DB

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -4171,7 +4171,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
     ENTER;
     SAVEOP();
     PL_op = (OP *) &myop;
-    if (PERLDB_SUB && PL_curstash != PL_debstash)
+    if (PERLDB_SUB && !CopSTASH_eq(PL_curcop, PL_debstash))
         PL_op->op_private |= OPpENTERSUB_DB;
     PUSHMARK(PL_stack_sp);
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -397,6 +397,13 @@ exit in other code during a match. For example in something like
 C<(?{ local $x = ... })>, the C<local> might have been unwound before the
 pattern has finished matching. [GH #16197]
 
+=item *
+
+C<DB::sub> is not meant to be called for sub calls from the DB
+package, but called to overloaded subs for overloaded values used in
+the DB package would result in calls in DB::sub.  Fixed the check for
+the current package in amagic_call().  [GH 24001]
+
 =back
 
 =head1 Known Problems

--- a/t/op/debug.t
+++ b/t/op/debug.t
@@ -123,7 +123,6 @@ EXPECT
 
 {
     # GH 24001
-    local $::TODO = "&DB::sub shouldn't be called when called from DB";
     local $ENV{PERL5DB} = 'sub DB::DB {}';
     fresh_perl_is(<<'CODE', "OK\n",
 package DB;

--- a/t/op/debug.t
+++ b/t/op/debug.t
@@ -121,4 +121,54 @@ EXPECT
                   );
 }
 
+{
+    # GH 24001
+    local $::TODO = "&DB::sub shouldn't be called when called from DB";
+    local $ENV{PERL5DB} = 'sub DB::DB {}';
+    fresh_perl_is(<<'CODE', "OK\n",
+package DB;
+sub DB::sub {
+    # avoid deep recursion
+    die "Fail" if $DB::sub =~ /^version::/;
+    # trigger overloading call from package DB
+    my $v = "$^V";
+    print $v ne "" ? "OK\n" : ""
+}
+package main;
+sub f {
+}
+f();
+CODE
+                  {
+                      switches => [ '-d' ],
+                  },
+                  "overloading call from DB doesn't break into DB::sub");
+}
+{
+    local $ENV{PERL5DB} = 'sub DB::DB {}';
+    # make sure we don't break the expected break
+    fresh_perl_is(<<'CODE', "OK\n",
+package DB;
+sub DB::sub {
+    our @count;
+    if ($DB::sub eq 'version::(""') {
+        print "OK\n";
+        exit;
+    }
+    push @count, $DB::sub;
+    die "Fail @count\n" if @count > 10;
+    &$DB::sub;
+}
+package main;
+sub f {
+    my $v = "$^V";
+}
+f();
+CODE
+                  {
+                      switches => [ '-d' ],
+                  },
+                  "overloading call from non-DB does break into DB::sub");
+}
+
 done_testing();


### PR DESCRIPTION
Perl decides on whether DB::sub is called for a sub called based on
the OPpENTERSUB_DB flag in the entersub op for that call.

At compilation time ck_subr sets if PL_curstash (the current
compilation stash) is not equal to PL_dbstash (%DB::), which is fine.

When calling an overload sub amagic_call() synthesizes an entersub OP
and sets OPpENTERSUB_DB based on the same condition, but PL_curstash
isn't set to the stash of the currently executing code, but is still
set to the last stash code was compiled in (as modified by scope
restoration).

This means the flag was (perhaps nearly) always set, so the debugger
would call &DB::sub even though the overload was occurring in package
DB.

Fix this by testing against CopSTASH(PL_curcop) instead, which other
runtime stash checks also do, eg. pp_caller, doeval_compile.
    
Fixes #24001

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
