### PR TITLE
Rearrange SvFLAGS bits to make a spare

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -472,6 +472,18 @@ Added the C<AMGf_force_overload> flag to the L<perlapi/C<amagic_call>>
 API to allow forcing overloading to be honored even in the context of
 C<no overloading;>.
 
+=item *
+
+The C<SvFLAGS> bits used by C<SvPCS_IMPORTED()> and C<SvOOK()> have now been
+merged into the same position, thus freeing up a flags bit for possible future
+purposes. This merge is distinguished by the fact that the C<PCS_IMPORTED>
+behaviour is only used on references (when C<SvROK> is true), whereas the
+C<OOK> only applies to string buffers (when C<SvROK> is false).
+
+This change shouldn't affect any C<XS> module code that is using the test
+macros correctly, though might cause confusion to code that attempts to analyse
+C<SvFLAGS> bits directly outside of the helper macros.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3639,6 +3639,7 @@ my @needed_by_ext = qw(
 my @undocumented_always_visible = qw(
     MAX_UNICODE_UTF8_BYTES
 
+    assert_scalar_or_IO_
     EXTEND_NEEDS_GROW_
     EXTEND_SAFE_N_
     MEM_WRAP_NEEDS_RUNTIME_CHECK_

--- a/sv.h
+++ b/sv.h
@@ -995,6 +995,8 @@ Set the size of the string buffer for the SV. See C<L</SvLEN>>.
 #define SvNIOK_off(sv)		(SvFLAGS(sv) &= ~(SVf_IOK|SVf_NOK| \
                                                   SVp_IOK|SVp_NOK|SVf_IVisUV))
 
+#define assert_scalar_or_IO_(sv) \
+                                assert_((SvTYPE(sv) <= SVt_PVMG) || (SvTYPE(sv) == SVt_PVIO))
 #define assert_not_ROK(sv)	assert_(!SvROK(sv) || !SvRV(sv))
 #define assert_not_glob(sv)	assert_(!isGV_with_GP(sv))
 
@@ -1114,8 +1116,17 @@ Returns the vstring magic, or NULL if none
 #define SvVSTRING_mg(sv)	(SvMAGICAL(sv) \
                                  ? mg_find(sv,PERL_MAGIC_vstring) : NULL)
 
-#define SvOOK(sv)		(SvFLAGS(sv) & SVf_OOK)
-#define SvOOK_on(sv)		(SvFLAGS(sv) |= SVf_OOK)
+/* The SVf_OOK flag is only meaningful on regular scalars when ROK is off, and
+ * in two other legacy conditions. Older modules might still use the SvOOK
+ * macro to test for SVphv_HasAUX, and in some circumstances IoTOP_GV() ends
+ * up using it despite being an SVt_PVIO. So we accept those cases as well.
+ */
+#define SvOOK(sv)		((SvTYPE(sv) <= SVt_PVMG ||         /* regular scalars */ \
+                                        SvTYPE(sv) == SVt_PVHV ||   /* hashes */          \
+                                        SvTYPE(sv) == SVt_PVIO) &&  /* IOs */             \
+                                    ((SvFLAGS(sv) & (SVf_ROK|SVf_OOK)) == SVf_OOK))
+#define SvOOK_on(sv)		(assert_scalar_or_IO_(sv) assert_not_ROK(sv) \
+                                    SvFLAGS(sv) |= SVf_OOK)
 
 
 /*

--- a/sv.h
+++ b/sv.h
@@ -438,10 +438,6 @@ These guys don't need the curly blocks
 #define SVp_SCREAM	0x00008000  /* currently unused on plain scalars */
 #define SVphv_CLONEABLE	SVp_SCREAM  /* PVHV (stashes) clone its objects */
 #define SVpgv_GP	SVp_SCREAM  /* GV has a valid GP */
-#define SVprv_PCS_IMPORTED  SVp_SCREAM  /* RV is a proxy for a constant
-                                       subroutine in another package. Set the
-                                       GvIMPORTED_CV_on() if it needs to be
-                                       expanded to a real GV */
 
 /* SVf_PROTECT is what SVf_READONLY should have been: i.e. modifying
  * this SV is completely illegal. However, SVf_READONLY (via
@@ -475,6 +471,10 @@ These guys don't need the curly blocks
                                        */
 #define SVf_OOK		0x02000000  /* has valid offset value */
 #define SVphv_HasAUX    SVf_OOK     /* PVHV has an additional hv_aux struct */
+#define SVprv_PCS_IMPORTED  SVf_OOK /* RV is a "proxy constant subroutine",
+                                       referring to a sub in another package.
+                                       Set the GvIMPORTED_CV_on() if it needs
+                                       to be expanded to a real GV */
 #define SVf_BREAK	0x04000000  /* refcnt is artificially low - used by
                                        SVs in final arena cleanup.
                                        Set in S_regtry on PL_reg_curpm, so that


### PR DESCRIPTION
For an upcoming possible project I really need another bit in `SvFLAGS` that is free for any regular scalar (it doesn't matter if it collides with AV/HV/CV/GV).

I couldn't see any spare bits, but I managed to work out that **as far as I can tell**, the `PCS_IMPORTED` and `OOK` effects are never both used at the same time. That hopefully being the case, I have moved `PCS_IMPORTED` to the same bit as `OOK`, thus leaving the previous location free for any regular scalar.

The reason for my thinking, is that `PCS_IMPORTED` only applies to references (SvROK), whereas `OOK` only applies to scalars with a PV buffer, and no scalar should ever have both ROK and POK at the same time.

To make that change safe, I did have to add more conditions to the `SvOOK()` test, to ensure it doesn't get confused by seeing the `PCS_IMPORTED` bit set at the same time. While I was there I added an `assert` condition to warn people of trying to turn on the `OOK` bit on inappropriate scalars.