### PR TITLE
op.c: Don't hand-roll is_dup_mode() attributes

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5023,6 +5023,7 @@ S	|void	|forget_pmop	|NN PMOP * const o
 S	|void	|gen_constant_list					\
 				|NULLOK OP *o
 S	|void	|inplace_aassign|NN OP *o
+ST	|bool	|is_dup_mode	|NN const OP *o
 RST	|bool	|is_handle_constructor					\
 				|NN const OP *o 			\
 				|I32 numargs

--- a/embed.h
+++ b/embed.h
@@ -1702,6 +1702,7 @@
 #     define forget_pmop(a)                     S_forget_pmop(aTHX_ a)
 #     define gen_constant_list(a)               S_gen_constant_list(aTHX_ a)
 #     define inplace_aassign(a)                 S_inplace_aassign(aTHX_ a)
+#     define is_dup_mode                        S_is_dup_mode
 #     define is_handle_constructor              S_is_handle_constructor
 #     define is_standard_filehandle_name        S_is_standard_filehandle_name
 #     define listkids(a)                        S_listkids(aTHX_ a)

--- a/op.c
+++ b/op.c
@@ -14130,11 +14130,9 @@ Perl_ck_null(pTHX_ OP *o)
     return o;
 }
 
-__attribute__nonnull__(1)
 static bool
 S_is_dup_mode(const OP *o)
 {
-    assert(o != NULL);
     if (o->op_type != OP_CONST) {
         return false;
     }
@@ -14182,7 +14180,7 @@ Perl_ck_open(pTHX_ OP *o)
              (last->op_private & OPpCONST_STRICT) &&
              (oa = OpSIBLING(first)) &&                 /* The fh. */
              (oa = OpSIBLING(oa)) &&                    /* The mode. */
-             S_is_dup_mode(oa) &&                       /* A dup open. */
+             is_dup_mode(oa) &&                         /* A dup open. */
              (last == OpSIBLING(oa))) {                 /* The bareword. */
              if (!FEATURE_BAREWORD_FILEHANDLES_IS_ENABLED)
                  no_bareword_filehandle(SvPVX(cSVOPx_sv(last)));

--- a/proto.h
+++ b/proto.h
@@ -7499,6 +7499,11 @@ S_inplace_aassign(pTHX_ OP *o);
         assert(o)
 
 STATIC bool
+S_is_dup_mode(const OP *o);
+# define PERL_ARGS_ASSERT_IS_DUP_MODE           \
+        assert(o)
+
+STATIC bool
 S_is_handle_constructor(const OP *o, I32 numargs)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_HANDLE_CONSTRUCTOR \


### PR DESCRIPTION
This commit adds an entry in embed.fnc for S_is_dup_mode, removing the assert and __attribute lines in op.c.

The proximal cause for this commit is that I tried compiling with Perl_assert() enabled, which resulted in a lot of compiler warnings because of the __attribute__non_null__ line

But I also think it is better to not hand-roll things unless absolutely necessary.  Changes someone makes to the general scheme are not likely to be propagated to the hand-rolled items.

* This set of changes does not require a perldelta entry.
