### PR TITLE
Add definitions for [IU}V_BITS to perl.h

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -281,7 +281,9 @@
 #   undef case_98_SBOX32
 #   undef case_99_SBOX32
 #   undef case_9_SBOX32
+#   undef IV_BITS
 #   undef USE_STDIO
+#   undef UV_BITS
 #   if !defined(PERL_EXT)
 #     undef invlist_intersection_
 #     undef invlist_subtract_

--- a/perl.h
+++ b/perl.h
@@ -2410,8 +2410,10 @@ typedef UVTYPE UV;
 #define Size_t_MAX (~(Size_t)0)
 #define SSize_t_MAX (SSize_t)(~(Size_t)0 >> 1)
 
-#define IV_DIG (BIT_DIGITS(IVSIZE * 8))
-#define UV_DIG (BIT_DIGITS(UVSIZE * 8))
+#define IV_BITS (IVSIZE * CHARBITS)
+#define IV_DIG (BIT_DIGITS(IV_BITS))
+#define UV_BITS (UVSIZE * CHARBITS)
+#define UV_DIG (BIT_DIGITS(UV_BITS))
 
 #ifndef NO_PERL_PRESERVE_IVUV
 #define PERL_PRESERVE_IVUV	/* We like our integers to stay integers. */

--- a/pp.c
+++ b/pp.c
@@ -2008,9 +2008,6 @@ PP(pp_subtract)
 
 }
 
-
-#define IV_BITS (IVSIZE * 8)
-
 /* Taking the right operand of bitwise shift operators, returns an int
  * indicating the shift amount clipped to the range [-IV_BITS, +IV_BITS].
  */


### PR DESCRIPTION
replacing the pp.c definition of IV_BITS



* This set of changes does not require a perldelta entry.
