### PR TITLE
Document (and export) [IU]_(BITS|DIG)

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -283,9 +283,7 @@
 #   undef case_9_SBOX32
 #   undef CC_UNDERSCORE_
 #   undef isFOO_or_UNDERSCORE_
-#   undef IV_BITS
 #   undef USE_STDIO
-#   undef UV_BITS
 #   if !defined(PERL_EXT)
 #     undef invlist_intersection_
 #     undef invlist_subtract_

--- a/perl.h
+++ b/perl.h
@@ -2410,6 +2410,23 @@ typedef UVTYPE UV;
 #define Size_t_MAX (~(Size_t)0)
 #define SSize_t_MAX (SSize_t)(~(Size_t)0 >> 1)
 
+/*
+=for apidoc_section $integer
+=for apidoc   Amn|unsigned|IV_BITS
+=for apidoc_item |unsigned|UV_BITS
+
+These return the number of bits in an IV and UV, respectively.  These values
+vary depending on platform capabilities and Configure options.
+
+=for apidoc   Amn|unsigned|IV_DIG
+=for apidoc_item |unsigned|UV_DIG
+
+These return the number of decimal digits required to represent any possible
+number of their respective types.  These values vary depending on platform
+capabilities and Configure options.
+
+=cut
+*/
 #define IV_BITS (IVSIZE * CHARBITS)
 #define IV_DIG (BIT_DIGITS(IV_BITS))
 #define UV_BITS (UVSIZE * CHARBITS)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1336,7 +1336,6 @@ my @unresolved_visibility_overrides = qw(
     is_XDIGIT_high
     isXDIGIT_LC_utf8
     isXDIGIT_uni
-    IV_DIG
     IV_MAX_P1
     JE_OLD_STACK_HWM_restore
     JE_OLD_STACK_HWM_save
@@ -3212,7 +3211,6 @@ my @unresolved_visibility_overrides = qw(
     UTF_START_MARK
     UTF_START_MASK
     UTF_TO_NATIVE
-    UV_DIG
     UV_MAX_P1
     UV_MAX_P1_HALF
     VCMP


### PR DESCRIPTION
Fixes #24083. Fixes #24084.

In d957e95daa0143d60933d96d6cbfb69eee6d6269 I changed the definitions of IV_DIG and UV_DIG to depend on IV_BITS and UV_BITS respectively, creating the latter in perl.h.  These had only visibility to the perl core.  But I forgot that the _DIG forms were visible everywhere, so the _BITS forms needed to be as well.

This commit merely documents all of them as public API (which should have been the case all along anyway), which automatically causes their visibility to be made everywhere.

An alternative would be to revert to the old definitions of the _DIG forms, but I think it is better to make the _BITS forms available in the API


* This set of changes does not require a perldelta entry.
