### PR TITLE
fix crash in refaliasing for loop on magical array

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -5117,7 +5117,7 @@ PP(pp_iter)
             if (refalias_this) {
                 /* TODO(leonerd): pull out this behaviour into a shared place.
                  * This is mostly copypaste from mg.c's Perl_magic_setlvref */
-                if(!SvROK(sv)) croak("Assigned value is not a reference");
+                if (!sv || !SvROK(sv)) croak("Assigned value is not a reference");
                 SV *rv = SvRV(sv);
 
                 const char *bad = NULL;

--- a/t/lib/croak/refalias
+++ b/t/lib/croak/refalias
@@ -137,3 +137,11 @@ foreach my (\$v1, $v2, $v3, $v4, $v5, $v6, $v7, $v8,
             $v249, $v250, $v251, $v252, $v253, $v254, $v255, $v256, $v257 ) ( @empty ) { }
 EXPECT
 Cannot use more than 256 iterator variables on a foreach loop if any are declared refs at - line 36.
+########
+# NAME foreach refalias does not crash on null elems of magical array
+# NOTE GH #24126
+package Foo;
+$ISA[1] = 'Bar';
+for \my $x (@ISA) {}
+EXPECT
+Assigned value is not a reference at - line 5.


### PR DESCRIPTION
Fixes #24126.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
