### PR TITLE
Some function args point to terminating NUL

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -622,7 +622,7 @@ sub check_and_add_proto_defn {
 
 
     my @munged_args= $args_ref->@*;
-    s/\b(?:NN|NULLOK|[SM]PTR|EPTRQ?)\b\s+//g for @munged_args;
+    s/\b(?:NN|NULLOK|[SM]PTR|EPTR\w+)\b\s+//g for @munged_args;
 
     my $flags_sans_d = $flags;
     my $docs_expected = $flags_sans_d =~ s/d//g;

--- a/embed.fnc
+++ b/embed.fnc
@@ -219,22 +219,26 @@
 :   EPTRgt  is like EPTRge, but the called function need not be prepared to
 :	    handle the case of an empty string; the value of this pointer must
 :	    be strictly greater than the corresponding MPTR or SPTR.
+:   EPTRtermNUL  means that the string delimitted by it and its corresponding
+:	    SPTR must be NUL-terminated.  This parameter points to that
+:	    terminating NUL character.  That means that when the string looks
+:	    empty, it really contains a single NUL.
 :
-:   To summarize, either
+:   To summarize, one of:
 :	    SPTR <= MPTR <  EPTRgt
-:   or
 :	    SPTR <= MPTR <= EPTRge
+:	    SPTR <= MPTR <= EPTR && *EPTR == '\0'
 :   In each equation all three or any two of the constraints must be present.
 :
-:   When only two constraints are present and one of them is either EPTRge or
-:   EPTRgt, the difference between your choosing to use SPTR or MPTR for the
-:   other one becomes somewhat fuzzy; the generated assertion will be the same
-:   whichever constraint is used.  You should choose the one that makes the
-:   most sense for the semantics of the parameter.  For example, there are
-:   currently some functions with parameters named 'curpos', and no SPTR
-:   parameter exists.  The name of the parameter clearly indicates it isn't
-:   necessarily the starting position of the string, so using MPTR as the
-:   constraint makes the most sense.
+:   When only two constraints are present and one of them is an EPTR form, the
+:   difference between your choosing to use SPTR or MPTR for the other one
+:   becomes somewhat fuzzy; the generated assertion will be the same whichever
+:   constraint is used.  You should choose the one that makes the most sense
+:   for the semantics of the parameter.  For example, there are currently some
+:   functions with parameters named 'curpos', and no SPTR parameter exists.
+:   The name of the parameter clearly indicates it isn't necessarily the
+:   starting position of the string, so using MPTR as the constraint makes the
+:   most sense.
 :
 :   The parameters for the function can be in any order, except if a function
 :   has multiple different character strings, all the parameters for the first

--- a/embed.fnc
+++ b/embed.fnc
@@ -5520,7 +5520,7 @@ ERST	|int	|edit_distance	|NN const UV *src			\
 ES	|I32	|execute_wildcard					\
 				|NN REGEXP * const prog 		\
 				|MPTR char *stringarg			\
-				|NN char *strend			\
+				|EPTRtermNUL char *strend		\
 				|SPTR char *strbeg			\
 				|SSize_t minend 			\
 				|NN SV *screamer			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -214,7 +214,8 @@
 :	    that this value may be equal to the corresponding SPTR or MPTR.
 :	    When this is true, it indicates the string is empty past the SPTR
 :	    or MPTR, and the called function must be prepared to handle this
-:	    case.
+:	    case by not dereferencing this parameter without first checking it
+:	    is valid.
 :   EPTRgt  is like EPTRge, but the called function need not be prepared to
 :	    handle the case of an empty string; the value of this pointer must
 :	    be strictly greater than the corresponding MPTR or SPTR.

--- a/embed.fnc
+++ b/embed.fnc
@@ -6172,7 +6172,7 @@ RS	|SV *	|get_and_check_backslash_N_name_wrapper 		\
 				|SPTR const char *s			\
 				|EPTRge const char * const e
 S	|void	|incline	|SPTR const char *s			\
-				|EPTRge const char *end
+				|EPTRtermNUL const char *end
 S	|int	|intuit_method	|NN char *start 			\
 				|NULLOK SV *ioname			\
 				|NULLOK NOCHECK CV *cv

--- a/embed.fnc
+++ b/embed.fnc
@@ -2588,8 +2588,8 @@ p	|void	|output_non_portable					\
 dp	|void	|package	|NN OP *name				\
 				|NULLOK OP *version
 Adp	|void	|packlist	|NN SV *cat				\
-				|NN const char *pat			\
-				|NN const char *patend			\
+				|SPTR const char *pat			\
+				|EPTRtermNUL const char *patend 	\
 				|NN SV **beglist			\
 				|NN SV **endlist
 Adp	|PADOFFSET|pad_add_anon |NN CV *func				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -6176,8 +6176,8 @@ S	|void	|incline	|SPTR const char *s			\
 S	|int	|intuit_method	|NN char *start 			\
 				|NULLOK SV *ioname			\
 				|NULLOK NOCHECK CV *cv
-S	|int	|intuit_more	|NN char *s				\
-				|NN char *e				\
+S	|int	|intuit_more	|SPTR char *s				\
+				|EPTRtermNUL char *e			\
 				|U8 caller_context			\
 				|NULLOK char *caller_s			\
 				|Size_t caller_length

--- a/proto.h
+++ b/proto.h
@@ -8384,7 +8384,8 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist);
 
 # define PERL_ARGS_ASSERT_EXECUTE_WILDCARD      \
         assert(prog); assert(stringarg); assert(strend); assert(strbeg); \
