### PR TITLE
tidy_embed.pl: accept & ignore '-v' option

### DIFF
--- a/regen/tidy_embed.pl
+++ b/regen/tidy_embed.pl
@@ -31,6 +31,10 @@ my $parser= HeaderParser->new(
             delete $_->{sort} for @$group_ary;
         },
     );
+if (@ARGV and $ARGV[0] eq "-v") {
+    # ignore
+    shift @ARGV;
+}
 my $tap;
 if (@ARGV and $ARGV[0] eq "--tap") {
     $tap = shift @ARGV;


### PR DESCRIPTION
Otherwise 'make regen-headers' fails with

    ...
    /home/mauke/perl5/perlbrew/perls/perl-5.42.0/bin/perl -I. regen/tidy_embed.pl -v
    Failed to open '-v' for read: No such file or directory at regen/HeaderParser.pm line 1794.
            HeaderParser::read_file(HeaderParser=HASH(0x595c00d97708), "-v") called at regen/tidy_embed.pl line 44

Fixes #24138.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
