### PR TITLE
Unify mg_free_struct() between mg.c and sv.c

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4972,6 +4972,10 @@ Tp	|bool	|translate_substr_offsets				\
 				|NN STRLEN *posp			\
 				|NN STRLEN *lenp
 #endif
+#if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
+p	|void	|mg_free_struct |NN SV *sv				\
+				|NN MAGIC *mg
+#endif
 #if defined(PERL_IN_MRO_C)
 S	|void	|mro_clean_isarev					\
 				|NN HV * const isa			\

--- a/embed.h
+++ b/embed.h
@@ -1682,6 +1682,9 @@
 #   if defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C)
 #     define translate_substr_offsets           Perl_translate_substr_offsets
 #   endif
+#   if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
+#     define mg_free_struct(a,b)                Perl_mg_free_struct(aTHX_ a,b)
+#   endif
 #   if defined(PERL_IN_MRO_C)
 #     define mro_clean_isarev(a,b,c,d,e,f)      S_mro_clean_isarev(aTHX_ a,b,c,d,e,f)
 #     define mro_gather_and_rename(a,b,c,d,e)   S_mro_gather_and_rename(aTHX_ a,b,c,d,e)

--- a/mg.c
+++ b/mg.c
@@ -510,18 +510,25 @@ Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
     }	    
 }
 
-#define mg_free_struct(sv, mg) S_mg_free_struct(aTHX_ sv, mg)
-static void
-S_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
+void
+Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MG_FREE_STRUCT;
+
     const MGVTBL* const vtbl = mg->mg_virtual;
     if (vtbl && vtbl->svt_free)
         vtbl->svt_free(aTHX_ sv, mg);
 
-    if (mg->mg_len > 0)
-        Safefree(mg->mg_ptr);
-    else if (mg->mg_len == HEf_SVKEY)
-        SvREFCNT_dec(MUTABLE_SV(mg->mg_ptr));
+    if(mg->mg_ptr) {
+        if (mg->mg_type == PERL_MAGIC_regex_global)
+            NOOP;
+        else if (mg->mg_len > 0)
+            Safefree(mg->mg_ptr);
+        else if (mg->mg_len == HEf_SVKEY)
+            SvREFCNT_dec(MUTABLE_SV(mg->mg_ptr));
+        else if (mg->mg_type == PERL_MAGIC_utf8)
+            Safefree(mg->mg_ptr);
+    }
 
     if (mg->mg_flags & MGf_REFCOUNTED)
         SvREFCNT_dec(mg->mg_obj);

--- a/proto.h
+++ b/proto.h
@@ -7406,6 +7406,14 @@ Perl_translate_substr_offsets(STRLEN curlen, IV pos1_iv, bool pos1_is_uv, IV len
         assert(posp); assert(lenp)
 
 #endif
+#if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
+PERL_CALLCONV void
+Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
+        __attribute__visibility__("hidden");
+# define PERL_ARGS_ASSERT_MG_FREE_STRUCT        \
+        assert(sv); assert(mg)
+
+#endif
 #if defined(PERL_IN_MRO_C)
 STATIC void
 S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN len, HV * const exceptions, U32 hash, U32 flags);

--- a/sv.c
+++ b/sv.c
@@ -6516,19 +6516,7 @@ S_sv_unmagicext_flags(pTHX_ SV *const sv, const int type, const MGVTBL *vtbl, co
         const MGVTBL* const virt = mg->mg_virtual;
         if (mg->mg_type == type && (!flags || virt == vtbl)) {
             *mgp = mg->mg_moremagic;
-            if (virt && virt->svt_free)
-                virt->svt_free(aTHX_ sv, mg);
-            if (mg->mg_ptr && mg->mg_type != PERL_MAGIC_regex_global) {
-                if (mg->mg_len > 0)
-                    Safefree(mg->mg_ptr);
-                else if (mg->mg_len == HEf_SVKEY)
-                    SvREFCNT_dec(MUTABLE_SV(mg->mg_ptr));
-                else if (mg->mg_type == PERL_MAGIC_utf8)
-                    Safefree(mg->mg_ptr);
-            }
-            if (mg->mg_flags & MGf_REFCOUNTED)
-                SvREFCNT_dec(mg->mg_obj);
-            Safefree(mg);
+            mg_free_struct(sv, mg);
         }
         else
             mgp = &mg->mg_moremagic;


### PR DESCRIPTION
Rather than copy-pasted code in two places, define a helper function to call from both. This also accounts for minor (but currently inconsequential) differences in behaviour between the two copy-pasted locations, that seem to have drifted apart over time.

* This set of changes does not require a perldelta entry.
