### PR TITLE
embed.fnc: Add string arg assertions for regexec

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2848,7 +2848,7 @@ Xdp	|struct refcounted_he *|refcounted_he_new_sv			\
 Cp	|void	|regdump	|NN const regexp *r
 Cp	|I32	|regexec_flags	|NN REGEXP * const rx			\
 				|MPTR char *stringarg			\
-				|NN char *strend			\
+				|EPTRge char *strend			\
 				|SPTR char *strbeg			\
 				|SSize_t minend 			\
 				|NN SV *sv				\

--- a/proto.h
+++ b/proto.h
@@ -3811,7 +3811,7 @@ PERL_CALLCONV I32
 Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *sv, void *data, U32 flags);
 #define PERL_ARGS_ASSERT_REGEXEC_FLAGS          \
         assert(rx); assert(stringarg); assert(strend); assert(strbeg); \
-        assert(sv); assert(strbeg <= stringarg)
+        assert(sv); assert(strbeg <= stringarg); assert(stringarg <= strend)
 
 PERL_CALLCONV void
 Perl_regfree_internal(pTHX_ REGEXP * const rx);

--- a/regexec.c
+++ b/regexec.c
@@ -848,7 +848,8 @@ I32
 Perl_pregexec(pTHX_ REGEXP * const prog, char* stringarg, char *strend,
          char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
 /* stringarg: the point in the string at which to begin matching */
-/* strend:    pointer to null at end of string */
+/* strend:    pointer to byte one beyond end of string, or to 'strbeg' if
+              string is empty */
 /* strbeg:    real beginning of string */
 /* minend:    end of match must be >= minend bytes after stringarg. */
 /* screamer:  SV being matched: only used for utf8 flag, pos() etc; string
@@ -3694,7 +3695,8 @@ I32
 Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
               char *strbeg, SSize_t minend, SV *sv, void *data, U32 flags)
 /* stringarg: the point in the string at which to begin matching */
-/* strend:    pointer to NUL at end of string */
+/* strend:    pointer to byte one beyond end of string, or to 'strbeg' if
+              string is empty */
 /* strbeg:    real beginning of string */
 /* minend:    end of match must be >= minend bytes after stringarg. */
 /* sv:        SV being matched: only used for utf8 flag, pos() etc; string


### PR DESCRIPTION
The two related functions pregexec() and regexec_flags() take arguments that point to the beginning and end of a string.  The comments in each function claimed that the end pointer pointed to a terminating NUL. This isn't true.  The final byte isn't looked at, hence need not be NUL (and there exist tests in our suite to be sure it works when not NUL). When the end pointer points to the same position as the start pointer, the string is considered empty, and is properly handled as such.

The embed.fnc entry for pregexec already was correct; only the comments in regexec.c are changed.

This changes the entry for regexec_flags in embed.fnc and updates its comments.


* This set of changes does not require a perldelta entry.
