### PR TITLE
New macros in 5.43 don't have to be backward compatible

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -25,23 +25,42 @@
  * earlier when this file was #included with this symbol undefined */
 #if defined(PERL_DO_UNDEFS)
 # if !defined(PERL_CORE)
+#   undef CC_MAGICAL_
 #   undef CC_UNDERSCORE_
+#   undef do_aexec
 #   undef is_WORD_BUT_NONCONT_safe
 #   undef isFOO_or_UNDERSCORE_
+#   undef isIDCONT_lazy_if_safe
+#   undef new_XPV
+#   undef new_XPVIV
+#   undef SHY_NATIVE
 #   undef sv_2num
 #   undef SvRVx
+#   undef UNI_DISPLAY_TR_
 #   if !defined(PERL_EXT)
 #     undef GV_CACHE_ONLY
 #     undef invlist_intersection_
 #     undef invlist_subtract_
 #     undef invlist_union_
+#     undef OPpPARAM_IF_FALSE
+#     undef OPpPARAM_IF_UNDEF
+#     undef OPpSELF_IN_PAD
+#     undef RXf_PMf_CHARSET_SHIFT_
+#     undef RXf_PMf_SHIFT_NEXT_
 #     undef utf16_to_utf8
 #     undef utf16_to_utf8_reversed
-#   endif
+#   endif /* !defined(PERL_EXT) */
 #   if !defined(PERL_EXT_RE_BUILD)
+#     undef FAIL_
+#     undef first_upper_bit_set_byte_number
+#     undef invlist_intersection_complement_2nd_
+#     undef invlist_union_complement_2nd_
 #     undef PARSE_IDENT_ERROR_POSITION
 #     undef PARSE_IDENT_ERROR_TEXT
-#   endif
+#     undef RExC_parse_advance
+#     undef RXf_PMf_SHIFT_COMPILETIME_
+#     undef WARN_HELPER_
+#   endif /* !defined(PERL_EXT_RE_BUILD) */
 # endif /* !defined(PERL_CORE) */
 #else /* if !defined(PERL_DO_UNDEFS) */
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -145,11 +145,17 @@ my %per_file_definitions = (
         'perl.h'             => { 'H_PERL' => 0 },
 );
 
-# Below is a list of symbols that are not documented to be available for
-# modules to use, but are nevertheless currently not kept by embed.h from
-# being visible to the world.
+# This is a list of symbols that are:
+#   1) not documented to be available for modules to use,
+#   2) not resolved as needed to be visible to any module (and that we don't
+#      plan to document any time soon),
+#   3) but are nevertheless currently not kept by embed.h from being visible
+#      to the world.
 #
 # Strive to make this list empty.
+#
+# Symbols in class 2) above should instead be placed in
+# @undocumented_always_visible.
 #
 # The list does not include symbols that we have documented as being reserved
 # for perl's use, namely those that match the pattern just above.
