### PR TITLE
inline.h: fix Perl_cx_poploop() build warning

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -4169,7 +4169,7 @@ Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
         else {
             // LV ref around a package lexical, mg_obj gives its GV
             GV *gv = (GV *)mg->mg_obj;
-            SV *oldsv;
+            SV *oldsv = NULL;
             switch(mg->mg_private & OPpLVREF_TYPE) {
                 case OPpLVREF_SV:
                     oldsv = GvSVn(gv);
@@ -4190,6 +4190,9 @@ Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
                     oldsv = (SV *)GvCV(gv);
                     GvCV_set(gv, (CV *)origval);
                     break;
+
+                default:
+                    NOT_REACHED;
             }
             SvREFCNT_dec(oldsv);
         }


### PR DESCRIPTION
... which results from the compiler being unable to prove that the switch is exhaustive, which it is indeed not.

This one:

    In file included from perl.h:7973,
                     from pp_ctl.c:35:
    In function ‘Perl_SvREFCNT_dec’,
        inlined from ‘Perl_cx_poploop’ at inline.h:4194:13:
    sv_inline.h:689:8: warning: ‘oldsv’ may be used uninitialized [-Wmaybe-uninitialized]
      689 |     if (LIKELY(sv != NULL)) {
          |        ^
    In file included from perl.h:7972:
    inline.h: In function ‘Perl_cx_poploop’:
    inline.h:4172:17: note: ‘oldsv’ was declared here
     4172 |             SV *oldsv;
          |                 ^~~~~

Fixes #24033.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
