### PR TITLE
 Standardize .h recursive #include guard names

### DIFF
--- a/hv_func.h
+++ b/hv_func.h
@@ -6,8 +6,8 @@
  * If USE_HASH_SEED is defined, hash randomisation is done by default
  * (see also perl.c:perl_parse() and S_init_tls_and_interp() and util.c:get_hash_seed())
  */
-#ifndef PERL_SEEN_HV_FUNC_H_ /* compile once */
-#define PERL_SEEN_HV_FUNC_H_
+#ifndef PERL_HV_FUNC_H_ /* compile once */
+#define PERL_HV_FUNC_H_
 #include "hv_macro.h"
 
 #if !( 0 \

--- a/hv_macro.h
+++ b/hv_macro.h
@@ -1,5 +1,5 @@
-#ifndef PERL_SEEN_HV_MACRO_H_ /* compile once */
-#define PERL_SEEN_HV_MACRO_H_
+#ifndef PERL_HV_MACRO_H_ /* compile once */
+#define PERL_HV_MACRO_H_
 
 #if IVSIZE == 8
 #define CAN64BITHASH

--- a/perl_inc_macro.h
+++ b/perl_inc_macro.h
@@ -17,10 +17,10 @@
 * - INCPUSH_PERL_OTHERLIBDIRS_ARCHONLY
 */
 
-#ifndef PERL_INC_MACROS_H
+#ifndef PERL_INC_MACRO_H
 
 /* protect against multiple inclusions */
-#define PERL_INC_MACROS_H 1
+#define PERL_INC_MACRO_H 1
 
 #ifdef APPLLIB_EXP
 #	define INCPUSH_APPLLIB_EXP  S_incpush_use_sep(aTHX_ STR_WITH_LEN(APPLLIB_EXP), \

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -1,5 +1,5 @@
-#ifndef REGCOMP_INTERNAL_H
-#define REGCOMP_INTERNAL_H
+#ifndef PERL_REGCOMP_INTERNAL_H
+#define PERL_REGCOMP_INTERNAL_H
 #ifndef STATIC
 #define STATIC  static
 #endif
@@ -1216,4 +1216,4 @@ static const scan_data_t zero_scan_data = {
 #define REGNODE_STEP_OVER(ret,t1,t2) \
     NEXT_OFF(REGNODE_p(ret)) = ((sizeof(t1)+sizeof(t2))/sizeof(regnode))
 
-#endif /* REGCOMP_INTERNAL_H */
+#endif /* PERL_REGCOMP_INTERNAL_H */

--- a/sbox32_hash.h
+++ b/sbox32_hash.h
@@ -27,7 +27,7 @@
 #define SBOX32_WARN2(pat,v0,v1)
 #endif
 
-#ifndef PERL_SEEN_HV_FUNC_H_
+#ifndef PERL_HV_FUNC_H_
 #if !defined(U32) 
 #include <stdint.h>
 #define U32 uint32_t

--- a/zaphod32_hash.h
+++ b/zaphod32_hash.h
@@ -38,7 +38,7 @@
 #endif
 #endif
 
-#ifndef PERL_SEEN_HV_FUNC_H_
+#ifndef PERL_HV_FUNC_H_
 #if !defined(U64)
 #include <stdint.h>
 #define U64 uint64_t


### PR DESCRIPTION
Some header files in the Perl core have guards to keep a recursive #include from compiling them again.  This is standard practice in C coding, and I was surprised at how many headers don't have it.  These seem to rely on only being included from perl.h, which does have its own guard.

Most of the guards use a common naming convention.  If the file is named foo.h, the guard is named 'PERL_FOO_H'.  Often, though, a trailing underscore is added,  'PERL_FOO_H_', making the convention slightly fuzzy.  The 'PERL_' is not added if the file 'foo' already includes 'perl' in its name,

Those rules are enough to describe all the guards in the core, except for the outliers in this commit, plus perl.h.

There are occasions in various Perl scripts that examine our source that we want to create a pattern that matches the header guard name for a particular file.  In spite of the slight fuzziness, that's easy using the above rules, except for the ones in this commit, and perl.h. It would be better for that code to not have to worry about the outliers, and since these are arbitrary names, we can just change them to follow the rules that already apply to most.

This commit changes the names of the outliers so that the only file the rules don't apply to is perl.h.  Its guard is named H_PERL.  That spelling is used in Encode, so it's not so easy to change it seamlessly. I'm willing to live with it continuing to be an outlier for the code I write.


* This set of changes does not require a perldelta entry.
