### PR TITLE
 embed.fnc: Add [SME]PTR asserts to some functions missing them

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1445,8 +1445,8 @@ Adp	|int	|grok_number_flags					\
 				|NULLOK UV *valuep			\
 				|U32 flags
 ARdp	|bool	|grok_numeric_radix					\
-				|NN const char **sp			\
-				|NN const char *send
+				|SPTR const char **sp			\
+				|EPTRge const char *send
 Adip	|UV	|grok_oct	|NN const char *start			\
 				|NN STRLEN *len_p			\
 				|NN I32 *flags				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4300,8 +4300,8 @@ ep	|void	|Slab_to_rw	|NN OPSLAB * const slab
 # endif
 #endif /* defined(PERL_CORE) */
 #if defined(PERL_CORE) || defined(PERL_EXT)
-ERXdp	|bool	|isSCRIPT_RUN	|NN const U8 *s 			\
-				|NN const U8 *send			\
+ERXdp	|bool	|isSCRIPT_RUN	|SPTR const U8 *s			\
+				|EPTRge const U8 *send			\
 				|const bool utf8_target
 ERTXdip |bool	|is_utf8_non_invariant_string				\
 				|NN const U8 * const s			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -6073,7 +6073,7 @@ S	|bool	|sv_2iuv_common |NN SV * const sv
 S	|STRLEN |sv_pos_b2u_midway					\
 				|SPTR const U8 * const s		\
 				|MPTR const U8 * const target		\
-				|NN const U8 *end			\
+				|EPTRge const U8 *end			\
 				|STRLEN endu
 S	|STRLEN |sv_pos_u2b_cached					\
 				|NN SV * const sv			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -5529,7 +5529,7 @@ ETi	|Size_t |find_first_differing_byte_pos				\
 ES	|U32	|get_quantifier_value					\
 				|NN RExC_state_t *pRExC_state		\
 				|SPTR const char *start 		\
-				|EPTRge const char *end
+				|EPTRgt const char *end
 ES	|bool	|grok_bslash_N	|NN RExC_state_t *pRExC_state		\
 				|NULLOK regnode_offset *nodep		\
 				|NULLOK UV *code_point_p		\

--- a/embed.fnc
+++ b/embed.fnc
@@ -5717,7 +5717,7 @@ ETXp	|UV	|to_fold_latin1_|const U8 c				\
 #endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C)
 ERTXp	|bool	|regcurly	|SPTR const char *s			\
-				|EPTRge const char *e			\
+				|EPTRgt const char *e			\
 				|NULLOK const char *result[5]
 #endif
 #if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)

--- a/embed.fnc
+++ b/embed.fnc
@@ -4552,7 +4552,7 @@ ERXp	|bool	|grok_bslash_c	|const char source			\
 				|NN const char **message		\
 				|NULLOK U32 *packed_warn
 ERXp	|bool	|grok_bslash_o	|SPTR char **s				\
-				|EPTRge const char * const send 	\
+				|EPTRgt const char * const send 	\
 				|NN UV *uv				\
 				|NN const char **message		\
 				|NULLOK U32 *packed_warn		\
@@ -4560,7 +4560,7 @@ ERXp	|bool	|grok_bslash_o	|SPTR char **s				\
 				|const bool allow_UV_MAX		\
 				|const bool utf8
 ERXp	|bool	|grok_bslash_x	|SPTR char **s				\
-				|EPTRge const char * const send 	\
+				|EPTRgt const char * const send 	\
 				|NN UV *uv				\
 				|NN const char **message		\
 				|NULLOK U32 *packed_warn		\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3841,13 +3841,13 @@ ARTdip	|U8 *	|utf8_hop_back_overshoot				\
 				|SPTR const U8 * const start		\
 				|NULLOK SSize_t *remaining
 ARTdmp	|U8 *	|utf8_hop_forward					\
-				|NN const U8 *s 			\
+				|SPTR const U8 *s			\
 				|SSize_t off				\
-				|NN const U8 * const end
+				|EPTRge const U8 * const end
 ARTdip	|U8 *	|utf8_hop_forward_overshoot				\
-				|NN const U8 *s 			\
+				|SPTR const U8 *s			\
 				|SSize_t off				\
-				|NN const U8 * const end		\
+				|EPTRge const U8 * const end		\
 				|NULLOK SSize_t *remaining
 ARTdip	|U8 *	|utf8_hop_overshoot					\
 				|MPTR const U8 *s			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -5937,8 +5937,8 @@ EWi	|void	|unwind_paren	|NN regexp *rex 			\
 ES	|void	|debug_start_match					\
 				|NN const REGEXP *prog			\
 				|const bool do_utf8			\
