### PR TITLE
S_scan_const: abort compilation after \N{} errors

### DIFF
--- a/t/lib/croak/toke
+++ b/t/lib/croak/toke
@@ -630,3 +630,8 @@ die $@ if $@;
 EXPECT
 syntax error at (eval 1) line 1, near "m[]]"
 Execution of (eval 1) aborted due to compilation errors.
+########
+# NAME GH #16930 - parsing after \N{} errors can trigger segfaults
+qr/(?{})\N{}/;while(my($0)=0){}
+EXPECT
+Unknown charname '' at - line 1, near "{})"

--- a/toke.c
+++ b/toke.c
@@ -4097,9 +4097,11 @@ S_scan_const(pTHX_ char *start)
                 }
                 else     /* Here is \N{NAME} but not \N{U+...}. */
                      if (! (res = get_and_check_backslash_N_name_wrapper(s, e)))
-                {   /* Failed.  We should die eventually, but for now use a NUL
-                       to keep parsing */
-                    *d++ = '\0';
+                {   /* Failed.  We used to keep parsing, but error conditions here
+                     * can sometimes result in scope problems, which later manifest
+                     * as the incorrect pad being operated upon. (See GH#16930.)
+                     * Safest to just abort now. */
+                    yyquit();
                 }
                 else {  /* Successfully evaluated the name */
                     STRLEN len;


### PR DESCRIPTION
Upon encountering errors in parsing `\N{}` sequences, the parser used to try to continue parsing for a bit before exiting. However, these errors are - under certain circumstances - associated with problems with the savestack being incorrectly adjusted.

GH #16930 is an example of this where:
* `PL_comppad_name` points to one struct during allocation of pad slots.
* Savestack activity causes `PL_comppad_name` to point somewhere else.
* The peephole optimiser is called, but needs `PL_comppad_name` to point to the first struct to match up with the pad allocations.

With this commit, errors in parsing `\N{}` sequences are immediately fatal.

Closes #16930

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
