### PR TITLE
installhtml: use warnings rather than -w

### DIFF
--- a/installhtml
+++ b/installhtml
@@ -1,9 +1,10 @@
-#!./perl -Ilib -w
+#!./perl -Ilib
 
 # This file should really be extracted from a .PL file
 
 $| = 1;
 use strict;
+use warnings;
 use Config;		# for config options in the makefile
 use File::Path qw(remove_tree);
 use File::Spec::Functions qw(rel2abs no_upwards);


### PR DESCRIPTION
The top-level installhtml script, which is used to implement the 'install.html' make target, has a -w on its #! line. This enables warnings globally, including in modules where it isn't welcome. This commit adds a 'use warnings' line instead.

This stops spurious lines to STDERR during 'make install.html' such as

    Use of uninitialized value $str in substitution (s///) at
        lib/Pod/Simple/XHTML.pm line 76.

* This set of changes does not require a perldelta entry.