-				|NN const char *start			\
-				|NN const char *end			\
+				|SPTR const char *start 		\
+				|EPTRge const char *end 		\
 				|NN const char *blurb
 ES	|void	|dump_exec_pos	|NN const char *locinput		\
 				|NN const regnode *scan 		\

--- a/embed.fnc
+++ b/embed.fnc
@@ -5940,9 +5940,9 @@ ES	|void	|debug_start_match					\
 				|SPTR const char *start 		\
 				|EPTRge const char *end 		\
 				|NN const char *blurb
-ES	|void	|dump_exec_pos	|NN const char *locinput		\
+ES	|void	|dump_exec_pos	|SPTR const char *locinput		\
 				|NN const regnode *scan 		\
-				|NN const char *loc_regeol		\
+				|EPTRge const char *loc_regeol		\
 				|NN const char *loc_bostr		\
 				|NN const char *loc_reg_starttry	\
 				|const bool do_utf8			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -4312,8 +4312,8 @@ Ei	|STRLEN |sv_or_pv_pos_u2b					\
 				|STRLEN pos				\
 				|NULLOK STRLEN *lenp
 ERTdi	|Size_t |variant_under_utf8_count				\
-				|NN const U8 * const s			\
-				|NN const U8 * const e
+				|SPTR const U8 * const s		\
+				|EPTRge const U8 * const e
 # if !defined(HAS_MEMRCHR)
 ETei	|void * |my_memrchr	|NN const char *s			\
 				|const char c				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -5316,8 +5316,8 @@ IR	|bool	|should_we_output_Debug_r				\
 #if defined(PERL_IN_PP_PACK_C)
 S	|int	|div128 	|NN SV *pnum				\
 				|NN bool *done
-ST	|char	|first_symbol	|NN const char *pat			\
-				|NN const char *patend
+ST	|char	|first_symbol	|SPTR const char *pat			\
+				|EPTRge const char *patend
 RS	|const char *|get_num	|NN const char *patptr			\
 				|NN SSize_t *lenptr
 S	|const char *|group_end |SPTR const char *patptr		\
@@ -5333,8 +5333,8 @@ RST	|char * |my_bytes_to_utf8					\
 				|STRLEN len				\
 				|NN char *dest				\
 				|const bool needs_swap
-ST	|bool	|need_utf8	|NN const char *pat			\
-				|NN const char *patend
+ST	|bool	|need_utf8	|SPTR const char *pat			\
+				|EPTRge const char *patend
 S	|bool	|next_symbol	|NN struct tempsym *symptr
 S	|SV **	|pack_rec	|NN SV *cat				\
 				|NN struct tempsym *symptr		\

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -804,7 +804,7 @@ S_next_symbol(pTHX_ tempsym_t* symptr )
    themselves if they need to do a lot of unpacks like this on it
 */
 STATIC bool
-need_utf8(const char *pat, const char *patend)
+S_need_utf8(const char *pat, const char *patend)
 {
     bool first = TRUE;
 
@@ -824,7 +824,7 @@ need_utf8(const char *pat, const char *patend)
 }
 
 STATIC char
-first_symbol(const char *pat, const char *patend) {
+S_first_symbol(const char *pat, const char *patend) {
     PERL_ARGS_ASSERT_FIRST_SYMBOL;
 
     while (pat < patend) {

--- a/proto.h
+++ b/proto.h
@@ -8912,7 +8912,8 @@ S_unwind_scan_frames(pTHX_ void *p);
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DEBUG_START_MATCH   \
-        assert(prog); assert(start); assert(end); assert(blurb)
+        assert(prog); assert(start); assert(end); assert(blurb); \
+        assert(start <= end)
 
 #   define PERL_ARGS_ASSERT_DUMP_EXEC_POS       \
         assert(locinput); assert(scan); assert(loc_regeol); assert(loc_bostr); \

--- a/proto.h
+++ b/proto.h
@@ -6880,11 +6880,11 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_O         \
         assert(s); assert(*s); assert(send); assert(uv); assert(message); \
-        assert(*s <= send)
+        assert(*s < send)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_X         \
         assert(s); assert(*s); assert(send); assert(uv); assert(message); \
-        assert(*s <= send)
+        assert(*s < send)
 
 #endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) ||
           defined(PERL_IN_TOKE_C) */

--- a/proto.h
+++ b/proto.h
@@ -9224,7 +9224,8 @@ S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size);
 STATIC STRLEN
 S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 *end, STRLEN endu);
 # define PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY     \
-        assert(s); assert(target); assert(end); assert(s <= target)
+        assert(s); assert(target); assert(end); assert(s <= target); \
+        assert(target <= end)
 
 STATIC STRLEN
 S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const start, const U8 * const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0);

