### PR TITLE
UCD.pm: Add check for parameter type, rm obsolete comments

### DIFF
--- a/charclass_invlists.inc
+++ b/charclass_invlists.inc
@@ -492608,7 +492608,7 @@ static const U8 WB_dfa_table[] = {
 #endif	/* defined(PERL_IN_REGEXEC_C) */
 
 /* Generated from:
- * 198105a1b3637a4bc7240628bae2f65f6d0c31df2cee4f0242c2561421ea2e75 lib/Unicode/UCD.pm
+ * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/charclass_invlists.inc
+++ b/charclass_invlists.inc
@@ -492608,7 +492608,7 @@ static const U8 WB_dfa_table[] = {
 #endif	/* defined(PERL_IN_REGEXEC_C) */
 
 /* Generated from:
- * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
+ * 1af6353444193daf752f97217069d76f3a50c00785c865a87e2f0e9cb451446b lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/lib/Unicode/UCD.pm
+++ b/lib/Unicode/UCD.pm
@@ -2461,18 +2461,6 @@ is passed, it would be set to 1 if the return is valid; or 0 if the return is
 C<undef>.  Note that the numeric value returned need not be a whole number.
 C<num("\N{TIBETAN DIGIT HALF ZERO}")>, for example returns -0.5.
 
-=cut
-
-#A few characters to which Unicode doesn't officially
-#assign a numeric value are considered numeric by C<num>.
-#These are:
-
-# EULER CONSTANT             0.5772...  (this is NOT Euler's number)
-# SCRIPT SMALL E             2.71828... (this IS Euler's number)
-# GREEK SMALL LETTER PI      3.14159...
-
-=pod
-
 If the string is more than one character, C<undef> is returned unless
 all its characters are decimal digits (that is, they would match C<\d+>),
 from the same script.  For example if you have an ASCII '0' and a Bengali

--- a/lib/Unicode/UCD.pm
+++ b/lib/Unicode/UCD.pm
@@ -5,7 +5,7 @@ use warnings;
 no warnings 'surrogate';    # surrogates can be inputs to this
 use charnames ();
 
-our $VERSION = '0.83';
+our $VERSION = '0.84';
 
 sub DEBUG () { 0 }
 $|=1 if DEBUG;
@@ -2533,6 +2533,8 @@ change these into digits, and then call C<num> on the result.
 
 sub num ($;$) {
     my ($string, $retlen_ref) = @_;
+    croak __PACKAGE__, "::num: second parameter must be a scalar reference"
+                        if defined $retlen_ref && ref $retlen_ref ne "SCALAR";
 
     if (defined $retlen_ref) {
         eval { $$retlen_ref = 0; 1 }    # Initialize to assume failure

--- a/lib/unicore/uni_keywords.pl
+++ b/lib/unicore/uni_keywords.pl
@@ -1374,7 +1374,7 @@
 1;
 
 # Generated from:
-# 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
+# 1af6353444193daf752f97217069d76f3a50c00785c865a87e2f0e9cb451446b lib/Unicode/UCD.pm
 # 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
 # dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
 # a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/lib/unicore/uni_keywords.pl
+++ b/lib/unicore/uni_keywords.pl
@@ -1374,7 +1374,7 @@
 1;
 
 # Generated from:
-# 198105a1b3637a4bc7240628bae2f65f6d0c31df2cee4f0242c2561421ea2e75 lib/Unicode/UCD.pm
+# 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
 # 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
 # dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
 # a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/regcharclass.h
+++ b/regcharclass.h
@@ -3801,7 +3801,7 @@
 #endif /* PERL_REGCHARCLASS_H_ */
 
 /* Generated from:
- * 198105a1b3637a4bc7240628bae2f65f6d0c31df2cee4f0242c2561421ea2e75 lib/Unicode/UCD.pm
+ * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/regcharclass.h
+++ b/regcharclass.h
@@ -3801,7 +3801,7 @@
 #endif /* PERL_REGCHARCLASS_H_ */
 
 /* Generated from:
- * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
+ * 1af6353444193daf752f97217069d76f3a50c00785c865a87e2f0e9cb451446b lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/regen.pl
+++ b/regen.pl
@@ -22,7 +22,6 @@ foreach my $pl (map {chomp; "regen/$_"} <DATA>) {
 }
 
 __END__
-embed.pl
 feature.pl
 mg_vtable.pl
 miniperlmain.pl
@@ -34,3 +33,4 @@ scope_types.pl
 tidy_embed.pl
 warnings.pl
 locale.pl
+embed.pl

--- a/regexp_constants.h
+++ b/regexp_constants.h
@@ -29,7 +29,7 @@
 #define MAX_FOLD_FROMS 3
 
 /* Generated from:
- * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
+ * 1af6353444193daf752f97217069d76f3a50c00785c865a87e2f0e9cb451446b lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/regexp_constants.h
+++ b/regexp_constants.h
@@ -29,7 +29,7 @@
 #define MAX_FOLD_FROMS 3
 
 /* Generated from:
- * 198105a1b3637a4bc7240628bae2f65f6d0c31df2cee4f0242c2561421ea2e75 lib/Unicode/UCD.pm
+ * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -8121,7 +8121,7 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
 #endif /* #if defined(PERL_CORE) || defined(PERL_EXT_RE_BUILD) */
 
 /* Generated from:
- * 198105a1b3637a4bc7240628bae2f65f6d0c31df2cee4f0242c2561421ea2e75 lib/Unicode/UCD.pm
+ * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -8121,7 +8121,7 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
 #endif /* #if defined(PERL_CORE) || defined(PERL_EXT_RE_BUILD) */
 
 /* Generated from:
- * 186059b9f179034210e8774c27514b495bff8efcf58ec4918d15677784725ac8 lib/Unicode/UCD.pm
+ * 1af6353444193daf752f97217069d76f3a50c00785c865a87e2f0e9cb451446b lib/Unicode/UCD.pm
  * 39afa01e680e27d0fd10b67a9b27be13fbaa3d0efecfb5be45991de9a0d267d0 lib/unicore/ArabicShaping.txt
  * dadbaf38a0d0246e5b805bf8725cb81b7c621f93d030595635f5ba2c2f179428 lib/unicore/BidiBrackets.txt
  * a2f16fb873ab4fcdf3221cb1a8a85a134ddd6ed03603181823ff5206af3741ce lib/unicore/BidiMirroring.txt


### PR DESCRIPTION
This needs to be a scalar reference; I got burned with it not doing the right thing when it wasn't.

* This set of changes does not require a perldelta entry.
