### PR TITLE
Pod::Html: fix anchorify() whitespace stripping

### DIFF
--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -2,7 +2,7 @@ package Pod::Html;
 use strict;
 use Exporter 'import';
 
-our $VERSION = 1.35;
+our $VERSION = 1.36;
 $VERSION = eval $VERSION;
 our @EXPORT = qw(pod2html);
 

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -2,7 +2,7 @@ package Pod::Html::Util;
 use strict;
 use Exporter 'import';
 
-our $VERSION = 1.35; # Please keep in synch with lib/Pod/Html.pm
+our $VERSION = 1.36; # Please keep in synch with lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @EXPORT_OK = qw(
     anchorify
@@ -250,7 +250,9 @@ sub anchorify {
     $anchor =~ s/"/_/g;                 # Replace double quotes with underscores
     $anchor =~ s/_$//;                  # ... but strip any final underscore
     $anchor =~ s/[<>&']//g;             # Strip the remaining HTML special characters
-    $anchor =~ s/^\s+//; s/\s+$//;      # Strip white space.
+    $anchor =~ s/^\s+//;                # Strip white space.
+    $anchor =~ s/\s+$//;
+
     $anchor =~ s/^([^a-zA-Z]+)$/pod$1/; # Prepend "pod" if no valid chars.
     $anchor =~ s/^[^a-zA-Z]+//;         # First char must be a letter.
     $anchor =~ s/[^-a-zA-Z0-9_:.]+/-/g; # All other chars must be valid.

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -2,7 +2,7 @@ package Testing;
 use 5.10.0;
 use warnings;
 use Exporter 'import';
-our $VERSION = 1.35; # Let's keep this same as lib/Pod/Html.pm
+our $VERSION = 1.36; # Let's keep this same as lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @EXPORT_OK = qw(
     setup_testing_dir


### PR DESCRIPTION
This method had the line

    $anchor =~ s/^\s+//; s/\s+$//;      # Strip white space.

where leading space was stripped from $anchor, but trailing space was being attempted to be stripped from $_ instead, giving rise to a bunch of warnings like:

    Use of uninitialized value $_ in substitution (s///)
        at lib/Pod/Html/Util.pm line 253.

during 'make install.html'

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
TODO: fill description here

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
