### PR TITLE
Use SvUPGRADE() macro instead of direct call to sv_upgrade()

### DIFF
--- a/op.c
+++ b/op.c
@@ -9642,10 +9642,10 @@ Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
 
     range->op_targ =
         pad_add_name_pvn("$", 1, padadd_NO_DUP_CHECK|padadd_STATE, 0, 0);
-    sv_upgrade(PAD_SV(range->op_targ), SVt_PVNV);
+    SvUPGRADE(PAD_SV(range->op_targ), SVt_PVNV);
     flip->op_targ =
         pad_add_name_pvn("$", 1, padadd_NO_DUP_CHECK|padadd_STATE, 0, 0);;
-    sv_upgrade(PAD_SV(flip->op_targ), SVt_PVNV);
+    SvUPGRADE(PAD_SV(flip->op_targ), SVt_PVNV);
     SvPADTMP_on(PAD_SV(flip->op_targ));
 
     flip->op_private =  left->op_type == OP_CONST ? OPpFLIP_LINENUM : 0;

--- a/toke.c
+++ b/toke.c
@@ -11360,7 +11360,7 @@ S_scan_subst(pTHX_ char *start)
         /* the IVX field indicates that the replacement string is a s///e;
          * the NVX field indicates how many src code lines the replacement
          * spreads over */
-        sv_upgrade(PL_parser->lex_sub_repl, SVt_PVNV);
+        SvUPGRADE(PL_parser->lex_sub_repl, SVt_PVNV);
         ((XPVNV*)SvANY(PL_parser->lex_sub_repl))->xnv_u.xnv_lines = linediff;
         ((XPVIV*)SvANY(PL_parser->lex_sub_repl))->xiv_u.xivu_eval_seen =
                                                                     cBOOL(es);


### PR DESCRIPTION
Adds consistency and avoids a weird cornercase in which due to non-standard circumstances these SVs are already magical.

These only happen at compile-time so performance hit of performing an extra SvTYPE() check is not critical.

This is a small prerequisite change that I encountered as part of my "magic v2" branch, but it can stand alone as a little fix.

* This set of changes does not require a perldelta entry.
