### PR TITLE
t/op/cond.t - add a specific test for GH#18576

### DIFF
--- a/t/op/cond.t
+++ b/t/op/cond.t
@@ -38,4 +38,13 @@ is( !$x ? 0 : 1, 1, 'run time, false');
     $x = ( $x ) ? () : "JAPH";
 }
 
+# [GH #18576] OP_ENTER not having the correct context can cause
+# inappropriate optimisation behaviour.
+
+{
+    my $y = do { if (0) { 5 } elsif (0) { 6 } };
+    ok(defined($y), 'False elsif conditional returns condition, not undef');
+    ok($y == 0, 'False elsif conditional returns correct condition value');
+}
+
 done_testing();


### PR DESCRIPTION
GH #18576 was concerned with the value returned from `if/elsif` statements that both have a false conditional, such as:

    my $y=do { if (0) { 5 } elsif(0) { 6 } };

where `$y` should contain an IV with value 0, the value of the last expression to be evaluated, but it did not.

This problem was fixed as a side-effect of following commit:

    4176abf7a8e425113debe55679c99b59bb9d299a
    Author: David Mitchell <davem@iabyn.com>
    Date:   Wed Sep 18 12:28:18 2019 +0100

        set VOID on OP_ENTER

        The OP_ENTER planted at the start of a program (and possibly elsewhere)
        gets left as UNKNOWN context rather than VOID context, due to op_scope()
        not honouring the current context.

        Fixing this makes things infinitesimally faster.

This commit adds the `if/else` example mentioned above as a specific test for GH #18576, to add assurance that a future regression would result in a test failure.

Closes #18576 

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
