### PR TITLE
toke.c: scan_num: %c format to print a non digit byte

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -12501,7 +12501,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
     switch (*s) {
     default:
-        croak("panic: scan_num, *s=%d", *s);
+        croak("panic: scan_num, *s=%c", *s);
 
     /* if it starts with a 0, it could be an octal number, a decimal in
        0.13 disguise, or a hexadecimal number, or a binary number. */


### PR DESCRIPTION
This panic croak was wrong, should it ever get executed.  Any byte that reaches it isn't a digit, so %d would give wrong results.


* This set of changes does not require a perldelta entry.
