### PR TITLE
Rebuild embed.h last, in case other regen steps wanted to add more things to it

### DIFF
--- a/regen.pl
+++ b/regen.pl
@@ -22,7 +22,6 @@ foreach my $pl (map {chomp; "regen/$_"} <DATA>) {
 }
 
 __END__
-embed.pl
 feature.pl
 mg_vtable.pl
 miniperlmain.pl
@@ -34,3 +33,4 @@ scope_types.pl
 tidy_embed.pl
 warnings.pl
 locale.pl
+embed.pl


### PR DESCRIPTION
Otherwise, it's possible that later steps add new macros that `embed.pl` would have wanted to add to its list of things to `#undef`, requiring a second run of `make regen`.

By running `embed.pl` last, we ensure this happens in the right order the first time.

* This set of changes does not require a perldelta entry.