### PR TITLE
embed.fnc: Add ptr args assert for unpack_rec, unpackstring

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3855,10 +3855,10 @@ ARTdp	|char * |uiv_2buf	|NN char * const buf			\
 				|UV uv					\
 				|const int is_uv			\
 				|NN char ** const peob
-Adp	|SSize_t|unpackstring	|NN const char *pat			\
-				|NN const char *patend			\
-				|NN const char *s			\
-				|NN const char *strend			\
+Adp	|SSize_t|unpackstring	|SPTR const char *pat			\
+				|EPTRge const char *patend		\
+				|SPTR const char *s			\
+				|EPTRge const char *strend		\
 				|U32 flags
 : Used in gv.c, hv.c
 Cp	|void	|unshare_hek	|NULLOK HEK *hek
@@ -5385,7 +5385,7 @@ RS	|char * |sv_exp_grow	|NN SV *sv				\
 S	|SSize_t|unpack_rec	|NN struct tempsym *symptr		\
 				|MPTR const char *s			\
 				|SPTR const char *strbeg		\
-				|NN const char *strend			\
+				|EPTRge const char *strend		\
 				|NULLOK const char **new_s
 #endif /* defined(PERL_IN_PP_PACK_C) */
 #if defined(PERL_IN_PP_SORT_C)

--- a/proto.h
+++ b/proto.h
@@ -5361,7 +5361,8 @@ Perl_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** con
 PERL_CALLCONV SSize_t
 Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags);
 #define PERL_ARGS_ASSERT_UNPACKSTRING           \
-        assert(pat); assert(patend); assert(s); assert(strend)
+        assert(pat); assert(patend); assert(s); assert(strend); \
+        assert(pat <= patend); assert(s <= strend)
 
 PERL_CALLCONV void
 Perl_unshare_hek(pTHX_ HEK *hek);
@@ -8154,7 +8155,7 @@ STATIC SSize_t
 S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, const char *strend, const char **new_s);
 # define PERL_ARGS_ASSERT_UNPACK_REC            \
         assert(symptr); assert(s); assert(strbeg); assert(strend); \
-        assert(strbeg <= s)
+        assert(strbeg <= s); assert(s <= strend)
 
 #endif /* defined(PERL_IN_PP_PACK_C) */
 #if defined(PERL_IN_PP_SORT_C)


### PR DESCRIPTION
unpackstring(), which is public API,  does some setup and calls unpack_rec(), which is an internal function.

Each function takes two strings as arguments; each string is denoted by a beginning and ending pointer.  The documentation for unpackstring() says that the end pointers for both strings should point to one byte beyond the final byte of the respective string.  This is false.  The end pointers can point to the same byte as their respective start pointers. And the test suite has tests where that gets exercised.

Thus the documentation says that the end pointer must be greater than the start pointer, but the functions do get tested (and pass) with the end pointer equal to the start pointer.  It turns out that in each case of that in the test suite, that that byte is NUL.  Given the documentation, I wondered if it being NUL is a requirement for proper operation.  I considered adding an EPTRgt_or_NUL rule for these two functions.

To that end, I read the code to see if they would work without it being NUL.  In the case of the pattern string, yes, it would work without that being NUL, so the assertion can be the existing EPTRge.

I gave up checking this for the target string argument.  The uses of this are quite complex, and little documented, with many paths through the code.  Some paths I traced do work without the byte being NUL.  But I don't know about all paths.  So I changed this assertion as well to EPTRge.

I decided to leave the documentation as-is, so callers will try to use a strictly gt paradigm.


* This set of changes does not require a perldelta entry.
