### PR TITLE
doc: Fix tiny typo in `perlop` and `perlfunc`

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -2849,7 +2849,7 @@ Case Charts available at L<https://www.unicode.org/charts/case/>.
 If EXPR is omitted, uses L<C<$_>|perlvar/$_>.
 
 This function behaves the same way under various pragmas, such as within
-L<S<C<"use feature 'unicode_strings">>|feature/The 'unicode_strings' feature>,
+L<S<C<"use feature 'unicode_strings'">>|feature/The 'unicode_strings' feature>,
 as L<C<lc>|/lc EXPR> does, with the single exception of
 C<fc> of I<LATIN CAPITAL LETTER SHARP S> (U+1E9E) within the
 scope of L<S<C<use locale>>|locale>.  The foldcase of this character

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -1296,7 +1296,7 @@ list.
 =back
 
 As of Perl 5.26, the list-context range operator on strings works as expected
-in the scope of L<< S<C<"use feature 'unicode_strings">>|feature/The
+in the scope of L<< S<C<"use feature 'unicode_strings'">>|feature/The
 'unicode_strings' feature >>. In previous versions, and outside the scope of
 that feature, it exhibits L<perlunicode/The "Unicode Bug">: its behavior
 depends on the internal encoding of the range endpoint.


### PR DESCRIPTION
Fix missing quote of link in `perlop`/`perlfunc`:

- "use feature 'unicode_strings" <~ missing `'`
&rarr; "use feature 'unicode_strings'"

Syntax of POD not affected, only the English syntax.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
