### PR TITLE
util.c: Removed an old unused function. Mentioned in #24078

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -6409,7 +6409,6 @@ S	|void	|warn_on_first_deprecated_use				\
 #if defined(PERL_IN_UTIL_C)
 S	|bool	|ckwarn_common	|U32 w
 S	|SV *	|mess_alloc
-Ti	|U32	|ptr_hash	|PTRV u
 S	|SV *	|with_queued_errors					\
 				|NN SV *ex
 So	|void	|xs_version_bootcheck					\

--- a/embed.h
+++ b/embed.h
@@ -1762,7 +1762,6 @@
 #   if defined(PERL_IN_UTIL_C)
 #     define ckwarn_common(a)                   S_ckwarn_common(aTHX_ a)
 #     define mess_alloc()                       S_mess_alloc(aTHX)
-#     define ptr_hash                           S_ptr_hash
 #     define with_queued_errors(a)              S_with_queued_errors(aTHX_ a)
 #     if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 #       define mem_log_common                   S_mem_log_common

--- a/proto.h
+++ b/proto.h
@@ -9740,12 +9740,6 @@ S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const cha
         assert(type_name); assert(filename); assert(funcname)
 
 # endif
-# if !defined(PERL_NO_INLINE_FUNCTIONS)
-PERL_STATIC_INLINE U32
-S_ptr_hash(PTRV u);
-#   define PERL_ARGS_ASSERT_PTR_HASH
-
-# endif
 # if defined(PERL_USES_PL_PIDSTATUS)
 STATIC void
 S_pidgone(pTHX_ Pid_t pid, int status);

--- a/util.c
+++ b/util.c
@@ -4548,7 +4548,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
 #endif
 
 /* Splitmix64 is a simple PRNG and integer hashing function. It was
- * introducted in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
+ * introduced in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
  * Examples: https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64
  */
 U64

--- a/util.c
+++ b/util.c
@@ -4547,37 +4547,6 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
 #  include <starlet.h>
 #endif
 
-/* hash a pointer and return a U32 */
-
-PERL_STATIC_INLINE U32 S_ptr_hash(PTRV u) {
-/* 64 bit input */
-#if PTRSIZE == 8
-    /*
-     * This is one of Thomas Wang's hash functions for 64-bit integers from:
-     * https://gist.github.com/scottchiefbaker/9e21877a0c6041fbf54bd583cd1c52b4
-     */
-    u = (~u) + (u << 18);
-    u = u ^ (u >> 31);
-    u = u * 21;
-    u = u ^ (u >> 11);
-    u = u + (u << 6);
-    u = u ^ (u >> 22);
-/* 32 bit input */
-#else
-    /*
-     * This is one of Bob Jenkins' hash functions for 32-bit integers
-     * from: https://burtleburtle.net/bob/hash/integer.html
-     */
-    u = (u + 0x7ed55d16) + (u << 12);
-    u = (u ^ 0xc761c23c) ^ (u >> 19);
-    u = (u + 0x165667b1) + (u << 5);
-    u = (u + 0xd3a2646c) ^ (u << 9);
-    u = (u + 0xfd7046c5) + (u << 3);
-    u = (u ^ 0xb55a4f09) ^ (u >> 16);
-#endif
-    return (U32)u;
-}
-
 /* Splitmix64 is a simple PRNG and integer hashing function. It was
  * introducted in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
  * Examples: https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64


### PR DESCRIPTION
As part of a previous PR we removed the last use of `S_ptr_hash()`. Since we're no longer using this function, and the algorithm is older, and probably shouldn't be used, I removed the function completely.

Also a tiny one character spelling correction. 