-        assert(screamer); assert(strbeg <= stringarg)
+        assert(screamer); assert(strbeg <= stringarg); \
+        assert(stringarg <= strend); assert(*strend == '\0')
 
 # define PERL_ARGS_ASSERT_GET_QUANTIFIER_VALUE  \
         assert(pRExC_state); assert(start); assert(end); assert(start < end)

--- a/proto.h
+++ b/proto.h
@@ -9403,7 +9403,7 @@ S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv);
 STATIC int
 S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t caller_length);
 # define PERL_ARGS_ASSERT_INTUIT_MORE           \
-        assert(s); assert(e)
+        assert(s); assert(e); assert(s <= e); assert(*e == '\0')
 
 STATIC bool
 S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8);

--- a/proto.h
+++ b/proto.h
@@ -3337,7 +3337,7 @@ PERL_CALLCONV void
 Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist);
 #define PERL_ARGS_ASSERT_PACKLIST               \
         assert(cat); assert(pat); assert(patend); assert(beglist); \
-        assert(endlist)
+        assert(endlist); assert(pat <= patend); assert(*patend == '\0')
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_anon(pTHX_ CV *func, I32 optype);

--- a/proto.h
+++ b/proto.h
@@ -9393,7 +9393,7 @@ S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const
 STATIC void
 S_incline(pTHX_ const char *s, const char *end);
 # define PERL_ARGS_ASSERT_INCLINE               \
