### PR TITLE
perlapi: CVf_SLABBED is not an API item

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -5167,7 +5167,7 @@ freeing is typically of benefit only for programs that make significant use of
 string eval.
 
 =for apidoc_section $concurrency
-=for apidoc Cmnh|    |CVf_SLABBED
+=for apidoc Emnh|    |CVf_SLABBED
 =for apidoc Cmh |OP *|CvROOT|CV * sv
 =for apidoc Cmh |OP *|CvSTART|CV * sv
 


### PR DESCRIPTION
Instead, C preprocessor constraints make sure it is visible only to extensions, so goes in perlintern.


* This set of changes does not require a perldelta entry.
