### PR TITLE
grok_bin_oct_hex:  slight speedup; improved overflow precision

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -371,9 +371,22 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         goto done_parse;
     }
 
+    if (! underscore_valid(s, e, class_bit)) {
+        goto done_parse;
+    }
+
+    /* check_underscore() succeeds only if the next char is a legal digit */
+    s++;
+
+    /* Here s points to a legal digit */
+
   loop: ;
 
-    /* The loop below accumulates the integral running total of the result,
+    /* Here, 'accumulated' contains the running total so far in the input,
+     * and 's' points to the next character, which is known to be a legal
+     * digit
+     *
+     * The loop below accumulates the integral running total of the result,
      * digit by digit.  If this total overflows, it is added to an NV
      * approximation, and the loop starts over, looking at the next batch of
      * digits, until they overflow, and so on.

--- a/numeric.c
+++ b/numeric.c
@@ -305,60 +305,60 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
   redo_switch:
     switch (e - s) {
       default:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 7:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 6:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 5:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 4:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 3:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 2:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 1:
-          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-          s++;
-          /* FALLTHROUGH */
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
+        /* FALLTHROUGH */
       case 0:
-          if (LIKELY(s >= e)) {
-              return accumulated;
-          }
+        if (LIKELY(s >= e)) {
+            return accumulated;
+        }
 
-          /* If we get here, and the accumulated value is still 0, it is
+        /* If we get here, and the accumulated value is still 0, it is
            * because there are more leading zeros than the cases of this
-           * switch(),  These are common enough with these kinds of
-           * binary-style numbers that it is worth this extra conditional to
-           * continue absorbing them via the switch. */
-          if (accumulated == 0) {
-              goto redo_switch;
-          }
+         * switch(),  These are common enough with these kinds of
+         * binary-style numbers that it is worth this extra conditional to
+         * continue absorbing them via the switch. */
+        if (accumulated == 0) {
+            goto redo_switch;
+        }
 
-          break;
+        break;
     }   /* End of switch on the first so-many characters */
 
     /* The loop below accumulates the integral running total of the result,

--- a/numeric.c
+++ b/numeric.c
@@ -297,6 +297,9 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
     const char * const s0 = s;  /* Where the significant digits start */
     UV accumulated = 0;               /* Running total */
+    bool overflowed = FALSE;
+    NV accumulated_nv = 0;
+    const PERL_UINT_FAST8_T base = 1 << shift;  /* 2, 8, or 16 */
 
     /* Unroll the loop so that numbers with 8 or fewer digits can be handled
      * with the minimum amount of work.  Anything higher would require extra
@@ -364,15 +367,13 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
      *
      * In overflows, this keeps track of how much to multiply the overflowed NV
      * by as we continue to parse the remaining digits */
-    NV factor = 0.0;
-
-    bool overflowed = FALSE;
-    NV accumulated_nv = 0;
-    const PERL_UINT_FAST8_T base = 1 << shift;  /* 2, 8, or 16 */
+    NV factor;
+    factor = 0.0;
 
     /* As long as the running total is less than this, the next digit will
      * fit. */
-    UV max_div = UV_MAX >> shift;
+    UV max_div;
+    max_div = UV_MAX >> shift;
 
     /* Loop through the characters */
     for (; s < e; s++) {

--- a/numeric.c
+++ b/numeric.c
@@ -248,7 +248,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
                         NV *result,
                         const unsigned shift, /* 1 for binary; 3 for octal;
                                                  4 for hex */
-                        const U32 class_bit,
+                        const U32 lookup_bit,
                         const char prefix
                      )
 
@@ -313,46 +313,46 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
   redo_switch:
     switch (e - s) {
       default:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         goto loop;
 
       case 8:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
       case 7:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
       case 6:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
       case 5:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
       case 4:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
       case 3:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
       case 2:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
       case 1:
-        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
@@ -371,7 +371,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         goto done_parse;
     }
 
