### PR TITLE
regen/embed.pl: Update copyright to 2026

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -4,8 +4,8 @@
  *
  *    Copyright (C) 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001,
  *    2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013,
- *    2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
- *    by Larry Wall and others
+ *    2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025,
+ *    2026 by Larry Wall and others
  *
  *    You may distribute under the terms of either the GNU General Public
  *    License or the Artistic License, as specified in the README file.

--- a/embedvar.h
+++ b/embedvar.h
@@ -4,8 +4,8 @@
  *
  *    Copyright (C) 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001,
  *    2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013,
- *    2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
- *    by Larry Wall and others
+ *    2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025,
+ *    2026 by Larry Wall and others
  *
  *    You may distribute under the terms of either the GNU General Public
  *    License or the Artistic License, as specified in the README file.

--- a/proto.h
+++ b/proto.h
@@ -4,8 +4,8 @@
  *
  *    Copyright (C) 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001,
  *    2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013,
- *    2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
- *    by Larry Wall and others
+ *    2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025,
+ *    2026 by Larry Wall and others
  *
  *    You may distribute under the terms of either the GNU General Public
  *    License or the Artistic License, as specified in the README file.

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3604,7 +3604,7 @@ sub open_print_header {
                                'regen/HeaderParser.pm',
                            ],
                       final => "\nEdit those files and run 'make regen_headers' to effect changes.\n",
-                      copyright => [1993 .. 2022],
+                      copyright => [1993 .. 2026],
                       quote => $quote });
 }
 


### PR DESCRIPTION

* This set of changes does not require a perldelta entry.
