### PR TITLE
compute the correct varname for control character variables starting with _

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -294,6 +294,23 @@ XXX Changes (i.e. rewording) of diagnostic messages go here
 
 =item *
 
+Variables whose name started with C<^_> were incorrectly shown in
+diagnostics with a literal C<Ctrl-_> (which is an invisible ASCII
+character) in their name.
+
+The names of variables whose names begin with a caret and are longer
+than two characters are now wrapped in braces, just as they have to be
+in the source code.
+
+Therefore, using an undefined C<${^_FOO}> will now correctly warn with
+C<Use of uninitialized value ${^_FOO}>, instead of the earlier C<Use of
+uninitialized value $FOO> (with a literal C<Ctrl-_> after the dollar
+sign).
+
+[GH #24135]
+
+=item *
+
 XXX Describe change here
 
 =back

--- a/sv.c
+++ b/sv.c
@@ -17553,7 +17553,7 @@ Perl_varname(pTHX_ const GV *const gv, const char gvtype, PADOFFSET targ,
 
     SV * const name = sv_newmortal();
     if (gv && isGV(gv)) {
-        char buffer[2];
+        char buffer[3];
         buffer[0] = gvtype;
         buffer[1] = 0;
 
@@ -17561,13 +17561,24 @@ Perl_varname(pTHX_ const GV *const gv, const char gvtype, PADOFFSET targ,
 
         gv_fullname4(name, gv, buffer, 0);
 
-        if ((unsigned int)SvPVX(name)[1] <= 26) {
-            buffer[0] = '^';
-            buffer[1] = SvPVX(name)[1] + 'A' - 1;
+        U8 first_char = SvPVX(name)[1];
+        if (first_char <= 31) {
 
             /* Swap the 1 unprintable control character for the 2 byte pretty
-               version - ie substr($name, 1, 1) = $buffer; */
-            sv_insert(name, 1, 1, buffer, 2);
+               version - i.e., substr($name, 1, 1) = $buffer;
+               wrap in { } if the name is longer than 2 character */
+            if (SvCUR(name) > 2) {
+                buffer[0] = '{';
+                buffer[1] = '^';
+                buffer[2] = toCTRL(first_char);
+                sv_insert(name, 1, 1, buffer, 3);
+                sv_catpvs(name, "}");
+            }
+            else {
+                buffer[0] = '^';
+                buffer[1] = toCTRL(first_char);
+                sv_insert(name, 1, 1, buffer, 2);
+            }
         }
     }
     else {

--- a/t/lib/warnings/9uninit
+++ b/t/lib/warnings/9uninit
@@ -1159,13 +1159,15 @@ Use of uninitialized value within %foo14 in join or string at - line 17.
 use warnings 'uninitialized';
 my ($v);
 
-undef $^A; $v = $^A + ${^FOO}; # should output '^A' not chr(1)
+undef $^A; $v = $^A + ${^FOO} + $^_ + ${^_FOO}; # should output '^A' not chr(1)
 *GLOB1 = *GLOB2;
 $v = $GLOB1 + 1;
 $v = $GLOB2 + 1;
 EXPECT
 Use of uninitialized value $^A in addition (+) at - line 4.
-Use of uninitialized value $^FOO in addition (+) at - line 4.
+Use of uninitialized value ${^FOO} in addition (+) at - line 4.
+Use of uninitialized value $^_ in addition (+) at - line 4.
+Use of uninitialized value ${^_FOO} in addition (+) at - line 4.
 Use of uninitialized value $GLOB1 in addition (+) at - line 6.
 Use of uninitialized value $GLOB2 in addition (+) at - line 7.
 ########


### PR DESCRIPTION
This also fixes the issue for the remaining (and unused) control character variables: `$^[`, `$^\`, `$^]`, `$^^`.

Fixes GH #24135.
