### PR TITLE
Test where we switch from one version to itself

### DIFF
--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -59,6 +59,11 @@ Helloworld
 eval "no " . ($]+1); print $@;
 EXPECT
 ########
+# requesting the same version again is fine
+use v5.20;
+use v5.20;
+EXPECT
+########
 # lower version after higher version
 sub evalbytes { print "evalbytes sub\n" }
 sub say { print "say sub\n" }


### PR DESCRIPTION
This should emit neither warning nor exception.

This pull request is part of the groundwork for implementing https://github.com/Perl/perl5/issues/23624, "Fatalization of changing 'use VERSION' while another 'use VERSION' is in scope".

The governing code in blead is found in `op.c`:
```
 8420         if (shortver && PL_prevailing_version) {
 8421             /* use VERSION while another use VERSION is in scope
 8422              * This should provoke at least a warning, if not an outright error
 8423              */
 8424             if (PL_prevailing_version < SHORTVER(5, 10)) {
 8425                 /* if the old version had no side effects, we can allow this
 8426                  * without any warnings or errors */
 8427             }
 8428             else if (shortver == PL_prevailing_version) {
 8429                 /* requesting the same version again is fine */
 8430             }
 8431             else if (shortver >= SHORTVER(5, 39)) {
 8432                 croak("use VERSION of 5.39 or above is not permitted while another use VERSION       is in scope");
 8433             }
 8434             else if (PL_prevailing_version >= SHORTVER(5, 39)) {
 8435                 croak("use VERSION is not permitted while another use VERSION of 5.39 or above is in scope");
 8436             }
 8437             else if (PL_prevailing_version >= SHORTVER(5, 11) && shortver < SHORTVER(5, 11)) {
 8438                 /* downgrading from >= 5.11 to < 5.11 is now fatal */
 8439                 croak("Downgrading a use VERSION declaration to below v5.11 is not permitted")      ;
 8440             }
 8441             else {
 8442                 /* OK let's at least warn */
 8443                 deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.44",
 8444                     "Changing use VERSION while another use VERSION is in scope");
 8445             }
 8446         }
```
If you were to:

* hack up this section of `op.c` with debugging statements, like this:
```
$ cat op.c.8414.diff 
diff --git a/op.c b/op.c
index d0e481b614..7dbf221f24 100644
--- a/op.c
+++ b/op.c
@@ -8418,28 +8418,35 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         U16 shortver = S_extract_shortver(aTHX_ use_version);
 
         if (shortver && PL_prevailing_version) {
+            warn("AAA:");
             /* use VERSION while another use VERSION is in scope
              * This should provoke at least a warning, if not an outright error
              */
             if (PL_prevailing_version < SHORTVER(5, 10)) {
+            warn("BBB:");
                 /* if the old version had no side effects, we can allow this
                  * without any warnings or errors */
             }
             else if (shortver == PL_prevailing_version) {
+            warn("CCC:");
                 /* requesting the same version again is fine */
             }
             else if (shortver >= SHORTVER(5, 39)) {
+            warn("DDD:");
                 croak("use VERSION of 5.39 or above is not permitted while another use VERSION is in scope");
             }
             else if (PL_prevailing_version >= SHORTVER(5, 39)) {
+            warn("EEE:");
                 croak("use VERSION is not permitted while another use VERSION of 5.39 or above is in scope");
             }
             else if (PL_prevailing_version >= SHORTVER(5, 11) && shortver < SHORTVER(5, 11)) {
                 /* downgrading from >= 5.11 to < 5.11 is now fatal */
+            warn("FFF:");
                 croak("Downgrading a use VERSION declaration to below v5.11 is not permitted");
             }
             else {
                 /* OK let's at least warn */
+            warn("GGG:");
                 deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.44",
                     "Changing use VERSION while another use VERSION is in scope");
             }
```
* run `make test` to see where these clauses are exercised in the test suite,

* set aside obvious cases like `t/porting/perldiag.t` and `t/lib/warnings.t`,

* you would get a distribution like this:
```
     17 AAA:
     11 BBB:
      1 DDD:
      1 EEE:
      1 FFF:
      3 GGG:
```
... which suggests that case `CCC:` is not currently directly exercised by the test suite.

Here is a patch which remedies that.


* This set of changes does not require a perldelta entry.
