### PR TITLE
ParseXS: allow XS files with no XS again

### DIFF
--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -76,7 +76,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.61';
+  $VERSION = '3.62';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Node; ExtUtils::ParseXS::Node->VERSION($VERSION);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -603,9 +603,13 @@ sub parse {
 
     my $C_part = ExtUtils::ParseXS::Node::C_part->new();
     $self->{C_part} = $C_part;
-    $C_part->parse($pxs, $self)
-        or return;
+    my $c_part_result = $C_part->parse($pxs, $self);
     push @{$self->{kids}}, $C_part;
+
+    # A failure when parsing the C part means that there wasn't a MODULE
+    # line. Don't try to parse the missing XS part, but still return
+    # success, passing through the lines from the C part.
+    return 1 unless $c_part_result;
 
     # "Parse" the bit following any C code. Doesn't actually consume any
     # lines: just a placeholder for emitting postamble code.
@@ -752,7 +756,7 @@ sub parse {
     }
 
     warn "Didn't find a 'MODULE ... PACKAGE ... PREFIX' line\n";
-    exit 0; # Not a fatal error for the caller process
+    return;
 }
 
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 require ExtUtils::ParseXS;
 require ExtUtils::ParseXS::Constants;

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::Cmd;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 use ExtUtils::Typemaps;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::InputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::OutputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 require ExtUtils::Typemaps;
 
-our $VERSION = '3.61';
+our $VERSION = '3.62';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -4954,7 +4954,7 @@ this model, the less likely conflicts will occur.
 
 =head1 XS VERSION
 
-This document covers features supported by F<xsubpp> 3.61.
+This document covers features supported by F<xsubpp> 3.62.
 
 =head1 AUTHOR DIAGNOSTICS
 

--- a/dist/ExtUtils-ParseXS/t/001-basic.t
+++ b/dist/ExtUtils-ParseXS/t/001-basic.t
@@ -5879,4 +5879,28 @@ EOF
     test_many($preamble, undef, \@test_fns);
 }
 
+{
+    # An XS file without a MODULE line should warn, but
+    # still emit the C code in the C part of the file (the whole file
+    # contents in this case).
+
+    my $preamble = '';
+
+    my @test_fns = (
+        [
+            "No MODULE line",
+            [ Q(<<'EOF') ],
+                |foo
+                |bar
+EOF
+
+            [ 0, 0, qr{#line 1 ".*"\nfoo\nbar\n#line 13 ".*"}, "all C present" ],
+            [ 1, 0, qr{Didn't find a 'MODULE ... PACKAGE ... PREFIX' line},
+                    "got expected MODULE warning"  ],
+        ],
+    );
+
+    test_many($preamble, undef, \@test_fns);
+}
+
 done_testing;


### PR DESCRIPTION
GH #24016

ParseXS / xsubpp allowed .xs files to contain only C code; i.e. no XS code. A warning was issued about about a missing MODULE line, but the C contents of the file was emitted as-is.

My recent refactoring broke this - it was now generating a C code file with zero lines. This was because ParseXS now splits the parsing and code-emitting into two separate phases, and this code during parsing:

     warn "Didn't find a 'MODULE ... PACKAGE ... PREFIX' line\n";
     exit 0; # Not a fatal error for the caller process

was now exiting before any lines had been emitted.

The fix is to not suddenly exit, but instead continue with pared-down parsing and code emitting.

* This set of changes does not require a perldelta entry.
