### PR TITLE
sync-with-cpan: Get type from Maintainer.pl FILES

### DIFF
--- a/Porting/sync-with-cpan
+++ b/Porting/sync-with-cpan
@@ -206,7 +206,7 @@ my $tmpdir = tmpdir();
 my $package      = "02packages.details.txt";
 my $package_url  = "http://www.cpan.org/modules/$package";
 my $package_file = "$tmpdir/$package"; # this is a cache
-my $type_dir     = "cpan";
+my $type_dir;
 
 my @problematic = (
     # no current entries as of perl-5.43.6
@@ -366,6 +366,10 @@ EOF
             "Bailing out. Use --force to go ahead anyway.\n";
     }
     pause_for_input("\n");
+}
+
+if (not defined $type_dir) {
+    ($type_dir) = split(/\//, $info->{FILES});
 }
 
 if (!$ENV{TEST_JOBS} and !WIN32) {


### PR DESCRIPTION
## Pick directory from FILES

When syncing a dist living in `dist`, `sync-with-cpan` fails even if the script was made compatible for it via 966386b1d80d391fcda81fffd4a13c06905e17cf 

(it's working but `--type dist` has to be explicitely passed)

With this change, the type is picked from the Maintainers.pl `FILES`. 

### Without this change
```
$ perl Porting/sync-with-cpan ExtUtils::CBuilder
[...]
Fetching https://cpan.metacpan.org/authors/id/A/AM/AMBS/ExtUtils-CBuilder-0.280236.tar.gz
Cleaning out old directory
Unpacking ExtUtils-CBuilder-0.280236.tar.gz
Renaming directories
Can't rename('ExtUtils-CBuilder', 'ExtUtils-CBuilder-0.280236-OLD'): No such file or directory at Porting/sync-with-cpan line 515
```
-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
