### PR TITLE
Restore iteration var after foreach refalias loop

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -4152,6 +4152,48 @@ Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
         cx->blk_loop.itersave = NULL;
         SvREFCNT_dec(cursv);
     }
+    if (cx->cx_type & CXp_FOR_LVREF) {
+        SV *itervar = (SV *)(cx)->blk_loop.itervar_u.gv;
+        SV *origval = (cx)->blk_loop.itersave;
+        assert(SvTYPE(itervar) == SVt_PVMG);
+        MAGIC *mg = SvMAGIC(itervar);
+        assert(mg);
+        assert(mg->mg_type == PERL_MAGIC_lvref);
+        if (!mg->mg_obj) {
+            // LV ref around a lexical, mg_len gives its pad index
+            SV **padslot = &PAD_SVl(mg->mg_len);
+            SV *oldsv = *padslot;
+            *padslot = origval;
+            SvREFCNT_dec(oldsv);
+        }
+        else {
+            // LV ref around a package lexical, mg_obj gives its GV
+            GV *gv = (GV *)mg->mg_obj;
+            SV *oldsv;
+            switch(mg->mg_private & OPpLVREF_TYPE) {
+                case OPpLVREF_SV:
+                    oldsv = GvSVn(gv);
+                    GvSVn(gv) = origval;
+                    break;
+
+                case OPpLVREF_AV:
+                    oldsv = (SV *)GvAV(gv);
+                    GvAV(gv) = (AV *)origval;
+                    break;
+
+                case OPpLVREF_HV:
+                    oldsv = (SV *)GvHV(gv);
+                    GvHV(gv) = (HV *)origval;
+                    break;
+
+                case OPpLVREF_CV:
+                    oldsv = (SV *)GvCV(gv);
+                    GvCV_set(gv, (CV *)origval);
+                    break;
+            }
+            SvREFCNT_dec(oldsv);
+        }
+    }
     if (cx->cx_type & (CXp_FOR_GV|CXp_FOR_LVREF))
         SvREFCNT_dec(cx->blk_loop.itervar_u.svp);
 }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2622,9 +2622,26 @@ PP(pp_enteriter)
         }
         else {                          /* LV ref: for \$foo (...) */
             assert(SvTYPE(sv) == SVt_PVMG);
-            assert(SvMAGIC(sv));
-            assert(SvMAGIC(sv)->mg_type == PERL_MAGIC_lvref);
             itersave = NULL;
+            MAGIC *mg = SvMAGIC(sv);
+            assert(mg);
+            assert(mg->mg_type == PERL_MAGIC_lvref);
+            if (!mg->mg_obj) {
+                // LV ref around a lexical, mg_len gives its pad index
+                itersave = SvREFCNT_inc_NN(PAD_SV(mg->mg_len));
+            }
+            else {
+                // LV ref around a package lexical, mg_obj gives its GV
+                GV *gv = (GV *)mg->mg_obj;
+                assert(SvTYPE(gv) == SVt_PVGV);
+                switch(mg->mg_private & OPpLVREF_TYPE) {
+                    case OPpLVREF_SV: itersave =       GvSVn(gv); break;
+                    case OPpLVREF_AV: itersave = (SV *)GvAV(gv);  break;
+                    case OPpLVREF_HV: itersave = (SV *)GvHV(gv);  break;
+                    case OPpLVREF_CV: itersave = (SV *)GvCV(gv);  break;
+                }
+                SvREFCNT_inc_void(itersave);
+            }
             cxflags = CXp_FOR_LVREF;
         }
         /* we transfer ownership of 1 ref count of itervarp from the stack

--- a/t/op/decl-refs.t
+++ b/t/op/decl-refs.t
@@ -4,7 +4,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan 402;
+plan 408;
 
 for my $decl (qw< my CORE::state our local >) {
     for my $funny (qw< $ @ % >) {
@@ -120,3 +120,30 @@ ENE
     $code =~ s/is ?no?t/is/g if $decl eq 'our';
     eval $code or die $@;
 }}
+
+# GH#24028
+{
+    my $slexical = 42;
+    for \$slexical ( \1, \2, \3 ) { }
+    is $slexical, 42, 'scalar lexical restored after foreach-refalias';
+
+    my @alexical = (42);
+    for \@alexical ( [1], [2], [3] ) { }
+    is $alexical[0], 42, 'array lexical restored after foreach-refalias';
+
+    my %hlexical = (k => 42);
+    for \%hlexical ( {k => 1}, {k => 2}, {k => 3} ) { }
+    is $hlexical{k}, 42, 'hash lexical restored after foreach-refalias';
+
+    our $spkgvar = 84;
+    for \$spkgvar ( \1, \2, \3 ) { }
+    is $spkgvar, 84, 'scalar pkgvar restored after foreach-refalias';
+
+    our @apkgvar = (84);
+    for \@apkgvar ( [1], [2], [3] ) { }
+    is $apkgvar[0], 84, 'array pkgvar restored after foreach-refalias';
+
+    our %hpkgvar = (k => 84);
+    for \%hpkgvar ( {k => 1}, {k => 2}, {k => 3} ) { }
+    is $hpkgvar{k}, 84, 'hash pkgvar restored after foreach-refalias';
+}


### PR DESCRIPTION
An initial attempt to solve #24028.

The code relies on some inner knowledge of how the `PERL_MAGIC_lvref` magic structure works, so it isn't great, but it solves the problem for now. Most importantly, it adds more unit tests to assert the behaviour we want.

My intention is to rework the implementation of `foreach` on refalias variables after this is merged, so it would be a neater solution to this problem, and also would be nicer to work out for #24027 as well.

As it is a bugfix to some behaviour on a still-experimental feature, I don't believe this needs a perldelta entry.