### PR TITLE
grok_infnan: Handle empty input

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1434,8 +1434,8 @@ Adip	|UV	|grok_hex	|NN const char *start			\
 				|NN STRLEN *len_p			\
 				|NN I32 *flags				\
 				|NULLOK NV *result
-Adp	|int	|grok_infnan	|NN const char **sp			\
-				|NN const char *send
+Adp	|int	|grok_infnan	|SPTR const char **sp			\
+				|EPTRge const char *send
 Adp	|int	|grok_number	|NN const char *pv			\
 				|STRLEN len				\
 				|NULLOK UV *valuep

--- a/numeric.c
+++ b/numeric.c
@@ -666,12 +666,17 @@ zero is returned, and C<*sp> will not move.
 int
 Perl_grok_infnan(pTHX_ const char** sp, const char* send)
 {
+    PERL_ARGS_ASSERT_GROK_INFNAN;
+
     const char* s = *sp;
+
+    if (UNLIKELY(s >= send)) {
+        return 0;
+    }
+
     int flags = 0;
 #if defined(NV_INF) || defined(NV_NAN)
     bool odh = FALSE; /* one-dot-hash: 1.#INF */
-
-    PERL_ARGS_ASSERT_GROK_INFNAN;
 
     if (*s == '+') {
         s++; if (s == send) return 0;

--- a/proto.h
+++ b/proto.h
@@ -1259,7 +1259,7 @@ Perl_grok_bin_oct_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags,
 PERL_CALLCONV int
 Perl_grok_infnan(pTHX_ const char **sp, const char *send);
 #define PERL_ARGS_ASSERT_GROK_INFNAN            \
-        assert(sp); assert(send)
+        assert(sp); assert(*sp); assert(send); assert(*sp <= send)
 
 PERL_CALLCONV int
 Perl_grok_number(pTHX_ const char *pv, STRLEN len, UV *valuep);


### PR DESCRIPTION
This public function dereferences its pointer parameter before checking its validity.


* This set of changes does not require a perldelta entry.
