### PR TITLE
"Unterminated q//" test in t/lib/croak/toke did test `qw//`, not `q//`

### DIFF
--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -68,7 +68,7 @@ EXPECT
 Can't find string terminator "/" anywhere before EOF at - line 1.
 ########
 # NAME Unterminated q//
-qw/
+q/
 EXPECT
 Can't find string terminator "/" anywhere before EOF at - line 1.
 ########


### PR DESCRIPTION
I found that `t/lib/croak.t` test 254 has been named "Unterminated q//", but used to actually test `qw//`, which was just a repetition of the previous test.

I think this does not mean that unterminated q// behavior hasn't been tested, as similar situations (but with non-ASCII delimiters) seem to be tested later in that file.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
