### PR TITLE
S_clear_special_blocks - allow caller to notice that cv has been freed

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5007,7 +5007,7 @@ S	|void	|bad_type_pv	|I32 n					\
 				|NN const char *t			\
 				|NN const OP *o 			\
 				|NN const OP *kid
-S	|void	|clear_special_blocks					\
+S	|CV *	|clear_special_blocks					\
 				|NN const char * const fullname 	\
 				|NN GV * const gv			\
 				|NN CV * const cv

--- a/op.c
+++ b/op.c
@@ -11739,6 +11739,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
             SvREFCNT_inc_simple_void_NN(cv);
     }
 
+    assert(cv);
     if (block && has_name) {
         if (PERLDB_SUBLINE && PL_curstash != PL_debstash) {
             SV * const tmpstr = cv_name(cv,NULL,0);
@@ -11765,14 +11766,14 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
         }
 
         if (name) {
-            if (PL_parser && PL_parser->error_count)
-                clear_special_blocks(name, gv, cv);
+            if (PL_parser && PL_parser->error_count) {
+                cv = clear_special_blocks(name, gv, cv);
+            }
             else
                 evanescent =
                     process_special_blocks(floor, name, gv, cv);
         }
     }
-    assert(cv);
 
   done:
     assert(!cv || evanescent || SvREFCNT((SV*)cv) != 0);
@@ -11792,7 +11793,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
     return cv;
 }
 
-STATIC void
+STATIC CV*
 S_clear_special_blocks(pTHX_ const char *const fullname,
                        GV *const gv, CV *const cv) {
     const char *colon;
@@ -11813,8 +11814,10 @@ S_clear_special_blocks(pTHX_ const char *const fullname,
             assert(isGV(gv));
         }
         GvCV_set(gv, NULL);
+
         SvREFCNT_dec_NN(MUTABLE_SV(cv));
     }
+    return SvIS_FREED(cv) ? NULL : cv;
 }
 
 /* Returns true if the sub has been freed.  */

--- a/proto.h
+++ b/proto.h
@@ -7454,7 +7454,7 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid);
 # define PERL_ARGS_ASSERT_BAD_TYPE_PV           \
         assert(t); assert(o); assert(kid)
 
-STATIC void
+STATIC CV *
 S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv);
 # define PERL_ARGS_ASSERT_CLEAR_SPECIAL_BLOCKS  \
         assert(fullname); assert(gv); assert(cv); \

--- a/t/op/sub.t
+++ b/t/op/sub.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan(tests => 65);
+plan(tests => 66);
 
 sub empty_sub {}
 
@@ -449,3 +449,12 @@ fresh_perl_like(
 # github #21044
 ok( eval { $_->{x} = 1 for sub { undef }->(); 1 }, "check sub return values are modifiable")
   or diag $@;
+
+# GH #16868
+
+fresh_perl_like(
+    q#use strict;END{{{{}}}}{END}END{e}#,
+    qr/Execution of - aborted due to compilation errors./,
+    {},
+    "GH #16868 - continuing to use a freed CV*"
+);


### PR DESCRIPTION
GH #16868: `use strict;END{{{{}}}}{END}END{e}` triggers an assertion failure:
```
perl​: op.c​:10342​: CV *Perl_newATTRSUB_x(I32, OP *, OP *, OP *, OP *,
_Bool)​: Assertion `!cv || evanescent || SvREFCNT((SV*)cv) != 0'
failed.
```

In the following block, `S_clear_special_blocks` frees `cv`, but doesn't signal that it has done so to the caller. The caller continues to act as if `cv` had not been freed.
```
        if (name) {
            if (PL_parser && PL_parser->error_count) {
                clear_special_blocks(name, gv, cv);
            }
```

This commit changes `S_clear_special_blocks` from a void function to returning the refcount of the CV. (Could have been a bool, this was an arbitrary choice.) The caller then checks for a refcount of 0, taking it to mean that `cv` has been freed.

This causes the test case to croak:
```
Bareword "e" not allowed while "strict subs" in use at -e line 1.
Execution of -e aborted due to compilation errors.
```

Closes #16868

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
