### PR TITLE
Faster path for (simple) class :reader and :writer accessors

### DIFF
--- a/class.c
+++ b/class.c
@@ -1180,8 +1180,18 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
     OP *nameop = newSVOP(OP_CONST, 0, value);
 
     CV *cv = newATTRSUB(floor_ix, nameop, NULL, NULL, ops);
-    if (cv)
+    if (cv) {
         CvIsMETHOD_on(cv);
+
+        U32 fieldix = PadnameFIELDINFO(pn)->fieldix;
+        /* Store the fieldix in the xpvcv and tag the CV for the
+         * attention of OP_METHOD_* OPs, for situations in which
+         * they can bypass normal method execution and reach into
+         * the class instance to pull out the SV and place
+         * it directly onto the stack. */
+        CvIsCLASS_FASTREADER_on(cv);
+        CvCLASS_PADIX_set(cv, fieldix);
+    }
 }
 
 static void
@@ -1249,8 +1259,18 @@ apply_field_attribute_writer(pTHX_ PADNAME *pn, SV *value)
     OP *nameop = newSVOP(OP_CONST, 0, value);
 
     CV *cv = newATTRSUB(floor_ix, nameop, NULL, NULL, ops);
-    if (cv)
+    if (cv) {
         CvIsMETHOD_on(cv);
+
+        U32 fieldix = PadnameFIELDINFO(pn)->fieldix;
+        /* Store the fieldix in the xpvcv and tag the CV for the
+         * attention of OP_METHOD_* OPs, for situations in which
+         * they can bypass normal method execution and reach into
+         * the class instance to pull out the SV and place
+         * it directly onto the stack. */
+        CvIsCLASS_FASTWRITER_on(cv);
+        CvCLASS_PADIX_set(cv, fieldix);
+    }
 }
 
 static struct {

--- a/cv.h
+++ b/cv.h
@@ -160,6 +160,53 @@ See L<perlguts/Autoloading with XSUBs>.
                                     reference-counted stack */
 #define CVf_EVAL_COMPILED 0x400000 /* an eval CV is fully compiled */
 
+/* Flags specific to perlclass CVs, used for the likes of triggering
+ * alternative code flows - such as fast accesors - inside pp_entersub */
+/* 4 bits have been reserved as of 2026. Multiple possible uses come to
+ * mind, warranting that many flag combinations, and it is desirable
+ * to have a simple bitmask test for checking "is there class-specific
+ * behaviour for this CV?" */
+
+/*
+=for apidoc_section $CV
+
+=for apidoc    Chx|bool|CVf_IsCLASS_MASK|bool
+
+Experimental
+
+=for apidoc    Chx|bool|CVf_IsCLASS_CONSTRUCTOR|bool
+
+Experimental
+
+=for apidoc    Chx|bool|CVf_IsCLASS_FASTREADER|bool
+
+Experimental
+
+=for apidoc    Chx|bool|CVf_IsCLASS_FASTWRITER|bool
+
+Experimental
+
+=for apidoc    Chx|bool|CVf_IsCLASS_METHOD|bool
+
+Experimental
+
+=cut
+*/
+#define CVf_IsCLASS_MASK        0xF000000 /* Test for any permutation set */
+#define CVf_IsCLASS_CONSTRUCTOR 0x1000000 /* RESERVED FOR FUTURE USE */
+                                          /* RL has some ideas to explore */
+#define CVf_IsCLASS_FASTREADER  0x2000000 /* can shortcut perlclass :reader */
+#define CVf_IsCLASS_FASTWRITER  0x4000000 /* can shortcut perlclass :writer */
+                                          /* Could use other flags in the
+                                           * future to indicate simple defaults
+                                           * or constraints. */
+#define CVf_IsCLASS_METHOD      0x8000000 /* RESERVED FOR FUTURE USE */
+                                          /* Perhaps to trigger the work currently
+                                           * done by pp_methstart, without that
+                                           * having to be a separate OP? */
+                                          /* Perhaps CVf_IsMETHOD is pulled up to
+                                           * be 0x8000000 ? */
+
 /* This symbol for optimised communication between toke.c and op.c: */
 #define CVf_BUILTIN_ATTRS	(CVf_NOWARN_AMBIGUOUS|CVf_LVALUE|CVf_ANONCONST)
 
@@ -299,6 +346,21 @@ Helper macro to turn off the C<CvREFCOUNTED_ANYSV> flag.
 #  define CvMETHOD(cv)          CvNOWARN_AMBIGUOUS(cv)
 #  define CvMETHOD_on(cv)       CvNOWARN_AMBIGUOUS_on(cv)
 #  define CvMETHOD_off(cv)      CvNOWARN_AMBIGUOUS_off(cv)
+#endif
+
+/* Helper macros for the perlclass implementation, specifically
+ * for use within class.c and by pp_entersub to implement fast
+ * (shortcutting) :reader and :writer accessors. */
+#ifdef PERL_CORE
+#  define CvCLASS_PADIX(cv)             (((XPVCV*)MUTABLE_PTR(SvANY(cv)))->xcv_class_fieldix)
+#  define CvCLASS_PADIX_set(cv,fieldix)   ((XPVCV*)MUTABLE_PTR(SvANY(cv)))->xcv_class_fieldix = (fieldix)
+#  define CvIsCLASS_FLAGSACTIVE(cv)         (CvFLAGS(cv) & CVf_IsCLASS_MASK)
+#  define CvIsCLASS_FASTREADER(cv)          (CvFLAGS(cv) & CVf_IsCLASS_FASTREADER)
+#  define CvIsCLASS_FASTREADER_on(cv)       (CvFLAGS(cv) |= CVf_IsCLASS_FASTREADER)
+#  define CvIsCLASS_FASTREADER_off(cv)      (CvFLAGS(cv) &= ~CVf_IsCLASS_FASTREADER)
+#  define CvIsCLASS_FASTWRITER(cv)          (CvFLAGS(cv) & CVf_IsCLASS_FASTWRITER)
+#  define CvIsCLASS_FASTWRITER_on(cv)       (CvFLAGS(cv) |= CVf_IsCLASS_FASTWRITER)
+#  define CvIsCLASS_FASTWRITER_off(cv)      (CvFLAGS(cv) &= ~CVf_IsCLASS_FASTWRITER)
 #endif
 
 /* Flags for newXS_flags  */

--- a/dump.c
+++ b/dump.c
@@ -2208,6 +2208,8 @@ const struct flag_to_name cv_flags_names[] = {
     {CVf_IsMETHOD,         "IsMETHOD,"},
     {CVf_XS_RCSTACK,       "XS_RCSTACK,"},
     {CVf_EVAL_COMPILED,    "EVAL_COMPILED,"},
+    {CVf_IsCLASS_FASTREADER,    "CLASS_FASTREADER,"},
+    {CVf_IsCLASS_FASTWRITER,    "CLASS_FASTWRITER,"},
 };
 
 const struct flag_to_name hv_flags_names[] = {
@@ -2908,6 +2910,10 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
         if (CvOUTSIDE(sv)
          && (nest < maxnest && (CvCLONE(sv) || CvCLONED(sv))))
             do_sv_dump(level+1, file, MUTABLE_SV(CvOUTSIDE(sv)), nest+1, maxnest, dumpops, pvlim);
+        if (!CvISXSUB(sv) && (CvIsCLASS_FASTREADER(sv) || CvIsCLASS_FASTWRITER(sv))) {
+            Perl_dump_indent(aTHX_ level, file, "  CLASS PADIX = %"
+                                          IVdf "\n", (IV)CvCLASS_PADIX(sv));
+        }
         break;
 
     case SVt_PVGV:

--- a/pad.h
+++ b/pad.h
@@ -11,11 +11,6 @@
  * variables, op targets and constants.
  */
 
-/* offsets within a pad */
-
-typedef SSize_t PADOFFSET; /* signed so that -1 is a valid value */
-#define NOT_IN_PAD ((PADOFFSET) -1)
-
 /* B.xs expects the first members of these two structs to line up
    (xpadl_max with xpadnl_fill).
  */

--- a/perl.h
+++ b/perl.h
@@ -3242,6 +3242,10 @@ typedef AV PAD;
 typedef struct padnamelist PADNAMELIST;
 typedef struct padname PADNAME;
 
+/* offsets within a pad */
+typedef SSize_t PADOFFSET; /* signed so that -1 is a valid value */
+#define NOT_IN_PAD ((PADOFFSET) -1)
+
 /* always enable PERL_OP_PARENT  */
 #if !defined(PERL_OP_PARENT)
 #  define PERL_OP_PARENT

--- a/pod/perlclassguts.pod
+++ b/pod/perlclassguts.pod
@@ -402,8 +402,54 @@ opcode also relies on this fact.
 In similar fashion, during the C<xhv_class_initfields_cv> the next pad slot is
 relied on to store the constructor parameters HV, at pad index 2.
 
+=head1 CV FLAGS AND THE PP_ENTERSUB ESCAPE HATCH
+
+=head2 CvFLAGS for fast accessors, fixups, and bypassing the CV entirely
+
+Initially added for experimental fast versions of simple :reader and :writer
+accessors, C<pp_entersub> performs an early check to see if CvFLAGS reserved
+for the class feature are set. If so, this indicates possibilities such as:
+
+=over 4
+
+=item *
+
+Entering the CV is unnecessary, the activity can be performed more efficiently
+via a C function without executing OPs within the CV. (The more efficent C code
+could still call CVs itself.) This means that C<pp_leavesub> will not be called
+and the C function is entirely responsible for fixing up the stack.
+
+It is currently unspecified whether the CV's optree is able to perform the same
+actions if the escape hatch is not used, or whether it contains just a stub
+optree - perhaps warning or croaking, as appropriate.
+
+=item *
+
+Some activity is required prior to entering the CV's optree.
+
+=back
+
+=head2 The escape hatch
+
+If any of the relevant flags is set, C<pp_entersub> calls a helper function to
+determine and perform the required activity. This function must return I<true>
+to indicate to C<pp_entersub> that it should immediately C<return NORMAL;>, or
+I<false> to indicate that C<pp_entersub> should continue execution as usual
+from that point.
+
+This currently looks like:
+
+    /* Some CVs associated with the class feature might shortcut a full
+     * method call. They are entirely responsible for correctly adjusting
+     * the stack in place of entersub/leavesub.*/
+    if (CvIsCLASS_FASTMETHOD(cv) && S_featureclass_escapehatch(cv)) {
+        return NORMAL;
+    }
+
 =head1 AUTHORS
 
 Paul Evans
+
+Additional contributions by Richard Leach.
 
 =cut

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -6310,6 +6310,253 @@ S_croak_undefined_subroutine(pTHX_ CV const *cv, GV const *gv)
     NOT_REACHED; /* NOTREACHED */
 }
 
+static bool
+S_featureclass_escapehatch(pTHX_ CV* cv) {
+    /* Assuming some stuff about the CV if it made it to this function. */
+    assert(!CvISXSUB(cv));
+    assert(!CvNODEBUG(cv));
+
+    if (CvIsCLASS_FASTREADER(cv)) {
+        /* A :reader does not take arguments. If some have been supplied, punt
+         * to the real method to grumble about it. */
+        if (UNLIKELY(PL_stack_sp != (PL_stack_base + TOPMARK + 2))) {
+            return false;
+        }
+    } else {
+        assert(CvIsCLASS_FASTWRITER(cv));
+        /* Only scalar :writer is implemented, so there should be a single
+           argument on the stack. If not, punt to the full method. */
+        if (UNLIKELY(PL_stack_sp != (PL_stack_base + TOPMARK + 3))) {
+            return false;
+        }
+    }
+
+    /* S_opmethod_stash has already handled this SV*, so extracting it again
+     * is not ideal. This may be revisited in a future commit. */
+    SV* const objr = *(PL_stack_base + TOPMARK + 1);
+
+    /* Try to ensure that the accessor is being called by an object... */
+    if (UNLIKELY(!objr) || UNLIKELY(!SvROK(objr)))
+        return false;
+    SV* const obj = SvRV(objr);
+    if (UNLIKELY(!SvOBJECT(obj) || UNLIKELY(SvTYPE(obj) != SVt_PVOBJ)))
+        return false;
+
+    /* Use the CV's padix field to pull the field SV* out of the object */
+    U32 const fieldix = CvCLASS_PADIX(cv);
+    SV** const fields = ObjectFIELDS(obj);
+    assert(fieldix <= ObjectMAXFIELD(obj));
+
+    SV* fsv = fields[fieldix];
+    assert(fsv);
+
+    /* Pop the CV */
+    rpp_popfree_1();
+
+    /* Won't call pp_entersub, so pop the associated markstack entry. */
+    (void)POPMARK;
+
+    U8 gimme = GIMME_V;
+    int fsv_type = SvTYPE(fsv);
+
+    if (CvIsCLASS_FASTWRITER(cv)) {
+        SV* argsv = *PL_stack_sp;
+
+/* QA feedback needed: Does tainting need to be considered here?
+ *        assert(TAINTING_get || !TAINT_get);
+ *        if (UNLIKELY(TAINT_get) && !SvTAINTED(argsv))
+ *            TAINT_NOT;
+*/
+
+        assert(SvTYPE(fsv) <= SVt_PVMG);
+        assert(fsv != argsv);
+
+#if NVSIZE <= IVSIZE
+        if ((fsv_type <= SVt_NV) && argsv && (SvTYPE(argsv) <= SVt_NV)) {
+#else
+        if ((fsv_type <= SVt_IV) && argsv && (SvTYPE(argsv) <= SVt_IV)) {
+#endif
+            /* Fast bodiless assignment as per Perl_sv_setsv_flags */
+            STATIC_ASSERT_STMT(SVt_NULL == 0);
+            STATIC_ASSERT_STMT(SVt_IV   == 1);
+            STATIC_ASSERT_STMT(SVt_NV   == 2);
+            assert(!SvGMAGICAL(argsv));
+            assert(!SvGMAGICAL(fsv));
+
+            U32 sflags;
+            U32 new_dflags;
+            SV *old_rv = NULL;
+            int dtype = SvTYPE(argsv);
+
+            /* minimal subset of SV_CHECK_THINKFIRST_COW_DROP(fsv) */
+            if (SvREADONLY(fsv))
+                croak_no_modify();
+            if (SvROK(fsv)) {
+                if (SvWEAKREF(fsv))
+                    sv_unref_flags(fsv, 0);
+                else
+                    old_rv = SvRV(fsv);
+                SvROK_off(fsv);
+            }
+            sflags = SvFLAGS(argsv);
+
+            if (sflags & (SVf_IOK|SVf_ROK)) {
+                SET_SVANY_FOR_BODYLESS_IV(fsv);
+                new_dflags = SVt_IV;
+
+                if (sflags & SVf_ROK) {
+                    fsv->sv_u.svu_rv = SvREFCNT_inc(SvRV(argsv));
+                    new_dflags |= SVf_ROK;
+                }
+                else {
+                    /* both src and dst are <= SVt_IV, so sv_any points to the
+                     * head; so access the head directly
+                     */
+                    assert(    &(argsv->sv_u.svu_iv)
+                            == &(((XPVIV*) SvANY(argsv))->xiv_iv));
+                    assert(    &(fsv->sv_u.svu_iv)
+                            == &(((XPVIV*) SvANY(fsv))->xiv_iv));
+                    fsv->sv_u.svu_iv = argsv->sv_u.svu_iv;
+                    new_dflags |= (SVf_IOK|SVp_IOK|(sflags & SVf_IVisUV));
+                }
+            }
+#if NVSIZE <= IVSIZE
+            else if (sflags & SVf_NOK) {
+                SET_SVANY_FOR_BODYLESS_NV(fsv);
+                new_dflags = (SVt_NV|SVf_NOK|SVp_NOK);
+
+                /* both src and dst are <= SVt_MV, so sv_any points to the
+                 * head; so access the head directly
+                 */
+                assert(    &(argsv->sv_u.svu_nv)
+                        == &(((XPVNV*) SvANY(argsv))->xnv_u.xnv_nv));
+                assert(    &(fsv->sv_u.svu_nv)
+                        == &(((XPVNV*) SvANY(fsv))->xnv_u.xnv_nv));
+                fsv->sv_u.svu_nv = argsv->sv_u.svu_nv;
+            }
+#endif
+            else {
+                new_dflags = dtype; /* turn off everything except the type */
+            }
+            /* Should preserve some fsv flags - at least SVs_TEMP, */
+            /* so cannot just set SvFLAGS(fsv) = new_dflags        */
+            /* First clear the flags that we do want to clobber    */
+            SvFLAGS(fsv) &= ~(SVTYPEMASK|SVf_OK|SVf_IVisUV);
+            /* Now set the new flags */
+            SvFLAGS(fsv) |= new_dflags;
+
+            SvREFCNT_dec(old_rv);
+        } else {
+            sv_setsv(fsv, argsv);
+            SvSETMAGIC(fsv);
+        }
+
+        if (gimme == G_VOID)
+            rpp_popfree_2(); /* Pop invocant and argument */
+        else
+            rpp_popfree_1(); /* Pop argument, leave invocant on the stack */
+
+    } else {
+        assert((SvTYPE(fsv) <= SVt_PVMG)
+            || (SvTYPE(fsv) == SVt_PVAV)
+            || (SvTYPE(fsv) == SVt_PVHV)
+        );
+
+        /* Possible enhancement: bake in the field type at compile time? (via CvFLAGS?) */
+        switch (gimme) {
+            case G_VOID:
+                /* Pop the invocant */
+                rpp_popfree_1();
+                break;
+            case G_SCALAR: {
+                SV* rsv = NULL;
+
+                switch (fsv_type) {
+                    default:
+                        rpp_replace_at_norc(PL_stack_sp, newSVsv(fsv));
+                        break;
+                    case SVt_PVAV: {
+                        // Doing it like a padav with no flags set
+                        const SSize_t maxarg = AvFILL(MUTABLE_AV(fsv)) + 1;
+                        rpp_replace_at_norc(PL_stack_sp,
+                            newSViv( (maxarg) ? maxarg : 0 ));
+                        break;
+                    }
+                    case SVt_PVHV: {
+                        // Doing it like a padhv with no flags set
+                        MAGIC *is_tied_mg = SvRMAGICAL(fsv)
+                            ? mg_find(MUTABLE_SV(fsv), PERL_MAGIC_tied)
+                            : NULL;
+                        rsv = (LIKELY(!is_tied_mg))
+                            ? newSViv(HvUSEDKEYS(fsv))
+                            : magic_scalarpack(MUTABLE_HV(fsv), is_tied_mg)
+                            ;
+                        rpp_replace_at_norc(PL_stack_sp, rsv);
+                        break;
+                    }
+                }
+                break;
+            }
+            case G_LIST: {
+                switch (fsv_type) {
+                    case SVt_PVAV: {
+                        /* Pop the invocant */
+                        rpp_popfree_1();
+
+                        // S_pushav except mortal copies of everything
+                        const SSize_t maxarg = AvFILL(fsv) + 1;
+                        rpp_extend(maxarg);
+                        assert(!SvRMAGICAL(fsv)); // Or is this possible/permitted?
+                        PADOFFSET i;
+                        for (i=0; i < (PADOFFSET)maxarg; i++) {
+                            SV* sv = AvARRAY(fsv)[i];
+                            SV* rsv = LIKELY(sv) ? newSVsv(sv) : newSV_type(SVt_NULL);
+                            rpp_push_1_norc(rsv);
+                         };
+                        break;
+                    }
+                    case SVt_PVHV: {
+                        /* Pop the invocant */
+                        rpp_popfree_1();
+
+                        // hv_pushkv((HV*)fsv, 3) except mortal copies of values
+                        assert(!SvRMAGICAL(fsv)); // Or is this possible/permitted?
+
+                        HV* hv = MUTABLE_HV(fsv);
+                        (void)hv_iterinit(hv);
+                        Size_t nkeys = HvUSEDKEYS(hv);
+                        SSize_t ext;
+                        if(nkeys) {
+                            HE *entry;
+                            assert(nkeys <= (SSize_t_MAX >> 1));
+                            ext = nkeys * 2;
+                            EXTEND_MORTAL(nkeys);
+                            rpp_extend(ext);
+                            while ((entry = hv_iternext(hv))) {
+                                SV *keysv = newSVhek(HeKEY_hek(entry));
+                                rpp_push_1_norc(keysv);
+                                rpp_push_1_norc(newSVsv(HeVAL(entry)));
+                            }
+                        }
+                        break;
+                    }
+                    default:
+                        rpp_replace_at_norc(PL_stack_sp, newSVsv(fsv));
+                }
+                break;
+            }
+            default:
+                NOT_REACHED;
+                break;
+        }
+    }
+
+    /* The stack should now look the same as it would if the :reader
+     * CV had been executed normally. pp_entersub should now just do
+     *    return NORMAL;*/
+    return true;
+}
+
 PP(pp_entersub)
 {
     GV *gv;
@@ -6387,6 +6634,13 @@ PP(pp_entersub)
           do_die:
             DIE(aTHX_ "Not a CODE reference");
         }
+    }
+
+    /* Some CVs associated with the class feature might shortcut a full
+     * method call. They are entirely responsible for correctly adjusting
+     * the stack in place of entersub/leavesub.*/
+    if (UNLIKELY(CvIsCLASS_FLAGSACTIVE(cv)) && S_featureclass_escapehatch(aTHX_ cv)) {
+        return NORMAL;
     }
 
     /* At this point we want to save PL_savestack_ix, either by doing a

--- a/sv.h
+++ b/sv.h
@@ -650,10 +650,10 @@ typedef U32 cv_flags_t;
         OP *	xcv_root;							\
         void	(*xcv_xsub) (pTHX_ CV*);					\
     }		xcv_root_u;							\
-    union {								\
-        GV *	xcv_gv;							\
-        HEK *	xcv_hek;						\
-    }		xcv_gv_u;						\
+    union {								        \
+        GV *	xcv_gv;							        \
+        HEK *	xcv_hek;						        \
+    }		xcv_gv_u;						        \
     char *	xcv_file;							\
     union {									\
         PADLIST *	xcv_padlist;						\
@@ -663,8 +663,9 @@ typedef U32 cv_flags_t;
     U32		xcv_outside_seq; /* the COP sequence (at the point of our	\
                                   * compilation) in the lexically enclosing	\
                                   * sub */					\
-    cv_flags_t	xcv_flags;						\
-    I32	xcv_depth	/* >= 2 indicates recursive call */
+    cv_flags_t	xcv_flags;						        \
+    I32	xcv_depth;	          /* >= 2 indicates recursive call */           \
+    U32 xcv_class_fieldix /* Used by feature class */
 
 /* This structure must match XPVCV in cv.h */
 

--- a/t/class/accessor.t
+++ b/t/class/accessor.t
@@ -30,6 +30,13 @@ no warnings 'experimental::class';
     ok(eq_array([$o->a], [qw( the array )]), '$o->a accessor');
     ok(eq_hash({$o->h}, {qw( the hash )}), '$o->h accessor');
 
+    my @x = ($o->s, $o->a, $o->h);
+    is($x[0], 'the scalar', '$o->s accessor + assignment');
+    is($x[1], 'the', '$o->a accessor + assignment pt1');
+    is($x[2], 'array', '$o->a accessor + assignment pt2');
+    is($x[3], 'the', '$o->h accessor + assignment pt1');
+    is($x[4], 'hash', '$o->h accessor + assignment pt2');
+
     is(scalar $o->a, 2, '$o->a accessor in scalar context');
     is(scalar $o->h, 1, '$o->h accessor in scalar context');
 

--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -222,3 +222,25 @@ X->new for 0;
 EXPECT
 Exiting subroutine via last at - line 7.
 Can't "last" outside a loop block at - line 7.
+########
+# NAME Reader accessor call on a non-object
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+class F {
+    field $x :reader;
+}
+F::x({});
+EXPECT
+Cannot invoke method "x" on a non-instance at - line 5.
+########
+# NAME Writer accessor call on a non-object
+use v5.42;
+use feature 'class';
+no warnings 'experimental::class';
+class F {
+    field $x :writer;
+}
+F::set_x(12,34);
+EXPECT
+Cannot invoke method "set_x" on a non-instance at - line 5.


### PR DESCRIPTION
This commit adds a fast path for simple `:reader` and `:writer` accessors created for class `field` variables. "Simple" because a static function reaches into the object to pull out or assign to the field variable. At least at this time, this does not support running any field-specific code, such as a constraint check on write.

Basic before/after benchmarks were run on a Linux VM:

```
use v5.42;
use Benchmark qw(cmpthese);
use experimental qw(class);

class Cor {
    field $name :param :reader :writer = "Perl";
}

my $x = Cor->new;

cmpthese(-3, {
    reader => sub { $x->name },
    writer => sub { $x->set_name("Perl") }
});

```

Crudely comparing the outputs for `:reader`:

Build   | Throughput
:-         | -: 
Before | 13753813/s
After    | 46366478/s

For `:writer`:

Build   | Throughput
:-         | -:  
Before| 9444377/s
After   | 32442939/s

The mechanism involved has three main parts:
* Eligible accessor CVs are tagged with a new CV flag.
* `pp_entersub` performs a cheap flag check before calling:
* A static function that implements the machinery.

If the static function returns TRUE, `pp_entersub` immediately returns without actually entering the sub. (The static function is *entirely* responsible for fixing up the stack.)

If the static function returns FALSE, `pp_entersub` continues execution as normal.

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and I will write one if the PR is approved.
