### PR TITLE
Add 'v' flag for embed.fnc/apidoc

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -75,7 +75,7 @@ use strict;
 use warnings;
 
 my $known_flags_re =
-            qr/[ aA bC dD eE fF h iI mM nN oO pP rR sS T uU vW xX y ;@#? ] /xx;
+          qr/[ aA bC dD eE fF h iI mM nN oO pP rR sS T uU v W xX y ;@#? ] /xx;
 
 # Flags that don't apply to this program, like implementation details.
 my $irrelevant_flags_re = qr/[ ab eE iI P rR X? ]/xx;
@@ -617,7 +617,9 @@ sub check_and_add_proto_defn {
 
     $flags .= "m" if $flags =~ /M/;
     $flags .= "U" if $flags =~ /@/;     # No usage output for @arrays
-    $flags .= "n" if $flags =~ /#/;    # No threads, arguments for #ifdef
+    $flags .= "n" if $flags =~ /[#v]/;  # No threads, arguments for #ifdef's,
+                                        # plain values
+
 
     my @munged_args= $args_ref->@*;
     s/\b(?:NN|NULLOK|[SM]PTR|EPTRQ?)\b\s+//g for @munged_args;
@@ -1904,9 +1906,9 @@ sub docout ($fh, $section_name, $element_name, $docref) {
 
             my $has_args = $flags !~ /n/;
             if (! $has_args) {
-                warn "$name: n flag without [m#] "
+                warn "$name: n flag without [mv#] "
                    . where_from_string($item->{file}, $item->{line_num})
-                                                        unless $flags =~ /[m#]/;
+                                                     unless $flags =~ /[mv#]/;
 
                 if ($item->{args} && $item->{args}->@*) {
                     warn "$name: n flag but apparently has args"

--- a/embed.fnc
+++ b/embed.fnc
@@ -364,7 +364,7 @@
 :
 : The 'name' in any such line must not be the same as any in this file (i.e.,
 : no redundant definitions), and one of the flags on the apidoc lines must be
-: 'm', 'y', or '@', indicating it is not a function.
+: 'm', 'v', 'y', or '@', indicating it is not a function.
 :
 : All but the name field of an apidoc_item line are optional, and if empty,
 : inherits from a corresponding apidoc_defn line, if one exists, or the
@@ -713,6 +713,13 @@
 :        tools, such as Devel::PPPort, that this requires special handling.
 :
 :   'U'  autodoc.pl will not output a usage example
+:
+:   'v'  The element is some sort of value that isn't any of the other types in
+:	 this file.  For example, it could be an enumeration constant; that is,
+:	 it is one of the members of the list of constants a variable declared
+:	 to be a particular enum can have.  These are always visible to XS code
+:	 unless guarded by preprocessor directives,  Also implies 'n'.
+
 :
 :   'W'  Add a comma_pDEPTH argument to function prototypes, and a comma_aDEPTH
 :        argument to the function calls. This means that under DEBUGGING a

--- a/pod/perlreapi.pod
+++ b/pod/perlreapi.pod
@@ -165,7 +165,7 @@ is defined as per L<isSPACE|perlapi/isSPACE>, and by the internal
 macros C<is_utf8_space> under UTF-8, and C<isSPACE_LC> under C<use
 locale>.
 
-=for apidoc Amnh||REGEX_LOCALE_CHARSET
+=for apidoc Avnh||REGEX_LOCALE_CHARSET
 
 =back
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3656,7 +3656,7 @@ sub generate_proto_h {
         my ($flags, $retval, $plain_func, $args, $assertions ) =
                         @{$embed}{qw(flags return_type name args assertions)};
         if ($flags =~
-             m/([^ aA b C dD eE fF h iI mM nN oO pP Rr sS T uU W xX ; ])/xx)
+             m/([^ aA b C dD eE fF h iI mM nN oO pP Rr sS T uU v W xX ; ])/xx)
         {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3655,7 +3655,9 @@ sub generate_proto_h {
 
         my ($flags, $retval, $plain_func, $args, $assertions ) =
                         @{$embed}{qw(flags return_type name args assertions)};
-        if ($flags =~ / ( [^ AabCDdEefFhIiMmNnOoPpRrSsTUuWXx;] ) /xx) {
+        if ($flags =~
+             m/([^ aA b C dD eE fF h iI mM nN oO pP Rr sS T uU W xX ; ])/xx)
+        {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }
 


### PR DESCRIPTION

An enum constant isn't a macro; it can't be #undef-ined.  This
distinction will matter in a future commit, so create a separate flag
for elements like this.  I suspect this would also apply to other types
of elements, such as struct members, should we eventually need to deal
with those.

* This set of changes does not require a perldelta entry.
