### PR TITLE
perlapi: Combine synonyms SvUVX, SvUVXx

### DIFF
--- a/sv.h
+++ b/sv.h
@@ -892,7 +892,7 @@ Only use when you are sure C<SvIOK> is true.  See also C<L</SvIV>>.
 
 =for apidoc Am|UV|SvUVX|SV* sv
 Returns the raw value in the SV's UV slot, without checks or conversions.
-Only use when you are sure C<SvIOK> is true.  See also C<L</SvUV>>.
+Only use when you are sure C<SvUOK> is true.  See also C<L</SvUV>>.
 
 =for apidoc AmD|UV|SvUVXx|SV* sv
 This is an unnecessary synonym for L</SvUVX>

--- a/sv.h
+++ b/sv.h
@@ -890,12 +890,14 @@ Dereferences an RV to return the SV.
 Returns the raw value in the SV's IV slot, without checks or conversions.
 Only use when you are sure C<SvIOK> is true.  See also C<L</SvIV>>.
 
-=for apidoc Am|UV|SvUVX|SV* sv
-Returns the raw value in the SV's UV slot, without checks or conversions.
-Only use when you are sure C<SvUOK> is true.  See also C<L</SvUV>>.
+=for apidoc      Am|UV|SvUVX|SV* sv
+=for apidoc_item Dm|UV|SvUVXx|SV* sv
 
-=for apidoc AmD|UV|SvUVXx|SV* sv
-This is an unnecessary synonym for L</SvUVX>
+These each return the raw value in the SV's UV slot, without checks or
+conversions.  Only use when you are sure C<SvUOK> is true.  See also
+C<L</SvUV>>.
+
+C<SvUVXx> is is an unnecessary synonym for C<SvUVX>.
 
 =for apidoc Am|NV|SvNVX|SV* sv
 Returns the raw value in the SV's NV slot, without checks or conversions.


### PR DESCRIPTION
The latter retains its deprecated status.  The only reason it got documented, in b7822a6dc596b40a42a5d599451fa677a9dfb98a, is because apparently it used to be used, and Devel::PPPort supports it, and needed it to be documented so that it could know how to generate tests for it.

That commit added the deprecation, so people wouldn't start using it.  This current commit makes it a bit less conspicuous in perlapi.

There are also undocumented SvIVXx and SvNVXx forms, that PPPort doesn't support.  I think it best to not document them, as they contribute nothing, and are unused in CPAN.

* This set of changes does not require a perldelta entry.