@@ -3653,8 +3659,21 @@ my @needed_by_ext_re = qw(
 my @needed_by_ext = qw(
 );
 
-# Turn all the lists above into hashes
+# This is a list of symbols that are needed to be visible everywhere and are
+# not documented, and we don't plan to document them any time soon.
+# Effectively these are symbols that would otherwise be in
+# @unresolved_visibility_overrides, but we have resolved them to here.
+#
+# Think twice about adding a symbol to this list.  Would it be better to
+# instead document the symbol?  Or maybe its name could easily be changed to
+# match $names_reserved_for_perl_use_re?
+#
+# Typically these are symbols that are behind-the-scenes helpers whose use is
+# obvious from inspection of the things they help.
+my @undocumented_always_visible = qw(
+);
 
+# Turn all the lists above into hashes
 my %unresolved_visibility_overrides;
 $unresolved_visibility_overrides{$_} = 1 for @unresolved_visibility_overrides;
 
@@ -3666,6 +3685,9 @@ $needed_by_ext_re{$_} = 1 for @needed_by_ext_re;
 
 my %needed_by_ext;
 $needed_by_ext{$_} = 1 for @needed_by_ext;
+
+my %undocumented_always_visible;
+$undocumented_always_visible{$_} = 1 for @undocumented_always_visible;
 
 # Keep lists of symbols to undef under various conditions.  We can initialize
 # the two ones for perl extensions with the lists above.
@@ -5562,6 +5584,7 @@ sub find_undefs {
                        keys %needed_by_ext,
                        keys %needed_by_ext_re,
                        keys %unresolved_visibility_overrides,
+                       keys %undocumented_always_visible,
                       )
     {
         $symbol_listed_count{$entry}++;

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -5562,9 +5562,9 @@ sub find_undefs {
     # Done deciding what should be #undef'd.  But don't #undef anything found
     # in the override hashes
     foreach my $entry (keys %system_symbols,
-                            %needed_by_ext,
-                            %needed_by_ext_re,
-                            %unresolved_visibility_overrides
+                       keys %needed_by_ext,
+                       keys %needed_by_ext_re,
+                       keys %unresolved_visibility_overrides,
                       )
     {
         delete $always_undefs{$entry};

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1234,7 +1234,6 @@ my @unresolved_visibility_overrides = qw(
     IN_SOME_LOCALE_FORM
     IN_SOME_LOCALE_FORM_COMPILETIME
     IN_SOME_LOCALE_FORM_RUNTIME
-    INT32_MIN
     INT_64_T
     INT_PAT_MODS
     IN_UNI_8_BIT
@@ -1723,7 +1722,6 @@ my @unresolved_visibility_overrides = qw(
     LC_COLLATE_UNLOCK
     LC_NUMERIC_LOCK
     LC_NUMERIC_UNLOCK
-    LDBL_DIG
     LEAVE_SCOPE
     LEX_NOTPARSING
     LF_NATIVE
@@ -2340,10 +2338,8 @@ my @unresolved_visibility_overrides = qw(
     ProgLen
     pthread_addr_t
     PTHREAD_ATFORK
-    pthread_attr_init
     PTHREAD_ATTR_SETDETACHSTATE
     pthread_condattr_default
-    pthread_create
     PTHREAD_CREATE
     PTHREAD_CREATE_JOINABLE
     PTHREAD_GETSPECIFIC
@@ -5561,13 +5557,21 @@ sub find_undefs {
 
     # Done deciding what should be #undef'd.  But don't #undef anything found
     # in the override hashes
+    my %symbol_listed_count;
     foreach my $entry (keys %system_symbols,
                        keys %needed_by_ext,
                        keys %needed_by_ext_re,
                        keys %unresolved_visibility_overrides,
                       )
     {
+        $symbol_listed_count{$entry}++;
         delete $always_undefs{$entry};
+    }
+
+    foreach my $symbol (keys %symbol_listed_count) {
+        next if $symbol_listed_count{$symbol} <= 1;
+        die_at_end "'$symbol' is listed in more than one of the override"
+                 . " lists";
     }
 }
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -708,7 +708,6 @@ my @unresolved_visibility_overrides = qw(
     DM_RUID
     DM_UID
     dMY_CXT_INTERP
-    do_aexec
     do_exec
     DOSISH
     DOUBLE_BIG_ENDIAN
@@ -823,7 +822,6 @@ my @unresolved_visibility_overrides = qw(
     FILTER_DATA
     FILTER_ISREADER
     FILTER_READ
-    first_upper_bit_set_byte_number
     FIT_ARENA
     FIT_ARENA0
     FIT_ARENAn
@@ -1304,7 +1302,6 @@ my @unresolved_visibility_overrides = qw(
     is_HANGUL_ED_utf8_safe
     is_HORIZWS_cp_high
     is_HORIZWS_high
-    isIDCONT_lazy_if_safe
     isIDCONT_LC_utf8
     isIDCONT_uni
     isIDFIRST_lazy_if_safe
@@ -1793,7 +1790,6 @@ my @unresolved_visibility_overrides = qw(
     MAX_SAVEt
     MAXSYSFD
     MAX_UNICODE_UTF8
-    MAX_UNICODE_UTF8_BYTES
     MAX_UTF8_TWO_BYTE
     MDEREF_ACTION_MASK
     MDEREF_AV_gvav_aelem
@@ -1911,8 +1907,6 @@ my @unresolved_visibility_overrides = qw(
     NEWSV
     NEW_VERSION
     new_XNV
-    new_XPV
-    new_XPVIV
     new_XPVMG
     new_XPVNV
     Newz
@@ -2155,14 +2149,11 @@ my @unresolved_visibility_overrides = qw(
     OPpPADRANGE_COUNTMASK
     OPpPADRANGE_COUNTSHIFT
     OPpPAD_STATE
-    OPpPARAM_IF_FALSE
-    OPpPARAM_IF_UNDEF
     OPpPV_IS_UTF8
     OPpREFCOUNTED
     OPpREPEAT_DOLIST
     OPpREVERSE_INPLACE
     OPpRV2HV_ISKEYS
-    OPpSELF_IN_PAD
     OPpSLICE
     OPpSLICEWARNING
     OPpSORT_DESCEND
@@ -2536,7 +2527,6 @@ my @unresolved_visibility_overrides = qw(
     RExC_parno_to_logical
     RExC_parno_to_logical_next
     RExC_parse
-    RExC_parse_advance
     RExC_parse_inc
     RExC_parse_inc_by
     RExC_parse_incf
@@ -2857,7 +2847,6 @@ my @unresolved_visibility_overrides = qw(
     SHARP_S_SKIP
     SH_PATH
     SHUTDOWN_TERM
-    SHY_NATIVE
     sI
     SIMPLE
     Simple_vFAIL
@@ -3416,7 +3405,6 @@ my @unresolved_visibility_overrides = qw(
     CC_IDFIRST_
     CC_IS_IN_SOME_FOLD_
     CC_LOWER_
-    CC_MAGICAL_
     CC_mask_A_
     CC_MNEMONIC_CNTRL_
     CC_NON_FINAL_FOLD_
@@ -3475,9 +3463,6 @@ my @unresolved_visibility_overrides = qw(
     DFA_RETURN_FAILURE_
     DFA_RETURN_SUCCESS_
     DFA_TEASE_APART_FF_
-    EXTEND_NEEDS_GROW_
-    EXTEND_SAFE_N_
-    FAIL_
     FUNCTION__
     generic_func_utf8_safe_
     generic_invlist_utf8_safe_
@@ -3499,8 +3484,6 @@ my @unresolved_visibility_overrides = qw(
     HAS_IGNORED_LOCALE_CATEGORIES_
     HIGHEST_REGCOMP_DOT_H_SYNC_
     inRANGE_helper_
-    invlist_intersection_complement_2nd_
-    invlist_union_complement_2nd_
     is_MULTI_CHAR_FOLD_utf8_safe_part0_
     is_MULTI_CHAR_FOLD_utf8_safe_part1_
     is_MULTI_CHAR_FOLD_utf8_safe_part2_
@@ -3544,12 +3527,9 @@ my @unresolved_visibility_overrides = qw(
     MBTOWC_LOCK_
     MBTOWC_UNLOCK_
     MEM_WRAP_CHECK_
-    MEM_WRAP_NEEDS_RUNTIME_CHECK_
-    MEM_WRAP_WILL_WRAP_
     msbit_pos_uintmax_
     NOT_IN_NUMERIC_STANDARD_
     NOT_IN_NUMERIC_UNDERLYING_
-    NV_BODYLESS_UNION_
     o1_
     OFFUNISKIP_helper_
     __PATCHLEVEL_H_INCLUDED__
@@ -3559,47 +3539,17 @@ my @unresolved_visibility_overrides = qw(
     pTHX__VALUE_
     pTHX_VALUE_
     pTHXx_
-    RXf_PMf_CHARSET_SHIFT_
-    RXf_PMf_SHIFT_COMPILETIME_
-    RXf_PMf_SHIFT_NEXT_
     SAFE_FUNCTION__
     SBOX32_CASE_
-    shifted_octet_
-    STATIC_ASSERT_STRUCT_BODY_
-    STATIC_ASSERT_STRUCT_NAME_
-    SV_HEAD_DEBUG_
     SVf_
-    toFOLD_utf8_flags_
-    toLOWER_utf8_flags_
     TOO_LATE_FOR_
-    toTITLE_utf8_flags_
-    toUPPER_utf8_flags_
     type1_
-    UNI_DISPLAY_TR_
     UNISKIP_BY_MSB_
-    UTF8_CHECK_ONLY_BIT_POS_
-    UTF8_DIE_IF_MALFORMED_BIT_POS_
-    UTF8_FORCE_WARN_IF_MALFORMED_BIT_POS_
-    UTF8_GOT_CONTINUATION_BIT_POS_
-    UTF8_GOT_EMPTY_BIT_POS_
-    UTF8_GOT_LONG_BIT_POS_
-    UTF8_GOT_LONG_WITH_VALUE_BIT_POS_
-    UTF8_GOT_NONCHAR_BIT_POS_
-    UTF8_GOT_NON_CONTINUATION_BIT_POS_
-    UTF8_GOT_OVERFLOW_BIT_POS_
-    UTF8_GOT_SHORT_BIT_POS_
-    UTF8_GOT_SUPER_BIT_POS_
-    UTF8_GOT_SURROGATE_BIT_POS_
     UTF8_IS_SUPER_NO_CHECK_
     UTF8_NO_CONFIDENCE_IN_CURLEN_
-    UTF8_NO_CONFIDENCE_IN_CURLEN_BIT_POS_
     utf8_safe_assert_
-    UTF8_WARN_NONCHAR_BIT_POS_
-    UTF8_WARN_SUPER_BIT_POS_
-    UTF8_WARN_SURROGATE_BIT_POS_
     UTF_FIRST_CONT_BYTE_110000_
     UTF_START_BYTE_110000_
-    WARN_HELPER_
     WCRTOMB_LOCK_
     WCRTOMB_UNLOCK_
     WCTOMB_LOCK_
@@ -3650,13 +3600,25 @@ my @system_symbols = qw(
 # This is a list of symbols that are needed by the ext/re module, and are not
 # documented.  They become undefined for any other modules.
 my @needed_by_ext_re = qw(
+    FAIL_
+    first_upper_bit_set_byte_number
+    invlist_intersection_complement_2nd_
+    invlist_union_complement_2nd_
     PARSE_IDENT_ERROR_POSITION
     PARSE_IDENT_ERROR_TEXT
+    RExC_parse_advance
+    RXf_PMf_SHIFT_COMPILETIME_
+    WARN_HELPER_
 );
 
 # This is a list of symbols that are needed by various ext/ modules, and are
 # not documented.  They become undefined for any other modules.
 my @needed_by_ext = qw(
+    OPpPARAM_IF_FALSE
+    OPpPARAM_IF_UNDEF
+    OPpSELF_IN_PAD
+    RXf_PMf_CHARSET_SHIFT_
+    RXf_PMf_SHIFT_NEXT_
 );
 
 # This is a list of symbols that are needed to be visible everywhere and are
@@ -3671,6 +3633,37 @@ my @needed_by_ext = qw(
 # Typically these are symbols that are behind-the-scenes helpers whose use is
 # obvious from inspection of the things they help.
 my @undocumented_always_visible = qw(
+    EXTEND_NEEDS_GROW_
+    EXTEND_SAFE_N_
+    MAX_UNICODE_UTF8_BYTES
+    MEM_WRAP_NEEDS_RUNTIME_CHECK_
+    MEM_WRAP_WILL_WRAP_
+    NV_BODYLESS_UNION_
+    shifted_octet_
+    STATIC_ASSERT_STRUCT_BODY_
+    STATIC_ASSERT_STRUCT_NAME_
+    SV_HEAD_DEBUG_
+    toFOLD_utf8_flags_
+    toLOWER_utf8_flags_
+    toTITLE_utf8_flags_
+    toUPPER_utf8_flags_
+    UTF8_CHECK_ONLY_BIT_POS_
+    UTF8_DIE_IF_MALFORMED_BIT_POS_
+    UTF8_FORCE_WARN_IF_MALFORMED_BIT_POS_
+    UTF8_GOT_CONTINUATION_BIT_POS_
+    UTF8_GOT_EMPTY_BIT_POS_
+    UTF8_GOT_LONG_BIT_POS_
+    UTF8_GOT_LONG_WITH_VALUE_BIT_POS_
+    UTF8_GOT_NONCHAR_BIT_POS_
+    UTF8_GOT_NON_CONTINUATION_BIT_POS_
+    UTF8_GOT_OVERFLOW_BIT_POS_
+    UTF8_GOT_SHORT_BIT_POS_
+    UTF8_GOT_SUPER_BIT_POS_
+    UTF8_GOT_SURROGATE_BIT_POS_
+    UTF8_NO_CONFIDENCE_IN_CURLEN_BIT_POS_
+    UTF8_WARN_NONCHAR_BIT_POS_
+    UTF8_WARN_SUPER_BIT_POS_
+    UTF8_WARN_SURROGATE_BIT_POS_
 );
 
 # Turn all the lists above into hashes


### PR DESCRIPTION
The default for newly created macros is now to be hidden from code outside the core.  In order to prevent any breakage of existing XS modules, a list was created to override this for every existing symbol that is visible.  That list was based on the symbols existing at the time the default was changed.  But any symbol created earlier in this development cycle was never in a stable release, so is fair game to be subject to the new default.  This commit changes those.

I went back to 5.43.0 and generated a list of existing symbols.  Then I subtracted that from the list as of when the default changed.  That gave the list of new symbols.  Then I inspected the 60-ish new symbols to see what visibility each requires.  In doing so, I noticed that a bunch of them are required to be visible, but really don't need to be documented.  I moved those from the override list to a newly created list of symbols that we've decided not to document any time soon.  These are all simple behind-the-scenes helpers for other macros and functions.

* This set of changes does not require a perldelta entry.
