### PR TITLE
Allow for integer values to $MACOSX_DEPLOYMENT_TARGET #24085

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -303,7 +303,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
    # capturing its value and adding it to the flags.
     case "$MACOSX_DEPLOYMENT_TARGET" in
-    [1-9][0-9].*)
+    [1-9][0-9].*|[1-9][0-9])
       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
       add_macosx_version_min lddlflags $MACOSX_DEPLOYMENT_TARGET


### PR DESCRIPTION
Previously it only allowed values with a decimal dot (e.g. "13.0"), now it also allows integers (e.g. "13").