### PR TITLE
call_sv: check the runtime package to decide whether DB::sub is callable

### DIFF
--- a/ext/XS-APItest/t/call.t
+++ b/ext/XS-APItest/t/call.t
@@ -11,7 +11,7 @@ use strict;
 
 BEGIN {
     require '../../t/test.pl';
-    plan(547);
+    plan(548);
     use_ok('XS::APItest')
 };
 use Config;
@@ -396,3 +396,47 @@ fresh_perl_like('use XS::APItest;'
               .'XS::APItest::XSUB::test_mismatch_xs_handshake_bad_struct_and_ver("Dog");'
               , qr/\QPerl API version v1.1337.0 of APItest.xs does not match\E/);
 
+{
+    local $ENV{PERL5DB} = 1;
+    fresh_perl_is(<<'CODE', <<'EXPECT', { switches => [ "-d" ] }, "call from package DB");
+use XS::APItest;
+$DB::enable = 1;  # avoid noise from XS loading
+print "Before\n";
+DB::doit();
+NonDB::doit();
+print "After\n";
+$DB::enable = 0;
+
+sub f {
+    print "In f\n";
+}
+
+package DB;
+
+sub DB {}
+
+sub doit {
+    XS::APItest::call_sv(\&main::f, 0);
+}
+
+sub sub {
+    print "sub $DB::sub\n" if $DB::enable;
+    &$DB::sub;
+}
+
+package NonDB;
+
+sub doit {
+    XS::APItest::call_sv(\&main::f, 0);
+}
+CODE
+Before
+sub DB::doit
+In f
+sub NonDB::doit
+sub XS::APItest::call_sv
+sub main::f
+In f
+After
+EXPECT
+}

--- a/ext/XS-APItest/t/call.t
+++ b/ext/XS-APItest/t/call.t
@@ -395,3 +395,4 @@ fresh_perl_like('use XS::APItest;'
 fresh_perl_like('use XS::APItest;'
               .'XS::APItest::XSUB::test_mismatch_xs_handshake_bad_struct_and_ver("Dog");'
               , qr/\QPerl API version v1.1337.0 of APItest.xs does not match\E/);
+

--- a/intrpvar.h
+++ b/intrpvar.h
@@ -141,6 +141,8 @@ PERLVAR(I, defgv,	GV *)           /* the *_ glob */
 
 The stash for the package code will be compiled into.
 
+You should use C<CopSTASH(PL_curcop)> to get the current runtime package.
+
 On threaded perls, each thread has an independent copy of this variable;
 each initialized at creation time with the current value of the creating
 thread's copy.

--- a/perl.c
+++ b/perl.c
@@ -3217,6 +3217,7 @@ Perl_call_sv(pTHX_ SV *sv, I32 arg_flags)
     oldmark = TOPMARK;
 
     if (PERLDB_SUB && PL_curstash != PL_debstash
+          && !CopSTASH_eq(PL_curcop, PL_debstash)
            /* Handle first BEGIN of -d. */
           && (PL_DBcv || (PL_DBcv = GvCV(PL_DBsub)))
            /* Try harder, since this may have been a sighandler, thus

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -429,6 +429,19 @@ that field being released when the method exited.  The next access to
 that field could result in a crash or an assertion, or if the freed SV
 had been re-used, random data.  Discussed in [GH #24187]
 
+=item *
+
+call_sv() and related functions now check the runtime package instead
+of the package being compiled to when deciding whether the call is
+breakable into C<DB::sub>.
+
+The compile-time package is typically C<main::> when nothing is being
+compiled so C<DB::sub> could be called for sub calls from package DB.
+
+This means that core features that use call_sv(), such as smart match
+against a code reference, no longer incorrectly call C<DB::sub> when
+used from package DB.  Related to [github #24001]
+
 =back
 
 =head1 Known Problems

--- a/t/op/debug.t
+++ b/t/op/debug.t
@@ -177,7 +177,6 @@ CODE
     # Make sure we test calls from a non-DB package too
     # github #24001
     local $ENV{PERL5DB} = 1;
-    local $::TODO = "~~ uses call_sv which mishandles package DB calls";
     fresh_perl_is(<<'CODE', <<'EXPECT', { switches => [ "-d" ] }, "call_sv from DB");
 print "Before\n";
 DB::doit();

--- a/t/op/debug.t
+++ b/t/op/debug.t
@@ -170,4 +170,52 @@ CODE
                   "overloading call from non-DB does break into DB::sub");
 }
 
+{
+    # smartmatch against a subref uses call_sv
+    # The use of this from inside the DB package shouldn't result in
+    # a call to DB::sub
+    # Make sure we test calls from a non-DB package too
+    # github #24001
+    local $ENV{PERL5DB} = 1;
+    local $::TODO = "~~ uses call_sv which mishandles package DB calls";
+    fresh_perl_is(<<'CODE', <<'EXPECT', { switches => [ "-d" ] }, "call_sv from DB");
+print "Before\n";
+DB::doit();
+NonDB::doit();
+print "After\n";
+
+sub f {
+  print "In f\n";
+  0;
+}
+
+package DB;
+
+sub doit {
+  0 ~~ \&main::f
+}
+
+sub DB {}
+
+sub sub {
+  print "sub $DB::sub\n";
+  goto &$DB::sub;
+}
+
+package NonDB;
+
+sub doit {
+  0 ~~ \&main::f;
+}
+CODE
+Before
+sub DB::doit
+In f
+sub NonDB::doit
+sub main::f
+In f
+After
+EXPECT
+}
+
 done_testing();


### PR DESCRIPTION

Similar to https://github.com/Perl/perl5/issues/24001 call_sv() was checking the current package being
compiled to, typically main:: when nothing is being compiled, rather
than the current runtime package.

Unfortunately, init_debugger() uses PL_curstash to suppress DB::sub
during initialization, so continue to check that

-------------------------------------------------------------------------------

* This set of changes requires a perldelta entry, and it is included.

