### PR TITLE
regcomp.c: Remove extraneous conditional

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -10213,7 +10213,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 }
             default:
                 /* Allow \_ to not give an error */
-                if (isWORDCHAR(value) && value != '_') {
+                if (isALPHANUMERIC_A(value)) {
                     if (strict) {
                         vFAIL2("Unrecognized escape \\%c in character class",
                                (int)value);


### PR DESCRIPTION
This is checking that the argument is an ASCII \w that isn't an underscore.  But in this range, that is identical to an alphanumeric, which there is already a macro for, so use that single macro instead of the two.


* This set of changes does not require a perldelta entry.
