### PR TITLE
Fix typos

### DIFF
--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -223,7 +223,7 @@ If you do need raw strings, use these instead:
   my_strlcpy(dt, src, sizeof(dt))
   my_strlcat(dt, src, sizeof(dt))
 
-Similiarly, you can use SVs for creating strings from formats
+Similarly, you can use SVs for creating strings from formats
 
   sprintf(s, fmt, ...)         sv_setpvf(sv, fmt, ...)
   vsprintf(str, fmt, va_list)  sv_vsetpvf(sv, fmt, va_list)
@@ -300,7 +300,7 @@ C<toUPPER_uvchr>, as described in L<perlapi/Character case changing>.)
 Note that the libc caseless comparisons are crippled; Unicode
 provides a richer set, using the concept of folding.  If you need
 more than equality/non-equality, it's probably best to store your
-strings in an SV and use SV functions to do the comparision.  Similarly
+strings in an SV and use SV functions to do the comparison.  Similarly
 for collation.
 
 =head2 F<stdlib.h> functions

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1345,7 +1345,7 @@ See also L<perlfunc/require>.
 (F) You called the C<import()> or C<unimport()> method of a class that has no
 such method defined in its inheritance graph, and passed an argument to the
 method. This is very often the sign of a misspelled package name in a C<use>
-or C<require> statement that has silently succeded due to a case insensitive
+or C<require> statement that has silently succeeded due to a case insensitive
 file system.
 
 =item Can't locate package %s for @%s::ISA


### PR DESCRIPTION
I was playing around with Debian's `spellintian` tool and found some typos in Perl's documentation, so I corrected them.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