-        assert(s); assert(end); assert(s <= end)
+        assert(s); assert(end); assert(s <= end); assert(*end == '\0')
 
 STATIC int
 S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv);

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3821,15 +3821,21 @@ sub generate_proto_h {
                     my $ptr_type;   # E, M, and S are the three types
                                     # corresponding respectively to EPTR,
                                     # MPTR, and SPTR
+                    my $ptr_name;   # The full name of $ptr_type
                     my $equal = ""; # set to "=" if can be equal to previous
                                     # pointer, empty if not
-                    if ($arg =~ s/ \b ( EPTRgt | EPTRge | MPTR | SPTR ) \b //x)
+                    if ($arg =~ s/ \b (  EPTRgt
+                                       | EPTRge
+                                       | EPTRtermNUL
+                                       | MPTR
+                                       | SPTR )
+                                   \b //x)
                     {
-                        my $name = $1;
-                        $ptr_type = substr($name, 0, 1);
+                        $ptr_name = $1;
+                        $ptr_type = substr($ptr_name, 0, 1);
                         $equal = "=" if $ptr_type eq 'M'
                                      or (   $ptr_type eq 'E'
-                                         && substr($name, -1, 1) eq 'e');
+                                         && $ptr_name !~ /gt/);
                     }
 
                     # A $ptr_type is a specialized 'nn'
@@ -3848,7 +3854,7 @@ sub generate_proto_h {
                     # times
                     die_at_end
                            ":$func: $arg Use only one of NN (including"
-                         . " EPTRge, EPTRgt, MPTR, SPTR), NULLOK, or NZ"
+                         . " an EPTR form, MPTR, SPTR), NULLOK, or NZ"
                                                if 0 + $nn + $nz + $nullok > 1;
 
                     push( @nonnull, $n ) if $nn;
@@ -3860,8 +3866,8 @@ sub generate_proto_h {
                     # pointer.
                     if ($args_assert_line && $arg =~ /\*/) {
                         if ($nn + $nullok == 0) {
-                            warn "$func: $arg needs one of: NN, EPTRge,"
-                               . " EPTRgt, MPTR, SPTR, or NULLOK\n";
+                            warn "$func: $arg needs one of: NN,"
+                               . " an EPTR form, MPTR, SPTR, or NULLOK";
                             ++$unflagged_pointers;
                         }
 
@@ -3920,9 +3926,10 @@ sub generate_proto_h {
 
                             # Save the data we need later
                             my %entry = (
-                                          argname => $argname,
-                                          equal   => $equal,
-                                          deref   => $derefs,
+                                          argname   => $argname,
+                                          equal     => $equal,
+                                          deref     => $derefs,
+                                          name      => $ptr_name,
                                         );
 
                             # The motivation for all this is that some string
@@ -3944,16 +3951,19 @@ sub generate_proto_h {
                             #               'equal' => '=',
                             #               'argname' => 'curpos',
                             #               'deref' => ''
+                            #               'name' => 'MPTR',
                             #               },
                             #       'E' => {
                             #               'equal' => '',
                             #               'argname' => 'strend',
                             #               'deref' => ''
+                            #               'name' => some-value,
                             #               },
                             #       'S' => {
                             #               'equal' => '',
                             #               'deref' => '',
                             #               'argname' => 'strbeg'
+                            #               'name' => 'SPTR',
                             #               }
                             #   }
                             #
@@ -4030,15 +4040,22 @@ sub generate_proto_h {
                     my $upper_obj= $string->{$i->[1]} or next;
                     my $lower = "$lower_obj->{deref}$lower_obj->{argname}";
                     my $upper= "$upper_obj->{deref}$upper_obj->{argname}";
-                    my $equal = $upper_obj->{equal};
 
-                    # This reduces to either;
-                    #   assert(lower < upper);
-                    # or
-                    #   assert(lower <= upper);
-                    #
-                    # There might also be some derefences, like **lower
-                    push @asserts, "assert($lower <$equal $upper)";
+                    if ($upper_obj->{name} eq 'EPTRtermNUL') {
+                            push @asserts, "assert($lower <= $upper)";
+                            push @asserts, "assert(*$upper == '\\0')";
+                    }
+                    else {
+                        my $equal = $upper_obj->{equal};
+
+                        # This reduces to either;
+                        #   assert(lower < upper);
+                        # or
+                        #   assert(lower <= upper);
+                        #
+                        # There might also be some derefences, like **lower
+                        push @asserts, "assert($lower <$equal $upper)";
+                    }
                 }
             }
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4026,8 +4026,11 @@ sub generate_proto_h {
                     next if defined $string->{M} &&    $i->[0] eq 'S'
                                                     && $i->[1] eq 'E';
 
-                    my $lower = $string->{$i->[0]} or next;
-                    my $upper = $string->{$i->[1]} or next;
+                    my $lower_obj= $string->{$i->[0]} or next;
+                    my $upper_obj= $string->{$i->[1]} or next;
+                    my $lower = "$lower_obj->{deref}$lower_obj->{argname}";
+                    my $upper= "$upper_obj->{deref}$upper_obj->{argname}";
+                    my $equal = $upper_obj->{equal};
 
                     # This reduces to either;
                     #   assert(lower < upper);
@@ -4035,11 +4038,7 @@ sub generate_proto_h {
                     #   assert(lower <= upper);
                     #
                     # There might also be some derefences, like **lower
-                    push @asserts, "assert("
-                                        . "$lower->{deref}$lower->{argname}"
-                                        . " <$upper->{equal} "
-                                        . "$upper->{deref}$upper->{argname}"
-                                        . ")";
+                    push @asserts, "assert($lower <$equal $upper)";
                 }
             }
 

--- a/toke.c
+++ b/toke.c
@@ -10601,8 +10601,9 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end,
      * identifier ends in the input.  If no identifier was found, the return
      * will be the the input 's' unchanged.
      *
-     * If the identifier is illegal, the function croaks unless this flag is
-     * passed in: */
+     * If the identifier is empty (s_end == s), *d is set to the NUL
+     * character; otherwise if the identifier is illegal, the function croaks
+     * unless this flag is passed in: */
     const bool check_only = flags & CHECK_ONLY;
 
     /* In this case NULL is returned instead of croaking, and the contents


### PR DESCRIPTION
Some functions that take pointer arguments to delimit a string expect the upper limit to point to a NUL character that is supposed to terminate that string.  This series of commits adds a way to specify this situation, and converts all the embed.fnc entries for the functions that currently are like this  to use the new syntax.

* This set of changes does not require a perldelta entry.
