### PR TITLE
make calling an undefined import method a warning

### DIFF
--- a/lib/warnings.pm
+++ b/lib/warnings.pm
@@ -5,7 +5,7 @@
 
 package warnings;
 
-our $VERSION = "1.76";
+our $VERSION = "1.77";
 
 # Verify that we're called correctly so that warnings will work.
 # Can't use Carp, since Carp uses us!
@@ -132,6 +132,7 @@ our %Offsets = (
 
     # Warnings Categories added in Perl 5.043
     'experimental::signature_named_parameters'=> 156,
+    'missing_import'			=> 158,
 );
 
 our %Bits = (
@@ -178,6 +179,7 @@ our %Bits = (
     'malloc'				=> "\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", # [25]
     'misc'				=> "\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", # [12]
     'missing'				=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00", # [58]
+    'missing_import'			=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x40", # [79]
     'newline'				=> "\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", # [9]
     'non_unicode'			=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00", # [49]
     'nonchar'				=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00", # [50]
@@ -260,6 +262,7 @@ our %DeadBits = (
     'malloc'				=> "\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", # [25]
     'misc'				=> "\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", # [12]
     'missing'				=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00\x00\x00", # [58]
+    'missing_import'			=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80", # [79]
     'newline'				=> "\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", # [9]
     'non_unicode'			=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00", # [49]
     'nonchar'				=> "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00\x00\x00\x00\x00", # [50]
@@ -316,8 +319,8 @@ our %NoOp = (
 
 # These are used by various things, including our own tests
 our $NONE				=  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-our $DEFAULT				=  "\x10\x01\x00\x00\x00\x50\x04\x00\x00\x00\x00\x00\x01\x40\x05\x45\x55\x15\x55\x15"; # [2,4,22,23,25,48,55..57,60,61,63..70,72..78]
-our $LAST_BIT				=  158 ;
+our $DEFAULT				=  "\x10\x01\x00\x00\x00\x50\x04\x00\x00\x00\x00\x00\x01\x40\x05\x45\x55\x15\x55\x55"; # [2,4,22,23,25,48,55..57,60,61,63..70,72..79]
+our $LAST_BIT				=  160 ;
 our $BYTES				=  20 ;
 
 sub Croaker
@@ -918,79 +921,81 @@ The current hierarchy is:
          |
          +- closure
          |
-         +- deprecated ----+
-         |                 |
-         |                 +- deprecated::delimiter_will_be_paired
-         |                 |
-         |                 +- deprecated::dot_in_inc
-         |                 |
-         |                 +- deprecated::subsequent_use_version
-         |                 |
-         |                 +- deprecated::unicode_property_name
-         |                 |
-         |                 +- deprecated::version_downgrade
+         +- deprecated -----+
+         |                  |
+         |                  +- deprecated::delimiter_will_be_paired
+         |                  |
+         |                  +- deprecated::dot_in_inc
+         |                  |
+         |                  +- deprecated::subsequent_use_version
+         |                  |
+         |                  +- deprecated::unicode_property_name
+         |                  |
+         |                  +- deprecated::version_downgrade
          |
          +- exiting
          |
-         +- experimental --+
-         |                 |
-         |                 +- experimental::args_array_with_signatures
-         |                 |
-         |                 +- experimental::builtin
-         |                 |
-         |                 +- experimental::class
-         |                 |
-         |                 +- experimental::declared_refs
-         |                 |
-         |                 +- experimental::defer
-         |                 |
-         |                 +- experimental::extra_paired_delimiters
-         |                 |
-         |                 +- experimental::keyword_all
-         |                 |
-         |                 +- experimental::keyword_any
-         |                 |
-         |                 +- experimental::private_use
-         |                 |
-         |                 +- experimental::re_strict
-         |                 |
-         |                 +- experimental::refaliasing
-         |                 |
-         |                 +- experimental::regex_sets
-         |                 |
-         |                 +- experimental::signature_named_parameters
-         |                 |
-         |                 +- experimental::try
-         |                 |
-         |                 +- experimental::uniprop_wildcards
-         |                 |
-         |                 +- experimental::vlb
+         +- experimental ---+
+         |                  |
+         |                  +- experimental::args_array_with_signatures
+         |                  |
+         |                  +- experimental::builtin
+         |                  |
+         |                  +- experimental::class
+         |                  |
+         |                  +- experimental::declared_refs
+         |                  |
+         |                  +- experimental::defer
+         |                  |
+         |                  +- experimental::extra_paired_delimiters
+         |                  |
+         |                  +- experimental::keyword_all
+         |                  |
+         |                  +- experimental::keyword_any
+         |                  |
+         |                  +- experimental::private_use
+         |                  |
+         |                  +- experimental::re_strict
+         |                  |
+         |                  +- experimental::refaliasing
+         |                  |
+         |                  +- experimental::regex_sets
+         |                  |
+         |                  +- experimental::signature_named_parameters
+         |                  |
+         |                  +- experimental::try
+         |                  |
+         |                  +- experimental::uniprop_wildcards
+         |                  |
+         |                  +- experimental::vlb
          |
          +- glob
          |
          +- imprecision
          |
-         +- io ------------+
-         |                 |
-         |                 +- closed
-         |                 |
-         |                 +- exec
-         |                 |
-         |                 +- layer
-         |                 |
-         |                 +- newline
-         |                 |
-         |                 +- pipe
-         |                 |
-         |                 +- syscalls
-         |                 |
-         |                 +- unopened
+         +- io -------------+
+         |                  |
+         |                  +- closed
+         |                  |
+         |                  +- exec
+         |                  |
+         |                  +- layer
+         |                  |
+         |                  +- newline
+         |                  |
+         |                  +- pipe
+         |                  |
+         |                  +- syscalls
+         |                  |
+         |                  +- unopened
          |
          +- locale
          |
          +- misc
          |
          +- missing
+         |
+         +- missing_import
          |
          +- numeric
          |
@@ -1012,15 +1017,15 @@ The current hierarchy is:
          |
          +- scalar
          |
-         +- severe --------+
-         |                 |
-         |                 +- debugging
-         |                 |
-         |                 +- inplace
-         |                 |
-         |                 +- internal
-         |                 |
-         |                 +- malloc
+         +- severe ---------+
+         |                  |
+         |                  +- debugging
+         |                  |
+         |                  +- inplace
+         |                  |
+         |                  +- internal
+         |                  |
+         |                  +- malloc
          |
          +- shadow
          |
@@ -1028,29 +1033,29 @@ The current hierarchy is:
          |
          +- substr
          |
-         +- syntax --------+
-         |                 |
-         |                 +- ambiguous
-         |                 |
-         |                 +- bareword
-         |                 |
-         |                 +- digit
-         |                 |
-         |                 +- illegalproto
-         |                 |
-         |                 +- parenthesis
-         |                 |
-         |                 +- precedence
-         |                 |
-         |                 +- printf
-         |                 |
-         |                 +- prototype
-         |                 |
-         |                 +- qw
-         |                 |
-         |                 +- reserved
-         |                 |
-         |                 +- semicolon
+         +- syntax ---------+
+         |                  |
+         |                  +- ambiguous
+         |                  |
+         |                  +- bareword
+         |                  |
+         |                  +- digit
+         |                  |
+         |                  +- illegalproto
+         |                  |
+         |                  +- parenthesis
+         |                  |
+         |                  +- precedence
+         |                  |
+         |                  +- printf
+         |                  |
+         |                  +- prototype
+         |                  |
+         |                  +- qw
+         |                  |
+         |                  +- reserved
+         |                  |
+         |                  +- semicolon
          |
          +- taint
          |
@@ -1062,13 +1067,13 @@ The current hierarchy is:
          |
          +- untie
          |
-         +- utf8 ----------+
-         |                 |
-         |                 +- non_unicode
-         |                 |
-         |                 +- nonchar
-         |                 |
-         |                 +- surrogate
+         +- utf8 -----------+
+         |                  |
+         |                  +- non_unicode
+         |                  |
+         |                  +- nonchar
+         |                  |
+         |                  +- surrogate
          |
          +- void
 

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -45,19 +45,6 @@ Category: "deprecated::unicode_property_name"
 
 =head2 Perl 5.44
 
-=head3 Calling a missing C<import()> or C<unimport()> method with an argument
-
-Historically calling C<import()> or C<unimport()> on any class which did not
-define such a method would be silently ignored. Effectively Perl behaved as
-though there was an empty method defined in the C<UNIVERSAL> package (even
-when there was no such method actually defined). Beginning with Perl version
-5.39.2 (production version 5.40), calling such a method I<with> an argument
-triggered a warning, and in Perl version 5.44 this warning became upgraded to
-an error. (Calling such a method with no arguments at all will always be
-safe.)
-
-Category: "deprecated::missing_import_called_with_args"
-
 =head3 Changing C<use VERSION> while another C<use VERSION> is in scope
 
 A C<use VERSION> declaration has many implicit effects on the surrounding
@@ -631,7 +618,6 @@ This was deprecated in Perl 5.14, and the bug was fixed in Perl 5.16.
 So now C<tie $scalar> will always tie the scalar, not the handle it holds.
 To tie the handle, use C<tie *$scalar> (with an explicit asterisk).  The same
 applies to C<tied *$scalar> and C<untie *$scalar>.
-
 
 =head1 SEE ALSO
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -1354,14 +1354,18 @@ a string overload and is also not a blessed CODE reference. In short the
 C<require> function does not know what to do with the object.
 See also L<perlfunc/require>.
 
-=item Attempt to call undefined %s method with arguments via package
-"%s" (Perhaps you forgot to load the package?)
+=item Attempt to call missing %s method with arguments ("%s"%s)
+via package "%s" (Perhaps you forgot to load the package?)
 
-(F) You called the C<import()> or C<unimport()> method of a class that has no
-such method defined in its inheritance graph, and passed an argument to the
-method. This is very often the sign of a misspelled package name in a C<use>
-or C<require> statement that has silently succeeded due to a case insensitive
-file system.
+(S missing_import) You called the C<import()> or C<unimport()> method of a
+class that has no import method defined in its inheritance graph, and passed
+an argument to the method. This is very often the sign of a misspelled package
+name in a C<use> statement that has silently succeeded due to a case
+insensitive file system.
+
+Another common reason this may happen is mistakenly attempting to import or
+unimport a symbol from a package which does not use C<Exporter> or otherwise
+define its own C<import> or C<unimport> method.
 
 =item Can't locate package %s for @%s::ISA
 

--- a/regen/warnings.pl
+++ b/regen/warnings.pl
@@ -16,7 +16,7 @@
 #
 # This script is normally invoked from regen.pl.
 
-$VERSION = '1.76';
+$VERSION = '1.77';
 
 BEGIN {
     require './regen/regen_lib.pl';
@@ -80,8 +80,6 @@ our $WARNING_TREE = {
                                 'deprecated::dot_in_inc'               => [ 5.025011, DEFAULT_ON],
                                 'deprecated::version_downgrade'        => [ 5.035009, DEFAULT_ON],
                                 'deprecated::delimiter_will_be_paired' => [ 5.035010, DEFAULT_ON],
-                                'deprecated::missing_import_called_with_args'   
-                                                                       => [ 5.039002, DEFAULT_ON],
                                 'deprecated::subsequent_use_version'   => [ 5.039008, DEFAULT_ON],
                         }],
         'void'          => [ 5.008, DEFAULT_OFF],
@@ -170,6 +168,7 @@ our $WARNING_TREE = {
         'locale'        => [ 5.021, DEFAULT_ON],
         'shadow'        => [ 5.027, DEFAULT_OFF],
         'scalar'        => [ 5.035, DEFAULT_OFF],
+        'missing_import'  => [ 5.043, DEFAULT_ON ],
 
          #'default'     => [ 5.008, DEFAULT_ON ],
 }]};

--- a/t/lib/warnings/universal
+++ b/t/lib/warnings/universal
@@ -25,3 +25,26 @@ my $a = bless [] ;
 UNIVERSAL::isa $a, Jim ;
 EXPECT
 Can't locate package Joe for @Ｙ::ISA at - line 8.
+########
+use warnings 'missing_import';
+Some::Package->import;
+EXPECT
+########
+Some::Package->import("bar");
+EXPECT
+Attempt to call missing import method with arguments ("bar") via package "Some::Package" (Perhaps you forgot to load the package?) at - line 1.
+########
+use warnings 'missing_import';
+Some::Package->import("bar", "guff");
+EXPECT
+Attempt to call missing import method with arguments ("bar" ...) via package "Some::Package" (Perhaps you forgot to load the package?) at - line 2.
+########
+use warnings;
+no warnings 'missing_import';
+Some::Package->import("bar", "guff");
+EXPECT
+########
+use warnings 'missing_import';
+Some::Package->unimport(1.234);
+EXPECT
+Attempt to call missing unimport method with arguments ("1.234") via package "Some::Package" (Perhaps you forgot to load the package?) at - line 2.

--- a/t/op/universal.t
+++ b/t/op/universal.t
@@ -11,7 +11,7 @@ BEGIN {
     require "./test.pl";
 }
 
-plan tests => 144;
+plan tests => 142;
 
 $a = {};
 bless $a, "Bob";
@@ -195,26 +195,6 @@ ok ! UNIVERSAL::isa("\xff\xff\xff\0", 'HASH');
 my $x = {}; bless $x, 'X';
 ok $x->isa('UNIVERSAL');
 ok $x->isa('UNIVERSAL');
-
-sub test_undefined_method {
-    my $method = shift;
-    my @message_components = (
-        q|Attempt to call undefined|,
-        q|method with arguments via package "Some::Package"|,
-        q|(Perhaps you forgot to load the package?)|,
-    );
-    my $message = join ' ' => (
-        $message_components[0],
-        $method,
-        @message_components[1,2],
-    );
-    my $pattern = qr/\Q$message\E/;
-
-    eval { Some::Package->$method("bar") };
-    like $@, $pattern, "Got expected pattern for undefined $method";
-}
-
-test_undefined_method($_) for (qw| import unimport |);
 
 # This segfaulted in a blead.
 fresh_perl_is('package Foo; Foo->VERSION;  print "ok"', 'ok');

--- a/universal.c
+++ b/universal.c
@@ -451,10 +451,14 @@ XS(XS_UNIVERSAL_import_unimport)
          * depends on it has its own "no import" logic that produces better
          * warnings than this does. */
         if (strNE(class_pv,"_charnames"))
-            Perl_croak(aTHX_
-                "Attempt to call undefined %s method with arguments via package "
-                 "%" SVf_QUOTEDPREFIX " (Perhaps you forgot to load the package?)",
-                ix ? "unimport" : "import", SVfARG(ST(0)));
+            ck_warner_d(packWARN(WARN_MISSING_IMPORT),
+                        "Attempt to call missing %s method with arguments "
+                        "(%" SVf_QUOTEDPREFIX "%s) via package "
+                        "%" SVf_QUOTEDPREFIX " (Perhaps you forgot to load the package?)",
+                        ix ? "unimport" : "import",
+                        SVfARG(ST(1)),
+                        (items > 2 ? " ..." : ""),
+                        SVfARG(ST(0)));
     }
     XSRETURN_EMPTY;
 }

