### PR TITLE
perlapi: Mark lex_stuff_pvs as API,

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -457,7 +457,7 @@ a string/length pair.
 
 
 /*
-=for apidoc_defn Emx|void|lex_stuff_pvs|"pv"|U32 flags
+=for apidoc_defn Amx|void|lex_stuff_pvs|"pv"|U32 flags
 
 =cut
 */


### PR DESCRIPTION
This was the only element in this group that wasn't.


* This set of changes does not require a perldelta entry.
