### PR TITLE
Perl_yyerror_pvn - don't try to add a negative number of chars to msg

### DIFF
--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -635,3 +635,13 @@ Execution of (eval 1) aborted due to compilation errors.
 qr/(?{})\N{}/;while(my($0)=0){}
 EXPECT
 Unknown charname '' at - line 1, near "{})"
+########
+# NAME GH #16945 - don't pass a negative string length to Perl_sv_catpvf
+eval q!format=
+@​
+for(0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+!;
+die $@ if $@;
+EXPECT
+syntax error at (eval 1) line 4, 
+Execution of (eval 1) aborted due to compilation errors.

--- a/toke.c
+++ b/toke.c
@@ -13571,7 +13571,11 @@ Perl_yyerror_pvn(pTHX_ const char *const s, STRLEN len, U32 flags)
             (PL_parser->preambling == NOLINE
                    ? CopLINE(PL_curcop)
                    : PL_parser->preambling));
-        if (context)
+
+        /* Some syntax errors in an eval to result in a context being set
+         * but contlen being < 0. See GH#16945 for an example. In this
+         * situation, don't try to include context in the error message. */
+        if (context && contlen > 0)
             sv_catpvf(msg, "near \"%" UTF8f "\"\n",
                                  UTF8fARG(UTF, contlen, context));
         else


### PR DESCRIPTION
`Perl_yyerror_pvn` attempts to identify a `context` - part of the parse buffer near to where the error was found - and concatenate that to the existing error message to help the end user narrow down the cause. However, sometimes the length (`contlen`) of that `context` is calculated to be negative, which trips an assertion in `Perl_sv_vcatpvfn_flags` when building the error message.

This was the cause of the assertion failure in #16945.

This commit adds a check on the `contlen` when a `context` is present, prior to calling `Perl_sv_vcatpvfn_flags`.

Closes #16945

Note: The failure doesn't happen if the string of zeros in the test case
is shortened by several characters. I'm not sufficiently familiar with the
parser to understand the implication of that, and whether there might be a
better fix.

In the original code:

        if (context)
             sv_catpvf(msg, "near \"%" UTF8f "\"\n",
                                  UTF8fARG(UTF, contlen, context));

#16945 gives `contlen` of `-1` and `context` contains `;`.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
