### PR TITLE
perlapi: Move apidoc lines to proper place

### DIFF
--- a/intrpvar.h
+++ b/intrpvar.h
@@ -375,14 +375,14 @@ Set by the L<perlfunc/exit> operator.
 
 =back
 
+On threaded perls, each thread has an independent copy of this variable;
+each initialized at creation time with the current value of the creating
+thread's copy.
+
 =for apidoc Amnh||PERL_EXIT_EXPECTED
 =for apidoc Amnh||PERL_EXIT_ABORT
 =for apidoc Amnh||PERL_EXIT_DESTRUCT_END
 =for apidoc Amnh||PERL_EXIT_WARN
-
-On threaded perls, each thread has an independent copy of this variable;
-each initialized at creation time with the current value of the creating
-thread's copy.
 
 =cut
 */


### PR DESCRIPTION
Where they were made autodoc.pl think they were from a new entry


* This set of changes does not require a perldelta entry.
