### PR TITLE
grok_bin_oct_hex(): Remove some runtime calculations

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1433,7 +1433,7 @@ Cp	|UV	|grok_bin_oct_hex					\
 				|NN I32 *flags				\
 				|NULLOK NV *result			\
 				|const unsigned shift			\
-				|const U8 lookup_bit			\
+				|const U32 lookup_bit			\
 				|const char prefix
 Adip	|UV	|grok_hex	|NN const char *start			\
 				|NN STRLEN *len_p			\

--- a/handy.h
+++ b/handy.h
@@ -1602,10 +1602,28 @@ END_EXTERN_C
     /* The 1U keeps Solaris from griping when shifting sets the uppermost bit */
 #   define CC_mask_(classnum) (1U << (classnum))
 
+/*
+=for apidoc_section $classification
+=for apidoc Cm|U32|CC_mask_|U8 c|U8 classnum
+
+This translates C<classnum> into a bit pattern to use in conjunction with
+entries in C<PL_charclass[]>, and operations such is C<L</Perl_isCC_by_bit>>.
+C<classnum> is one of the classes defined in F<handy.h> for this purpose.
+
+=for apidoc Cm|bool|Perl_isCC_by_bit|U8 c|U32 bit_pattern
+
+Returns a boolean as to whether or not the character C<c> in the Latin1 range
+is a member of the class(es) given by C<bit_pattern>, as formed by
+C<L</CC_mask_>>.
+
+=cut
+*/
+#  define Perl_isCC_by_bit(c, bit_pattern)                              \
+       (FITS_IN_8_BITS(c) && (PL_charclass[(U8) (c)] & (bit_pattern)))
+
     /* For internal core Perl use only: the base macro for defining macros like
      * isALPHA */
-#   define generic_isCC_(c, classnum)                                       \
-       (FITS_IN_8_BITS(c) && (PL_charclass[(U8) (c)] & CC_mask_(classnum)))
+#   define generic_isCC_(c, classnum)  Perl_isCC_by_bit(c, CC_mask_(classnum))
 
     /* The mask for the _A versions of the macros; it just adds in the bit for
      * ASCII. */

--- a/inline.h
+++ b/inline.h
@@ -3862,7 +3862,7 @@ Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
     PERL_ARGS_ASSERT_GROK_BIN;
 
     return grok_bin_oct_hex(start, len_p, flags, result,
-                            1, CC_BINDIGIT_, 'b');
+                            1, CC_mask_(CC_BINDIGIT_), 'b');
 }
 
 PERL_STATIC_INLINE UV
@@ -3871,7 +3871,7 @@ Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
     PERL_ARGS_ASSERT_GROK_HEX;
 
     return grok_bin_oct_hex(start, len_p, flags, result,
-                            4, CC_XDIGIT_, 'x');
+                            4, CC_mask_(CC_XDIGIT_), 'x');
 }
 
 PERL_STATIC_INLINE UV
@@ -3881,7 +3881,7 @@ Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
 
     *flags |= PERL_SCAN_DISALLOW_PREFIX;
     return grok_bin_oct_hex(start, len_p, flags, result,
-                            3, CC_OCTDIGIT_, '\0');
+                            3, CC_mask_(CC_OCTDIGIT_), '\0');
 }
 
 /* ------------------ pp.c, regcomp.c, toke.c, universal.c ------------ */

--- a/numeric.c
+++ b/numeric.c
@@ -243,7 +243,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
                         NV *result,
                         const unsigned shift, /* 1 for binary; 3 for octal;
                                                  4 for hex */
-                        const U8 class_bit,
+                        const U32 class_bit,
                         const char prefix
                      )
 
@@ -305,42 +305,42 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
   redo_switch:
     switch (e - s) {
       default:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 7:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 6:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 5:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 4:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 3:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 2:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
       case 1:
-          if (UNLIKELY(! generic_isCC_(*s, class_bit)))  break;
+          if (UNLIKELY(! Perl_isCC_by_bit(*s, class_bit)))  break;
           value = (value << shift) | XDIGIT_VALUE(*s);
           s++;
           /* FALLTHROUGH */
@@ -380,7 +380,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
 
     /* Loop through the characters */
     for (; s < e; s++) {
-        if (generic_isCC_(*s, class_bit)) {
+        if (Perl_isCC_by_bit(*s, class_bit)) {
             /* Write it in this wonky order with a goto to attempt to get the
                compiler to make the common case integer-only loop pretty tight.
                With gcc seems to be much straighter code than old scan_hex.
@@ -422,7 +422,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start,
         if (   UNLIKELY(*s == '_')
             && s < e - 1
             && allow_underscores
-            && generic_isCC_(s[1], class_bit)
+            && Perl_isCC_by_bit(s[1], class_bit)
             && (   LIKELY(s > s0)
                    /* Including initial underscores if those are accepted */
                 || UNLIKELY(! (  input_flags

--- a/proto.h
+++ b/proto.h
@@ -1252,7 +1252,7 @@ Perl_grok_atoUV(const char *pv, UV *valptr, const char **endptr);
         assert(pv); assert(valptr)
 
 PERL_CALLCONV UV
-Perl_grok_bin_oct_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *result, const unsigned shift, const U8 lookup_bit, const char prefix);
+Perl_grok_bin_oct_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *result, const unsigned shift, const U32 lookup_bit, const char prefix);
 #define PERL_ARGS_ASSERT_GROK_BIN_OCT_HEX       \
         assert(start); assert(len_p); assert(flags)
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3424,7 +3424,6 @@ my @unresolved_visibility_overrides = qw(
     CC_IS_IN_SOME_FOLD_
     CC_LOWER_
     CC_MAGICAL_
-    CC_mask_
     CC_mask_A_
     CC_MNEMONIC_CNTRL_
     CC_NON_FINAL_FOLD_


### PR DESCRIPTION
By making a few simple changes, this function can be called with a value determined at compile time, instead of it having to derive it multiple times at runtime.

* This set of changes does not require a perldelta entry.