--- a/proto.h
+++ b/proto.h
@@ -8388,7 +8388,7 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist);
         assert(screamer); assert(strbeg <= stringarg)
 
 # define PERL_ARGS_ASSERT_GET_QUANTIFIER_VALUE  \
-        assert(pRExC_state); assert(start); assert(end); assert(start <= end)
+        assert(pRExC_state); assert(start); assert(end); assert(start < end)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_N         \
         assert(pRExC_state); assert(flagp)

--- a/proto.h
+++ b/proto.h
@@ -8644,7 +8644,7 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 *bitmap, const Size_t bitmap_le
 #endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C)
 # define PERL_ARGS_ASSERT_REGCURLY              \
-        assert(s); assert(e); assert(s <= e)
+        assert(s); assert(e); assert(s < e)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV bool

--- a/proto.h
+++ b/proto.h
@@ -8917,7 +8917,7 @@ S_unwind_scan_frames(pTHX_ void *p);
 
 #   define PERL_ARGS_ASSERT_DUMP_EXEC_POS       \
         assert(locinput); assert(scan); assert(loc_regeol); assert(loc_bostr); \
-        assert(loc_reg_starttry)
+        assert(loc_reg_starttry); assert(locinput <= loc_regeol)
 
 #   define PERL_ARGS_ASSERT_RE_EXEC_INDENTF     \
         assert(fmt)

--- a/proto.h
+++ b/proto.h
@@ -8040,7 +8040,7 @@ S_div128(pTHX_ SV *pnum, bool *done);
 STATIC char
 S_first_symbol(const char *pat, const char *patend);
 # define PERL_ARGS_ASSERT_FIRST_SYMBOL          \
-        assert(pat); assert(patend)
+        assert(pat); assert(patend); assert(pat <= patend)
 
 STATIC const char *
 S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
@@ -8078,7 +8078,7 @@ S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swa
 STATIC bool
 S_need_utf8(const char *pat, const char *patend);
 # define PERL_ARGS_ASSERT_NEED_UTF8             \
-        assert(pat); assert(patend)
+        assert(pat); assert(patend); assert(pat <= patend)
 
 STATIC bool
 S_next_symbol(pTHX_ struct tempsym *symptr);

--- a/proto.h
+++ b/proto.h
@@ -1275,7 +1275,7 @@ PERL_CALLCONV bool
 Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GROK_NUMERIC_RADIX     \
-        assert(sp); assert(send)
+        assert(sp); assert(*sp); assert(send); assert(*sp <= send)
 
 /* PERL_CALLCONV GV *
 Perl_gv_AVadd(pTHX_ GV *gv); */

--- a/proto.h
+++ b/proto.h
@@ -10496,7 +10496,7 @@ PERL_STATIC_INLINE Size_t
 S_variant_under_utf8_count(const U8 * const s, const U8 * const e)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_VARIANT_UNDER_UTF8_COUNT \
-        assert(s); assert(e)
+        assert(s); assert(e); assert(s <= e)
 
 #   if !defined(HAS_MEMRCHR)
 PERL_STATIC_INLINE void *

--- a/proto.h
+++ b/proto.h
@@ -10297,7 +10297,7 @@ PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_forward_overshoot(const U8 *s, SSize_t off, const U8 * const end, SSize_t *remaining)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD_OVERSHOOT \
-        assert(s); assert(end)
+        assert(s); assert(end); assert(s <= end)
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end, SSize_t *remaining)

--- a/proto.h
+++ b/proto.h
@@ -6126,7 +6126,7 @@ PERL_CALLCONV bool
 Perl_isSCRIPT_RUN(pTHX_ const U8 *s, const U8 *send, const bool utf8_target)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISSCRIPT_RUN          \
-        assert(s); assert(send)
+        assert(s); assert(send); assert(s <= send)
 
 # if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
      defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \

--- a/regexec.c
+++ b/regexec.c
@@ -11761,6 +11761,8 @@ it are from the Inherited or Common scripts.
 bool
 Perl_isSCRIPT_RUN(pTHX_ const U8 * s, const U8 * send, const bool utf8_target)
 {
+    PERL_ARGS_ASSERT_ISSCRIPT_RUN;
+
     /* Basically, it looks at each character in the sequence to see if the
      * above conditions are met; if not it fails.  It uses an inversion map to
      * find the enum corresponding to the script of each character.  But this


### PR DESCRIPTION
This replaces #24021 which was mistakenly closed

These have not been done in earlier commits because they needed more manual analysis, which I have now done. In a couple cases, I changed the EPTR assert to EPTRgt, based on that analysis.

- This set of changes does not require a perldelta entry.


