### PR TITLE
perlintern: Combine some refcounted entries

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -3807,26 +3807,33 @@ Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain,
 }
 
 /*
-=for apidoc refcounted_he_new_pvn
+=for apidoc         refcounted_he_new_pv
+=for apidoc_item    refcounted_he_new_pvn
+=for apidoc_item m||refcounted_he_new_pvs
+=for apidoc_item    refcounted_he_new_sv
 
-Creates a new C<refcounted_he>.  This consists of a single key/value
-pair and a reference to an existing C<refcounted_he> chain (which may
-be empty), and thus forms a longer chain.  When using the longer chain,
-the new key/value pair takes precedence over any entry for the same key
-further along the chain.
+These each create a new C<refcounted_he>.  This consists of a single key/value
+pair and a reference to an existing C<refcounted_he> chain (which may be
+empty), thus forming a longer chain.  When using the longer chain, the new
+key/value pair takes precedence over any entry for the same key further along
+the chain.
+
+C<hash> is a precomputed hash of the key string, or zero if it has not been
+precomputed.  C<refcounted_he_new_pvs> doesn't have a C<hash> parameter, as
+that is determinable at compile time.
+
+The forms otherwise differ only in how the key is specified.
 
 The new key is specified by C<keypv> and C<keylen>.  If C<flags> has
 the C<REFCOUNTED_HE_KEY_UTF8> bit set, the key octets are interpreted
-as UTF-8, otherwise they are interpreted as Latin-1.  C<hash> is
-a precomputed hash of the key string, or zero if it has not been
-precomputed.
+as UTF-8, otherwise they are interpreted as Latin-1.
 
 C<value> is the scalar value to store for this key.  C<value> is copied
 by this function, which thus does not take ownership of any reference
 to it, and later changes to the scalar will not be reflected in the
 value visible in the C<refcounted_he>.  Complex types of scalar will not
 be stored with referential integrity, but will be coerced to strings.
-C<value> may be either null or C<&PL_sv_placeholder> to indicate that no
+C<value> may be either NULL or C<&PL_sv_placeholder> to indicate that no
 value is to be associated with the key; this, as with any non-null value,
 takes precedence over the existence of a value for the key further along
 the chain.
@@ -3924,15 +3931,6 @@ Perl_refcounted_he_new_pvn(pTHX_ struct refcounted_he *parent,
     return he;
 }
 
-/*
-=for apidoc refcounted_he_new_pv
-
-Like L</refcounted_he_new_pvn>, but takes a nul-terminated string instead
-of a string/length pair.
-
-=cut
-*/
-
 struct refcounted_he *
 Perl_refcounted_he_new_pv(pTHX_ struct refcounted_he *parent,
         const char *key, U32 hash, SV *value, U32 flags)
@@ -3940,15 +3938,6 @@ Perl_refcounted_he_new_pv(pTHX_ struct refcounted_he *parent,
     PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PV;
     return refcounted_he_new_pvn(parent, key, strlen(key), hash, value, flags);
 }
-
-/*
-=for apidoc refcounted_he_new_sv
-
-Like L</refcounted_he_new_pvn>, but takes a Perl scalar instead of a
-string/length pair.
-
-=cut
-*/
 
 struct refcounted_he *
 Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent,

