### PR TITLE
Tidy up the `SVf_AMAGIC` flag

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -2265,7 +2265,7 @@ const struct flag_to_name hv_flags_names[] = {
     {SVphv_SHAREKEYS, "SHAREKEYS,"},
     {SVphv_LAZYDEL, "LAZYDEL,"},
     {SVphv_HASKFLAGS, "HASKFLAGS,"},
-    {SVf_AMAGIC, "OVERLOAD,"},
+    {SVphv_OVERLOAD, "OVERLOAD,"},
     {SVphv_CLONEABLE, "CLONEABLE,"}
 };
 

--- a/mro_core.c
+++ b/mro_core.c
@@ -563,7 +563,7 @@ Perl_mro_isa_changed_in(pTHX_ HV* stash)
     if(meta->mro_nextmethod) hv_clear(meta->mro_nextmethod);
 
     /* Changes to @ISA might turn overloading on */
-    HvAMAGIC_on(stash);
+    HvOVERLOAD_on(stash);
     /* pessimise derefs for now. Will get recalculated by Gv_AMupdate() */
     HvAUX(stash)->xhv_aux_flags &= ~HvAUXf_NO_DEREF;
 
@@ -1383,7 +1383,7 @@ Perl_mro_method_changed_in(pTHX_ HV *stash)
 
     /* The method change may be due to *{$package . "::()"} = \&nil; in
        overload.pm. */
-    HvAMAGIC_on(stash);
+    HvOVERLOAD_on(stash);
     /* pessimise derefs for now. Will get recalculated by Gv_AMupdate() */
     HvAUX(stash)->xhv_aux_flags &= ~HvAUXf_NO_DEREF;
 }

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -2949,6 +2949,7 @@ my @unresolved_visibility_overrides = qw(
     SVphv_HasAUX
     SVphv_HASKFLAGS
     SVphv_LAZYDEL
+    SVphv_OVERLOAD
     SVphv_SHAREKEYS
     SVp_IOK
     SVp_NOK

--- a/sv.h
+++ b/sv.h
@@ -495,13 +495,7 @@ These guys don't need the curly blocks
 
 #define PRIVSHIFT 4	/* (SVp_?OK >> PRIVSHIFT) == SVf_?OK */
 
-/* SVf_AMAGIC means that the stash *may* have overload methods. It's
- * set each time a function is compiled into a stash, and is reset by the
- * overload code when called for the first time and finds that there are
- * no overload methods. Note that this used to be set on the object; but
- * is now only set on stashes.
- */
-#define SVf_AMAGIC	0x10000000  /* has magical overloaded methods */
+#define SVphv_OVERLOAD  0x10000000  /* stash has magical overloaded methods */
 #define SVf_IsCOW	0x10000000  /* copy on write (shared hash key if
                                        SvLEN == 0) */
 
@@ -1208,12 +1202,36 @@ Note: A GET magic check should be performed prior to an active magic check.
 */
 
 #define SvAMAGIC(sv)		(SvROK(sv) && SvOBJECT(SvRV(sv)) &&	\
-                                 HvAMAGIC(SvSTASH(SvRV(sv))))
+                                 HvOVERLOAD(SvSTASH(SvRV(sv))))
 
 /* To be used on the stashes themselves: */
-#define HvAMAGIC(hv)		(SvFLAGS(hv) & SVf_AMAGIC)
-#define HvAMAGIC_on(hv)		(SvFLAGS(hv) |= SVf_AMAGIC)
-#define HvAMAGIC_off(hv)	(SvFLAGS(hv) &=~ SVf_AMAGIC)
+#define perl_assert_HV_(sv)          assert_(SvTYPE(sv) == SVt_PVHV)
+
+/*
+=for apidoc Am|bool|HvOVERLOAD|HV *hv
+
+Returns a boolean as to whether the stash C<hv> has overloaded methods defined
+on it.
+
+=for apidoc      Am|void|HvOVERLOAD_on|HV *hv
+=for apidoc_item       ||HvOVERLOAD_off|HV *hv
+
+Turns on or off the L</HvOVERLOAD> flag.
+
+=cut
+*/
+
+#define HvOVERLOAD(hv)          (SvFLAGS(hv) & SVphv_OVERLOAD)
+#define HvOVERLOAD_on(hv)       (perl_assert_HV_(hv) SvFLAGS(hv) |= SVphv_OVERLOAD)
+#define HvOVERLOAD_off(hv)      (perl_assert_HV_(hv) SvFLAGS(hv) &=~ SVphv_OVERLOAD)
+/* These used to be called "AMAGIC", for "active magic", a rather vague
+ * description of what we now call operator overloading. */
+#ifndef PERL_CORE
+#  define SVf_AMAGIC            SVphv_OVERLOAD
+#  define HvAMAGIC              HvOVERLOAD
+#  define HvAMAGIC_on           HvOVERLOAD_on
+#  define HvAMAGIC_off          HvOVERLOAD_off
+#endif
 
 
 /* "nog" means "doesn't have get magic" */
@@ -1272,7 +1290,7 @@ the scalar's value cannot change unless written to.
 #define Gv_AMG(stash) \
         (HvNAME(stash) && Gv_AMupdate(stash,FALSE) \
             ? 1					    \
-            : (HvAMAGIC_off(stash), 0))
+            : (HvOVERLOAD_off(stash), 0))
 
 #define SvWEAKREF(sv)		((SvFLAGS(sv) & (SVf_ROK|SVprv_WEAKREF)) \
                                   == (SVf_ROK|SVprv_WEAKREF))

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -656,7 +656,7 @@ Perl_SvTRUE_common(pTHX_ SV * sv, const bool sv_2bool_is_fallback)
     if (SvIOK(sv))
         return SvIVX(sv) != 0; /* casts to bool */
 
-    if (SvROK(sv) && !(SvOBJECT(SvRV(sv)) && HvAMAGIC(SvSTASH(SvRV(sv)))))
+    if (SvROK(sv) && !(SvOBJECT(SvRV(sv)) && HvOVERLOAD(SvSTASH(SvRV(sv)))))
         return TRUE;
 
     if (sv_2bool_is_fallback)
@@ -743,7 +743,8 @@ Perl_SvAMAGIC_on(SV *sv)
     PERL_ARGS_ASSERT_SVAMAGIC_ON;
     assert(SvROK(sv));
 
-    if (SvOBJECT(SvRV(sv))) HvAMAGIC_on(SvSTASH(SvRV(sv)));
+    if (SvOBJECT(SvRV(sv)))
+        HvOVERLOAD_on(SvSTASH(SvRV(sv)));
 }
 
 /*
@@ -760,7 +761,7 @@ Perl_SvAMAGIC_off(SV *sv)
     PERL_ARGS_ASSERT_SVAMAGIC_OFF;
 
     if (SvROK(sv) && SvOBJECT(SvRV(sv)))
-        HvAMAGIC_off(SvSTASH(SvRV(sv)));
+        HvOVERLOAD_off(SvSTASH(SvRV(sv)));
 }
 
 PERL_STATIC_INLINE U32


### PR DESCRIPTION
This flag is only meaningful on HVs (moreover, HVs that are stashes), so it would be nicer to have an `SVphv_...` name. Also, while the name "AMAGIC" appears in a lot of core source code currently, I'd like to try to gradually nudge it away from being considered a kind of "magic". ((In the very longterm, I'd like to see the "amagic" table disappear in favour of just another field in the STASHAUX structure and therefore not be a kind of magic at all. But I digress...))

This change is just the first little step towards that goal, that I encountered on the route to making some other, somewhat unrelated changes to the SvFLAGS surroundings.