### PR TITLE
Avoid referencing uninitialized memory in PerlIOScalar_write

### DIFF
--- a/perlio.c
+++ b/perlio.c
@@ -1265,14 +1265,14 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
 	    SETERRNO(EINVAL, SS_IVCHAN);
 	    return 0;
 	}
+        /* Avoid calling SvCUR() on undef'ed SVs */
+        STRLEN const cur = SvOK(sv) ? SvCUR(sv) : 0;
 	if ((PerlIOBase(f)->flags) & PERLIO_F_APPEND) {
-	    dst = SvGROW(sv, SvCUR(sv) + count + 1);
+	    dst = SvGROW(sv, cur + count + 1);
 	    offset = SvCUR(sv);
 	    s->posn = offset + count;
 	}
 	else {
-	    STRLEN const cur = SvCUR(sv);
-
             /* ensure we don't try to create ridiculously large
              * SVs on small platforms
              */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -496,6 +496,12 @@ correctly, losing precision for large overloaded integer arguments that
 are not exactly representable as a Perl floating point value (NV).
 [GH #23956]
 
+=item *
+
+When a scalar variable used as the target of a filehandle is C<undef>'ed
+while being output, garbage bytes would be left in that scalar.
+[GH #24008]
+
 =back
 
 =head1 Known Problems

--- a/t/io/scalar.t
+++ b/t/io/scalar.t
@@ -12,7 +12,7 @@ use strict;
 use Fcntl qw(SEEK_SET SEEK_CUR SEEK_END); # Not 0, 1, 2 everywhere.
 use Errno qw(EACCES);
 
-plan(128);
+plan(129);
 
 my $fh;
 my $var = "aaa\n";
@@ -527,4 +527,12 @@ SKIP:
     ok(seek($fh, 2**32, SEEK_SET), "seek to a large position");
     select((select($fh), ++$|)[0]);
     ok(!(print $fh "x"), "write to a large offset");
+}
+
+{ # GH #24008
+    open my $fh, '>', \my $str or die $!;
+    print $fh "xxxxx";
+    undef $str;
+    print $fh "y";
+    is($str, "\0\0\0\0\0y", "write to undef'ed variable");
 }


### PR DESCRIPTION
`PerlIOScalar_write` used to blindly use `SvCUR()` for SVs that is not SvPOK nor SvPOKp and bypasses the code that world normally clear out the leading bytes.  This would result as garbage (uninitialized) bytes when the target scalar once held a non-empty string and then `undef`'ed.

This will fix #24008.

-------------------------------------------------------------------------------

* This set of changes requires a perldelta entry, and it is included.