-    if (! underscore_valid(s, e, class_bit)) {
+    if (! underscore_valid(s, e, lookup_bit)) {
         goto done_parse;
     }
 
@@ -403,7 +403,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
     /* Loop through the characters */
     for (; s < e; s++) {
-        if (Perl_isCC_by_bit(*s, class_bit)) {
+        if (Perl_isCC_by_bit(*s, lookup_bit)) {
             /* Write it in this wonky order with a goto to attempt to get the
                compiler to make the common case integer-only loop pretty tight.
                With gcc seems to be much straighter code than old scan_hex.
@@ -444,7 +444,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         /* Handle non-trailing underscores when those are accepted */
         if (   UNLIKELY(*s == '_')
             && allow_underscores
-            && underscore_valid(s, e, class_bit))
+            && underscore_valid(s, e, lookup_bit))
         {
             ++s;
 

--- a/numeric.c
+++ b/numeric.c
@@ -236,6 +236,11 @@ Perl_output_non_portable(pTHX_ const U8 base)
     ck_warner(packWARN(WARN_PORTABLE), "%s non-portable", which);
 }
 
+/* An acceptable underscore must not be trailing, which also implies there
+ * must be a legal digit after it */
+#define underscore_valid(s, e, lookup_bit)                                  \
+                            (s < e - 1 && Perl_isCC_by_bit(s[1], lookup_bit))
+
 UV
 Perl_grok_bin_oct_hex(pTHX_ const char * const start,
                         STRLEN *len_p,
@@ -425,9 +430,8 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
         /* Handle non-trailing underscores when those are accepted */
         if (   UNLIKELY(*s == '_')
-            && s < e - 1
             && allow_underscores
-            && Perl_isCC_by_bit(s[1], class_bit))
+            && underscore_valid(s, e, class_bit))
         {
             ++s;
 

--- a/numeric.c
+++ b/numeric.c
@@ -306,7 +306,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     switch (e - s) {
       default:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+          accumulated = XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 7:

--- a/numeric.c
+++ b/numeric.c
@@ -425,13 +425,20 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
     /* Loop through the characters */
     for (; s < e; s++) {
+
+        /* Handle non-trailing underscores when those are accepted */
+        if (UNLIKELY(*s == '_')) {
+            if (   ! allow_underscores
+                || ! underscore_valid(s, e, lookup_bit))
+            {
+                break;
+            }
+
+            ++s;
+        }
+
         if (Perl_isCC_by_bit(*s, lookup_bit)) {
-            /* Write it in this wonky order with a goto to attempt to get the
-               compiler to make the common case integer-only loop pretty tight.
-               With gcc seems to be much straighter code than old scan_hex.
-               (khw suspects that adding a LIKELY() just above would do the
-               same thing) */
-          redo: ;
+
             /* If there is room for this digit, accumulate it and repeat */
             if (LIKELY(accumulated <= max_div)) {
                 /* Note XDIGIT_VALUE() is branchless, works on binary and
@@ -462,15 +469,6 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
             overflowed = TRUE;
             continue;
         } /* End of handling legal digit */
-
-        /* Handle non-trailing underscores when those are accepted */
-        if (   UNLIKELY(*s == '_')
-            && allow_underscores
-            && underscore_valid(s, e, lookup_bit))
-        {
-            ++s;
-            goto redo;
-        }
 
         /* We get here when done with the parse, or it got interrupted by a
          * non-digit or a digit that is outside the bounds of the base, like a

--- a/numeric.c
+++ b/numeric.c
@@ -441,34 +441,34 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
             ++s;
         }
 
-            /* If there is room for this digit, accumulate it and repeat */
-            if (LIKELY(accumulated <= max_div)) {
-                /* Note XDIGIT_VALUE() is branchless, works on binary and
-                 * octal as well, so can be used here, without noticeably
-                 * slowing those down (it does have unnecessary shifts, ANDSs,
-                 * and additions for those) */
-                accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-                factor *= base;
-                continue;
-            }
+        /* If there is room for this digit, accumulate it and repeat */
+        if (LIKELY(accumulated <= max_div)) {
+        /* Note XDIGIT_VALUE() is branchless, works on binary and octal as
+         * well, so can be used here, without noticeably slowing those down
+         * (it does have unnecessary shifts, ANDSs, and additions for those)
+         * */
+        accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        factor *= base;
+        continue;
+        }
 
-            /* Bah. We are about to overflow.  Instead, add the unoverflowed
-             * accumulated to an NV that contains an approximation to the correct
-             * value.  Each time through the loop we have increased 'factor' so
-             * that it gives how much the current approximation needs to
-             * effectively be shifted to make room for this new value */
-            accumulated_nv *= factor;
-            accumulated_nv += (NV) accumulated;
+        /* Bah. We are about to overflow.  Instead, add the unoverflowed
+         * accumulated to an NV that contains an approximation to the correct
+         * value.  Each time through the loop we have increased 'factor' so
+         * that it gives how much the current approximation needs to
+         * effectively be shifted to make room for this new value */
+        accumulated_nv *= factor;
+        accumulated_nv += (NV) accumulated;
 
-            /* Then we keep accumulating digits, until all are parsed.  We
-             * start over using the current input value as the initial digit.
-             * This will be added to 'accumulated_nv' eventually, either when all
-             * digits are gone, or we have overflowed this fresh start.  This
-             * method uses the fewest floating point multiplications possible,
-             * losing the least precision. */
-            accumulated = XDIGIT_VALUE(*s);
-            factor = base;
-            overflowed = TRUE;
+        /* Then we keep accumulating digits, until all are parsed.  We
+         * start over using the current input value as the initial digit.
+         * This will be added to 'accumulated_nv' eventually, either when all
+         * digits are gone, or we have overflowed this fresh start.  This
+         * method uses the fewest floating point multiplications possible,
+         * losing the least precision. */
+        accumulated = XDIGIT_VALUE(*s);
+        factor = base;
+        overflowed = TRUE;
     }   /* End of parsing loop */
 
   done_parse:

--- a/numeric.c
+++ b/numeric.c
@@ -424,8 +424,8 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     valid_digit_or_underscore_bits = (lookup_bit|CC_mask_(CC_UNDERSCORE_));
 
     /* Loop through the characters */
-    for (; s < e && Perl_isCC_by_bit(*s, valid_digit_or_underscore_bits); s++)
-    {
+    while (s < e && Perl_isCC_by_bit(*s, valid_digit_or_underscore_bits)) {
+
         /* Handle non-trailing underscores when those are accepted */
         if (UNLIKELY(*s == '_')) {
             if (   ! allow_underscores
@@ -451,6 +451,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
          * (it does have unnecessary shifts, ANDSs, and additions for those)
          * */
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+        s++;
     }   /* End of parsing loop */
 
   done_parse:

--- a/numeric.c
+++ b/numeric.c
@@ -272,7 +272,14 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
      *      ...
      */
 
-    const I32 input_flags = *flags;
+#if UVSIZE > 4
+    I32 input_flags = *flags;
+#else
+    /* Only overflow can be non-portable on this platform, and that turns off
+     * this flag unconditionally */
+    I32 input_flags = *flags | PERL_SCAN_SILENT_NON_PORTABLE;
+#endif
+
     /* Clear output flags; unlikely to find a problem that sets them */
     *flags = 0;
 
@@ -303,7 +310,6 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     const char * const s0 = s;  /* Where the significant digits start */
     UV accumulated = 0;               /* Running total */
     const PERL_UINT_FAST8_T base = 1 << shift;  /* 2, 8, or 16 */
-    bool do_non_portable_output = false;
 
     /* Unroll the loop so that numbers with 8 or fewer digits can be handled
      * with the minimum amount of work.  Anything higher would require extra
@@ -450,14 +456,22 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
   done_parse:
 
 #if UVSIZE > 4
-    if (UNLIKELY(accumulated > 0xffffffff)) {
-        if (! (input_flags & PERL_SCAN_SILENT_NON_PORTABLE)) {
-            do_non_portable_output = true;
-        }
+    if (UNLIKELY(accumulated <= 0xffffffff)) {
+        /* Fits in 32 bits; no warning necessary */
+        input_flags |= PERL_SCAN_SILENT_NON_PORTABLE;
+    }
+    else {
+        /* Doesn't fit; return that to caller */
         *flags |= PERL_SCAN_SILENT_NON_PORTABLE;
+
+        /* If caller doesn't want warning raised, turn it off */
+        if (! (input_flags & PERL_SCAN_SILENT_NON_PORTABLE)) {
+            input_flags &= ~PERL_SCAN_SILENT_NON_PORTABLE;
+        }
     }
 #endif
 
+  finish:
     if (s < e && *s) {  /* *s is to keep a terminating NUL from warning */
         if (   ! (input_flags & PERL_SCAN_SILENT_ILLDIGIT)
             &&    ckWARN(WARN_DIGIT))
@@ -487,7 +501,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         }
     }
 
-    if (UNLIKELY(do_non_portable_output)) {
+    if (UNLIKELY(! (input_flags & PERL_SCAN_SILENT_NON_PORTABLE))) {
         output_non_portable(base);
     }
 
@@ -561,8 +575,8 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     }
 
     accumulated = UV_MAX;
-    do_non_portable_output = true;
-    goto done_parse;
+    input_flags &= ~PERL_SCAN_SILENT_NON_PORTABLE;
+    goto finish;
 }
 
 /*

--- a/numeric.c
+++ b/numeric.c
@@ -296,7 +296,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     }
 
     const char * const s0 = s;  /* Where the significant digits start */
-    UV value = 0;               /* Running total */
+    UV accumulated = 0;               /* Running total */
 
     /* Unroll the loop so that numbers with 8 or fewer digits can be handled
      * with the minimum amount of work.  Anything higher would require extra
@@ -306,47 +306,47 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     switch (e - s) {
       default:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 7:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 6:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 5:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 4:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 3:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 2:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 1:
           if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
-          value = (value << shift) | XDIGIT_VALUE(*s);
+          accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 0:
           if (LIKELY(s >= e)) {
-              return value;
+              return accumulated;
           }
 
           /* If we get here, and the accumulated value is still 0, it is
@@ -354,7 +354,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
            * switch(),  These are common enough with these kinds of
            * binary-style numbers that it is worth this extra conditional to
            * continue absorbing them via the switch. */
-          if (value == 0) {
+          if (accumulated == 0) {
               goto redo_switch;
           }
 
@@ -371,7 +371,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     NV factor = 0.0;
 
     bool overflowed = FALSE;
-    NV value_nv = 0;
+    NV accumulated_nv = 0;
     const PERL_UINT_FAST8_T base = 1 << shift;  /* 2, 8, or 16 */
 
     /* As long as the running total is less than this, the next digit will
@@ -388,31 +388,31 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
                same thing) */
           redo: ;
             /* If there is room for this digit, accumulate it and repeat */
-            if (LIKELY(value <= max_div)) {
+            if (LIKELY(accumulated <= max_div)) {
                 /* Note XDIGIT_VALUE() is branchless, works on binary and
                  * octal as well, so can be used here, without noticeably
                  * slowing those down (it does have unnecessary shifts, ANDSs,
                  * and additions for those) */
-                value = (value << shift) | XDIGIT_VALUE(*s);
+                accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
                 factor *= base;
                 continue;
             }
 
             /* Bah. We are about to overflow.  Instead, add the unoverflowed
-             * value to an NV that contains an approximation to the correct
+             * accumulated to an NV that contains an approximation to the correct
              * value.  Each time through the loop we have increased 'factor' so
              * that it gives how much the current approximation needs to
              * effectively be shifted to make room for this new value */
-            value_nv *= factor;
-            value_nv += (NV) value;
+            accumulated_nv *= factor;
+            accumulated_nv += (NV) accumulated;
 
             /* Then we keep accumulating digits, until all are parsed.  We
              * start over using the current input value as the initial digit.
-             * This will be added to 'value_nv' eventually, either when all
+             * This will be added to 'accumulated_nv' eventually, either when all
              * digits are gone, or we have overflowed this fresh start.  This
              * method uses the fewest floating point multiplications possible,
              * losing the least precision. */
-            value = XDIGIT_VALUE(*s);
+            accumulated = XDIGIT_VALUE(*s);
             factor = base;
             overflowed = TRUE;
             continue;
@@ -433,7 +433,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
             /* To get here with the value so-far being 0 means we've only had
              * leading zeros, then an underscore.  We can continue with the
              * branchless switch() instead of this loop */
-            if (UNLIKELY(value == 0)) {
+            if (UNLIKELY(accumulated == 0)) {
                 goto redo_switch;
             }
             else {
@@ -453,14 +453,14 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     if (UNLIKELY(overflowed)) {
 
         /* Calculate the final overflow approximation */
-        value_nv *= factor;
-        value_nv += (NV) value;
+        accumulated_nv *= factor;
+        accumulated_nv += (NV) accumulated;
 
         *flags |= PERL_SCAN_GREATER_THAN_UV_MAX
                |  PERL_SCAN_SILENT_NON_PORTABLE;
 
         if (result)
-            *result = value_nv;
+            *result = accumulated_nv;
 
         if (input_flags & PERL_SCAN_SILENT_OVERFLOW) {
             *flags |= PERL_SCAN_SILENT_OVERFLOW;
@@ -474,12 +474,12 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
                                     : "octal");
         }
 
-        value = UV_MAX;
+        accumulated = UV_MAX;
         do_non_portable_output = true;
     }
     else {
 #if UVSIZE > 4
-        if (UNLIKELY(value > 0xffffffff)) {
+        if (UNLIKELY(accumulated > 0xffffffff)) {
             if (! (input_flags & PERL_SCAN_SILENT_NON_PORTABLE)) {
                 do_non_portable_output = true;
             }
@@ -523,7 +523,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
     /* s here points to e or to the first illegal character */
     *len_p = s - start;
-    return value;
+    return accumulated;
 }
 
 /*

--- a/numeric.c
+++ b/numeric.c
@@ -511,50 +511,83 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
   overflowed: ;
 
-    /* Bah. We are about to overflow.  Instead, place the unoverflowed
-     * accumulated value in an NV that will contain an approximation to the
-     * correct value. */
-    NV accumulated_nv = (NV) accumulated;
-
-    /* In overflows, this keeps track of how much to multiply the overflowed NV
-     * by as we continue to parse the remaining digits */
-    NV accumulated_factor = 1.0;
-
-    /* Then we continue parsing, starting over with a new batch of digits to
-     * accumulate */
-    UV this_batch_accumulated = 0;
-    for (; s < e && Perl_isCC_by_bit(*s, valid_digit_or_underscore_bits); s++)
-    {
-        /* Handle non-trailing underscores when those are accepted */
-        if (UNLIKELY(*s == '_')) {
-            if (   ! allow_underscores
-                || ! underscore_valid(s, e, lookup_bit))
-            {
-                break;
-            }
-
-            ++s;
+    /* Bah. We are about to overflow.  Instead compute an approximation to the
+     * correct value.
+     *
+     * It turns out that there is less precision loss if we start at the low
+     * order digits of the string and build up the number from there.  This is
+     * because if we overflow multiple times, the low order digits will be so
+     * small in comparison to the larger ones that they are completely
+     * disregarded.  But going the other way allows them to contribute
+     * whatever bits they have to offer.
+     *
+     * So, find the end of the string */
+    const char * s1 = s;    /* Save our place */
+    s++;
+    while (s < e && Perl_isCC_by_bit(*s, valid_digit_or_underscore_bits)) {
+        if (   UNLIKELY(*s == '_')
+            && (   ! allow_underscores
+                || ! underscore_valid(s, e, lookup_bit)))
+        {
+            break;
         }
 
-        if (LIKELY(this_batch_accumulated <= max_div)) {
-            this_batch_accumulated =
-                            (this_batch_accumulated << shift) | XDIGIT_VALUE(*s);
-            accumulated_factor *= base;
+        s++;
+    }
+
+    /* Here we got to the end of the string; either we encountered an illegal
+     * character, which ends it, or got to the final position in it.  's'
+     * points to the position just after the final legal character.
+     *
+     * Accumulate the value starting at the lowest order digit and going
+     * backwards */
+    const char * t = s - 1;
+    NV accumulated_nv = 0;
+    NV accumulated_factor = 1;
+
+    UV this_batch_accumulated = 0;
+    UV this_batch_factor = 1;
+
+    /* To minimize precision loss, we do integer arithmetic on batches that
+     * don't overflow.  When one does, the final integer that didn't overflow
+     * is factored in to the running total, and a new batch is started */
+    while (t >= s1) {
+
+        /* Any underscores were already determined to be valid */
+        if (UNLIKELY(*t == '_')) {
+            t--;
             continue;
         }
 
-        /* Bah. We are about to overflow again.  Instead, add this batch to
-         * the NV, and start a new batch */
-        accumulated_nv *= accumulated_factor;
-        accumulated_nv += (NV) this_batch_accumulated;
+        /* If will fit, accumulate it and repeat.  Each digit has to be
+         * multiplied by the position it occupies, like 1, 8, 8-squared,
+         * 8-cubed, etc */
+        if (   LIKELY(this_batch_accumulated <= max_div)
+            && LIKELY(this_batch_factor <= max_div))
+        {
+            U8 this_digit_value = XDIGIT_VALUE(*t);
+            this_batch_accumulated += this_digit_value * this_batch_factor;
+            this_batch_factor <<= shift;
+            t--;
+            continue;
+        }
 
-        this_batch_accumulated = XDIGIT_VALUE(*s);
-        accumulated_factor = base;
+        /* Bah. We are about to overflow again.  Instead, accumulate this
+         * batch into the running total for all low order batches, and start a
+         * new batch. */
+        accumulated_nv += this_batch_accumulated * accumulated_factor;
+        accumulated_factor *= this_batch_factor;
+
+        this_batch_accumulated = 0;
+        this_batch_factor = 1;
     }
 
-    /* Calculate the final overflow approximation */
-    accumulated_nv *= accumulated_factor;
-    accumulated_nv += (NV) accumulated;
+    /* Here have accumulated everything.  Combine the low order bits with the
+     * high order that we have saved in 'accumulated'.  Those must be shifted
+     * left to account for the low order ones */
+    accumulated_nv += this_batch_accumulated * accumulated_factor;
+    accumulated_factor *= this_batch_factor;
+    accumulated_nv += accumulated * accumulated_factor;
 
     *flags |= PERL_SCAN_GREATER_THAN_UV_MAX
            |  PERL_SCAN_SILENT_NON_PORTABLE;

--- a/numeric.c
+++ b/numeric.c
@@ -378,6 +378,12 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     /* check_underscore() succeeds only if the next char is a legal digit */
     s++;
 
+    /* If we haven't seen any non-zero digits yet, we can jump back in to the
+     * switch() without fear of exceeding the portability limits */
+    if (UNLIKELY(accumulated == 0)) {
+        goto redo_switch;
+    }
+
     /* Here s points to a legal digit */
 
   loop: ;

--- a/numeric.c
+++ b/numeric.c
@@ -314,6 +314,8 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     switch (e - s) {
       default:
         if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
+        accumulated = XDIGIT_VALUE(*s);
+        s++;
         goto loop;
 
       case 8:
@@ -384,13 +386,16 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         goto redo_switch;
     }
 
-    /* Here s points to a legal digit */
+    /* Here s points to a legal digit.  We can save some operations by
+     * accumulating it now, and positioning the loop to start on the next
+     * character (whose value is unknown here). */
+    accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
+    s++;
 
   loop: ;
 
     /* Here, 'accumulated' contains the running total so far in the input,
-     * and 's' points to the next character, which is known to be a legal
-     * digit
+     * and 's' points to the next character.
      *
      * The loop below accumulates the integral running total of the result,
      * digit by digit.  If this total overflows, it is added to an NV

--- a/numeric.c
+++ b/numeric.c
@@ -306,6 +306,10 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     switch (e - s) {
       default:
         if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
+        goto loop;
+
+      case 8:
+        if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
         accumulated = XDIGIT_VALUE(*s);
         s++;
         /* FALLTHROUGH */
@@ -345,21 +349,13 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         s++;
         /* FALLTHROUGH */
       case 0:
-        if (LIKELY(s >= e)) {
-            return accumulated;
-        }
-
-        /* If we get here, and the accumulated value is still 0, it is
-           * because there are more leading zeros than the cases of this
-         * switch(),  These are common enough with these kinds of
-         * binary-style numbers that it is worth this extra conditional to
-         * continue absorbing them via the switch. */
-        if (accumulated == 0) {
-            goto redo_switch;
-        }
-
-        break;
+        return accumulated;
     }   /* End of switch on the first so-many characters */
+
+  loop: ;
+    /* To get here, either the input is too long for the switch() statement
+     * above, or there was an unexpected character in the input (including
+     * an underscore, which is optionally acceptable). */
 
     /* The loop below accumulates the integral running total of the result,
      * digit by digit.  If this total overflows, it is added to an NV

--- a/numeric.c
+++ b/numeric.c
@@ -422,10 +422,12 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
      * fit. */
     UV max_div;
     max_div = UV_MAX >> shift;
+    U32 valid_digit_or_underscore_bits;
+    valid_digit_or_underscore_bits = (lookup_bit|CC_mask_(CC_UNDERSCORE_));
 
     /* Loop through the characters */
-    for (; s < e; s++) {
-
+    for (; s < e && Perl_isCC_by_bit(*s, valid_digit_or_underscore_bits); s++)
+    {
         /* Handle non-trailing underscores when those are accepted */
         if (UNLIKELY(*s == '_')) {
             if (   ! allow_underscores
@@ -434,10 +436,10 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
                 break;
             }
 
+            /* check_underscore() succeeds only if the next char is a legal
+             * digit */
             ++s;
         }
-
-        if (Perl_isCC_by_bit(*s, lookup_bit)) {
 
             /* If there is room for this digit, accumulate it and repeat */
             if (LIKELY(accumulated <= max_div)) {
@@ -467,14 +469,6 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
             accumulated = XDIGIT_VALUE(*s);
             factor = base;
             overflowed = TRUE;
-            continue;
-        } /* End of handling legal digit */
-
-        /* We get here when done with the parse, or it got interrupted by a
-         * non-digit or a digit that is outside the bounds of the base, like a
-         * digit 2 in a binary number.  In either case, we are done with the
-         * loop */
-        break;
     }   /* End of parsing loop */
 
   done_parse:

--- a/numeric.c
+++ b/numeric.c
@@ -355,10 +355,18 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         return accumulated;
     }   /* End of switch on the first so-many characters */
 
-  loop: ;
-    /* To get here, either the input is too long for the switch() statement
-     * above, or there was an unexpected character in the input (including
+    /* To get here, there was an unexpected character in the input (including
      * an underscore, which is optionally acceptable). */
+    if (*s != '_' || ! allow_underscores) {
+        goto done_parse;
+    }
+
+    /* An acceptable initial underscore has to have the right flag */
+    if (s == s0 && (input_flags & PERL_SCAN_ALLOW_MEDIAL_UNDERSCORES_ONLY)) {
+        goto done_parse;
+    }
+
+  loop: ;
 
     /* The loop below accumulates the integral running total of the result,
      * digit by digit.  If this total overflows, it is added to an NV
@@ -419,11 +427,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         if (   UNLIKELY(*s == '_')
             && s < e - 1
             && allow_underscores
-            && Perl_isCC_by_bit(s[1], class_bit)
-            && (   LIKELY(s > s0)
-                   /* Including initial underscores if those are accepted */
-                || UNLIKELY(! (  input_flags
-                               & PERL_SCAN_ALLOW_MEDIAL_UNDERSCORES_ONLY))))
+            && Perl_isCC_by_bit(s[1], class_bit))
         {
             ++s;
 
@@ -444,6 +448,8 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
          * loop */
         break;
     }   /* End of parsing loop */
+
+  done_parse:
 
     bool do_non_portable_output = false;
 

--- a/numeric.c
+++ b/numeric.c
@@ -450,12 +450,12 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
   done_parse:
 
 #if UVSIZE > 4
-        if (UNLIKELY(accumulated > 0xffffffff)) {
-            if (! (input_flags & PERL_SCAN_SILENT_NON_PORTABLE)) {
-                do_non_portable_output = true;
-            }
-            *flags |= PERL_SCAN_SILENT_NON_PORTABLE;
+    if (UNLIKELY(accumulated > 0xffffffff)) {
+        if (! (input_flags & PERL_SCAN_SILENT_NON_PORTABLE)) {
+            do_non_portable_output = true;
         }
+        *flags |= PERL_SCAN_SILENT_NON_PORTABLE;
+    }
 #endif
 
     if (s < e && *s) {  /* *s is to keep a terminating NUL from warning */

--- a/numeric.c
+++ b/numeric.c
@@ -518,7 +518,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
     /* In overflows, this keeps track of how much to multiply the overflowed NV
      * by as we continue to parse the remaining digits */
-    NV factor = 1.0;
+    NV accumulated_factor = 1.0;
 
     /* Then we continue parsing, starting over with a new batch of digits to
      * accumulate */
@@ -539,21 +539,21 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         if (LIKELY(this_batch_accumulated <= max_div)) {
             this_batch_accumulated =
                             (this_batch_accumulated << shift) | XDIGIT_VALUE(*s);
-            factor *= base;
+            accumulated_factor *= base;
             continue;
         }
 
         /* Bah. We are about to overflow again.  Instead, add this batch to
          * the NV, and start a new batch */
-        accumulated_nv *= factor;
+        accumulated_nv *= accumulated_factor;
         accumulated_nv += (NV) this_batch_accumulated;
 
         this_batch_accumulated = XDIGIT_VALUE(*s);
-        factor = base;
+        accumulated_factor = base;
     }
 
     /* Calculate the final overflow approximation */
-    accumulated_nv *= factor;
+    accumulated_nv *= accumulated_factor;
     accumulated_nv += (NV) accumulated;
 
     *flags |= PERL_SCAN_GREATER_THAN_UV_MAX

--- a/numeric.c
+++ b/numeric.c
@@ -313,6 +313,17 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
   redo_switch:
     switch (e - s) {
       default:
+
+        /* Leading zeros are common enough to deserve a special case when
+         * there are more digits than we handle in the switch.  Strip them
+         * off, and try again */
+        if (UNLIKELY(*s == '0')) {
+            do {
+                s++;
+            } while (s < e && *s == '0');
+            goto redo_switch;
+        }
+
         if (UNLIKELY(! Perl_isCC_by_bit(*s, lookup_bit)))  break;
         accumulated = XDIGIT_VALUE(*s);
         s++;
@@ -458,16 +469,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
             && underscore_valid(s, e, lookup_bit))
         {
             ++s;
-
-            /* To get here with the value so-far being 0 means we've only had
-             * leading zeros, then an underscore.  We can continue with the
-             * branchless switch() instead of this loop */
-            if (UNLIKELY(accumulated == 0)) {
-                goto redo_switch;
-            }
-            else {
-                goto redo;
-            }
+            goto redo;
         }
 
         /* We get here when done with the parse, or it got interrupted by a

--- a/numeric.c
+++ b/numeric.c
@@ -302,9 +302,8 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
     const char * const s0 = s;  /* Where the significant digits start */
     UV accumulated = 0;               /* Running total */
-    bool overflowed = FALSE;
-    NV accumulated_nv = 0;
     const PERL_UINT_FAST8_T base = 1 << shift;  /* 2, 8, or 16 */
+    bool do_non_portable_output = false;
 
     /* Unroll the loop so that numbers with 8 or fewer digits can be handled
      * with the minimum amount of work.  Anything higher would require extra
@@ -409,16 +408,9 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
      * and 's' points to the next character.
      *
      * The loop below accumulates the integral running total of the result,
-     * digit by digit.  If this total overflows, it is added to an NV
-     * approximation, and the loop starts over, looking at the next batch of
-     * digits, until they overflow, and so on.
+     * digit by digit.
      *
-     * In overflows, this keeps track of how much to multiply the overflowed NV
-     * by as we continue to parse the remaining digits */
-    NV factor;
-    factor = 0.0;
-
-    /* As long as the running total is less than this, the next digit will
+     * As long as the running total is less than this, the next digit will
      * fit. */
     UV max_div;
     max_div = UV_MAX >> shift;
@@ -441,68 +433,22 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
             ++s;
         }
 
-        /* If there is room for this digit, accumulate it and repeat */
-        if (LIKELY(accumulated <= max_div)) {
-        /* Note XDIGIT_VALUE() is branchless, works on binary and octal as
+        /* If would overflow, handle elsewhere */
+        if (UNLIKELY(accumulated > max_div)) {
+            goto overflowed;
+        }
+
+        /* Otherwise, there is room for this digit; accumulate it and repeat
+         *
+         * Note XDIGIT_VALUE() is branchless, works on binary and octal as
          * well, so can be used here, without noticeably slowing those down
          * (it does have unnecessary shifts, ANDSs, and additions for those)
          * */
         accumulated = (accumulated << shift) | XDIGIT_VALUE(*s);
-        factor *= base;
-        continue;
-        }
-
-        /* Bah. We are about to overflow.  Instead, add the unoverflowed
-         * accumulated to an NV that contains an approximation to the correct
-         * value.  Each time through the loop we have increased 'factor' so
-         * that it gives how much the current approximation needs to
-         * effectively be shifted to make room for this new value */
-        accumulated_nv *= factor;
-        accumulated_nv += (NV) accumulated;
-
-        /* Then we keep accumulating digits, until all are parsed.  We
-         * start over using the current input value as the initial digit.
-         * This will be added to 'accumulated_nv' eventually, either when all
-         * digits are gone, or we have overflowed this fresh start.  This
-         * method uses the fewest floating point multiplications possible,
-         * losing the least precision. */
-        accumulated = XDIGIT_VALUE(*s);
-        factor = base;
-        overflowed = TRUE;
     }   /* End of parsing loop */
 
   done_parse:
 
-    bool do_non_portable_output = false;
-
-    if (UNLIKELY(overflowed)) {
-
-        /* Calculate the final overflow approximation */
-        accumulated_nv *= factor;
-        accumulated_nv += (NV) accumulated;
-
-        *flags |= PERL_SCAN_GREATER_THAN_UV_MAX
-               |  PERL_SCAN_SILENT_NON_PORTABLE;
-
-        if (result)
-            *result = accumulated_nv;
-
-        if (input_flags & PERL_SCAN_SILENT_OVERFLOW) {
-            *flags |= PERL_SCAN_SILENT_OVERFLOW;
-        }
-        else if (ckWARN_d(WARN_OVERFLOW)) {
-            warner(packWARN(WARN_OVERFLOW),
-                    "Integer overflow in %s number",
-                    (base == 16) ? "hexadecimal"
-                                : (base == 2)
-                                    ? "binary"
-                                    : "octal");
-        }
-
-        accumulated = UV_MAX;
-        do_non_portable_output = true;
-    }
-    else {
 #if UVSIZE > 4
         if (UNLIKELY(accumulated > 0xffffffff)) {
             if (! (input_flags & PERL_SCAN_SILENT_NON_PORTABLE)) {
@@ -511,7 +457,6 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
             *flags |= PERL_SCAN_SILENT_NON_PORTABLE;
         }
 #endif
-    }
 
     if (s < e && *s) {  /* *s is to keep a terminating NUL from warning */
         if (   ! (input_flags & PERL_SCAN_SILENT_ILLDIGIT)
@@ -549,6 +494,75 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
     /* s here points to e or to the first illegal character */
     *len_p = s - start;
     return accumulated;
+
+  overflowed: ;
+
+    /* Bah. We are about to overflow.  Instead, place the unoverflowed
+     * accumulated value in an NV that will contain an approximation to the
+     * correct value. */
+    NV accumulated_nv = (NV) accumulated;
+
+    /* In overflows, this keeps track of how much to multiply the overflowed NV
+     * by as we continue to parse the remaining digits */
+    NV factor = 1.0;
+
+    /* Then we continue parsing, starting over with a new batch of digits to
+     * accumulate */
+    UV this_batch_accumulated = 0;
+    for (; s < e && Perl_isCC_by_bit(*s, valid_digit_or_underscore_bits); s++)
+    {
+        /* Handle non-trailing underscores when those are accepted */
+        if (UNLIKELY(*s == '_')) {
+            if (   ! allow_underscores
+                || ! underscore_valid(s, e, lookup_bit))
+            {
+                break;
+            }
+
+            ++s;
+        }
+
+        if (LIKELY(this_batch_accumulated <= max_div)) {
+            this_batch_accumulated =
+                            (this_batch_accumulated << shift) | XDIGIT_VALUE(*s);
+            factor *= base;
+            continue;
+        }
+
+        /* Bah. We are about to overflow again.  Instead, add this batch to
+         * the NV, and start a new batch */
+        accumulated_nv *= factor;
+        accumulated_nv += (NV) this_batch_accumulated;
+
+        this_batch_accumulated = XDIGIT_VALUE(*s);
+        factor = base;
+    }
+
+    /* Calculate the final overflow approximation */
+    accumulated_nv *= factor;
+    accumulated_nv += (NV) accumulated;
+
+    *flags |= PERL_SCAN_GREATER_THAN_UV_MAX
+           |  PERL_SCAN_SILENT_NON_PORTABLE;
+
+    if (result)
+        *result = accumulated_nv;
+
+    if (input_flags & PERL_SCAN_SILENT_OVERFLOW) {
+        *flags |= PERL_SCAN_SILENT_OVERFLOW;
+    }
+    else if (ckWARN_d(WARN_OVERFLOW)) {
+        warner(packWARN(WARN_OVERFLOW),
+                "Integer overflow in %s number",
+                (base == 16) ? "hexadecimal"
+                            : (base == 2)
+                                ? "binary"
+                                : "octal");
+    }
+
+    accumulated = UV_MAX;
+    do_non_portable_output = true;
+    goto done_parse;
 }
 
 /*


### PR DESCRIPTION
This p.r. includes slight efficiency gains for the common cases, and improved precision when handling overflowing values that are converted to NVs.

The previous algorithm loses more precision than this one.  It did not show up in our test suite, but a WIP I have did show that, and this new algorithm fixes it.

The problem with the old one is that it started with the highest order digits, and worked down to the low order which don't contribute very much to result, but they can contribute more than what that algorithm used.  This is because those low order digits can end up contributing nothing, being dwarfed by the high order ones.

The new algorithm doesn't take effect until the rare case that the input string overflows.  It finds the end of the input digits and then works backwards.  For example, in the string 0x123 it calculates
    3 * 1 + 2 * 16 + 1 * 256
It creates batches of these that don't overflow and then combines them with the previous set of batches, like the old algorithm, except working backwards.

Each new batch will contribute to the overall value, instead of being discarded.  The previous batches which are lower order will become less and less important, but their contribution is not prematurely discarded, which is the effect of the old algorithm.

The extra inefficiency is due to finding the end of the string, and then reparsing it backwards.  But again, this only happens when overflow occurs.

* This set of changes does not require a perldelta entry.