--- a/hv.c
+++ b/hv.c
@@ -3696,15 +3696,35 @@ Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *chain, U32 flags)
 }
 
 /*
-=for apidoc refcounted_he_fetch_pvn
+=for apidoc      refcounted_he_fetch_pv
+=for apidoc_item refcounted_he_fetch_pvn
+=for apidoc_item m||refcounted_he_fetch_pvs
+=for apidoc_item refcounted_he_fetch_sv
 
-Search along a C<refcounted_he> chain for an entry with the key specified
-by C<keypv> and C<keylen>.  If C<flags> has the C<REFCOUNTED_HE_KEY_UTF8>
-bit set, the key octets are interpreted as UTF-8, otherwise they
-are interpreted as Latin-1.  C<hash> is a precomputed hash of the key
-string, or zero if it has not been precomputed.  Returns a mortal scalar
-representing the value associated with the key, or C<&PL_sv_placeholder>
-if there is no value associated with the key.
+These each search along a C<refcounted_he> C<chain> for an entry with the
+specified key.  The return depends on the C<REFCOUNTED_HE_EXISTS> bit in
+C<flags>.  If unset, a mortal scalar representing the value associated with
+the key is returned, or C<&PL_sv_placeholder> if there is no value associated
+with the key.  If set, and there is such a value C<&PL_yes> is returned; if no
+such value, NULL is returned.
+
+C<hash> is a precomputed hash of the key string, or zero if it has not been
+precomputed
+
+The forms differ only in how the key is specified.
+
+In C<refcounted_he_fetch_pv>, C<key> specifies the key as a C language
+NUL-terminated string.
+
+In C<refcounted_he_fetch_pvs>, the key is a C language string literal, enclosed
+in double quotes.
+
+In C<refcounted_he_fetch_pvn>, C<key> points to the first byte of the string
+specifying the key, and an additional parameter, C<keylen>, specifies its
+length in bytes.  Hence, C<key> may contain embedded-NUL characters.
+
+In C<refcounted_he_fetch_sv>, C<*key> is an SV, and the key is the PV
+extracted from that using L<perlapi/C<SvPV_const>>.
 
 =cut
 */
@@ -3760,15 +3780,6 @@ Perl_refcounted_he_fetch_pvn(pTHX_ const struct refcounted_he *chain,
     return flags & REFCOUNTED_HE_EXISTS ? NULL : &PL_sv_placeholder;
 }
 
-/*
-=for apidoc refcounted_he_fetch_pv
-
-Like L</refcounted_he_fetch_pvn>, but takes a nul-terminated string
-instead of a string/length pair.
-
-=cut
-*/
-
 SV *
 Perl_refcounted_he_fetch_pv(pTHX_ const struct refcounted_he *chain,
                          const char *key, U32 hash, U32 flags)
@@ -3776,15 +3787,6 @@ Perl_refcounted_he_fetch_pv(pTHX_ const struct refcounted_he *chain,
     PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PV;
     return refcounted_he_fetch_pvn(chain, key, strlen(key), hash, flags);
 }
-
-/*
-=for apidoc refcounted_he_fetch_sv
-
-Like L</refcounted_he_fetch_pvn>, but takes a Perl scalar instead of a
-string/length pair.
-
-=cut
-*/
 
 SV *
 Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain,

--- a/hv.h
+++ b/hv.h
@@ -653,15 +653,6 @@ struct refcounted_he {
     char                  refcounted_he_data[1];
 };
 
-/*
-=for apidoc m|SV *|refcounted_he_fetch_pvs|const struct refcounted_he *chain|"key"|U32 flags
-
-Like L</refcounted_he_fetch_pvn>, but takes a literal string
-instead of a string/length pair, and no precomputed hash.
-
-=cut
-*/
-
 #define refcounted_he_fetch_pvs(chain, key, flags) \
     Perl_refcounted_he_fetch_pvn(aTHX_ chain, STR_WITH_LEN(key), 0, flags)
 

--- a/hv.h
+++ b/hv.h
@@ -656,15 +656,6 @@ struct refcounted_he {
 #define refcounted_he_fetch_pvs(chain, key, flags) \
     Perl_refcounted_he_fetch_pvn(aTHX_ chain, STR_WITH_LEN(key), 0, flags)
 
-/*
-=for apidoc m|struct refcounted_he *|refcounted_he_new_pvs|struct refcounted_he *parent|"key"|SV *value|U32 flags
-
-Like L</refcounted_he_new_pvn>, but takes a literal string
-instead of a string/length pair, and no precomputed hash.
-
-=cut
-*/
-
 #define refcounted_he_new_pvs(parent, key, value, flags) \
     Perl_refcounted_he_new_pvn(aTHX_ parent, STR_WITH_LEN(key), 0, value, flags)
 


### PR DESCRIPTION
 perlapi: Combine hv_refcounted_new entries

This removes redundancies in the pod, enables the reader to see all the similar possibilities at a glance, to compare and contrast them, and hence to choose the best form  for their needs.
  
  * This set of changes does not require a perldelta entry.