--- a/warnings.h
+++ b/warnings.h
@@ -161,10 +161,11 @@
 /* Warnings Categories added in Perl 5.043 */
 
 #define WARN_EXPERIMENTAL__SIGNATURE_NAMED_PARAMETERS 78
+#define WARN_MISSING_IMPORT		 79
 #define WARNsize			 20
 #define WARN_ALLstring			 "\125\125\125\125\125\125\125\125\125\125\125\125\125\125\125\125\125\125\125\125"
 #define WARN_NONEstring			 "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-#define WARN_DEFAULTstring		 "\x10\x01\x00\x00\x00\x50\x04\x00\x00\x00\x00\x00\x01\x40\x05\x45\x55\x15\x55\x15"
+#define WARN_DEFAULTstring		 "\x10\x01\x00\x00\x00\x50\x04\x00\x00\x00\x00\x00\x01\x40\x05\x45\x55\x15\x55\x55"
 
 #define isLEXWARN_on \
         cBOOL(PL_curcop && PL_curcop->cop_warnings != pWARN_STD)
@@ -355,6 +356,7 @@ category parameters passed.
 =for apidoc Amnh||WARN_EXPERIMENTAL__KEYWORD_ALL
 =for apidoc Amnh||WARN_EXPERIMENTAL__KEYWORD_ANY
 =for apidoc Amnh||WARN_EXPERIMENTAL__SIGNATURE_NAMED_PARAMETERS
+=for apidoc Amnh||WARN_MISSING_IMPORT
 
 =cut
 */


### PR DESCRIPTION
Partial revert of f430ad845a2f4f64125379fb1e31ac5bd85a4e91 (PR #23992)

This changes calling an undefined import or unimport method with arguments back to a warning, but not a deprecation. Making this fatal had a very large amount of fallout for extremely marginal gains. It has been decided that a warning is enough, and making it fatal in the future will not be pursued.

Fixes #24058
