### PR TITLE
util.c: mark internal symbols 'static'

### DIFF
--- a/util.c
+++ b/util.c
@@ -3155,7 +3155,7 @@ Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
 #endif /* !DOSISH || OS2 || WIN32 */
 
 #ifdef PERL_USES_PL_PIDSTATUS
-void
+static void
 S_pidgone(pTHX_ Pid_t pid, int status)
 {
     SV *sv;

--- a/util.c
+++ b/util.c
@@ -4551,7 +4551,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
  * introduced in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
  * Examples: https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64
  */
-U64
+static U64
 splitmix64(U64 *state)
 {
     U64 z = (*state += 0x9e3779b97f4a7c15);

--- a/util.c
+++ b/util.c
@@ -5902,12 +5902,12 @@ Perl_get_re_arg(pTHX_ SV *sv) {
 #define FREEBSD_DRAND48_MULT_2   (0x0005)
 #define FREEBSD_DRAND48_ADD      (0x000b)
 
-const unsigned short rand48_mult_[3] = {
-                FREEBSD_DRAND48_MULT_0,
-                FREEBSD_DRAND48_MULT_1,
-                FREEBSD_DRAND48_MULT_2
+static const unsigned short rand48_mult_[3] = {
+    FREEBSD_DRAND48_MULT_0,
+    FREEBSD_DRAND48_MULT_1,
+    FREEBSD_DRAND48_MULT_2
 };
-const unsigned short rand48_add_ = FREEBSD_DRAND48_ADD;
+static const unsigned short rand48_add_ = FREEBSD_DRAND48_ADD;
 
 #endif
 


### PR DESCRIPTION
As a general rule, our symbols are either public API (with a `Perl_` prefix) or internal (often with an `S_` prefix) and declared as `static`. A few symbols in `util.c` have been overlooked: They are clearly intended to be internal (no prefix, only used within this file), but not declared `static`, so they were visible to the linker. These patches add the missing `static` keyword to those symbols.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
