### PR TITLE
MM.pm: treat undefined mtimes as 0 to avoid warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1033,6 +1033,7 @@ Neil Bowers                    <neilb@neilb.org>
 Neil Watkiss                   <neil.watkiss@sophos.com>
 Neil Williams                  <codehelp@debian.org>
 Nga Tang Chan
+Nic Boet                       <nic@boet.cc>
 Nicholas Clark                 <nick@ccl4.org>
 Nicholas Oxhøj
 Nicholas Perez                 <nperez@cpan.org>

--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command/MM.pm
+++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/Command/MM.pm
@@ -146,7 +146,7 @@ sub pod2man {
 
         next if ((-e $man) &&
                  (mtime($man) > mtime($pod)) &&
-                 (mtime($man) > mtime("Makefile")));
+                 (mtime($man) > (mtime("Makefile") // 0)) );
 
         my $parser = Pod::Man->new(%options);
         $parser->parse_from_file($pod, $man)


### PR DESCRIPTION
Insert `// 0` for mtime comparisons so missing pod or Makefile are treated as 0. Preserves original skip behavior while preventing "uninitialized value" warnings in numeric comparisons.

This suppresses 3077 uninitialized occurrences when building ZoneMinder on Gentoo using cmake 4.1.2 perl 5.42.0

`Use of uninitialized value in numeric gt (>) at /usr/lib64/perl5/5.42/ExtUtils/Command/MM.pm line 147.`


* This set of changes does not require a perldelta entry.
