### PR TITLE
Add a test for GH #16943 assertion failure

### DIFF
--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -623,3 +623,10 @@ syntax error at - line 3, near "ok @<< - format '"
 eval"${sub{sub{//]]]"}}
 EXPECT
 syntax error at - line 1, near "//]"
+########
+# NAME GH #16943 - don't continue parsing with a malformed CV
+eval q!s,,$0[sub{m[]]],;s,,$0[sub{m[]]],}}!;
+die $@ if $@;
+EXPECT
+syntax error at (eval 1) line 1, near "m[]]"
+Execution of (eval 1) aborted due to compilation errors.


### PR DESCRIPTION
The asserting fuzzed test case was:

    eval q!s,,$0[sub{m[]]],;s,,$0[sub{m[]]],}}!

The assertion triggered was:

    pad.c​:614​: Perl_pad_add_anon​: Assertion `!CvWEAKOUTSIDE((const CV *)sv)' failed.

This behaviour was long standing, present in v5.8.8 if not earlier, then was addressed by:
```
commit eb54d46
Author: Yves Orton <demerphq@gmail.com>
Date:   Fri Aug 26 18:26:14 2022 +0200

    Stop parsing on first syntax error.

    We try to keep parsing after many types of errors, up to a (current)
    maximum of 10 errors. Continuing after a semantic error (like
    undeclared variables) can be helpful, for instance showing a set of
    common errors, but continuing after a syntax error isn't helpful
    most of the time as the internal state of the parser can get confused
    and is not reliably restored in between attempts. This can produce
    sometimes completely bizarre errors which just obscure the true error,
    and has resulted in security tickets being filed in the past.

    This patch makes the parser stop after the first syntax error, while
    preserving the current behavior for other errors. An error is considered
    a syntax error if the error message from our internals is the literal
    text "syntax error". This may not be a complete list of true syntax
    errors, we can iterate on that in the future.

    This fixes the segfaults reported in Issue #17397, and #16944 and
    likely fixes other "segfault due to compiler continuation after syntax
    error" bugs that we have on record, which has been a recurring issue
    over the years.
```
Closes #16943

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
