### PR TITLE
remove all uses of STATIC in core

### DIFF
--- a/XSUB.h
+++ b/XSUB.h
@@ -128,7 +128,7 @@ is a lexical C<$_> in scope.
  * XS macro.
  *
  * XS_EXTERNAL is the same as XS_INTERNAL except it does not include
- * "STATIC", ie. it exports XSUB symbols. You probably don't want that.
+ * "static", ie. it exports XSUB symbols. You probably don't want that.
  */
 
 #define XSPROTO(name) void name(pTHX_ CV* cv __attribute__unused__)
@@ -143,7 +143,7 @@ is a lexical C<$_> in scope.
 #else
 #  define XS_EXTERNAL(name) XSPROTO(name)
 #endif
-#define XS_INTERNAL(name) STATIC XSPROTO(name)
+#define XS_INTERNAL(name) static XSPROTO(name)
 
 /* We do export xsub symbols by default for the public XS macro.
  * Try explicitly using XS_INTERNAL/XS_EXTERNAL instead, please. */

--- a/deb.c
+++ b/deb.c
@@ -133,7 +133,7 @@ Perl_debstackptrs(pTHX)     /* Currently unused in cpan and core */
  * Only displays top 30 max
  */
 
-STATIC void
+static void
 S_deb_stack_n(pTHX_ SV** stack_base, SSize_t stack_min, SSize_t stack_max,
         SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base)
 {

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -76,7 +76,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.62';
+  $VERSION = '3.63';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Node; ExtUtils::ParseXS::Node->VERSION($VERSION);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -1,7 +1,7 @@
 package ExtUtils::ParseXS::CountLines;
 use strict;
 
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 =head1 NAME
 
@@ -953,7 +953,7 @@ sub as_code {
         | * XS macro.
         | *
         | * XS_EXTERNAL is the same as XS_INTERNAL except it does not include
-        | * "STATIC", ie. it exports XSUB symbols. You probably don't want that
+        | * "static", ie. it exports XSUB symbols. You probably don't want that
         | * for anything but the BOOT XSUB.
         | *
         | * See XSUB.h in core!
@@ -966,23 +966,23 @@ sub as_code {
         |#  undef XS_INTERNAL
         |#  if defined(__CYGWIN__) && defined(USE_DYNAMIC_LOADING)
         |#    define XS_EXTERNAL(name) __declspec(dllexport) XSPROTO(name)
-        |#    define XS_INTERNAL(name) STATIC XSPROTO(name)
+        |#    define XS_INTERNAL(name) static XSPROTO(name)
         |#  endif
         |#  if defined(__SYMBIAN32__)
         |#    define XS_EXTERNAL(name) EXPORT_C XSPROTO(name)
-        |#    define XS_INTERNAL(name) EXPORT_C STATIC XSPROTO(name)
+        |#    define XS_INTERNAL(name) EXPORT_C static XSPROTO(name)
         |#  endif
         |#  ifndef XS_EXTERNAL
         |#    if defined(HASATTRIBUTE_UNUSED) && !defined(__cplusplus)
         |#      define XS_EXTERNAL(name) void name(pTHX_ CV* cv __attribute__unused__)
-        |#      define XS_INTERNAL(name) STATIC void name(pTHX_ CV* cv __attribute__unused__)
+        |#      define XS_INTERNAL(name) static void name(pTHX_ CV* cv __attribute__unused__)
         |#    else
         |#      ifdef __cplusplus
         |#        define XS_EXTERNAL(name) extern "C" XSPROTO(name)
         |#        define XS_INTERNAL(name) static XSPROTO(name)
         |#      else
         |#        define XS_EXTERNAL(name) XSPROTO(name)
-        |#        define XS_INTERNAL(name) STATIC XSPROTO(name)
+        |#        define XS_INTERNAL(name) static XSPROTO(name)
         |#      endif
         |#    endif
         |#  endif
@@ -1021,10 +1021,10 @@ sub as_code {
         |#define PERL_ARGS_ASSERT_CROAK_XS_USAGE assert(cv); assert(params)
         |
         |/* prototype to pass -Wmissing-prototypes */
-        |STATIC void
+        |static void
         |S_croak_xs_usage(const CV *const cv, const char *const params);
         |
-        |STATIC void
+        |static void
         |S_croak_xs_usage(const CV *const cv, const char *const params)
         |{
         |    const GV *const gv = CvGV(cv);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 require ExtUtils::ParseXS;
 require ExtUtils::ParseXS::Constants;

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::Cmd;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 use ExtUtils::Typemaps;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::InputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::OutputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 require ExtUtils::Typemaps;
 
-our $VERSION = '3.62';
+our $VERSION = '3.63';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -4954,7 +4954,7 @@ this model, the less likely conflicts will occur.
 
 =head1 XS VERSION
 
-This document covers features supported by F<xsubpp> 3.62.
+This document covers features supported by F<xsubpp> 3.63.
 
 =head1 AUTHOR DIAGNOSTICS
 

--- a/dist/ExtUtils-ParseXS/t/XSMore.xs
+++ b/dist/ExtUtils-ParseXS/t/XSMore.xs
@@ -36,13 +36,13 @@ This parts are ignored.
 #endif
 
 
-STATIC void
+static void
 outlist(int* a, int* b){
 	*a = 'a';
 	*b = 'b';
 }
 
-STATIC bool
+static bool
 outlist_bool(const char *a, const char *b, char **c)
 {
    dTHX;
@@ -57,7 +57,7 @@ outlist_bool(const char *a, const char *b, char **c)
    return TRUE;
 }
 
-STATIC int
+static int
 outlist_int(const char *a, const char *b, char **c)
 {
    dTHX;
@@ -72,17 +72,17 @@ outlist_int(const char *a, const char *b, char **c)
    return 11;
 }
 
-STATIC int
+static int
 len(const char* const s, int const l){
 	PERL_UNUSED_ARG(s);
 	return l;
 }
 
-STATIC int
+static int
 myadd1(int a, int b)
 { return a + b; }
 
-STATIC int
+static int
 myadd2(int a, int b)
 { return a + b; }
 

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9779';
+our $VERSION = '1.9780';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -683,7 +683,7 @@ hrstatns(UV *atime_nsec, UV *mtime_nsec, UV *ctime_nsec)
 #  endif
 
 #  ifdef PERL_DARWIN_MUTEX
-STATIC perl_mutex darwin_time_mutex;
+static perl_mutex darwin_time_mutex;
 #  endif
 
 #  include <mach/mach_time.h>

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.71'; # Please update the pod, too.
+our $VERSION = '1.72'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.71
+This document describes threads::shared version 1.72
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -475,7 +475,7 @@ sharedsv_elem_vtbl = {
 /* Return the user_lock structure (if any) associated with a shared SV.
  * If create is true, create one if it doesn't exist
  */
-STATIC user_lock *
+static user_lock *
 S_get_userlock(pTHX_ SV* ssv, bool create)
 {
     MAGIC *mg;
@@ -613,7 +613,7 @@ Perl_sharedsv_associate(pTHX_ SV *sv, SV *ssv)
 /* Given a private SV, create and return an associated shared SV.
  * Assumes lock is held.
  */
-STATIC SV *
+static SV *
 S_sharedsv_new_shared(pTHX_ SV *sv)
 {
     dTHXc;
@@ -635,7 +635,7 @@ S_sharedsv_new_shared(pTHX_ SV *sv)
 /* Given a shared SV, create and return an associated private SV.
  * Assumes lock is held.
  */
-STATIC SV *
+static SV *
 S_sharedsv_new_private(pTHX_ SV *ssv)
 {
     SV *sv;
@@ -652,7 +652,7 @@ S_sharedsv_new_private(pTHX_ SV *ssv)
 
 /* A threadsafe version of SvREFCNT_dec(ssv) */
 
-STATIC void
+static void
 S_sharedsv_dec(pTHX_ SV* ssv)
 {
     if (! ssv)
@@ -700,7 +700,7 @@ Perl_sharedsv_share(pTHX_ SV *sv)
 #define EPOCH_BIAS      11644473600000.
 
 /* Returns relative time in milliseconds.  (Adapted from Time::HiRes.) */
-STATIC DWORD
+static DWORD
 S_abs_2_rel_milli(double abs)
 {
     double rel;
@@ -809,7 +809,7 @@ Perl_sharedsv_cond_timedwait(perl_cond *cond, perl_mutex *mut, double abs)
  * If the private side is already an appropriate RV->SV combination, keep
  * it if possible.
  */
-STATIC void
+static void
 S_get_RV(pTHX_ SV *sv, SV *sobj) {
     SV *obj;
     if (! (SvROK(sv) &&
@@ -1311,9 +1311,9 @@ Perl_shared_object_destroy(pTHX_ SV *sv)
 
 #ifdef PL_signalhook
 
-STATIC despatch_signals_proc_t prev_signal_hook = NULL;
+static despatch_signals_proc_t prev_signal_hook = NULL;
 
-STATIC void
+static void
 S_shared_signal_hook(pTHX) {
     int us;
     MUTEX_LOCK(&PL_sharedsv_lock.mutex);

--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.43';      # remember to update version in POD!
+our $VERSION = '2.44';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 #$VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.43
+This document describes threads version 2.44
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -147,7 +147,7 @@ typedef struct {
 
 /* Block most signals for calling thread, setting the old signal mask to
  * oldmask, if it is not NULL */
-STATIC int
+static int
 S_block_most_signals(sigset_t *oldmask)
 {
     sigset_t newmask;
@@ -173,7 +173,7 @@ S_block_most_signals(sigset_t *oldmask)
 }
 
 /* Set the signal mask for this thread to newmask */
-STATIC int
+static int
 S_set_sigmask(sigset_t *newmask)
 {
 #if defined(VMS)
@@ -185,14 +185,14 @@ S_set_sigmask(sigset_t *newmask)
 #endif /* WIN32 */
 
 /* Used by Perl interpreter for thread context switching */
-STATIC void
+static void
 S_ithread_set(pTHX_ ithread *thread)
 {
     dMY_CXT;
     MY_CXT.context = thread;
 }
 
-STATIC ithread *
+static ithread *
 S_ithread_get(pTHX)
 {
     dMY_CXT;
@@ -207,7 +207,7 @@ S_ithread_get(pTHX)
  * of the interpreter can lead to recursive destruction calls that could
  * lead to a deadlock on that mutex.
  */
-STATIC void
+static void
 S_ithread_clear(pTHX_ ithread *thread)
 {
     PerlInterpreter *interp;
@@ -276,7 +276,7 @@ S_ithread_clear(pTHX_ ithread *thread)
  * Must be called with the mutex held.
  * On return, mutex is released (or destroyed).
  */
-STATIC void
+static void
 S_ithread_free(pTHX_ ithread *thread)
   PERL_TSA_RELEASE(thread->mutex)
 {
@@ -350,7 +350,7 @@ S_ithread_count_inc(pTHX_ ithread *thread)
 
 
 /* Warn if exiting with any unjoined threads */
-STATIC int
+static int
 S_exit_warning(pTHX)
 {
     int veto_cleanup, warn;
@@ -389,7 +389,7 @@ S_exit_warning(pTHX)
 /* Called from perl_destruct() in each thread.  If it's the main thread,
  * stop it from freeing everything if there are other threads still running.
  */
-STATIC int
+static int
 Perl_ithread_hook(pTHX)
 {
     dMY_POOL;
@@ -399,7 +399,7 @@ Perl_ithread_hook(pTHX)
 
 /* MAGIC (in mg.h sense) hooks */
 
-STATIC int
+static int
 ithread_mg_get(pTHX_ SV *sv, MAGIC *mg)
 {
     ithread *thread = (ithread *)mg->mg_ptr;
@@ -408,7 +408,7 @@ ithread_mg_get(pTHX_ SV *sv, MAGIC *mg)
     return (0);
 }
 
-STATIC int
+static int
 ithread_mg_free(pTHX_ SV *sv, MAGIC *mg)
 {
     ithread *thread = (ithread *)mg->mg_ptr;
@@ -418,7 +418,7 @@ ithread_mg_free(pTHX_ SV *sv, MAGIC *mg)
     return (0);
 }
 
-STATIC int
+static int
 ithread_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS *param)
 {
     PERL_UNUSED_ARG(param);
@@ -426,7 +426,7 @@ ithread_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS *param)
     return (0);
 }
 
-STATIC const MGVTBL ithread_vtbl = {
+static const MGVTBL ithread_vtbl = {
     ithread_mg_get,     /* get */
     0,                  /* set */
     0,                  /* len */
@@ -441,7 +441,7 @@ STATIC const MGVTBL ithread_vtbl = {
 
 
 /* Provided default, minimum and rational stack sizes */
-STATIC IV
+static IV
 S_good_stack_size(pTHX_ IV stack_size)
 {
     dMY_POOL;
@@ -543,10 +543,10 @@ S_jmpenv_run(pTHX_ int action, ithread *thread,
  */
 #ifdef WIN32
 PERL_STACK_REALIGN
-STATIC THREAD_RET_TYPE
+static THREAD_RET_TYPE
 S_ithread_run(LPVOID arg)
 #else
-STATIC void *
+static void *
 S_ithread_run(void * arg)
 #endif
 {
@@ -726,7 +726,7 @@ S_ithread_run(void * arg)
 
 /* Type conversion helper functions */
 
-STATIC SV *
+static SV *
 S_ithread_to_SV(pTHX_ SV *obj, ithread *thread, char *classname, bool inc)
 {
     SV *sv;
@@ -748,7 +748,7 @@ S_ithread_to_SV(pTHX_ SV *obj, ithread *thread, char *classname, bool inc)
     return (obj);
 }
 
-STATIC ithread *
+static ithread *
 S_SV_to_ithread(pTHX_ SV *sv)
 {
     /* Argument is a thread */
@@ -765,7 +765,7 @@ S_SV_to_ithread(pTHX_ SV *sv)
  * Called with my_pool->create_destruct_mutex locked.
  * (Unlocked both on error and on success.)
  */
-STATIC ithread *
+static ithread *
 S_ithread_create(
         PerlInterpreter *parent_perl,
         my_pool_t *my_pool,
@@ -978,9 +978,9 @@ S_ithread_create(
                                   &thread->thr);
 #else
     {
-        STATIC pthread_attr_t attr;
-        STATIC int attr_inited = 0;
-        STATIC int attr_joinable = PTHREAD_CREATE_JOINABLE;
+        static pthread_attr_t attr;
+        static int attr_inited = 0;
+        static int attr_joinable = PTHREAD_CREATE_JOINABLE;
         if (! attr_inited) {
             pthread_attr_init(&attr);
             attr_inited = 1;

--- a/doio.c
+++ b/doio.c
@@ -1613,7 +1613,7 @@ S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg) {
 #define dir_unchanged(orig_psv, mg) \
     S_dir_unchanged(aTHX_ (orig_psv), (mg))
 
-STATIC bool
+static bool
 S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict) {
     bool retval;
 

--- a/doop.c
+++ b/doop.c
@@ -35,7 +35,7 @@
  * be in the to-translate set
  */
 
-STATIC Size_t
+static Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 {
     Size_t matches = 0;
@@ -124,7 +124,7 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
  * be in the to-translate set
  */
 
-STATIC Size_t
+static Size_t
 S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 {
     STRLEN len;
@@ -173,7 +173,7 @@ S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
  * be in the to-translate set
  */
 
-STATIC Size_t
+static Size_t
 S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 {
     STRLEN len;
@@ -332,7 +332,7 @@ S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
  * sv may or may not be utf8.
  */
 
-STATIC Size_t
+static Size_t
 S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
 {
     U8 *s;
@@ -398,7 +398,7 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
  * sv may or may not be utf8.
  */
 
-STATIC Size_t
+static Size_t
 S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
 {
     U8 *s;

--- a/dump.c
+++ b/dump.c
@@ -410,7 +410,7 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
     return SvPVX(dsv);
 }
 
-STATIC char *
+static char *
 S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim, I32 pretty_flags)
 {
     PERL_ARGS_ASSERT_PV_DISPLAY_FLAGS;
@@ -1257,7 +1257,7 @@ Perl_pmop_dump(pTHX_ PMOP *pm)
  * otherwise add it.
  *  *** Note that this isn't thread-safe */
 
-STATIC UV
+static UV
 S_sequence_num(pTHX_ const OP *o)
 {
     SV     *op,
@@ -1280,7 +1280,7 @@ S_sequence_num(pTHX_ const OP *o)
 
 
 /* forward declaration */
-STATIC void
+static void
 S_deb_padvar_cv(pTHX_ CV *cv, PADOFFSET off, int n, bool paren);
 
 
@@ -3301,7 +3301,7 @@ Perl_runops_debug(pTHX)
 /* Print the names of the n lexical vars starting at pad offset off
  * in the specified CV */
 
-STATIC void
+static void
 S_deb_padvar_cv(pTHX_ CV *cv, PADOFFSET off, int n, bool paren)
 {
     PADNAME *sv;
@@ -3331,7 +3331,7 @@ S_deb_padvar_cv(pTHX_ CV *cv, PADOFFSET off, int n, bool paren)
 /* Print the names of the n lexical vars starting at pad offset off n the
  * currently executing CV */
 
-STATIC void
+static void
 S_deb_padvar(pTHX_ PADOFFSET off, int n, bool paren)
 {
     S_deb_padvar_cv(aTHX_ deb_curcv(cxstack_ix), off, n, paren);
@@ -3821,7 +3821,7 @@ Perl_op_class(pTHX_ const OP *o)
 
 
 
-STATIC CV*
+static CV*
 S_deb_curcv(pTHX_ I32 ix)
 {
     PERL_SI *si = PL_curstackinfo;
@@ -3865,7 +3865,7 @@ C<-DP> command line option.
 =cut
 */
 
-STATIC void
+static void
 S_debprof(pTHX_ const OP *o)
 {
     PERL_ARGS_ASSERT_DEBPROF;

--- a/embed.fnc
+++ b/embed.fnc
@@ -716,7 +716,7 @@
 :   'S'  Static function: function in source code has a S_ prefix:
 :
 :          proto.h: function is declared as S_foo rather than foo,
-:                STATIC is added to declaration;
+:                static is added to declaration;
 :          embed.h: "#define foo S_foo" entries added
 :
 :   's'  Static function, but function in source code has a Perl_ prefix:
@@ -725,7 +725,7 @@
 :        have been moved to a header file and declared static.
 :
 :          proto.h: function is declared as Perl_foo rather than foo
-:                STATIC is added to declaration;
+:                static is added to declaration;
 :          embed.h: "#define foo Perl_foo" entries added
 :
 :   'T'  Has no implicit interpreter/thread context argument:

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -196,7 +196,7 @@ S_mycopy_copy(pTHX_ SV *sv, MAGIC* mg, SV *nsv, const char *name, I32 namlen) {
     return 0;
 }
 
-STATIC MGVTBL vtbl_mycopy = { 0, 0, 0, 0, 0, S_mycopy_copy, 0, 0 };
+static MGVTBL vtbl_mycopy = { 0, 0, 0, 0, 0, S_mycopy_copy, 0, 0 };
 
 /* indirect functions to test the [pa]MY_CXT macros */
 
@@ -433,7 +433,7 @@ rot13_key(pTHX_ IV action, SV *field) {
     return 0;
 }
 
-STATIC I32
+static I32
 rmagical_a_dummy(pTHX_ IV idx, SV *sv) {
     PERL_UNUSED_ARG(idx);
     PERL_UNUSED_ARG(sv);
@@ -445,9 +445,9 @@ rmagical_a_dummy(pTHX_ IV idx, SV *sv) {
  * being a bit too paranoid.  But since this is file-static, we can
  * just have it without initializer, since it should get
  * zero-initialized. */
-STATIC MGVTBL rmagical_b;
+static MGVTBL rmagical_b;
 
-STATIC void
+static void
 blockhook_csc_start(pTHX_ int full)
 {
     dMY_CXT;
@@ -470,7 +470,7 @@ blockhook_csc_start(pTHX_ int full)
     }
 }
 
-STATIC void
+static void
 blockhook_csc_pre_end(pTHX_ OP **o)
 {
     dMY_CXT;
@@ -484,7 +484,7 @@ blockhook_csc_pre_end(pTHX_ OP **o)
 
 }
 
-STATIC void
+static void
 blockhook_test_start(pTHX_ int full)
 {
     dMY_CXT;
@@ -498,7 +498,7 @@ blockhook_test_start(pTHX_ int full)
     }
 }
 
-STATIC void
+static void
 blockhook_test_pre_end(pTHX_ OP **o)
 {
     dMY_CXT;
@@ -508,7 +508,7 @@ blockhook_test_pre_end(pTHX_ OP **o)
         av_push(MY_CXT.bhkav, newSVpvs("pre_end"));
 }
 
-STATIC void
+static void
 blockhook_test_post_end(pTHX_ OP **o)
 {
     dMY_CXT;
@@ -518,7 +518,7 @@ blockhook_test_post_end(pTHX_ OP **o)
         av_push(MY_CXT.bhkav, newSVpvs("post_end"));
 }
 
-STATIC void
+static void
 blockhook_test_eval(pTHX_ OP *const o)
 {
     dMY_CXT;
@@ -532,9 +532,9 @@ blockhook_test_eval(pTHX_ OP *const o)
     }
 }
 
-STATIC BHK bhk_csc, bhk_test;
+static BHK bhk_csc, bhk_test;
 
-STATIC void
+static void
 my_peep (pTHX_ OP *o)
 {
     dMY_CXT;
@@ -554,7 +554,7 @@ my_peep (pTHX_ OP *o)
     }
 }
 
-STATIC void
+static void
 my_rpeep (pTHX_ OP *first)
 {
     dMY_CXT;
@@ -580,7 +580,7 @@ my_rpeep (pTHX_ OP *first)
     }
 }
 
-STATIC OP *
+static OP *
 THX_ck_entersub_args_lists(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 {
     PERL_UNUSED_ARG(namegv);
@@ -588,7 +588,7 @@ THX_ck_entersub_args_lists(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     return ck_entersub_args_list(entersubop);
 }
 
-STATIC OP *
+static OP *
 THX_ck_entersub_args_scalars(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 {
     OP *aop = cUNOPx(entersubop)->op_first;
@@ -602,7 +602,7 @@ THX_ck_entersub_args_scalars(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     return entersubop;
 }
 
-STATIC OP *
+static OP *
 THX_ck_entersub_multi_sum(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 {
     OP *sumop = NULL;
@@ -633,8 +633,8 @@ THX_ck_entersub_multi_sum(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     return sumop;
 }
 
-STATIC void test_op_list_describe_part(SV *res, OP *o);
-STATIC void
+static void test_op_list_describe_part(SV *res, OP *o);
+static void
 test_op_list_describe_part(SV *res, OP *o)
 {
     sv_catpv(res, PL_op_name[o->op_type]);
@@ -654,7 +654,7 @@ test_op_list_describe_part(SV *res, OP *o)
     }
 }
 
-STATIC char *
+static char *
 test_op_list_describe(OP *o)
 {
     SV *res = sv_2mortal(newSVpvs(""));
@@ -720,7 +720,7 @@ test_op_linklist_describe(OP *start)
 
 /** establish_cleanup operator, ripped off from Scope::Cleanup **/
 
-STATIC void
+static void
 THX_run_cleanup(pTHX_ void *cleanup_code_ref)
 {
     dSP;
@@ -736,7 +736,7 @@ THX_run_cleanup(pTHX_ void *cleanup_code_ref)
 
 /* Note that this is a pp function attached to an OP */
 
-STATIC OP *
+static OP *
 THX_pp_establish_cleanup(pTHX)
 {
     SV *cleanup_code_ref;
@@ -750,7 +750,7 @@ THX_pp_establish_cleanup(pTHX)
     ;
 }
 
-STATIC OP *
+static OP *
 THX_ck_entersub_establish_cleanup(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 {
     OP *parent, *pushop, *argop, *estop;
@@ -772,7 +772,7 @@ THX_ck_entersub_establish_cleanup(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
     return estop;
 }
 
-STATIC OP *
+static OP *
 THX_ck_entersub_postinc(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 {
     OP *parent, *pushop, *argop;
@@ -790,7 +790,7 @@ THX_ck_entersub_postinc(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
         op_lvalue(op_contextualize(argop, G_SCALAR), OP_POSTINC));
 }
 
-STATIC OP *
+static OP *
 THX_ck_entersub_pad_scalar(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 {
     OP *pushop, *argop;

--- a/ext/XS-Typemap/Typemap.pm
+++ b/ext/XS-Typemap/Typemap.pm
@@ -34,7 +34,7 @@ to the test script.
 use parent qw/ Exporter /;
 require XSLoader;
 
-our $VERSION = '0.20';
+our $VERSION = '0.21';
 
 our @EXPORT = (qw/
 	   T_SV

--- a/ext/XS-Typemap/Typemap.xs
+++ b/ext/XS-Typemap/Typemap.xs
@@ -67,7 +67,7 @@ intArray * intArrayPtr( int nelem ) {
 }
 
 /* test T_PACKED */
-STATIC void
+static void
 XS_pack_anotherstructPtr(SV *out, anotherstruct *in)
 {
     dTHX;
@@ -81,7 +81,7 @@ XS_pack_anotherstructPtr(SV *out, anotherstruct *in)
     sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hash)));
 }
 
-STATIC anotherstruct *
+static anotherstruct *
 XS_unpack_anotherstructPtr(SV *in)
 {
     dTHX; /* rats, this is expensive */
@@ -118,7 +118,7 @@ XS_unpack_anotherstructPtr(SV *in)
 }
 
 /* test T_PACKEDARRAY */
-STATIC void
+static void
 XS_pack_anotherstructPtrPtr(SV *out, anotherstruct **in, UV cnt)
 {
     dTHX;
@@ -137,7 +137,7 @@ XS_pack_anotherstructPtrPtr(SV *out, anotherstruct **in, UV cnt)
     sv_setsv(out, sv_2mortal(newRV_noinc((SV*)ary)));
 }
 
-STATIC anotherstruct **
+static anotherstruct **
 XS_unpack_anotherstructPtrPtr(SV *in)
 {
     dTHX; /* rats, this is expensive */

--- a/gv.c
+++ b/gv.c
@@ -558,7 +558,7 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
     }
 }
 
-STATIC void
+static void
 S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type)
 {
     PERL_ARGS_ASSERT_GV_INIT_SVTYPE;
@@ -1512,7 +1512,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
  * For the protection of $! to work (it is set by this routine)
  * the sv slot must already be magicalized.
  */
-STATIC void
+static void
 S_require_tie_mod(pTHX_ GV *gv, const char varname, const char * name,
                         STRLEN len, const U32 flags)
 {

--- a/hv.c
+++ b/hv.c
@@ -152,7 +152,7 @@ STMT_START {                                                            \
 
 #else
 
-STATIC HE*
+static HE*
 S_new_he(pTHX)
 {
     HE* he;
@@ -177,7 +177,7 @@ S_new_he(pTHX)
 
 #endif
 
-STATIC HEK *
+static HEK *
 S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
 {
     char *k;
@@ -1088,7 +1088,7 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
     return (void *) entry;
 }
 
-STATIC void
+static void
 S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
 {
     const MAGIC *mg = SvMAGIC(hv);
@@ -1292,7 +1292,7 @@ found.
 =cut
 */
 
-STATIC SV *
+static SV *
 S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                    int k_flags, I32 d_flags, U32 hash)
 {
@@ -1641,7 +1641,7 @@ S_large_hash_heuristic(pTHX_ HV *hv, STRLEN size) {
 }
 #endif
 
-STATIC void
+static void
 S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
 {
     STRLEN i = 0;
@@ -1973,7 +1973,7 @@ Perl_hv_copy_hints_hv(pTHX_ HV *const ohv)
 #undef HV_SET_MAX_ADJUSTED_FOR_KEYS
 
 /* like hv_free_ent, but returns the SV rather than freeing it */
-STATIC SV*
+static SV*
 S_hv_free_ent_ret(pTHX_ HE *entry)
 {
     PERL_ARGS_ASSERT_HV_FREE_ENT_RET;
@@ -2170,7 +2170,7 @@ S_clear_placeholders(pTHX_ HV *hv, const U32 placeholders)
     NOT_REACHED; /* NOTREACHED */
 }
 
-STATIC void
+static void
 S_hv_free_entries(pTHX_ HV *hv)
 {
     STRLEN index = 0;
@@ -2736,7 +2736,7 @@ This is basically sv_eq_flags() in sv.c, but we avoid the magic
 and bytes checking.
 */
 
-STATIC I32
+static I32
 hek_eq_pvn_flags(pTHX_ const HEK *hek, const char* pv, const I32 pvlen, const U32 flags) {
     if ( (HEK_UTF8(hek) ? 1 : 0) != (flags & SVf_UTF8 ? 1 : 0) ) {
         if (flags & SVf_UTF8)
@@ -3266,7 +3266,7 @@ Perl_unshare_hek(pTHX_ HEK *hek)
    hek if non-NULL takes priority over the other 3, else str, len and hash
    are used.  If so, len and hash must both be valid for str.
  */
-STATIC void
+static void
 S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash)
 {
     HE *entry;
@@ -3392,7 +3392,7 @@ Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
     return share_hek_flags (str, len, hash, flags);
 }
 
-STATIC HEK *
+static HEK *
 S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
 {
     HE *entry;
@@ -3541,7 +3541,7 @@ Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
     /* else we don't need to add magic to record 0 placeholders.  */
 }
 
-STATIC SV *
+static SV *
 S_refcounted_he_value(pTHX_ const struct refcounted_he *he)
 {
     SV *value;

--- a/invlist_inline.h
+++ b/invlist_inline.h
@@ -238,7 +238,7 @@ S_invlist_iterfinish(SV* invlist)
     *get_invlist_iter_addr(invlist) = (STRLEN) UV_MAX;
 }
 
-STATIC bool
+static bool
 S_invlist_iternext(SV* invlist, UV* start, UV* end)
 {
     /* An C<invlist_iterinit> call on <invlist> must be used to set this up.

--- a/locale.c
+++ b/locale.c
@@ -446,7 +446,7 @@ static PerlInterpreter * wsetlocale_buf_aTHX = NULL;
 
 #    endif
 
-STATIC
+static
 const wchar_t *
 S_wsetlocale(const int category, const wchar_t * wlocale)
 {
@@ -527,7 +527,7 @@ S_wsetlocale(const int category, const wchar_t * wlocale)
  * NOTE it redefines setlocale() and usequerylocale()
  * */
 
-STATIC const char *
+static const char *
 S_positional_name_value_xlation(const char * locale, bool direction)
 {   /* direction == 1 is from name=value to positional
        direction == 0 is from positional to name=value */
@@ -573,7 +573,7 @@ S_positional_name_value_xlation(const char * locale, bool direction)
     }
 }
 
-STATIC const char *
+static const char *
 S_positional_setlocale(int cat, const char * locale)
 {
     if (cat != LC_ALL) return setlocale(cat, locale);
@@ -592,7 +592,7 @@ S_positional_setlocale(int cat, const char * locale)
 #    define setlocale(a,b)  S_positional_setlocale(a,b)
 #    ifdef USE_POSIX_2008_LOCALE
 
-STATIC locale_t
+static locale_t
 S_positional_newlocale(int mask, const char * locale, locale_t base)
 {
     assert(locale);
@@ -796,7 +796,7 @@ static const char C_thousands_sep[] = "";
 
 /* The first array is the locale categories perl uses on this system, used to
  * map our index back to the system's category number. */
-STATIC const int categories[] = {
+static const int categories[] = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  LC_ ## name,
@@ -816,7 +816,7 @@ STATIC const int categories[] = {
 # define GET_LC_NAME_AS_STRING(token) GET_NAME_AS_STRING(LC_ ## token)
 
 /* The second array is the category names. */
-STATIC const char * const category_names[] = {
+static const char * const category_names[] = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  GET_LC_NAME_AS_STRING(name),
@@ -837,7 +837,7 @@ STATIC const char * const category_names[] = {
     LC_UNKNOWN_STRING
 };
 
-STATIC const Size_t category_name_lengths[] = {
+static const Size_t category_name_lengths[] = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)                          \
@@ -853,13 +853,13 @@ STATIC const Size_t category_name_lengths[] = {
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)                          \
                                 + STRLENs(GET_LC_NAME_AS_STRING(name)) + 2
 
-STATIC const Size_t lc_all_boiler_plate_length = 1  /* space for trailing NUL */
+static const Size_t lc_all_boiler_plate_length = 1  /* space for trailing NUL */
 #  include "locale_table.h"
 ;
 
 /* A few categories require additional setup when they are changed.  This table
  * points to the functions that do that setup */
-STATIC void (*update_functions[]) (pTHX_ const char *, bool force) = {
+static void (*update_functions[]) (pTHX_ const char *, bool force) = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  call_back,
@@ -874,7 +874,7 @@ STATIC void (*update_functions[]) (pTHX_ const char *, bool force) = {
 
 /* Indicates if each category on this platform is available to use not in
  * the C locale */
-STATIC const bool category_available[] = {
+static const bool category_available[] = {
 
 #  undef PERL_LOCALE_TABLE_ENTRY
 #  define PERL_LOCALE_TABLE_ENTRY(name, call_back)  LC_ ## name ## _AVAIL_,
@@ -892,7 +892,7 @@ STATIC const bool category_available[] = {
 #  endif
 #  if defined(USE_POSIX_2008_LOCALE)
 
-STATIC const int category_masks[] = {
+static const int category_masks[] = {
 
 #    undef PERL_LOCALE_TABLE_ENTRY
 #    define PERL_LOCALE_TABLE_ENTRY(name, call_back)  LC_ ## name ## _MASK,
@@ -910,7 +910,7 @@ STATIC const int category_masks[] = {
  * This is initialized at run time if needed.  LC_ALL_INDEX_ is not legal for
  * an individual locale, hence marks the elements here as not actually
  * initialized. */
-STATIC
+static
 unsigned int
 map_LC_ALL_position_to_index[LC_ALL_INDEX_] = { LC_ALL_INDEX_ };
 
@@ -918,7 +918,7 @@ map_LC_ALL_position_to_index[LC_ALL_INDEX_] = { LC_ALL_INDEX_ };
 #endif
 #if defined(USE_LOCALE) || defined(DEBUGGING)
 
-STATIC const char *
+static const char *
 S_get_displayable_string(pTHX_
                          const char * const s,
                          const char * const e,
@@ -985,7 +985,7 @@ S_get_displayable_string(pTHX_
 
 # define get_category_index(cat) get_category_index_helper(cat, NULL, __LINE__)
 
-STATIC locale_category_index
+static locale_category_index
 S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
                                   const line_t caller_line)
 {
@@ -1058,7 +1058,7 @@ Perl_force_locale_unlock(pTHX)
 
 #ifdef USE_POSIX_2008_LOCALE
 
-STATIC locale_t
+static locale_t
 S_use_curlocale_scratch(pTHX)
 {
     /* This function is used to hide from the caller the case where the current
@@ -1174,7 +1174,7 @@ Perl_locale_panic(const char * msg,
         } STMT_END
 #  endif
 
-STATIC parse_LC_ALL_string_return
+static parse_LC_ALL_string_return
 S_parse_LC_ALL_string(pTHX_ const char * string,
                             const char ** output,
                             const parse_LC_ALL_STRING_action  override,
@@ -1543,7 +1543,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
 #  define posix_setlocale(cat, locale)                                      \
         S_posix_setlocale_with_complications(aTHX_ cat, locale, __LINE__)
 
-STATIC const char *
+static const char *
 S_posix_setlocale_with_complications(pTHX_ const int cat,
                                            const char * new_locale,
                                            const line_t caller_line)
@@ -1688,7 +1688,7 @@ S_posix_setlocale_with_complications(pTHX_ const int cat,
 #  define stdized_setlocale(cat, locale)                                    \
         S_stdize_locale(aTHX_ cat, posix_setlocale(cat, locale), __LINE__)
 
-STATIC const char *
+static const char *
 S_stdize_locale(pTHX_ const int category,
                       const char *input_locale,
                       const line_t caller_line)
@@ -1929,7 +1929,7 @@ S_stdize_locale(pTHX_ const int category,
 
 #    define setlocale_i(i, locale)   S_setlocale_i(aTHX_ categories[i], locale)
 
-STATIC const char *
+static const char *
 S_setlocale_i(pTHX_ const int category, const char * locale)
 {
     if (LIKELY(_configthreadlocale(0) == _ENABLE_PER_THREAD_LOCALE)) {
@@ -1960,7 +1960,7 @@ S_setlocale_i(pTHX_ const int category, const char * locale)
 #  define querylocale_r(cat)                                                \
                       mortalized_pv_copy(less_dicey_setlocale_r(cat, NULL))
 
-STATIC const char *
+static const char *
 S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale)
 {
     const char * retval;
@@ -1983,7 +1983,7 @@ S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale)
 #  define bool_setlocale_r(cat, locale)                                     \
                                less_dicey_bool_setlocale_r(cat, locale)
 
-STATIC bool
+static bool
 S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 {
     bool retval;
@@ -2039,7 +2039,7 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
      * will complain if the definition gets out of sync */
 #  define querylocale_c(cat)      querylocale_i(cat##_INDEX_)
 
-STATIC const char *
+static const char *
 S_querylocale_2008_i(pTHX_ const locale_category_index index,
                            const line_t caller_line)
 {
@@ -2268,7 +2268,7 @@ S_querylocale_2008_i(pTHX_ const locale_category_index index,
 #    define update_PL_curlocales_i(index, new_locale, caller_line)
 #  endif
 
-STATIC bool
+static bool
 S_bool_setlocale_2008_i(pTHX_
 
         /* Our internal index of the 'category' setlocale is called with */
@@ -2796,7 +2796,7 @@ S_bool_setlocale_2008_i(pTHX_
 
 #ifdef USE_PL_CURLOCALES
 
-STATIC void
+static void
 S_update_PL_curlocales_i(pTHX_
                          const locale_category_index index,
                          const char * new_locale,
@@ -2872,7 +2872,7 @@ S_update_PL_curlocales_i(pTHX_
         : array[i])
 #  endif
 
-STATIC
+static
 const char *
 S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
                                 const calc_LC_ALL_format format,
@@ -3205,7 +3205,7 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
 #  if defined(WIN32) || (     defined(USE_POSIX_2008_LOCALE)        \
                          && ! defined(USE_QUERYLOCALE))
 
-STATIC const char *
+static const char *
 S_find_locale_from_environment(pTHX_ const locale_category_index index)
 {
     /* NB: This function may actually change the locale on Windows.  It
@@ -3372,7 +3372,7 @@ S_find_locale_from_environment(pTHX_ const locale_category_index index)
 #  endif
 #  if defined(DEBUGGING) || defined(USE_PERL_SWITCH_LOCALE_CONTEXT)
 
-STATIC const char *
+static const char *
 S_get_LC_ALL_display(pTHX)
 {
     return calculate_LC_ALL_string(NULL, INTERNAL_FORMAT,
@@ -3382,7 +3382,7 @@ S_get_LC_ALL_display(pTHX)
 
 #  endif
 
-STATIC void
+static void
 S_setlocale_failure_panic_via_i(pTHX_
                                 const locale_category_index cat_index,
                                 const char * current,
@@ -3452,7 +3452,7 @@ S_setlocale_failure_panic_via_i(pTHX_
 
 #  ifdef USE_LOCALE_NUMERIC
 
-STATIC void
+static void
 S_new_numeric(pTHX_ const char *newnum, bool force)
 {
     PERL_ARGS_ASSERT_NEW_NUMERIC;
@@ -3672,7 +3672,7 @@ Perl_set_numeric_underlying(pTHX_ const char * const file, const line_t line)
 
 #  ifdef USE_LOCALE_CTYPE
 
-STATIC void
+static void
 S_new_ctype(pTHX_ const char *newctype, bool force)
 {
     PERL_ARGS_ASSERT_NEW_CTYPE;
@@ -4119,7 +4119,7 @@ Perl_warn_problematic_locale()
 
 #  endif /* USE_LOCALE_CTYPE */
 
-STATIC void
+static void
 S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
 {
     PERL_ARGS_ASSERT_NEW_LC_ALL;
@@ -4161,7 +4161,7 @@ S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
 
 #  ifdef USE_LOCALE_COLLATE
 
-STATIC void
+static void
 S_new_collate(pTHX_ const char *newcoll, bool force)
 {
     PERL_ARGS_ASSERT_NEW_COLLATE;
@@ -4221,7 +4221,7 @@ S_new_collate(pTHX_ const char *newcoll, bool force)
 
 #  ifdef WIN32
 
-STATIC wchar_t *
+static wchar_t *
 S_Win_byte_string_to_wstring(const UINT code_page, const char * byte_string)
 {
     /* Caller must arrange to free the returned string */
@@ -4248,7 +4248,7 @@ S_Win_byte_string_to_wstring(const UINT code_page, const char * byte_string)
 #    define Win_utf8_string_to_wstring(s)                                   \
                                     Win_byte_string_to_wstring(CP_UTF8, (s))
 
-STATIC char *
+static char *
 S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t * wstring)
 {
     /* Caller must arrange to free the returned string */
@@ -4273,7 +4273,7 @@ S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t * wstring)
 #    define Win_wstring_to_utf8_string(ws)                                  \
                                    Win_wstring_to_byte_string(CP_UTF8, (ws))
 
-STATIC const char *
+static const char *
 S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
 {
     PERL_ARGS_ASSERT_WRAP_WSETLOCALE;
@@ -4309,7 +4309,7 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
     return result;
 }
 
-STATIC const char *
+static const char *
 S_win32_setlocale(pTHX_ int category, const char* locale)
 {
     /* This, for Windows, emulates POSIX setlocale() behavior.  There is no
@@ -4377,7 +4377,7 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
 
 #  endif
 
-STATIC const char *
+static const char *
 S_native_querylocale_i(pTHX_ const locale_category_index cat_index)
 {
     /* Determine the current locale and return it in the form the platform's
@@ -4597,7 +4597,7 @@ Perl_setlocale(const int category, const char * locale)
 #ifdef USE_LOCALE
 #  ifdef DEBUGGING
 
-STATIC char *
+static char *
 S_my_setlocale_debug_string_i(pTHX_
                               const locale_category_index cat_index,
                               const char* locale, /* Optional locale name */
@@ -4658,7 +4658,7 @@ S_my_setlocale_debug_string_i(pTHX_
 #    define TOGGLE_UNLOCK(i)
 #  endif
 
-STATIC const char *
+static const char *
 S_toggle_locale_i(pTHX_ const locale_category_index cat_index,
                         const char * new_locale,
                         const line_t caller_line)
@@ -4719,7 +4719,7 @@ S_toggle_locale_i(pTHX_ const locale_category_index cat_index,
 
 }
 
-STATIC void
+static void
 S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index,
                                  const char * restore_locale,
                                  const line_t caller_line)
@@ -4758,7 +4758,7 @@ S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index,
 #endif
 #if defined(USE_LOCALE) || defined(HAS_SOME_LANGINFO) || defined(HAS_LOCALECONV)
 
-STATIC utf8ness_t
+static utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char * string,
                                      const locale_utf8ness_t known_utf8,
                                      const char * locale,
@@ -4848,7 +4848,7 @@ S_get_locale_string_utf8ness_i(pTHX_ const char * string,
 
 }
 
-STATIC bool
+static bool
 S_is_locale_utf8(pTHX_ const char * locale)
 {
     PERL_ARGS_ASSERT_IS_LOCALE_UTF8;
@@ -4973,7 +4973,7 @@ S_is_locale_utf8(pTHX_ const char * locale)
 #ifdef USE_LOCALE
 #  ifdef USE_LOCALE_CTYPE
 
-STATIC bool
+static bool
 S_is_codeset_name_UTF8(const char * name)
 {
     /* Return a boolean as to if the passed-in name indicates it is a UTF-8
@@ -5030,7 +5030,7 @@ Perl_get_win32_message_utf8ness(pTHX_ const char * string)
 
 #  endif
 
-STATIC void
+static void
 S_set_save_buffer_min_size(pTHX_ Size_t min_len,
                                  char **buf,
                                  Size_t * buf_cursize)
@@ -5053,7 +5053,7 @@ S_set_save_buffer_min_size(pTHX_ Size_t min_len,
     }
 }
 
-STATIC const char *
+static const char *
 S_save_to_buffer(pTHX_ const char * string, char **buf, Size_t *buf_size)
 {
     PERL_ARGS_ASSERT_SAVE_TO_BUFFER;
@@ -5660,7 +5660,7 @@ S_my_localeconv(pTHX_ const int item)
 
 }
 
-STATIC void
+static void
 S_populate_hash_from_C_localeconv(pTHX_ HV * hv,
                                         const char * locale,  /* Unused */
 
@@ -5743,7 +5743,7 @@ S_populate_hash_from_C_localeconv(pTHX_ HV * hv,
 #if defined(HAS_LOCALECONV) && (   defined(USE_LOCALE_NUMERIC)      \
                                 || defined(USE_LOCALE_MONETARY))
 
-STATIC void
+static void
 S_populate_hash_from_localeconv(pTHX_ HV * hv,
 
                                       /* Switch to this locale to run
@@ -6376,7 +6376,7 @@ S_external_call_langinfo(pTHX_ const nl_item item,
 #endif
 #if defined(USE_LOCALE) && defined(HAS_NL_LANGINFO)
 
-STATIC const char *
+static const char *
 S_langinfo_sv_i(pTHX_
                 const nl_item item,           /* The item to look up */
 
@@ -6790,14 +6790,14 @@ S_langinfo_sv_i(pTHX_
  * make its removal easier, as there may not be any extant platforms that need
  * it; and the function is located after emulate_langinfo() because it's easier
  * to understand when placed in the context of that code */
-STATIC bool
+static bool
 S_maybe_override_codeset(pTHX_ const char * codeset,
                                const char * locale,
                                const char ** new_codeset);
 #endif
 #if ! defined(HAS_NL_LANGINFO) || defined(HAS_MISSING_LANGINFO_ITEM_)
 
-STATIC const char *
+static const char *
 S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item,
                          const char * locale,
                          SV * sv,
@@ -7851,7 +7851,7 @@ S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item,
 #endif      /* Needs emulate_langinfo() */
 #ifndef HAS_DEFINITIVE_UTF8NESS_DETERMINATION
 
-STATIC bool
+static bool
 S_maybe_override_codeset(pTHX_ const char * codeset,
                                const char * locale,
                                const char ** new_codeset)
@@ -8417,7 +8417,7 @@ S_sv_strftime_common(pTHX_ SV * fmt,
     return sv;
 }
 
-STATIC void
+static void
 S_ints_to_tm(pTHX_ struct tm * mytm,
                    const char * locale,
                    int sec, int min, int hour, int mday, int mon, int year,
@@ -8531,7 +8531,7 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
     return;
 }
 
-STATIC bool
+static bool
 S_strftime_tm(pTHX_ const char *fmt,
                     SV * sv,
                     const char *locale,
@@ -8685,7 +8685,7 @@ S_strftime_tm(pTHX_ const char *fmt,
     return succeeded;
 }
 
-STATIC bool
+static bool
 S_strftime8(pTHX_ const char * fmt,
                   SV * sv,
                   const char * locale,
@@ -8790,7 +8790,7 @@ S_strftime8(pTHX_ const char * fmt,
 
 #ifdef USE_LOCALE
 
-STATIC void
+static void
 S_give_perl_locale_control(pTHX_
 #  ifdef LC_ALL
                            const char * lc_all_string,
@@ -8859,7 +8859,7 @@ S_give_perl_locale_control(pTHX_
 
 }
 
-STATIC void
+static void
 S_output_check_environment_warning(pTHX_ const char * const language,
                                          const char * const lc_all,
                                          const char * const lang)
@@ -9552,7 +9552,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 #undef GET_DESCRIPTION
 #ifdef USE_LOCALE_COLLATE
 
-STATIC bool
+static bool
 S_compute_collxfrm_coefficients(pTHX)
 {
     /* This is called from mem_collxfrm() the first time the latter is called
@@ -10416,7 +10416,7 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string,
 
 #  ifdef DEBUGGING
 
-STATIC void
+static void
 S_print_collxfrm_input_and_return(pTHX_
                                   const char * s,
                                   const char * e,

--- a/malloc.c
+++ b/malloc.c
@@ -1163,7 +1163,7 @@ cmp_pat_4bytes(unsigned char *s, size_t nbytes, const unsigned char *fill)
 #  define FILLCHECK_DEADBEEF(s, n)	((void)0)
 #endif
 
-STATIC int
+static int
 S_adjust_size_and_find_bucket(size_t *nbytes_p)
 {
         MEM_SIZE shiftr;

--- a/mg.c
+++ b/mg.c
@@ -86,7 +86,7 @@ struct magic_state {
 };
 /* MGS is typedef'ed to struct magic_state in perl.h */
 
-STATIC void
+static void
 S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags)
 {
     MGS* mgs;
@@ -815,7 +815,7 @@ Perl_get_extended_os_errno(void)
 
 }
 
-STATIC void
+static void
 S_fixup_errno_string(pTHX_ SV* sv)
 {
     /* Do what is necessary to fixup the non-empty string in 'sv' for return to
@@ -2171,7 +2171,7 @@ Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
 
 /* wrapper for magic_methcall that creates the first arg */
 
-STATIC SV*
+static SV*
 S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
     int n, SV *val)
 {
@@ -2196,7 +2196,7 @@ S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
     return Perl_magic_methcall(aTHX_ sv, mg, meth, flags, n, arg1, val);
 }
 
-STATIC int
+static int
 S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
 {
     SV* ret;

--- a/mro_core.c
+++ b/mro_core.c
@@ -701,7 +701,7 @@ Perl_mro_isa_changed_in(pTHX_ HV* stash)
 
 /* Deletes name from all the isarev entries listed in isa.
    Don't call this if isa is already empty. */
-STATIC void
+static void
 S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name,
                          const STRLEN len, HV * const exceptions, U32 hash,
                          U32 flags)
@@ -897,7 +897,7 @@ Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash,
     }
 }
 
-STATIC void
+static void
 S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                               HV *stash, HV *oldstash, SV *namesv)
 {

--- a/numeric.c
+++ b/numeric.c
@@ -1319,7 +1319,7 @@ Perl_grok_atoUV(const char *pv, UV *valptr, const char** endptr)
 }
 
 #ifndef Perl_strtod
-STATIC NV
+static NV
 S_mulexp10(NV value, I32 exponent)
 {
     NV result = 1.0;

--- a/op.c
+++ b/op.c
@@ -674,7 +674,7 @@ Perl_op_refcnt_dec(pTHX_ OP *o)
 
 #define RETURN_UNLIMITED_NUMBER (PERL_INT_MAX / 2)
 
-STATIC OP *
+static OP *
 S_no_fh_allowed(pTHX_ OP *o)
 {
     PERL_ARGS_ASSERT_NO_FH_ALLOWED;
@@ -684,7 +684,7 @@ S_no_fh_allowed(pTHX_ OP *o)
     return o;
 }
 
-STATIC OP *
+static OP *
 S_too_few_arguments_pv(pTHX_ OP *o, const char* name, U32 flags)
 {
     PERL_ARGS_ASSERT_TOO_FEW_ARGUMENTS_PV;
@@ -692,7 +692,7 @@ S_too_few_arguments_pv(pTHX_ OP *o, const char* name, U32 flags)
     return o;
 }
 
-STATIC OP *
+static OP *
 S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
 {
     PERL_ARGS_ASSERT_TOO_MANY_ARGUMENTS_PV;
@@ -701,7 +701,7 @@ S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
     return o;
 }
 
-STATIC void
+static void
 S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
 {
     PERL_ARGS_ASSERT_BAD_TYPE_PV;
@@ -710,7 +710,7 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
                  (int)n, PL_op_desc[(o)->op_type], t, OP_DESC(kid)), 0);
 }
 
-STATIC void
+static void
 S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
 {
     SV * const namesv = cv_name((CV *)gv, NULL, 0);
@@ -1027,7 +1027,7 @@ Perl_op_free(pTHX_ OP *o)
 
 /* S_op_clear_gv(): free a GV attached to an OP */
 
-STATIC
+static
 #ifdef USE_ITHREADS
 void S_op_clear_gv(pTHX_ OP *o, PADOFFSET *ixp)
 #else
@@ -1388,7 +1388,7 @@ Perl_op_clear(pTHX_ OP *o)
     }
 }
 
-STATIC void
+static void
 S_cop_free(pTHX_ COP* cop)
 {
     PERL_ARGS_ASSERT_COP_FREE;
@@ -1419,7 +1419,7 @@ S_cop_free(pTHX_ COP* cop)
        PL_curcop = NULL;
 }
 
-STATIC void
+static void
 S_forget_pmop(pTHX_ PMOP *const o)
 {
     HV * const pmstash = PmopSTASH(o);
@@ -1455,7 +1455,7 @@ S_forget_pmop(pTHX_ PMOP *const o)
 }
 
 
-STATIC void
+static void
 S_find_and_forget_pmops(pTHX_ OP *o)
 {
     OP* top_op = o;
@@ -1728,7 +1728,7 @@ Perl_op_parent(OP *o)
  * Returns the new UNOP.
  */
 
-STATIC OP *
+static OP *
 S_op_sibling_newUNOP(pTHX_ OP *parent, OP *start, I32 type, I32 flags)
 {
     OP *kid, *newop;
@@ -1864,7 +1864,7 @@ S_scalarkids(pTHX_ OP *o)
     return o;
 }
 
-STATIC OP *
+static OP *
 S_scalarboolean(pTHX_ OP *o)
 {
     PERL_ARGS_ASSERT_SCALARBOOLEAN;
@@ -2731,7 +2731,7 @@ S_voidnonfinal(pTHX_ OP *o)
     return o;
 }
 
-STATIC OP *
+static OP *
 S_modkids(pTHX_ OP *o, I32 type)
 {
     if (o && o->op_flags & OPf_KIDS) {
@@ -3649,7 +3649,7 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
 }
 
 
-STATIC bool
+static bool
 S_scalar_mod_type(const OP *o, I32 type)
 {
     switch (type) {
@@ -3707,7 +3707,7 @@ S_scalar_mod_type(const OP *o, I32 type)
     }
 }
 
-STATIC bool
+static bool
 S_is_handle_constructor(const OP *o, I32 numargs)
 {
     PERL_ARGS_ASSERT_IS_HANDLE_CONSTRUCTOR;
@@ -3879,7 +3879,7 @@ Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref)
 }
 
 
-STATIC OP *
+static OP *
 S_dup_attrlist(pTHX_ OP *o)
 {
     OP *rop;
@@ -3905,7 +3905,7 @@ S_dup_attrlist(pTHX_ OP *o)
     return rop;
 }
 
-STATIC void
+static void
 S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
 {
     PERL_ARGS_ASSERT_APPLY_ATTRS;
@@ -3930,7 +3930,7 @@ S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
     }
 }
 
-STATIC void
+static void
 S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
 {
     OP *pack, *imop, *arg;
@@ -4029,7 +4029,7 @@ Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv,
                                                attrs)));
 }
 
-STATIC void
+static void
 S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV * name,
                         bool curstash)
 {
@@ -4145,7 +4145,7 @@ S_cant_declare(pTHX_ OP *o)
                                                              "my"));
 }
 
-STATIC OP *
+static OP *
 S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
 {
     I32 type;
@@ -4973,7 +4973,7 @@ S_op_integerize(pTHX_ OP *o)
    setjmp/longjmp() messing with auto variables.  It cannot be inlined because
    it uses setjmp
  */
-STATIC int
+static int
 S_fold_constants_eval(pTHX) {
     int ret = 0;
     dJMPENV;
@@ -8259,7 +8259,7 @@ Perl_newPVOP(pTHX_ I32 type, I32 flags, char *pv)
     return CHECKOP(type, pvop);
 }
 
-STATIC void
+static void
 S_set_package_name(pTHX_ OP *o)
 {
     SV *const sv = cSVOPo->op_sv;
@@ -8277,7 +8277,7 @@ S_set_package_name(pTHX_ OP *o)
     op_free(o);
 }
 
-STATIC void
+static void
 S_set_package_version( pTHX_ OP *v )
 {
     U32 savehints = PL_hints;
@@ -8701,7 +8701,7 @@ Perl_newSLICEOP(pTHX_ I32 flags, OP *subscript, OP *listval)
  *  ASSIGN_REF     \$x  = ...
  */
 
-STATIC I32
+static I32
 S_assignment_type(pTHX_ const OP *o)
 {
     unsigned type;
@@ -9151,7 +9151,7 @@ Perl_cop_has_warning(pTHX_ const COP *cop, int warn_bit)
 }
 
 #define cop_inplace_expand_warning_bitmask(cop)  S_cop_inplace_expand_warning_bitmask(aTHX_ cop)
-STATIC void
+static void
 S_cop_inplace_expand_warning_bitmask(pTHX_ COP *cop)
 {
     const char *warning_bits = cop->cop_warnings;
@@ -9251,7 +9251,7 @@ Perl_newLOGOP(pTHX_ I32 type, I32 flags, OP *first, OP *other)
  * NULL.
  */
 
-STATIC OP *
+static OP *
 S_search_const(pTHX_ OP *o)
 {
     PERL_ARGS_ASSERT_SEARCH_CONST;
@@ -9301,7 +9301,7 @@ S_search_const(pTHX_ OP *o)
 }
 
 
-STATIC OP *
+static OP *
 S_new_logop(pTHX_ I32 type, I32 flags, OP** firstp, OP** otherp)
 {
     LOGOP *logop;
@@ -10352,7 +10352,7 @@ Perl_newLOOPEX(pTHX_ I32 type, OP *label)
 /* if the condition is a literal array or hash
    (or @{ ... } etc), make a reference to it.
  */
-STATIC OP *
+static OP *
 S_ref_array_or_hash(pTHX_ OP *cond)
 {
     if (cond
@@ -10391,7 +10391,7 @@ S_ref_array_or_hash(pTHX_ OP *cond)
    op_other if the match fails.)
  */
 
-STATIC OP *
+static OP *
 S_newGIVWHENOP(pTHX_ OP *cond, OP *block,
                    I32 enter_opcode, I32 leave_opcode,
                    PADOFFSET entertarg)
@@ -10447,7 +10447,7 @@ S_newGIVWHENOP(pTHX_ OP *cond, OP *block,
 
    [*] possibly surprising
  */
-STATIC bool
+static bool
 S_looks_like_bool(pTHX_ const OP *o)
 {
     PERL_ARGS_ASSERT_LOOKS_LIKE_BOOL;
@@ -11852,7 +11852,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
     return cv;
 }
 
-STATIC CV*
+static CV*
 S_clear_special_blocks(pTHX_ const char *const fullname,
                        GV *const gv, CV *const cv) {
     const char *colon;
@@ -11880,7 +11880,7 @@ S_clear_special_blocks(pTHX_ const char *const fullname,
 }
 
 /* Returns true if the sub has been freed.  */
-STATIC bool
+static bool
 S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
                          GV *const gv,
                          CV *const cv)
@@ -14630,7 +14630,7 @@ Perl_ck_sort(pTHX_ OP *o)
  * Also, check and warn on lexical $a, $b.
  */
 
-STATIC void
+static void
 S_simplify_sort(pTHX_ OP *o)
 {
     OP *kid = OpSIBLING(cLISTOPo->op_first);	/* get past pushmark */
@@ -15557,7 +15557,7 @@ The C-level function pointer is supplied in C<ckfun>, an SV argument for
 it is supplied in C<ckobj>, and control flags are supplied in C<ckflags>.
 The function should be defined like this:
 
-    STATIC OP * ckfun(pTHX_ OP *op, GV *namegv, SV *ckobj)
+    static OP * ckfun(pTHX_ OP *op, GV *namegv, SV *ckobj)
 
 It is intended to be called in this manner:
 
@@ -15993,7 +15993,7 @@ Perl_ck_isa(pTHX_ OP *o)
 /* Check for in place reverse and sort assignments like "@a = reverse @a"
    and modify the optree to make them work inplace */
 
-STATIC void
+static void
 S_inplace_aassign(pTHX_ OP *o) {
 
     OP *modop, *modop_pushmark;

--- a/packsizetables.inc
+++ b/packsizetables.inc
@@ -11,7 +11,7 @@
 typedef U8 packprops_t;
 #if 'J'-'I' == 1
 /* ASCII */
-STATIC const packprops_t packprops[512] = {
+static const packprops_t packprops[512] = {
     /* normal */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -116,7 +116,7 @@ STATIC const packprops_t packprops[512] = {
 };
 #else
 /* EBCDIC (or bust) */
-STATIC const packprops_t packprops[512] = {
+static const packprops_t packprops[512] = {
     /* normal */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/pad.c
+++ b/pad.c
@@ -867,7 +867,7 @@ C<is_our> indicates that the name to check is an C<"our"> declaration.
 =cut
 */
 
-STATIC void
+static void
 S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
 {
     PADNAME	**svp;
@@ -1102,7 +1102,7 @@ S_unavailable(pTHX_ PADNAME *name)
                PNfARG(name));
 }
 
-STATIC PADOFFSET
+static PADOFFSET
 S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv, U32 seq,
         int warn, SV** out_capture, PADNAME** out_name, int *out_flags)
 {
@@ -1876,7 +1876,7 @@ dump the contents of a CV
 =cut
 */
 
-STATIC void
+static void
 S_cv_dump(pTHX_ const CV *cv, const char *title)
 {
     const CV * const outside = CvOUTSIDE(cv);

--- a/peep.c
+++ b/peep.c
@@ -108,7 +108,7 @@ struct sprintf_ismc_info {
  * populated.
  */
 
-STATIC bool
+static bool
 S_sprintf_is_multiconcatable(pTHX_ OP *o,struct sprintf_ismc_info *info)
 {
     OP    *pm, *constop, *kid;
@@ -229,7 +229,7 @@ S_sprintf_is_multiconcatable(pTHX_ OP *o,struct sprintf_ismc_info *info)
  * away with OPpTARGET_MY set on the OP_STRINGIFY or OP_CONCAT.
  */
 
-STATIC void
+static void
 S_maybe_multiconcat(pTHX_ OP *o)
 {
     OP *lastkidop;   /* the right-most of any kids unshifted onto o */
@@ -1064,7 +1064,7 @@ S_warn_implicit_snail_cvsig(pTHX_ OP *o)
  * to optimise any children.
  */
 
-STATIC void
+static void
 S_optimize_op(pTHX_ OP* o)
 {
     OP *top_op = o;
@@ -1210,7 +1210,7 @@ For now it's static, but it may be exposed to the API in the future.
 =cut
 */
 
-STATIC OP*
+static OP*
 S_traverse_op_tree(pTHX_ OP *top, OP *o) {
     OP *sib;
 
@@ -1236,7 +1236,7 @@ S_traverse_op_tree(pTHX_ OP *top, OP *o) {
     }
 }
 
-STATIC void
+static void
 S_finalize_op(pTHX_ OP* o)
 {
     OP * const top = o;
@@ -1909,7 +1909,7 @@ S_aassign_scan(pTHX_ OP* o, bool rhs, int *scalars_p)
  * OPpHINT_STRICT_REFS) as found in any rv2av/hv skipped by the caller.
  */
 
-STATIC void
+static void
 S_maybe_multideref(pTHX_ OP *start, OP *orig_o, UV orig_action, U8 hints)
 {
     int pass;

--- a/perl.c
+++ b/perl.c
@@ -2200,7 +2200,7 @@ S_moreswitch_m(pTHX_ char option, const char *s)
 #define INCPUSH_ADD_SUB_DIRS	\
     (INCPUSH_ADD_VERSIONED_SUB_DIRS|INCPUSH_ADD_ARCHONLY_SUB_DIRS)
 
-STATIC void *
+static void *
 S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
 {
     PerlIO *rsfp;
@@ -2829,7 +2829,7 @@ perl_run(pTHXx)
     return ret;
 }
 
-STATIC void
+static void
 S_run_body(pTHX_ I32 oldscope)
 {
     DEBUG_r(PerlIO_printf(Perl_debug_log, "%s $` $& $' support (0x%x).\n",
@@ -3525,7 +3525,7 @@ Perl_require_pv(pTHX_ const char *pv)
     POPSTACK;
 }
 
-STATIC void
+static void
 S_usage(pTHX)		/* XXX move this out into a module ? */
 {
     /* This message really ought to be max 23 lines.
@@ -3974,7 +3974,7 @@ Perl_moreswitches(pTHX_ const char *s)
 }
 
 
-STATIC void
+static void
 S_minus_v(pTHX)
 {
         PerlIO * PIO_stdout;
@@ -4094,7 +4094,7 @@ Perl_my_unexec(pTHX)
 }
 
 /* initialize curinterp */
-STATIC void
+static void
 S_init_interp(pTHX)
 {
 #ifdef MULTIPLICITY
@@ -4126,7 +4126,7 @@ S_init_interp(pTHX)
 
 }
 
-STATIC void
+static void
 S_init_main_stash(pTHX)
 {
     GV *gv;
@@ -4175,7 +4175,7 @@ S_init_main_stash(pTHX)
     sv_setpvs(get_sv("/", GV_ADD), "\n");
 }
 
-STATIC PerlIO *
+static PerlIO *
 S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
 {
     int fdscript = -1;
@@ -4313,7 +4313,7 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
 #ifdef SETUID_SCRIPTS_ARE_SECURE_NOW
 /* Don't even need this function.  */
 #else
-STATIC void
+static void
 S_validate_suid(pTHX_ PerlIO *rsfp)
 {
     const Uid_t  my_uid = PerlProc_getuid();
@@ -4341,7 +4341,7 @@ FIX YOUR KERNEL, PUT A C WRAPPER AROUND THIS SCRIPT, OR USE -u AND UNDUMP!\n");
 }
 #endif /* SETUID_SCRIPTS_ARE_SECURE_NOW */
 
-STATIC void
+static void
 S_find_beginning(pTHX_ SV* linestr_sv, PerlIO *rsfp)
 {
     const char *s;
@@ -4370,7 +4370,7 @@ S_find_beginning(pTHX_ SV* linestr_sv, PerlIO *rsfp)
 }
 
 
-STATIC void
+static void
 S_init_ids(pTHX)
 {
     /* no need to do anything here any more if we don't
@@ -4441,7 +4441,7 @@ Perl_doing_taint(int argc, char *argv[], char *envp[])
    optimisation.  The only message that isn't /^-.$/ is
    "program input from stdin", which is substituted in place of '\0', which
    could never be a command line flag.  */
-STATIC void
+static void
 S_forbid_setid(pTHX_ const char flag, const bool suidscript) /* g */
 {
     char string[3] = "-x";
@@ -4578,7 +4578,7 @@ Perl_init_stacks(pTHX)
 
 #undef REASONABLE
 
-STATIC void
+static void
 S_nuke_stacks(pTHX)
 {
     while (PL_curstackinfo->si_next)
@@ -4633,7 +4633,7 @@ Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
 }
 
 
-STATIC void
+static void
 S_init_predump_symbols(pTHX)
 {
     GV *tmpgv;
@@ -4747,7 +4747,7 @@ Perl_init_argv_symbols(pTHX_ int argc, char **argv)
                     "reading from STDIN");
 }
 
-STATIC void
+static void
 S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
 {
     GV* tmpgv;
@@ -4895,7 +4895,7 @@ S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
     }
 }
 
-STATIC void
+static void
 S_init_perllib(pTHX)
 {
 #ifndef VMS
@@ -4982,7 +4982,7 @@ S_init_perllib(pTHX)
 /* Push a directory onto @INC if it exists.
    Generate a new SV if we do this, to save needing to copy the SV we push
    onto @INC  */
-STATIC SV *
+static SV *
 S_incpush_if_exists(pTHX_ AV *const av, SV *dir, SV *const stem)
 {
     Stat_t tmpstatbuf;
@@ -5001,7 +5001,7 @@ S_incpush_if_exists(pTHX_ AV *const av, SV *dir, SV *const stem)
 }
 #endif
 
-STATIC SV *
+static SV *
 S_mayberelocate(pTHX_ const char *const dir, STRLEN len, U32 flags)
 {
     const U8 canrelocate = (U8)flags & INCPUSH_CAN_RELOCATE;
@@ -5136,7 +5136,7 @@ S_mayberelocate(pTHX_ const char *const dir, STRLEN len, U32 flags)
     return libdir;
 }
 
-STATIC void
+static void
 S_incpush(pTHX_ const char *const dir, STRLEN len, U32 flags)
 {
 #ifndef PERL_IS_MINIPERL
@@ -5253,7 +5253,7 @@ S_incpush(pTHX_ const char *const dir, STRLEN len, U32 flags)
     }
 }
 
-STATIC void
+static void
 S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags)
 {
     const char *s;
@@ -5517,7 +5517,7 @@ Perl_my_failure_exit(pTHX)
     my_exit_jump();
 }
 
-STATIC void
+static void
 S_my_exit_jump(pTHX)
 {
     if (PL_e_script) {

--- a/perl.h
+++ b/perl.h
@@ -252,8 +252,6 @@ Now a synonym for C<L</dTHXa>>.
 #  define dTHX_DEBUGGING dNOOP
 #endif
 
-#define STATIC static
-
 #ifndef PERL_CORE
 /* Do not use these macros. They were part of PERL_OBJECT, which was an
  * implementation of multiplicity using C++ objects. They have been left
@@ -268,6 +266,7 @@ Now a no-op.
 
 =cut
  */
+#  define STATIC static
 #  define CPERLscope(x) x
 #  define CPERLarg void
 #  define CPERLarg_

--- a/perl.h
+++ b/perl.h
@@ -4477,11 +4477,11 @@ typedef        struct crypt_data {     /* straight from /usr/include/crypt.h */
 #    define PERL_CALLCONV_NO_RET PERL_CALLCONV
 #endif
 
-/* PERL_STATIC_NO_RET is supposed to be equivalent to STATIC on builds that
+/* PERL_STATIC_NO_RET is supposed to be equivalent to static on builds that
    dont have a noreturn as a declaration specifier
 */
 #ifndef PERL_STATIC_NO_RET
-#  define PERL_STATIC_NO_RET STATIC
+#  define PERL_STATIC_NO_RET static
 #endif
 
 /* PERL_STATIC_INLINE_NO_RET is supposed to be equivalent to PERL_STATIC_INLINE

--- a/perlstatic.h
+++ b/perlstatic.h
@@ -18,7 +18,7 @@
 /* saves machine code for a common noreturn idiom typically used in Newx*() */
 GCC_DIAG_IGNORE_DECL(-Wunused-function);
 
-STATIC void
+static void
 Perl_croak_memory_wrap(void)
 {
     Perl_croak_nocontext("%s",PL_memory_wrap);

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -1784,7 +1784,7 @@ C<MAGIC> pointers can be identified as a particular kind of magic
 using their magic virtual table.  C<mg_findext> provides an easy way
 to do that:
 
-    STATIC MGVTBL my_vtbl = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    static MGVTBL my_vtbl = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     MAGIC *mg;
     if ((mg = mg_findext(sv, PERL_MAGIC_ext, &my_vtbl))) {
@@ -2763,8 +2763,8 @@ As of perl 5.14 it is possible to hook into the compile-time lexical
 scope mechanism using C<Perl_blockhook_register>.  This is used like
 this:
 
-    STATIC void my_start_hook(pTHX_ int full);
-    STATIC BHK my_hooks;
+    static void my_start_hook(pTHX_ int full);
+    static BHK my_hooks;
 
     BOOT:
         BhkENTRY_set(&my_hooks, bhk_start, my_start_hook);
@@ -2934,14 +2934,8 @@ or pass nothing.  To solve this, the subroutines are named and
 declared in a particular way.  Here's a typical start of a static
 function used within the Perl guts:
 
-  STATIC void
+  static void
   S_incline(pTHX_ char *s)
-
-STATIC becomes "static" in C, and may be #define'd to nothing in some
-configurations in the future.
-
-=for apidoc_section $directives
-=for apidoc Ayh||STATIC
 
 A public function (i.e. part of the internal API, but not necessarily
 sanctioned for use in extensions) begins like this:
@@ -3057,9 +3051,9 @@ your Foo.xs:
         #include "perl.h"
         #include "XSUB.h"
 
-        STATIC void my_private_function(int arg1, int arg2);
+        static void my_private_function(int arg1, int arg2);
 
-        STATIC void
+        static void
         my_private_function(int arg1, int arg2)
         {
             dTHX;       /* fetch context */
@@ -3100,9 +3094,9 @@ the Perl guts:
         #include "XSUB.h"
 
         /* pTHX_ only needed for functions that call Perl API */
-        STATIC void my_private_function(pTHX_ int arg1, int arg2);
+        static void my_private_function(pTHX_ int arg1, int arg2);
 
-        STATIC void
+        static void
         my_private_function(pTHX_ int arg1, int arg2)
         {
             /* dTHX; not needed here, because THX is an argument */
@@ -4712,7 +4706,7 @@ ignored). On RC builds it expands to something like
         return Perl_pp_wrap(aTHX_ S_Perl_pp_foo_norc, nargs, nlists);
     }
 
-    STATIC OP* S_Perl_pp_foo_norc(pTHX)
+    static OP* S_Perl_pp_foo_norc(pTHX)
     {
         ...
     }

--- a/pp.c
+++ b/pp.c
@@ -499,7 +499,7 @@ PP(pp_refgen)
 }
 
 
-STATIC SV*
+static SV*
 S_refto(pTHX_ SV *sv)
 {
     SV* rv;
@@ -5505,7 +5505,7 @@ PP_wrapped(pp_each, 1, 0)
     RETURN;
 }
 
-STATIC OP *
+static OP *
 S_do_delete_local(pTHX)
 {
     dSP;
@@ -7787,7 +7787,7 @@ PP(pp_anonconst)
  * at each position from startix onwards until endix.
  */
 #define av_refresh_elements_range(av, startix, endix)  S_av_refresh_elements_range(aTHX_ av, startix, endix)
-STATIC void
+static void
 S_av_refresh_elements_range(pTHX_ AV *av, IV startix, IV endix)
 {
     for(IV ix = startix; ix < endix; ix++) {
@@ -8036,7 +8036,7 @@ PP(pp_argcheck)
  * error message string
  */
 #define accumulate_error_names(n_errorsp, error_namesp, namepv, namelen)  S_accumulate_error_names(aTHX_ n_errorsp, error_namesp, namepv, namelen)
-STATIC void
+static void
 S_accumulate_error_names(pTHX_ size_t *n_errorsp, SV **error_namesp, const char *namepv, STRLEN namelen)
 {
     size_t n_errors = ++(*n_errorsp);

--- a/pp.h
+++ b/pp.h
@@ -43,13 +43,13 @@ rewritten to replace PUSHs() etc with rpp_push_1() etc.
 #ifdef PERL_RC_STACK
 #  define XSPP_wrapped(xsppw_name, xsppw_nargs, xsppw_nlists)  \
                                                                \
-STATIC OP* S_##xsppw_name##_norc(pTHX);                        \
+static OP* S_##xsppw_name##_norc(pTHX);                        \
 OP* xsppw_name(pTHX)                                           \
 {                                                              \
     return Perl_pp_wrap(aTHX_ S_##xsppw_name##_norc,           \
                         (xsppw_nargs), (xsppw_nlists));        \
 }                                                              \
-STATIC OP* S_##xsppw_name##_norc(pTHX)
+static OP* S_##xsppw_name##_norc(pTHX)
 
 #else
 #  define XSPP_wrapped(xsppw_name, xsppw_nargs, xsppw_nlists)  \

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1571,7 +1571,7 @@ static const char * const context_name[] = {
     "defer block",
 };
 
-STATIC I32
+static I32
 S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
 {
     I32 i;
@@ -1696,7 +1696,7 @@ Perl_was_lvalue_sub(pTHX)
         return 0;
 }
 
-STATIC I32
+static I32
 S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
 {
     I32 i;
@@ -1735,7 +1735,7 @@ S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
     return i;
 }
 
-STATIC I32
+static I32
 S_dopoptoeval(pTHX_ I32 startingblock)
 {
     I32 i;
@@ -1752,7 +1752,7 @@ S_dopoptoeval(pTHX_ I32 startingblock)
     return i;
 }
 
-STATIC I32
+static I32
 S_dopoptoloop(pTHX_ I32 startingblock)
 {
     I32 i;
@@ -1787,7 +1787,7 @@ S_dopoptoloop(pTHX_ I32 startingblock)
 
 /* find the next GIVEN or FOR (with implicit $_) loop context block */
 
-STATIC I32
+static I32
 S_dopoptogivenfor(pTHX_ I32 startingblock)
 {
     I32 i;
@@ -1815,7 +1815,7 @@ S_dopoptogivenfor(pTHX_ I32 startingblock)
     return i;
 }
 
-STATIC I32
+static I32
 S_dopoptowhen(pTHX_ I32 startingblock)
 {
     I32 i;
@@ -3165,7 +3165,7 @@ PP(pp_redo)
 #define UNENTERABLE (OP *)1
 #define GOTO_DEPTH 64
 
-STATIC OP *
+static OP *
 S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstack, OP **oplimit)
 {
     OP **ops = opstack;
@@ -3764,7 +3764,7 @@ PP_wrapped(pp_exit, 1, 0)
 
 /* Eval. */
 
-STATIC void
+static void
 S_save_lines(pTHX_ AV *array, SV *sv)
 {
     const char *s = SvPVX_const(sv);
@@ -3854,7 +3854,7 @@ See L<perlinterp/"Exception handing"> for further details.
 =cut
 */
 
-STATIC OP *
+static OP *
 S_docatch(pTHX_ Perl_ppaddr_t firstpp)
 {
     int ret;
@@ -3987,7 +3987,7 @@ Perl_find_runcv_where(pTHX_ U8 cond, IV arg, U32 *db_seqp)
  * See also try_run_unitcheck().
  *
  */
-STATIC int
+static int
 S_try_yyparse(pTHX_ int gramtype, OP *caller_op)
 {
     /* if we die during compilation PL_restartop and PL_restartjmpenv
@@ -4043,7 +4043,7 @@ S_try_yyparse(pTHX_ int gramtype, OP *caller_op)
  *
  * See also try_yyparse().
  */
-STATIC int
+static int
 S_try_run_unitcheck(pTHX_ OP* caller_op)
 {
     /* if we die during compilation PL_restartop and PL_restartjmpenv
@@ -4102,7 +4102,7 @@ S_try_run_unitcheck(pTHX_ OP* caller_op)
  * These can be distinguished by whether PL_op is entereval.
  */
 
-STATIC bool
+static bool
 S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
 {
     OP * const saveop = PL_op;
@@ -4360,7 +4360,7 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
  * else return PerlIO_openn().
  */
 
-STATIC PerlIO *
+static PerlIO *
 S_check_type_and_open(pTHX_ SV *name)
 {
     Stat_t st;
@@ -4434,7 +4434,7 @@ S_check_type_and_open(pTHX_ SV *name)
  * try loading Foo.pmc first.
  */
 #ifndef PERL_DISABLE_PMC
-STATIC PerlIO *
+static PerlIO *
 S_doopen_pm(pTHX_ SV *name)
 {
     STRLEN namelen;
@@ -5868,7 +5868,7 @@ PP(pp_leavegiven)
 }
 
 /* Helper routines used by pp_smartmatch */
-STATIC PMOP *
+static PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
 {
     PMOP *matcher = cPMOPx(newPMOP(OP_MATCH, OPf_WANT_SCALAR | OPf_STACKED));
@@ -5883,7 +5883,7 @@ S_make_matcher(pTHX_ REGEXP *re)
     return matcher;
 }
 
-STATIC bool
+static bool
 S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
 {
     bool result;
@@ -5898,7 +5898,7 @@ S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
     return result;
 }
 
-STATIC void
+static void
 S_destroy_matcher(pTHX_ PMOP *matcher)
 {
     PERL_ARGS_ASSERT_DESTROY_MATCHER;
@@ -5920,7 +5920,7 @@ PP(pp_smartmatch)
 /* This version of do_smartmatch() implements the
  * table of smart matches that is found in perlsyn.
  */
-STATIC OP *
+static OP *
 S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
 {
     bool object_on_left = FALSE;
@@ -6853,7 +6853,7 @@ S_doparseform(pTHX_ SV *sv)
 }
 
 
-STATIC bool
+static bool
 S_num_overflow(NV value, I32 fldsize, I32 frcsize)
 {
     /* Can value be printed in fldsize chars, using %*.*f ? */

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -47,7 +47,7 @@
  * args
  */
 
-STATIC void
+static void
 S_pp_xs_wrap_return(pTHX_ I32 nargs, I32 old_sp)
 {
     I32 nret = (I32)(PL_stack_sp - PL_stack_base) - old_sp;
@@ -1439,7 +1439,7 @@ PP(pp_multiconcat)
 /* push the elements of av onto the stack.
  * Returns PL_op->op_next to allow tail-call optimisation of its callers */
 
-STATIC OP*
+static OP*
 S_pushav(pTHX_ AV* const av)
 {
     const SSize_t maxarg = AvFILL(av) + 1;
@@ -2494,7 +2494,7 @@ PP(pp_rv2av)
 }
 
 
-STATIC void
+static void
 S_do_oddball(pTHX_ SV **oddkey, SV **firstkey)
 {
     PERL_ARGS_ASSERT_DO_ODDBALL;
@@ -2705,7 +2705,7 @@ S_aassign_copy_common(pTHX_ SV **firstlelem, SV **lastlelem,
  * PL_delaymagic; now we tell the OS to update the uids/gids atomically.
  */
 
-STATIC void
+static void
 S_aassign_uid(pTHX)
 {
     /* Will be used to set PL_tainting below */
@@ -3649,7 +3649,7 @@ PP(pp_qr)
     return NORMAL;
 }
 
-STATIC bool
+static bool
 S_are_we_in_Debug_EXECUTE_r(pTHX)
 {
     /* Given a 'use re' is in effect, does it ask for outputting execution
@@ -4443,7 +4443,7 @@ PP(pp_helem)
 /* a stripped-down version of Perl_softref2xv() for use by
  * pp_multideref(), which doesn't use PL_op->op_flags */
 
-STATIC GV *
+static GV *
 S_softref2xv_lite(pTHX_ SV *const sv, const char *const what,
                 const svtype type)
 {

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -182,7 +182,7 @@ STMT_START {						\
 #define FLAG_COMMA            0x02
 #define FLAG_PACK             0x01
 
-STATIC SV *
+static SV *
 S_mul128(pTHX_ SV *sv, U8 m)
 {
   STRLEN          len;
@@ -244,7 +244,7 @@ S_reverse_copy(const char *src, char *dest, STRLEN len)
         *--dest = *src++;
 }
 
-STATIC U8
+static U8
 utf8_to_byte(pTHX_ const char **s, const char *end, I32 datumtype)
 {
     STRLEN retlen;
@@ -275,7 +275,7 @@ utf8_to_byte(pTHX_ const char **s, const char *end, I32 datumtype)
         utf8_to_byte(aTHX_ &(s), (strend), (datumtype)) : \
         *(U8 *)(s)++)
 
-STATIC bool
+static bool
 S_utf8_to_bytes(pTHX_ const char **s, const char *end, const char *buf, SSize_t buf_len, I32 datumtype)
 {
     UV val;
@@ -355,7 +355,7 @@ S_utf8_to_bytes(pTHX_ const char **s, const char *end, const char *buf, SSize_t 
     return TRUE;
 }
 
-STATIC char *
+static char *
 S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swap) {
     PERL_ARGS_ASSERT_MY_BYTES_TO_UTF8;
 
@@ -455,7 +455,7 @@ static const char *action_( const tempsym_t* symptr )
 }
 
 /* Returns the sizeof() struct described by pat */
-STATIC SSize_t
+static SSize_t
 S_measure_struct(pTHX_ tempsym_t* symptr)
 {
     SSize_t total = 0;
@@ -566,7 +566,7 @@ S_measure_struct(pTHX_ tempsym_t* symptr)
 /* locate matching closing parenthesis or bracket
  * returns char pointer to char after match, or NULL
  */
-STATIC const char *
+static const char *
 S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
 {
     PERL_ARGS_ASSERT_GROUP_END;
@@ -599,7 +599,7 @@ S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
  * Expects a pointer to the first digit and address of length variable
  * Advances char pointer to 1st non-digit char and returns number
  */
-STATIC const char *
+static const char *
 S_get_num(pTHX_ const char *patptr, SSize_t *lenptr )
 {
   SSize_t len = *patptr++ - '0';
@@ -619,7 +619,7 @@ S_get_num(pTHX_ const char *patptr, SSize_t *lenptr )
 /* The marvellous template parsing routine: Using state stored in *symptr,
  * locates next template code and count
  */
-STATIC bool
+static bool
 S_next_symbol(pTHX_ tempsym_t* symptr )
 {
   const char* patptr = symptr->patptr;
@@ -803,7 +803,7 @@ S_next_symbol(pTHX_ tempsym_t* symptr )
    version of the string. Users are advised to upgrade their pack string
    themselves if they need to do a lot of unpacks like this on it
 */
-STATIC bool
+static bool
 S_need_utf8(const char *pat, const char *patend)
 {
     bool first = TRUE;
@@ -823,7 +823,7 @@ S_need_utf8(const char *pat, const char *patend)
     return FALSE;
 }
 
-STATIC char
+static char
 S_first_symbol(const char *pat, const char *patend) {
     PERL_ARGS_ASSERT_FIRST_SYMBOL;
 
@@ -884,7 +884,7 @@ Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, cons
     return unpack_rec(&sym, s, s, strend, NULL );
 }
 
-STATIC SSize_t
+static SSize_t
 S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const char *strend, const char **new_s )
 {
     dSP;
@@ -1902,7 +1902,7 @@ PP_wrapped(pp_unpack, 2, 0)
     RETURN;
 }
 
-STATIC U8 *
+static U8 *
 doencodes(U8 *h, const U8 *s, SSize_t len)
 {
     *h++ = PL_uuemap[len];
@@ -1925,7 +1925,7 @@ doencodes(U8 *h, const U8 *s, SSize_t len)
     return h;
 }
 
-STATIC SV *
+static SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)
 {
   SV *result = newSVpvn(s, l);
@@ -1976,7 +1976,7 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
 }
 
 /* pnum must be '\0' terminated */
-STATIC int
+static int
 S_div128(pTHX_ SV *pnum, bool *done)
 {
     STRLEN len;
@@ -2028,7 +2028,7 @@ Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, 
 }
 
 /* like sv_utf8_upgrade, but also repoint the group start markers */
-STATIC void
+static void
 marked_upgrade(pTHX_ SV *sv, tempsym_t *sym_ptr) {
     STRLEN len;
     tempsym_t *group;
@@ -2096,7 +2096,7 @@ marked_upgrade(pTHX_ SV *sv, tempsym_t *sym_ptr) {
    needed says how many extra bytes we need (not counting the final '\0')
    Only grows the string if there is an actual lack of space
 */
-STATIC char *
+static char *
 S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed) {
     const STRLEN cur = SvCUR(sv);
     const STRLEN len = SvLEN(sv);
@@ -2131,7 +2131,7 @@ S_sv_check_infnan(pTHX_ SV *sv, I32 datumtype)
 #define SvUV_no_inf(sv,d) \
         ((sv) = S_sv_check_infnan(aTHX_ sv,d), SvUV_nomg(sv))
 
-STATIC
+static
 SV **
 S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
 {

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -222,7 +222,7 @@ void endservent(void);
     && (defined(HAS_SETREUID) || defined(HAS_SETRESUID)		\
         || defined(HAS_SETREGID) || defined(HAS_SETRESGID))
 /* The Hard Way. */
-STATIC int
+static int
 S_emulate_eaccess(pTHX_ const char* path, Mode_t mode)
 {
     const Uid_t ruid = getuid();
@@ -1632,7 +1632,7 @@ PP_wrapped(pp_getc, MAXARG, 0)
     RETURN;
 }
 
-STATIC OP *
+static OP *
 S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
 {
     PERL_CONTEXT *cx;
@@ -3345,7 +3345,7 @@ S_ft_return_true(pTHX_ SV *ret) {
         }						   \
     } STMT_END
 
-STATIC OP *
+static OP *
 S_try_amagic_ftest(pTHX_ char chr) {
     SV *const arg = *PL_stack_sp;
 
@@ -4091,7 +4091,7 @@ PP_wrapped(pp_readlink, 1, 0)
 }
 
 #if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
-STATIC int
+static int
 S_dooneliner(pTHX_ const char *cmd, const char *filename)
 {
     char * const save_filename = filename;

--- a/proto.h
+++ b/proto.h
@@ -5839,7 +5839,7 @@ Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *
 
 #endif
 #if !defined(HAS_STRLCPY)
-STATIC Size_t
+static Size_t
 Perl_my_strlcpy(char *dst, const char *src, Size_t size);
 # define PERL_ARGS_ASSERT_MY_STRLCPY
 
@@ -6267,19 +6267,19 @@ PERL_CALLCONV UV
 Perl_to_fold_latin1_(const U8 c, U8 *p, STRLEN *lenp, const unsigned int flags);
 # endif
 # if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
-STATIC U8
+static U8
 S_put_charclass_bitmap_innards(pTHX_ SV *sv, char *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display);
-STATIC SV *
+static SV *
 S_put_charclass_bitmap_innards_common(pTHX_ SV *invlist, SV *posixes, SV *only_utf8, SV *not_utf8, SV *only_utf8_locale, const bool invert);
-STATIC void
+static void
 S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV *invlist);
-STATIC void
+static void
 S_put_code_point(pTHX_ SV *sv, UV c);
-STATIC void
+static void
 S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals);
-STATIC void
+static void
 S_regdump_extflags(pTHX_ const char *lead, const U32 flags);
-STATIC void
+static void
 S_regdump_intflags(pTHX_ const char *lead, const U32 flags);
 # endif /* defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING) */
 #endif /* defined(PERL_CORE) || defined(PERL_EXT) */
@@ -6361,7 +6361,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode);
 
 #endif /* !defined(PERL_IMPLICIT_SYS) */
 #if defined(PERL_IN_AV_C)
-STATIC MAGIC *
+static MAGIC *
 S_get_aux_mg(pTHX_ AV *av);
 # define PERL_ARGS_ASSERT_GET_AUX_MG            \
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
@@ -6391,7 +6391,7 @@ Perl_prepare_export_lexical(pTHX)
 
 #endif /* defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C) */
 #if defined(PERL_IN_CLASS_C)
-STATIC void
+static void
 S_class_cleanup_definition(pTHX_ HV *stash);
 # define PERL_ARGS_ASSERT_CLASS_CLEANUP_DEFINITION \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
@@ -6819,41 +6819,41 @@ Perl_croak_kw_unless_class(pTHX_ const char *kw);
           defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) ||
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DEB_C)
-STATIC void
+static void
 S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base);
 # define PERL_ARGS_ASSERT_DEB_STACK_N           \
         assert(stack_base)
 
 #endif
 #if defined(PERL_IN_DOIO_C)
-STATIC bool
+static bool
 S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit);
 # define PERL_ARGS_ASSERT_ARGVOUT_FINAL         \
         assert(mg); assert(io)
 
-STATIC void
+static void
 S_exec_failed(pTHX_ const char *cmd, int fd, int do_report);
 # define PERL_ARGS_ASSERT_EXEC_FAILED           \
         assert(cmd)
 
-STATIC bool
+static bool
 S_is_fork_open(const char *name);
 # define PERL_ARGS_ASSERT_IS_FORK_OPEN          \
         assert(name)
 
-STATIC bool
+static bool
 S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname, PerlIO *saveifp, PerlIO *saveofp, int savefd, char savetype, int writing, bool was_fdopen, const char *type, Stat_t *statbufp);
 # define PERL_ARGS_ASSERT_OPENN_CLEANUP         \
         assert(gv); assert(io); assert(mode); assert(oname)
 
-STATIC IO *
+static IO *
 S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int *savefd, char *savetype);
 # define PERL_ARGS_ASSERT_OPENN_SETUP           \
         assert(gv); assert(mode); assert(saveifp); assert(saveofp); \
         assert(savefd); assert(savetype)
 
 # if !defined(DOSISH)
-STATIC bool
+static bool
 S_ingroup(pTHX_ Gid_t testgid, bool effective)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_INGROUP
@@ -6861,31 +6861,31 @@ S_ingroup(pTHX_ Gid_t testgid, bool effective)
 # endif
 #endif /* defined(PERL_IN_DOIO_C) */
 #if defined(PERL_IN_DOOP_C)
-STATIC Size_t
+static Size_t
 S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COMPLEX      \
         assert(sv); assert(tbl)
 
-STATIC Size_t
+static Size_t
 S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT        \
         assert(sv); assert(tbl)
 
-STATIC Size_t
+static Size_t
 S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP \
         assert(sv); assert(invmap); assert(SvTYPE(invmap) == SVt_PVAV)
 
-STATIC Size_t
+static Size_t
 S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_INVMAP       \
         assert(sv); assert(invmap); assert(SvTYPE(invmap) == SVt_PVAV)
 
-STATIC Size_t
+static Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_SIMPLE       \
@@ -6952,26 +6952,26 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 
 #endif
 #if defined(PERL_IN_DUMP_C)
-STATIC CV *
+static CV *
 S_deb_curcv(pTHX_ I32 ix);
 # define PERL_ARGS_ASSERT_DEB_CURCV
 
-STATIC void
+static void
 S_debprof(pTHX_ const OP *o);
 # define PERL_ARGS_ASSERT_DEBPROF               \
         assert(o)
 
-STATIC SV *
+static SV *
 S_pm_description(pTHX_ const PMOP *pm);
 # define PERL_ARGS_ASSERT_PM_DESCRIPTION        \
         assert(pm)
 
-STATIC char *
+static char *
 S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim, I32 pretty_flags);
 # define PERL_ARGS_ASSERT_PV_DISPLAY_FLAGS      \
         assert(dsv); assert(pv)
 
-STATIC UV
+static UV
 S_sequence_num(pTHX_ const OP *o);
 # define PERL_ARGS_ASSERT_SEQUENCE_NUM
 
@@ -6992,44 +6992,44 @@ Perl_hv_kill_backrefs(pTHX_ HV *hv)
 
 #endif
 #if defined(PERL_IN_GV_C)
-STATIC bool
+static bool
 S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len, const U32 is_utf8, const I32 add, const svtype sv_type);
 # define PERL_ARGS_ASSERT_FIND_DEFAULT_STASH    \
         assert(stash); assert(name)
 
-STATIC void
+static void
 S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type);
 # define PERL_ARGS_ASSERT_GV_INIT_SVTYPE        \
         assert(gv)
 
-STATIC bool
+static bool
 S_gv_is_in_main(pTHX_ const char *name, STRLEN len, const U32 is_utf8);
 # define PERL_ARGS_ASSERT_GV_IS_IN_MAIN         \
         assert(name)
 
-STATIC bool
+static bool
 S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svtype sv_type);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE         \
         assert(gv); assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
         assert(name)
 
-STATIC void
+static void
 S_gv_magicalize_isa(pTHX_ GV *gv);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE_ISA     \
         assert(gv)
 
-STATIC void
+static void
 S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type);
 # define PERL_ARGS_ASSERT_MAYBE_MULTIMAGIC_GV   \
         assert(gv); assert(name)
 
-STATIC bool
+static bool
 S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len, const char *nambeg, STRLEN full_len, const U32 is_utf8, const I32 add);
 # define PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME   \
         assert(stash); assert(gv); assert(name); assert(*name); assert(len); \
         assert(nambeg); assert(nambeg <= *name)
 
-STATIC void
+static void
 S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len, const U32 flags);
 # define PERL_ARGS_ASSERT_REQUIRE_TIE_MOD       \
         assert(gv); assert(name)
@@ -7067,37 +7067,37 @@ Perl_gv_stashsvpvn_cached(pTHX_ SV *namesv, const char *name, U32 namelen, I32 f
 # endif
 #endif /* defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C) */
 #if defined(PERL_IN_HV_C)
-STATIC void
+static void
 S_clear_placeholders(pTHX_ HV *hv, U32 items);
 # define PERL_ARGS_ASSERT_CLEAR_PLACEHOLDERS    \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
-STATIC void
+static void
 S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize);
 # define PERL_ARGS_ASSERT_HSPLIT                \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
-STATIC struct xpvhv_aux *
+static struct xpvhv_aux *
 S_hv_auxinit(pTHX_ HV *hv);
 # define PERL_ARGS_ASSERT_HV_AUXINIT            \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
-STATIC SV *
+static SV *
 S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int k_flags, I32 d_flags, U32 hash);
 # define PERL_ARGS_ASSERT_HV_DELETE_COMMON      \
         assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
-STATIC SV *
+static SV *
 S_hv_free_ent_ret(pTHX_ HE *entry);
 # define PERL_ARGS_ASSERT_HV_FREE_ENT_RET       \
         assert(entry)
 
-STATIC void
+static void
 S_hv_free_entries(pTHX_ HV *hv);
 # define PERL_ARGS_ASSERT_HV_FREE_ENTRIES       \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
-STATIC void
+static void
 S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store);
 # define PERL_ARGS_ASSERT_HV_MAGIC_CHECK        \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(needs_copy); \
@@ -7109,30 +7109,30 @@ S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
 # define PERL_ARGS_ASSERT_HV_NOTALLOWED         \
         assert(key); assert(msg)
 
-STATIC SV *
+static SV *
 S_refcounted_he_value(pTHX_ const struct refcounted_he *he);
 # define PERL_ARGS_ASSERT_REFCOUNTED_HE_VALUE   \
         assert(he)
 
-STATIC HEK *
+static HEK *
 S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVE_HEK_FLAGS        \
         assert(str)
 
-STATIC HEK *
+static HEK *
 S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SHARE_HEK_FLAGS       \
         assert(str)
 
-STATIC void
+static void
 S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash);
 # define PERL_ARGS_ASSERT_UNSHARE_HEK_OR_PVN
 
 # if !defined(PURIFY)
-STATIC HE *
+static HE *
 S_new_he(pTHX)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_NEW_HE
@@ -7156,96 +7156,96 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 
 #endif
 #if defined(PERL_IN_LOCALE_C)
-STATIC utf8ness_t
+static utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const locale_category_index cat_index);
 # define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
 
-STATIC void
+static void
 S_ints_to_tm(pTHX_ struct tm *my_tm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int isdst);
 # define PERL_ARGS_ASSERT_INTS_TO_TM            \
         assert(my_tm); assert(locale)
 
-STATIC bool
+static bool
 S_is_locale_utf8(pTHX_ const char *locale);
 # define PERL_ARGS_ASSERT_IS_LOCALE_UTF8        \
         assert(locale)
 
-STATIC HV *
+static HV *
 S_my_localeconv(pTHX_ const int item);
 # define PERL_ARGS_ASSERT_MY_LOCALECONV
 
-STATIC void
+static void
 S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
 # define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(locale); \
         assert(strings); assert(integers)
 
-STATIC bool
+static bool
 S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool called_externally);
 # define PERL_ARGS_ASSERT_STRFTIME8             \
         assert(fmt); assert(sv); assert(locale); assert(mytm); \
         assert(result_utf8ness)
 
-STATIC bool
+static bool
 S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm)
         __attribute__format__(__strftime__,pTHX_1,0);
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
         assert(fmt); assert(sv); assert(locale); assert(mytm)
 
-STATIC SV *
+static SV *
 S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm);
 # define PERL_ARGS_ASSERT_SV_STRFTIME_COMMON    \
         assert(fmt); assert(locale); assert(mytm)
 
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
-STATIC const char *
+static const char *
 S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item, const char *locale, SV *sv, utf8ness_t *utf8ness);
 #   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \
         assert(locale); assert(sv)
 
 # endif
 # if defined(USE_LOCALE)
-STATIC const char *
+static const char *
 S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING
 
-STATIC const char *
+static const char *
 S_external_call_langinfo(pTHX_ const nl_item item, SV *sv, utf8ness_t *utf8ness);
 #   define PERL_ARGS_ASSERT_EXTERNAL_CALL_LANGINFO \
         assert(sv)
 
-STATIC locale_category_index
+static locale_category_index
 S_get_category_index_helper(pTHX_ const int category, bool *success, const line_t caller_line)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER
 
-STATIC const char *
+static const char *
 S_native_querylocale_i(pTHX_ const locale_category_index cat_index);
 #   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
 
-STATIC void
+static void
 S_new_LC_ALL(pTHX_ const char *lc_all, bool force);
 #   define PERL_ARGS_ASSERT_NEW_LC_ALL          \
         assert(lc_all)
 
-STATIC void
+static void
 S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang);
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
 
-STATIC parse_LC_ALL_string_return
+static parse_LC_ALL_string_return
 S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
         assert(string); assert(output)
 
-STATIC void
+static void
 S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index, const char *original_locale, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
 
-STATIC const char *
+static const char *
 S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size);
 #   define PERL_ARGS_ASSERT_SAVE_TO_BUFFER
 
-STATIC void
+static void
 S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_size);
 #   define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE
 
@@ -7255,13 +7255,13 @@ S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, con
 #   define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_VIA_I \
         assert(failed); assert(higher_caller_file)
 
-STATIC const char *
+static const char *
 S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_locale, const line_t caller_line);
 #   define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I     \
         assert(new_locale)
 
 #   if defined(DEBUGGING)
-STATIC char *
+static char *
 S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const char *locale, const char *retval, const line_t line)
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
@@ -7269,7 +7269,7 @@ S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const
 #   endif
 #   if   defined(HAS_LOCALECONV) && \
        ( defined(USE_LOCALE_MONETARY) || defined(USE_LOCALE_NUMERIC) )
-STATIC void
+static void
 S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2]);
 #     define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
         assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(locale); \
@@ -7277,20 +7277,20 @@ S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 whic
 
 #   endif
 #   if defined(HAS_NL_LANGINFO)
-STATIC const char *
+static const char *
 S_langinfo_sv_i(pTHX_ const nl_item item, locale_category_index cat_index, const char *locale, SV *sv, utf8ness_t *utf8ness);
 #     define PERL_ARGS_ASSERT_LANGINFO_SV_I     \
         assert(locale); assert(sv)
 
 #   endif
 #   if defined(LC_ALL)
-STATIC void
+static void
 S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_line);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(lc_all_string)
 
 #   else
-STATIC void
+static void
 S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_line);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
         assert(curlocales)
@@ -7304,13 +7304,13 @@ S_mortalized_pv_copy(pTHX_ const char * const pv)
 
 #   endif
 #   if defined(USE_LOCALE_COLLATE)
-STATIC void
+static void
 S_new_collate(pTHX_ const char *newcoll, bool force);
 #     define PERL_ARGS_ASSERT_NEW_COLLATE       \
         assert(newcoll)
 
 #     if defined(DEBUGGING)
-STATIC void
+static void
 S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char *xbuf, const STRLEN xlen, const bool is_utf8);
 #       define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN \
         assert(s); assert(e); assert(s <= e)
@@ -7318,46 +7318,46 @@ S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char
 #     endif
 #   endif /* defined(USE_LOCALE_COLLATE) */
 #   if defined(USE_LOCALE_CTYPE)
-STATIC bool
+static bool
 S_is_codeset_name_UTF8(const char *name);
 #     define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8 \
         assert(name)
 
-STATIC void
+static void
 S_new_ctype(pTHX_ const char *newctype, bool force);
 #     define PERL_ARGS_ASSERT_NEW_CTYPE         \
         assert(newctype)
 
 #   endif /* defined(USE_LOCALE_CTYPE) */
 #   if defined(USE_LOCALE_NUMERIC)
-STATIC void
+static void
 S_new_numeric(pTHX_ const char *newnum, bool force);
 #     define PERL_ARGS_ASSERT_NEW_NUMERIC       \
         assert(newnum)
 
 #   endif
 #   if defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING)
-STATIC const char *
+static const char *
 S_get_LC_ALL_display(pTHX);
 #     define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
 
 #   endif
 #   if defined(USE_POSIX_2008_LOCALE)
-STATIC bool
+static bool
 S_bool_setlocale_2008_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line);
 #     define PERL_ARGS_ASSERT_BOOL_SETLOCALE_2008_I \
         assert(new_locale)
 
-STATIC const char *
+static const char *
 S_querylocale_2008_i(pTHX_ const locale_category_index index, const line_t line);
 #     define PERL_ARGS_ASSERT_QUERYLOCALE_2008_I
 
-STATIC locale_t
+static locale_t
 S_use_curlocale_scratch(pTHX);
 #     define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH
 
 #     if !defined(USE_QUERYLOCALE)
-STATIC void
+static void
 S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *new_locale, const line_t caller_line);
 #       define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I \
         assert(new_locale)
@@ -7367,12 +7367,12 @@ S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *ne
          !defined(USE_THREAD_SAFE_LOCALE) &&              \
          !defined(USE_THREAD_SAFE_LOCALE_EMULATION) /* &&
          !defined(USE_POSIX_2008_LOCALE) */
-STATIC bool
+static bool
 S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale);
 #     define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R \
         assert(locale)
 
-STATIC const char *
+static const char *
 S_less_dicey_setlocale_r(pTHX_ const int category, const char *locale);
 #     define PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R
 
@@ -7381,33 +7381,33 @@ S_less_dicey_setlocale_r(pTHX_ const int category, const char *locale);
              !defined(USE_THREAD_SAFE_LOCALE) &&
              !defined(USE_THREAD_SAFE_LOCALE_EMULATION) */
 #   if defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES)
-STATIC wchar_t *
+static wchar_t *
 S_Win_byte_string_to_wstring(const UINT code_page, const char *byte_string);
 #     define PERL_ARGS_ASSERT_WIN_BYTE_STRING_TO_WSTRING
 
-STATIC char *
+static char *
 S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t *wstring);
 #     define PERL_ARGS_ASSERT_WIN_WSTRING_TO_BYTE_STRING
 
-STATIC const char *
+static const char *
 S_win32_setlocale(pTHX_ int category, const char *locale);
 #     define PERL_ARGS_ASSERT_WIN32_SETLOCALE
 
-STATIC const char *
+static const char *
 S_wrap_wsetlocale(pTHX_ const int category, const char *locale);
 #     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
 
 #   endif /* defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) */
 #   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
        ( defined(USE_POSIX_2008_LOCALE) && !defined(USE_QUERYLOCALE) )
-STATIC const char *
+static const char *
 S_find_locale_from_environment(pTHX_ const locale_category_index index);
 #     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
 
 #   endif
 # endif /* defined(USE_LOCALE) */
 # if defined(USE_LOCALE) || defined(DEBUGGING)
-STATIC const char *
+static const char *
 S_get_displayable_string(pTHX_ const char * const s, const char * const e, const bool is_utf8);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING \
         assert(s); assert(e); assert(s <= e)
@@ -7415,38 +7415,38 @@ S_get_displayable_string(pTHX_ const char * const s, const char * const e, const
 # endif
 #endif /* defined(PERL_IN_LOCALE_C) */
 #if defined(PERL_IN_MALLOC_C)
-STATIC int
+static int
 S_adjust_size_and_find_bucket(size_t *nbytes_p);
 # define PERL_ARGS_ASSERT_ADJUST_SIZE_AND_FIND_BUCKET \
         assert(nbytes_p)
 
 #endif
 #if defined(PERL_IN_MG_C)
-STATIC void
+static void
 S_fixup_errno_string(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_FIXUP_ERRNO_STRING    \
         assert(sv)
 
-STATIC SV *
+static SV *
 S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV *val);
 # define PERL_ARGS_ASSERT_MAGIC_METHCALL1       \
         assert(sv); assert(mg); assert(meth)
 
-STATIC int
+static int
 S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth);
 # define PERL_ARGS_ASSERT_MAGIC_METHPACK        \
         assert(sv); assert(mg); assert(meth)
 
-STATIC void
+static void
 S_restore_magic(pTHX_ void *p);
 # define PERL_ARGS_ASSERT_RESTORE_MAGIC
 
-STATIC void
+static void
 S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags);
 # define PERL_ARGS_ASSERT_SAVE_MAGIC_FLAGS      \
         assert(sv)
 
-STATIC void
+static void
 S_unwind_handler_stack(pTHX_ void *p);
 # define PERL_ARGS_ASSERT_UNWIND_HANDLER_STACK
 
@@ -7468,13 +7468,13 @@ Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
 
 #endif
 #if defined(PERL_IN_MRO_C)
-STATIC void
+static void
 S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN len, HV * const exceptions, U32 hash, U32 flags);
 # define PERL_ARGS_ASSERT_MRO_CLEAN_ISAREV      \
         assert(isa); assert(SvTYPE(isa) == SVt_PVHV); assert(name); \
         assert(!exceptions || SvTYPE(exceptions) == SVt_PVHV)
 
-STATIC void
+static void
 S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *stash, HV *oldstash, SV *namesv);
 # define PERL_ARGS_ASSERT_MRO_GATHER_AND_RENAME \
         assert(stashes); assert(SvTYPE(stashes) == SVt_PVHV); \
@@ -7482,195 +7482,195 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *s
         assert(!stash || SvTYPE(stash) == SVt_PVHV); \
         assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(namesv)
 
-STATIC AV *
+static AV *
 S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level);
 # define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA_DFS \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 #endif /* defined(PERL_IN_MRO_C) */
 #if defined(PERL_IN_OP_C)
-STATIC void
+static void
 S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS           \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(target)
 
-STATIC void
+static void
 S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS_MY        \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(target); \
         assert(imopsp)
 
-STATIC I32
+static I32
 S_assignment_type(pTHX_ const OP *o)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ASSIGNMENT_TYPE
 
-STATIC void
+static void
 S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t);
 # define PERL_ARGS_ASSERT_BAD_TYPE_GV           \
         assert(gv); assert(kid); assert(t)
 
-STATIC void
+static void
 S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid);
 # define PERL_ARGS_ASSERT_BAD_TYPE_PV           \
         assert(t); assert(o); assert(kid)
 
-STATIC CV *
+static CV *
 S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv);
 # define PERL_ARGS_ASSERT_CLEAR_SPECIAL_BLOCKS  \
         assert(fullname); assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
-STATIC void
+static void
 S_cop_free(pTHX_ COP *cop);
 # define PERL_ARGS_ASSERT_COP_FREE              \
         assert(cop)
 
-STATIC OP *
+static OP *
 S_dup_attrlist(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_DUP_ATTRLIST          \
         assert(o)
 
-STATIC void
+static void
 S_find_and_forget_pmops(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_FIND_AND_FORGET_PMOPS \
         assert(o)
 
-STATIC OP *
+static OP *
 S_fold_constants(pTHX_ OP * const o);
 # define PERL_ARGS_ASSERT_FOLD_CONSTANTS        \
         assert(o)
 
-STATIC OP *
+static OP *
 S_force_list(pTHX_ OP *arg, bool nullit);
 # define PERL_ARGS_ASSERT_FORCE_LIST
 
-STATIC void
+static void
 S_forget_pmop(pTHX_ PMOP * const o);
 # define PERL_ARGS_ASSERT_FORGET_PMOP           \
         assert(o)
 
-STATIC void
+static void
 S_gen_constant_list(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_GEN_CONSTANT_LIST
 
-STATIC void
+static void
 S_inplace_aassign(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_INPLACE_AASSIGN       \
         assert(o)
 
-STATIC bool
+static bool
 S_is_dup_mode(const OP *o);
 # define PERL_ARGS_ASSERT_IS_DUP_MODE           \
         assert(o)
 
-STATIC bool
+static bool
 S_is_handle_constructor(const OP *o, I32 numargs)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_HANDLE_CONSTRUCTOR \
         assert(o)
 
-STATIC OP *
+static OP *
 S_listkids(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_LISTKIDS
 
-STATIC bool
+static bool
 S_looks_like_bool(pTHX_ const OP *o);
 # define PERL_ARGS_ASSERT_LOOKS_LIKE_BOOL       \
         assert(o)
 
-STATIC OP *
+static OP *
 S_modkids(pTHX_ OP *o, I32 type);
 # define PERL_ARGS_ASSERT_MODKIDS
 
-STATIC void
+static void
 S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash);
 # define PERL_ARGS_ASSERT_MOVE_PROTO_ATTR       \
         assert(proto); assert(attrs); assert(name)
 
-STATIC OP *
+static OP *
 S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp);
 # define PERL_ARGS_ASSERT_MY_KID                \
         assert(imopsp)
 
-STATIC OP *
+static OP *
 S_newGIVWHENOP(pTHX_ OP *cond, OP *block, I32 enter_opcode, I32 leave_opcode, PADOFFSET entertarg);
 # define PERL_ARGS_ASSERT_NEWGIVWHENOP          \
         assert(block)
 
-STATIC OP *
+static OP *
 S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_LOGOP             \
         assert(firstp); assert(otherp)
 
-STATIC OP *
+static OP *
 S_no_fh_allowed(pTHX_ OP *o)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NO_FH_ALLOWED         \
         assert(o)
 
-STATIC OP *
+static OP *
 S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl);
 # define PERL_ARGS_ASSERT_PMTRANS               \
         assert(o); assert(expr); assert(repl)
 
-STATIC bool
+static bool
 S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * const gv, CV * const cv);
 # define PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS \
         assert(fullname); assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
-STATIC OP *
+static OP *
 S_ref_array_or_hash(pTHX_ OP *cond);
 # define PERL_ARGS_ASSERT_REF_ARRAY_OR_HASH
 
-STATIC OP *
+static OP *
 S_refkids(pTHX_ OP *o, I32 type);
 # define PERL_ARGS_ASSERT_REFKIDS
 
-STATIC bool
+static bool
 S_scalar_mod_type(const OP *o, I32 type)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCALAR_MOD_TYPE
 
-STATIC OP *
+static OP *
 S_scalarboolean(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_SCALARBOOLEAN         \
         assert(o)
 
-STATIC OP *
+static OP *
 S_scalarkids(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_SCALARKIDS
 
-STATIC OP *
+static OP *
 S_search_const(pTHX_ OP *o)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SEARCH_CONST          \
         assert(o)
 
-STATIC void
+static void
 S_simplify_sort(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_SIMPLIFY_SORT         \
         assert(o)
 
-STATIC OP *
+static OP *
 S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOO_FEW_ARGUMENTS_PV  \
         assert(o); assert(name)
 
-STATIC OP *
+static OP *
 S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags);
 # define PERL_ARGS_ASSERT_TOO_MANY_ARGUMENTS_PV \
         assert(o); assert(name)
 
-STATIC OP *
+static OP *
 S_voidnonfinal(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_VOIDNONFINAL
 
 # if defined(DEBUGGING)
-STATIC const char *
+static const char *
 S_get_displayable_tr_operand(pTHX_ const U8 *s, STRLEN len, bool is_utf8);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_TR_OPERAND \
         assert(s)
@@ -7756,27 +7756,27 @@ Perl_varname(pTHX_ const GV * const gv, const char gvtype, PADOFFSET targ, const
 
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_PAD_C)
-STATIC PADOFFSET
+static PADOFFSET
 S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash, HV *ourstash);
 # define PERL_ARGS_ASSERT_PAD_ALLOC_NAME        \
         assert(name); assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
-STATIC void
+static void
 S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash);
 # define PERL_ARGS_ASSERT_PAD_CHECK_DUP         \
         assert(name)
 
-STATIC PADOFFSET
+static PADOFFSET
 S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags);
 # define PERL_ARGS_ASSERT_PAD_FINDLEX           \
         assert(namepv); assert(cv); assert(out_name); assert(out_flags)
 
-STATIC void
+static void
 S_pad_reset(pTHX);
 # define PERL_ARGS_ASSERT_PAD_RESET
 
 # if defined(DEBUGGING)
-STATIC void
+static void
 S_cv_dump(pTHX_ const CV *cv, const char *title);
 #   define PERL_ARGS_ASSERT_CV_DUMP             \
         assert(cv); assert(title)
@@ -7784,68 +7784,68 @@ S_cv_dump(pTHX_ const CV *cv, const char *title);
 # endif
 #endif /* defined(PERL_IN_PAD_C) */
 #if defined(PERL_IN_PEEP_C)
-STATIC void
+static void
 S_finalize_op(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_FINALIZE_OP           \
         assert(o)
 
-STATIC void
+static void
 S_optimize_op(pTHX_ OP *o);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OP           \
         assert(o)
 
-STATIC OP *
+static OP *
 S_traverse_op_tree(pTHX_ OP *top, OP *o);
 # define PERL_ARGS_ASSERT_TRAVERSE_OP_TREE      \
         assert(top); assert(o)
 
 #endif /* defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_PERL_C)
-STATIC void
+static void
 S_find_beginning(pTHX_ SV *linestr_sv, PerlIO *rsfp);
 # define PERL_ARGS_ASSERT_FIND_BEGINNING        \
         assert(linestr_sv); assert(rsfp)
 
-STATIC void
+static void
 S_forbid_setid(pTHX_ const char flag, const bool suidscript);
 # define PERL_ARGS_ASSERT_FORBID_SETID
 
-STATIC void
+static void
 S_incpush(pTHX_ const char * const dir, STRLEN len, U32 flags);
 # define PERL_ARGS_ASSERT_INCPUSH               \
         assert(dir)
 
-STATIC void
+static void
 S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags);
 # define PERL_ARGS_ASSERT_INCPUSH_USE_SEP       \
         assert(p)
 
-STATIC void
+static void
 S_init_ids(pTHX);
 # define PERL_ARGS_ASSERT_INIT_IDS
 
-STATIC void
+static void
 S_init_interp(pTHX);
 # define PERL_ARGS_ASSERT_INIT_INTERP
 
-STATIC void
+static void
 S_init_main_stash(pTHX);
 # define PERL_ARGS_ASSERT_INIT_MAIN_STASH
 
-STATIC void
+static void
 S_init_perllib(pTHX);
 # define PERL_ARGS_ASSERT_INIT_PERLLIB
 
-STATIC void
+static void
 S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env);
 # define PERL_ARGS_ASSERT_INIT_POSTDUMP_SYMBOLS \
         assert(argv)
 
-STATIC void
+static void
 S_init_predump_symbols(pTHX);
 # define PERL_ARGS_ASSERT_INIT_PREDUMP_SYMBOLS
 
-STATIC SV *
+static SV *
 S_mayberelocate(pTHX_ const char * const dir, STRLEN len, U32 flags);
 # define PERL_ARGS_ASSERT_MAYBERELOCATE         \
         assert(dir)
@@ -7860,16 +7860,16 @@ S_my_exit_jump(pTHX)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MY_EXIT_JUMP
 
-STATIC void
+static void
 S_nuke_stacks(pTHX);
 # define PERL_ARGS_ASSERT_NUKE_STACKS
 
-STATIC PerlIO *
+static PerlIO *
 S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript);
 # define PERL_ARGS_ASSERT_OPEN_SCRIPT           \
         assert(scriptname); assert(suidscript)
 
-STATIC void *
+static void *
 S_parse_body(pTHX_ char **env, XSINIT_t xsinit);
 # define PERL_ARGS_ASSERT_PARSE_BODY
 
@@ -7884,14 +7884,14 @@ S_usage(pTHX)
 # define PERL_ARGS_ASSERT_USAGE
 
 # if !defined(PERL_IS_MINIPERL)
-STATIC SV *
+static SV *
 S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem);
 #   define PERL_ARGS_ASSERT_INCPUSH_IF_EXISTS   \
         assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(dir); assert(stem)
 
 # endif
 # if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
-STATIC void
+static void
 S_validate_suid(pTHX_ PerlIO *rsfp);
 #   define PERL_ARGS_ASSERT_VALIDATE_SUID       \
         assert(rsfp)
@@ -7908,16 +7908,16 @@ S_validate_suid(pTHX_ PerlIO *rsfp);
 
 #endif
 #if defined(PERL_IN_PP_C)
-STATIC size_t
+static size_t
 S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping);
 # define PERL_ARGS_ASSERT_DO_CHOMP              \
         assert(retval); assert(sv)
 
-STATIC OP *
+static OP *
 S_do_delete_local(pTHX);
 # define PERL_ARGS_ASSERT_DO_DELETE_LOCAL
 
-STATIC SV *
+static SV *
 S_refto(pTHX_ SV *sv)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REFTO                 \
@@ -7942,117 +7942,117 @@ Perl_to_upper_title_latin1_(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_
 
 #endif
 #if defined(PERL_IN_PP_CTL_C)
-STATIC PerlIO *
+static PerlIO *
 S_check_type_and_open(pTHX_ SV *name)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_TYPE_AND_OPEN   \
         assert(name)
 
-STATIC void
+static void
 S_destroy_matcher(pTHX_ PMOP *matcher);
 # define PERL_ARGS_ASSERT_DESTROY_MATCHER       \
         assert(matcher)
 
-STATIC OP *
+static OP *
 S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied);
 # define PERL_ARGS_ASSERT_DO_SMARTMATCH         \
         assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV); \
         assert(!seen_other || SvTYPE(seen_other) == SVt_PVHV)
 
-STATIC OP *
+static OP *
 S_docatch(pTHX_ Perl_ppaddr_t firstpp)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOCATCH
 
-STATIC bool
+static bool
 S_doeval_compile(pTHX_ U8 gimme, CV *outside, U32 seq, HV *hh);
 # define PERL_ARGS_ASSERT_DOEVAL_COMPILE        \
         assert(!outside || SvTYPE(outside) == SVt_PVCV || SvTYPE(outside) == SVt_PVFM); \
         assert(!hh || SvTYPE(hh) == SVt_PVHV)
 
-STATIC OP *
+static OP *
 S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstack, OP **oplimit)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOFINDLABEL           \
         assert(o); assert(label); assert(opstack); assert(oplimit)
 
-STATIC MAGIC *
+static MAGIC *
 S_doparseform(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_DOPARSEFORM           \
         assert(sv)
 
-STATIC I32
+static I32
 S_dopoptoeval(pTHX_ I32 startingblock)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOEVAL
 
-STATIC I32
+static I32
 S_dopoptogivenfor(pTHX_ I32 startingblock)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOGIVENFOR
 
-STATIC I32
+static I32
 S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLABEL          \
         assert(label)
 
-STATIC I32
+static I32
 S_dopoptoloop(pTHX_ I32 startingblock)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLOOP
 
-STATIC I32
+static I32
 S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOSUB_AT         \
         assert(cxstk)
 
-STATIC I32
+static I32
 S_dopoptowhen(pTHX_ I32 startingblock)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOWHEN
 
-STATIC PMOP *
+static PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MAKE_MATCHER          \
         assert(re)
 
-STATIC bool
+static bool
 S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MATCHER_MATCHES_SV    \
         assert(matcher); assert(sv)
 
-STATIC bool
+static bool
 S_num_overflow(NV value, I32 fldsize, I32 frcsize)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NUM_OVERFLOW
 
-STATIC I32
+static I32
 S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_RUN_USER_FILTER       \
         assert(buf_sv)
 
-STATIC void
+static void
 S_rxres_free(pTHX_ void **rsp);
 # define PERL_ARGS_ASSERT_RXRES_FREE            \
         assert(rsp)
 
-STATIC void
+static void
 S_rxres_restore(pTHX_ void **rsp, REGEXP *rx);
 # define PERL_ARGS_ASSERT_RXRES_RESTORE         \
         assert(rsp); assert(rx)
 
-STATIC void
+static void
 S_save_lines(pTHX_ AV *array, SV *sv);
 # define PERL_ARGS_ASSERT_SAVE_LINES            \
         assert(!array || SvTYPE(array) == SVt_PVAV); assert(sv)
 
 # if !defined(PERL_DISABLE_PMC)
-STATIC PerlIO *
+static PerlIO *
 S_doopen_pm(pTHX_ SV *name)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOOPEN_PM           \
@@ -8076,7 +8076,7 @@ Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
 
 #endif
 #if defined(PERL_IN_PP_HOT_C)
-STATIC void
+static void
 S_do_oddball(pTHX_ SV **oddkey, SV **firstkey);
 # define PERL_ARGS_ASSERT_DO_ODDBALL            \
         assert(oddkey); assert(firstkey)
@@ -8097,71 +8097,71 @@ S_should_we_output_Debug_r(pTHX_ regexp *prog)
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_PP_HOT_C) */
 #if defined(PERL_IN_PP_PACK_C)
-STATIC int
+static int
 S_div128(pTHX_ SV *pnum, bool *done);
 # define PERL_ARGS_ASSERT_DIV128                \
         assert(pnum); assert(done)
 
-STATIC char
+static char
 S_first_symbol(const char *pat, const char *patend);
 # define PERL_ARGS_ASSERT_FIRST_SYMBOL          \
         assert(pat); assert(patend); assert(pat <= patend)
 
-STATIC const char *
+static const char *
 S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_NUM               \
         assert(patptr); assert(lenptr)
 
-STATIC const char *
+static const char *
 S_group_end(pTHX_ const char *patptr, const char *patend, char ender);
 # define PERL_ARGS_ASSERT_GROUP_END             \
         assert(patptr); assert(patend); assert(patptr <= patend)
 
-STATIC SV *
+static SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_AN_INT             \
         assert(s)
 
-STATIC SSize_t
+static SSize_t
 S_measure_struct(pTHX_ struct tempsym *symptr);
 # define PERL_ARGS_ASSERT_MEASURE_STRUCT        \
         assert(symptr)
 
-STATIC SV *
+static SV *
 S_mul128(pTHX_ SV *sv, U8 m);
 # define PERL_ARGS_ASSERT_MUL128                \
         assert(sv)
 
-STATIC char *
+static char *
 S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swap)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MY_BYTES_TO_UTF8      \
         assert(start); assert(dest)
 
-STATIC bool
+static bool
 S_need_utf8(const char *pat, const char *patend);
 # define PERL_ARGS_ASSERT_NEED_UTF8             \
         assert(pat); assert(patend); assert(pat <= patend)
 
-STATIC bool
+static bool
 S_next_symbol(pTHX_ struct tempsym *symptr);
 # define PERL_ARGS_ASSERT_NEXT_SYMBOL           \
         assert(symptr)
 
-STATIC SV **
+static SV **
 S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist);
 # define PERL_ARGS_ASSERT_PACK_REC              \
         assert(cat); assert(symptr); assert(beglist); assert(endlist)
 
-STATIC char *
+static char *
 S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_EXP_GROW           \
         assert(sv)
 
-STATIC SSize_t
+static SSize_t
 S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, const char *strend, const char **new_s);
 # define PERL_ARGS_ASSERT_UNPACK_REC            \
         assert(symptr); assert(s); assert(strbeg); assert(strend); \
@@ -8169,17 +8169,17 @@ S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, co
 
 #endif /* defined(PERL_IN_PP_PACK_C) */
 #if defined(PERL_IN_PP_SORT_C)
-STATIC I32
+static I32
 S_sortcv(pTHX_ SV * const a, SV * const b);
 # define PERL_ARGS_ASSERT_SORTCV                \
         assert(a); assert(b)
 
-STATIC I32
+static I32
 S_sortcv_stacked(pTHX_ SV * const a, SV * const b);
 # define PERL_ARGS_ASSERT_SORTCV_STACKED        \
         assert(a); assert(b)
 
-STATIC I32
+static I32
 S_sortcv_xsub(pTHX_ SV * const a, SV * const b);
 # define PERL_ARGS_ASSERT_SORTCV_XSUB           \
         assert(a); assert(b)
@@ -8266,23 +8266,23 @@ S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2);
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_PP_SORT_C) */
 #if defined(PERL_IN_PP_SYS_C)
-STATIC OP *
+static OP *
 S_doform(pTHX_ CV *cv, GV *gv, OP *retop);
 # define PERL_ARGS_ASSERT_DOFORM                \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(gv)
 
-STATIC SV *
+static SV *
 S_space_join_names_mortal(pTHX_ char * const *array);
 # define PERL_ARGS_ASSERT_SPACE_JOIN_NAMES_MORTAL
 
-STATIC void
+static void
 S_warn_not_dirhandle(pTHX_ GV *gv);
 # define PERL_ARGS_ASSERT_WARN_NOT_DIRHANDLE    \
         assert(gv)
 
 # if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
-STATIC int
+static int
 S_dooneliner(pTHX_ const char *cmd, const char *filename)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOONELINER          \
@@ -8371,11 +8371,11 @@ PERL_CALLCONV SSize_t
 Perl_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp, SSize_t *minlenp, SSize_t *deltap, regnode *last, struct scan_data_t *data, I32 stopparen, U32 recursed_depth, regnode_ssc *and_withp, U32 flags, U32 depth, bool was_mutate_ok)
         __attribute__visibility__("hidden");
 #   if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
-STATIC void
+static void
 S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 depth);
-STATIC void
+static void
 S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth);
-STATIC void
+static void
 S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth);
 #   endif
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
@@ -8572,94 +8572,94 @@ S_re_croak(pTHX_ bool utf8, const char *pat, ...)
 #   endif
 # endif /* defined(DEBUGGING) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
-STATIC AV *
+static AV *
 S_add_multi_match(pTHX_ AV *multi_char_matches, SV *multi_string, const STRLEN cp_count);
-STATIC void
+static void
 S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size);
-STATIC REGEXP *
+static REGEXP *
 S_compile_wildcard(pTHX_ const char *subpattern, const STRLEN len, const bool ignore_case)
         __attribute__warn_unused_result__;
-STATIC U8
+static U8
 S_compute_EXACTish(RExC_state_t *pRExC_state);
-STATIC int
+static int
 S_edit_distance(const UV *src, const UV *tgt, const STRLEN x, const STRLEN y, const SSize_t maxDistance)
         __attribute__warn_unused_result__;
-STATIC I32
+static I32
 S_execute_wildcard(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave);
-STATIC U32
+static U32
 S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state, const char *start, const char *end);
-STATIC bool
+static bool
 S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state, regnode_offset *nodep, UV *code_point_p, int *cp_count, I32 *flagp, const bool strict, const U32 depth);
-STATIC regnode_offset
+static regnode_offset
 S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, char *backref_parse_start, char ch);
-STATIC bool
+static bool
 S_handle_names_wildcard(pTHX_ const char *wname, const STRLEN wname_len, SV **prop_definition, AV **strings);
-STATIC int
+static int
 S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state, const char * const s, char **updated_parse_ptr, AV **posix_warnings, const bool check_only);
-STATIC regnode_offset
+static regnode_offset
 S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV **return_invlist, I32 *flagp, U32 depth);
-STATIC SV *
+static SV *
 S_handle_user_defined_property(pTHX_ const char *name, const STRLEN name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, SV *contents, bool *user_defined_ptr, SV *msg, const STRLEN level);
-STATIC bool
+static bool
 S_is_ssc_worth_it(const RExC_state_t *pRExC_state, const regnode_ssc *ssc);
-STATIC void
+static void
 S_nextchar(pTHX_ RExC_state_t *pRExC_state);
-STATIC U8
+static U8
 S_optimize_regclass(pTHX_ RExC_state_t *pRExC_state, SV *cp_list, SV *only_utf8_locale_list, SV *upper_latin1_only_utf8_matches, const U32 has_runtime_dependency, const U32 posixl, U8 *anyof_flags, bool *invert, regnode_offset *ret, I32 *flagp);
-STATIC void
+static void
 S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV *posix_warnings);
-STATIC void
+static void
 S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state);
-STATIC SV *
+static SV *
 S_parse_uniprop_string(pTHX_ const char * const name, Size_t name_len, const bool is_utf8, const bool to_fold, const bool runtime, const bool deferrable, AV **strings, bool *user_defined_ptr, SV *msg, const STRLEN level);
-STATIC regnode_offset
+static regnode_offset
 S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth);
-STATIC regnode_offset
+static regnode_offset
 S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg);
-STATIC regnode_offset
+static regnode_offset
 S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I32 arg2);
-STATIC regnode_offset
+static regnode_offset
 S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type);
-STATIC regnode_offset
+static regnode_offset
 S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags, const char *type);
-STATIC regnode_offset
+static regnode_offset
 S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op);
-STATIC SV *
+static SV *
 S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags);
-STATIC regnode_offset
+static regnode_offset
 S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth);
-STATIC regnode_offset
+static regnode_offset
 S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth);
-STATIC regnode_offset
+static regnode_offset
 S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth, const bool stop_at_1, bool allow_multi_fold, const bool silence_non_portable, const bool strict, bool optimizable, SV **ret_invlist);
-STATIC unsigned int
+static unsigned int
 S_regex_set_precedence(const U8 my_operator)
         __attribute__warn_unused_result__;
-STATIC void
+static void
 S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op, const regnode_offset operand, const U32 depth);
-STATIC regnode_offset
+static regnode_offset
 S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_len);
-STATIC regnode_offset
+static regnode_offset
 S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth);
-STATIC regnode_offset
+static regnode_offset
 S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV *arg);
-STATIC bool
+static bool
 S_regtail(pTHX_ RExC_state_t *pRExC_state, const regnode_offset p, const regnode_offset val, const U32 depth)
         __attribute__warn_unused_result__;
-STATIC void
+static void
 S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx);
-STATIC void
+static void
 S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state, char **p, const bool force_to_xmod);
-STATIC void
+static void
 S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc);
 #   if defined(DEBUGGING)
-STATIC regnode_offset
+static regnode_offset
 S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_len);
-STATIC bool
+static bool
 S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p, const regnode_offset val, U32 depth)
         __attribute__warn_unused_result__;
 #     if defined(ENABLE_REGEX_SETS_DEBUGGING)
-STATIC void
+static void
 S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const IV fence, AV *fence_stack);
 #     endif
 #   endif /* defined(DEBUGGING) */
@@ -8743,7 +8743,7 @@ Perl_regcurly(const char *s, const char *e, const char *result[5])
 # define PERL_ARGS_ASSERT_APPEND_RANGE_TO_INVLIST_ \
         assert(invlist)
 
-STATIC void
+static void
 S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size);
 # define PERL_ARGS_ASSERT_INITIALIZE_INVLIST_GUTS \
         assert(invlist)
@@ -8752,9 +8752,9 @@ S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size);
         assert(dest); assert(src)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
-STATIC void
+static void
 S_append_range_to_invlist_(pTHX_ SV * const invlist, const UV start, const UV end);
-STATIC void
+static void
 S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src);
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -8845,36 +8845,36 @@ S_invlist_trim(SV *invlist);
         assert(p)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
-STATIC SV *
+static SV *
 S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state, const regnode_charclass * const node);
-STATIC SV *
+static SV *
 S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
         __attribute__warn_unused_result__;
-STATIC void
+static void
 S_rck_elide_nothing(pTHX_ regnode *node);
-STATIC void
+static void
 S_ssc_add_range(pTHX_ regnode_ssc *ssc, UV const start, UV const end);
-STATIC void
+static void
 S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *and_with);
-STATIC void
+static void
 S_ssc_anything(pTHX_ regnode_ssc *ssc);
-STATIC void
+static void
 S_ssc_clear_locale(regnode_ssc *ssc);
-STATIC void
+static void
 S_ssc_cp_and(pTHX_ regnode_ssc *ssc, UV const cp);
-STATIC void
+static void
 S_ssc_intersection(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd);
-STATIC int
+static int
 S_ssc_is_anything(const regnode_ssc *ssc)
         __attribute__warn_unused_result__;
-STATIC int
+static int
 S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state, const regnode_ssc *ssc)
         __attribute__warn_unused_result__;
-STATIC void
+static void
 S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc, const regnode_charclass *or_with);
-STATIC void
+static void
 S_ssc_union(pTHX_ regnode_ssc *ssc, SV * const invlist, const bool invert_2nd);
-STATIC void
+static void
 S_unwind_scan_frames(pTHX_ void *p);
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 #endif /* defined(PERL_IN_REGCOMP_STUDY_C) */
@@ -8990,92 +8990,92 @@ S_unwind_scan_frames(pTHX_ void *p);
 
 # endif /* defined(DEBUGGING) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
-STATIC LB_enum
+static LB_enum
 S_advance_one_LB(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC SB_enum
+static SB_enum
 S_advance_one_SB(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC WB_enum
+static WB_enum
 S_advance_one_WB_(pTHX_ U8 **curpos, const U8 * const strend, const bool utf8_target, const bool skip_Extend_Format)
         __attribute__warn_unused_result__;
-STATIC GCB_enum
+static GCB_enum
 S_backup_one_GCB(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC LB_enum
+static LB_enum
 S_backup_one_LB_(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target, bool skip_CM_ZWJ)
         __attribute__warn_unused_result__;
-STATIC SB_enum
+static SB_enum
 S_backup_one_SB(pTHX_ const U8 * const strbeg, U8 **curpos, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC WB_enum
+static WB_enum
 S_backup_one_WB_but_over_Extend_FO(pTHX_ WB_enum *previous, const U8 * const strbeg, U8 **curpos, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC char *
+static char *
 S_find_byclass(pTHX_ regexp *prog, const regnode *c, char *s, const char *strend, regmatch_info *reginfo)
         __attribute__warn_unused_result__;
-STATIC U8 *
+static U8 *
 S_find_next_masked(U8 *s, const U8 *send, const U8 byte, const U8 mask)
         __attribute__warn_unused_result__;
-STATIC U8 *
+static U8 *
 S_find_span_end(U8 *s, const U8 *send, const U8 span_byte)
         __attribute__warn_unused_result__;
-STATIC U8 *
+static U8 *
 S_find_span_end_mask(U8 *s, const U8 *send, const U8 span_byte, const U8 mask)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8 *character, const U8 *e)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strbeg, const U8 * const curpos, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_isLB(pTHX_ LB_enum before, LB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_isSB(pTHX_ SB_enum before, SB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_isWB(pTHX_ WB_enum previous, WB_enum before, WB_enum after, const U8 * const strbeg, const U8 * const curpos, const U8 * const strend, const bool utf8_target)
         __attribute__warn_unused_result__;
-STATIC I32
+static I32
 S_reg_check_named_buff_matched(const regexp *rex, const regnode *scan)
         __attribute__warn_unused_result__;
-STATIC void
+static void
 S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH);
-STATIC void
+static void
 S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH);
-STATIC CHECKPOINT
+static CHECKPOINT
 S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH);
-STATIC U8 *
+static U8 *
 S_reghop3(U8 *s, SSize_t off, const U8 *lim)
         __attribute__warn_unused_result__;
-STATIC U8 *
+static U8 *
 S_reghopmaybe3(U8 *s, SSize_t off, const U8 * const lim)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8 * const p, const U8 * const p_end, bool const utf8_target)
         __attribute__warn_unused_result__;
-STATIC SSize_t
+static SSize_t
 S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
         __attribute__warn_unused_result__;
-STATIC I32
+static I32
 S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p, char *loceol, regmatch_info * const reginfo, I32 max comma_pDEPTH)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
         __attribute__warn_unused_result__;
-STATIC bool
+static bool
 S_to_byte_substr(pTHX_ regexp *prog);
-STATIC void
+static void
 S_to_utf8_substr(pTHX_ regexp *prog);
 #   if defined(DEBUGGING)
-STATIC void
+static void
 S_debug_start_match(pTHX_ const REGEXP *prog, const bool do_utf8, const char *start, const char *end, const char *blurb);
-STATIC void
+static void
 S_dump_exec_pos(pTHX_ const char *locinput, const regnode *scan, const char *loc_regeol, const char *loc_bostr, const char *loc_reg_starttry, const bool do_utf8, const U32 depth);
 PERL_CALLCONV int
 Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
@@ -9189,150 +9189,150 @@ Perl_regnode_after(pTHX_ const regnode *p, bool varies)
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_REGEX_ENGINE) */
 #if defined(PERL_IN_SCOPE_C)
-STATIC void
+static void
 S_save_pushptri32ptr(pTHX_ void * const ptr1, const I32 i, void * const ptr2, const int type);
 # define PERL_ARGS_ASSERT_SAVE_PUSHPTRI32PTR
 
-STATIC SV *
+static SV *
 S_save_scalar_at(pTHX_ SV **sptr, const U32 flags);
 # define PERL_ARGS_ASSERT_SAVE_SCALAR_AT        \
         assert(sptr)
 
 #endif /* defined(PERL_IN_SCOPE_C) */
 #if defined(PERL_IN_SV_C)
-STATIC char *
+static char *
 S_F0convert(NV nv, char * const endbuf, STRLEN * const len);
 # define PERL_ARGS_ASSERT_F0CONVERT             \
         assert(endbuf); assert(len)
 
-STATIC void
+static void
 S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv);
 # define PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE    \
         assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
-STATIC void
+static void
 S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, STRLEN real, SV * const sv);
 # define PERL_ARGS_ASSERT_ASSERT_UFT8_CACHE_COHERENT \
         assert(func); assert(sv)
 
-STATIC void
+static void
 S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv);
 # define PERL_ARGS_ASSERT_CROAK_SV_SETSV_FLAGS  \
         assert(dsv); assert(ssv)
 
-STATIC bool
+static bool
 S_curse(pTHX_ SV * const sv, const bool check_refcnt);
 # define PERL_ARGS_ASSERT_CURSE                 \
         assert(sv)
 
-STATIC STRLEN
+static STRLEN
 S_expect_number(pTHX_ const char ** const pattern)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_EXPECT_NUMBER         \
         assert(pattern)
 
-STATIC SSize_t
+static SSize_t
 S_find_array_subscript(pTHX_ const AV * const av, const SV * const val);
 # define PERL_ARGS_ASSERT_FIND_ARRAY_SUBSCRIPT  \
         assert(val)
 
-STATIC SV *
+static SV *
 S_find_hash_subscript(pTHX_ const HV * const hv, const SV * const val);
 # define PERL_ARGS_ASSERT_FIND_HASH_SUBSCRIPT   \
         assert(val)
 
-STATIC SV *
+static SV *
 S_find_uninit_var(pTHX_ const OP * const obase, const SV * const uninit_sv, bool match, const char **desc_p);
 # define PERL_ARGS_ASSERT_FIND_UNINIT_VAR       \
         assert(desc_p)
 
-STATIC bool
+static bool
 S_glob_2number(pTHX_ GV * const gv);
 # define PERL_ARGS_ASSERT_GLOB_2NUMBER          \
         assert(gv)
 
-STATIC void
+static void
 S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype);
 # define PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB      \
         assert(dsv); assert(ssv)
 
-STATIC void
+static void
 S_not_a_number(pTHX_ SV * const sv);
 # define PERL_ARGS_ASSERT_NOT_A_NUMBER          \
         assert(sv)
 
-STATIC void
+static void
 S_not_incrementable(pTHX_ SV * const sv);
 # define PERL_ARGS_ASSERT_NOT_INCREMENTABLE     \
         assert(sv)
 
-STATIC PTR_TBL_ENT_t *
+static PTR_TBL_ENT_t *
 S_ptr_table_find(PTR_TBL_t * const tbl, const void * const sv)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PTR_TABLE_FIND        \
         assert(tbl)
 
-STATIC bool
+static bool
 S_sv_2iuv_common(pTHX_ SV * const sv);
 # define PERL_ARGS_ASSERT_SV_2IUV_COMMON        \
         assert(sv)
 
-STATIC void
+static void
 S_sv_add_arena(pTHX_ char * const ptr, const U32 size, const U32 flags);
 # define PERL_ARGS_ASSERT_SV_ADD_ARENA          \
         assert(ptr)
 
-STATIC const char *
+static const char *
 S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size);
 # define PERL_ARGS_ASSERT_SV_DISPLAY            \
         assert(sv); assert(tmpbuf)
 
-STATIC bool
+static bool
 S_sv_numcmp_common(pTHX_ SV **sv1, SV **sv2, const U32 flags, int method, SV **result);
 # define PERL_ARGS_ASSERT_SV_NUMCMP_COMMON      \
         assert(result)
 
-STATIC STRLEN
+static STRLEN
 S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 *end, STRLEN endu);
 # define PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY     \
         assert(s); assert(target); assert(end); assert(s <= target); \
         assert(target <= end)
 
-STATIC STRLEN
+static STRLEN
 S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const start, const U8 * const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_CACHED     \
         assert(sv); assert(mgp); assert(start); assert(send); \
         assert(start < send)
 
-STATIC STRLEN
+static STRLEN
 S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * const uoffset, bool * const at_end, bool *canonical_position);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS   \
         assert(start); assert(send); assert(uoffset); assert(at_end); \
         assert(canonical_position); assert(start < send)
 
-STATIC STRLEN
+static STRLEN
 S_sv_pos_u2b_midway(const U8 * const start, const U8 *send, STRLEN uoffset, const STRLEN uend);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_MIDWAY     \
         assert(start); assert(send); assert(start < send)
 
-STATIC void
+static void
 S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN ulen);
 # define PERL_ARGS_ASSERT_UTF8_MG_LEN_CACHE_UPDATE \
         assert(sv); assert(mgp)
 
-STATIC void
+static void
 S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN byte, const STRLEN utf8, const STRLEN blen);
 # define PERL_ARGS_ASSERT_UTF8_MG_POS_CACHE_UPDATE \
         assert(sv); assert(mgp)
 
-STATIC SSize_t
+static SSize_t
 S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask);
 # define PERL_ARGS_ASSERT_VISIT                 \
         assert(f)
 
 # if defined(DEBUGGING)
-STATIC void
+static void
 S_del_sv(pTHX_ SV *p);
 #   define PERL_ARGS_ASSERT_DEL_SV              \
         assert(p)
@@ -9350,13 +9350,13 @@ Perl_sv_sweep_arenas(pTHX)
 # endif /* defined(DEBUGGING) */
 # if !defined(NV_PRESERVES_UV)
 #   if defined(DEBUGGING)
-STATIC int
+static int
 S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
 
 #   else
-STATIC int
+static int
 S_sv_2iuv_non_preserve(pTHX_ SV * const sv);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
         assert(sv)
@@ -9364,7 +9364,7 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv);
 #   endif
 # endif /* !defined(NV_PRESERVES_UV) */
 # if defined(PERL_DEBUG_READONLY_COW)
-STATIC void
+static void
 S_sv_buf_to_rw(pTHX_ SV *sv);
 #   define PERL_ARGS_ASSERT_SV_BUF_TO_RW        \
         assert(sv)
@@ -9378,23 +9378,23 @@ S_sv_unglob(pTHX_ SV * const sv, U32 flags);
 
 # endif
 # if defined(USE_ITHREADS)
-STATIC SV *
+static SV *
 S_sv_dup_common(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_SV_DUP_COMMON       \
         assert(ssv); assert(param)
 
-STATIC void
+static void
 S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param);
 #   define PERL_ARGS_ASSERT_SV_DUP_HVAUX        \
         assert(ssv); assert(dsv); assert(param)
 
-STATIC SV **
+static SV **
 S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_PARAMS * const param);
 #   define PERL_ARGS_ASSERT_SV_DUP_INC_MULTIPLE \
         assert(source); assert(dest); assert(param)
 
-STATIC void
+static void
 S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced);
 #   define PERL_ARGS_ASSERT_UNREFERENCED_TO_TMP_STACK \
         assert(unreferenced); assert(SvTYPE(unreferenced) == SVt_PVAV)
@@ -9402,86 +9402,86 @@ S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced);
 # endif /* defined(USE_ITHREADS) */
 #endif /* defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_TOKE_C)
-STATIC int
+static int
 S_ao(pTHX_ int toketype);
 # define PERL_ARGS_ASSERT_AO
 
-STATIC void
+static void
 S_check_unary(pTHX);
 # define PERL_ARGS_ASSERT_CHECK_UNARY
 
-STATIC void
+static void
 S_checkcomma(pTHX_ const char *s, const char *name, const char *what);
 # define PERL_ARGS_ASSERT_CHECKCOMMA            \
         assert(s); assert(name); assert(what)
 
-STATIC char *
+static char *
 S_filter_gets(pTHX_ SV *sv, STRLEN append)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FILTER_GETS           \
         assert(sv)
 
-STATIC HV *
+static HV *
 S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FIND_IN_MY_STASH      \
         assert(pkgname)
 
-STATIC void
+static void
 S_force_ident(pTHX_ const char *s, int kind);
 # define PERL_ARGS_ASSERT_FORCE_IDENT           \
         assert(s)
 
-STATIC void
+static void
 S_force_ident_maybe_lex(pTHX_ char pit);
 # define PERL_ARGS_ASSERT_FORCE_IDENT_MAYBE_LEX
 
-STATIC void
+static void
 S_force_next(pTHX_ I32 type);
 # define PERL_ARGS_ASSERT_FORCE_NEXT
 
-STATIC char *
+static char *
 S_force_strict_version(pTHX_ char *s);
 # define PERL_ARGS_ASSERT_FORCE_STRICT_VERSION  \
         assert(s)
 
-STATIC char *
+static char *
 S_force_version(pTHX_ char *s, int guessing);
 # define PERL_ARGS_ASSERT_FORCE_VERSION         \
         assert(s)
 
-STATIC char *
+static char *
 S_force_word(pTHX_ char *start, int token, U32 flags);
 # define PERL_ARGS_ASSERT_FORCE_WORD            \
         assert(start)
 
-STATIC SV *
+static SV *
 S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const e)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME_WRAPPER \
         assert(s); assert(e); assert(s <= e)
 
-STATIC void
+static void
 S_incline(pTHX_ const char *s, const char *end);
 # define PERL_ARGS_ASSERT_INCLINE               \
         assert(s); assert(end); assert(s <= end); assert(*end == '\0')
 
-STATIC int
+static int
 S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv);
 # define PERL_ARGS_ASSERT_INTUIT_METHOD         \
         assert(start)
 
-STATIC int
+static int
 S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t caller_length);
 # define PERL_ARGS_ASSERT_INTUIT_MORE           \
         assert(s); assert(e); assert(s <= e); assert(*e == '\0')
 
-STATIC bool
+static bool
 S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8);
 # define PERL_ARGS_ASSERT_IS_EXISTING_IDENTIFIER \
         assert(s)
 
-STATIC I32
+static I32
 S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s);
 # define PERL_ARGS_ASSERT_LOP                   \
         assert(s)
@@ -9491,144 +9491,144 @@ S_missingterm(pTHX_ char *s, STRLEN len)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MISSINGTERM
 
-STATIC SV *
+static SV *
 S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, SV *sv, SV *pv, const char *type, STRLEN typelen, const char **error_msg);
 # define PERL_ARGS_ASSERT_NEW_CONSTANT          \
         assert(key); assert(sv)
 
-STATIC char *
+static char *
 S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * const e, bool is_utf8, HV **failure_details, U32 flags);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
         assert(s); assert(s_end); assert(d); assert(*d); assert(e); \
         assert(s <= s_end); assert(*d < e)
 
-STATIC char *
+static char *
 S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf8, HV **failure_details, U32 flags);
 # define PERL_ARGS_ASSERT_PARSE_IDENT_NO_COPY   \
         assert(s); assert(s_end); assert(s < s_end)
 
-STATIC int
+static int
 S_pending_ident(pTHX);
 # define PERL_ARGS_ASSERT_PENDING_IDENT
 
-STATIC char *
+static char *
 S_scan_const(pTHX_ char *start)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_CONST            \
         assert(start)
 
-STATIC char *
+static char *
 S_scan_formline(pTHX_ char *s)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_FORMLINE         \
         assert(s)
 
-STATIC char *
+static char *
 S_scan_heredoc(pTHX_ char *s)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_HEREDOC          \
         assert(s)
 
-STATIC char *
+static char *
 S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags);
 # define PERL_ARGS_ASSERT_SCAN_IDENT            \
         assert(s); assert(dest); assert(dest_end); assert(dest < dest_end)
 
-STATIC char *
+static char *
 S_scan_inputsymbol(pTHX_ char *start)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_INPUTSYMBOL      \
         assert(start)
 
-STATIC char *
+static char *
 S_scan_pat(pTHX_ char *start, I32 type)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_PAT              \
         assert(start)
 
-STATIC char *
+static char *
 S_scan_subst(pTHX_ char *start)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_SUBST            \
         assert(start)
 
-STATIC char *
+static char *
 S_scan_trans(pTHX_ char *start)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_TRANS            \
         assert(start)
 
-STATIC I32
+static I32
 S_sublex_done(pTHX)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_DONE
 
-STATIC I32
+static I32
 S_sublex_push(pTHX)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_PUSH
 
-STATIC I32
+static I32
 S_sublex_start(pTHX)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_START
 
-STATIC char *
+static char *
 S_swallow_bom(pTHX_ U8 *s)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SWALLOW_BOM           \
         assert(s)
 
-STATIC char *
+static char *
 S_tokenize_use(pTHX_ int is_use, char *s)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOKENIZE_USE          \
         assert(s)
 
-STATIC SV *
+static SV *
 S_tokeq(pTHX_ SV *sv);
 # define PERL_ARGS_ASSERT_TOKEQ                 \
         assert(sv)
 
-STATIC void
+static void
 S_update_debugger_info(pTHX_ SV *orig_sv, const char * const buf, STRLEN len);
 # define PERL_ARGS_ASSERT_UPDATE_DEBUGGER_INFO
 
-STATIC void
+static void
 S_warn_expect_operator(pTHX_ const char * const what, char *s, I32 pop_oldbufptr);
 # define PERL_ARGS_ASSERT_WARN_EXPECT_OPERATOR  \
         assert(what)
 
-STATIC void
+static void
 S_yyerror_non_ascii_message(pTHX_ const U8 * const s);
 # define PERL_ARGS_ASSERT_YYERROR_NON_ASCII_MESSAGE \
         assert(s)
 
-STATIC int
+static int
 S_yywarn(pTHX_ const char * const s, U32 flags);
 # define PERL_ARGS_ASSERT_YYWARN                \
         assert(s)
 
 # if defined(DEBUGGING)
-STATIC void
+static void
 S_printbuf(pTHX_ const char * const fmt, const char * const s)
         __attribute__format__(__printf__,pTHX_1,0);
 #   define PERL_ARGS_ASSERT_PRINTBUF            \
         assert(fmt); assert(s)
 
-STATIC int
+static int
 S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp);
 #   define PERL_ARGS_ASSERT_TOKEREPORT          \
         assert(lvalp)
 
 # endif /* defined(DEBUGGING) */
 # if !defined(PERL_NO_UTF16_FILTER)
-STATIC U8 *
+static U8 *
 S_add_utf16_textfilter(pTHX_ U8 * const s, bool reversed);
 #   define PERL_ARGS_ASSERT_ADD_UTF16_TEXTFILTER \
         assert(s)
 
-STATIC I32
+static I32
 S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen);
 #   define PERL_ARGS_ASSERT_UTF16_TEXTFILTER    \
         assert(sv)
@@ -9636,69 +9636,69 @@ S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen);
 # endif /* !defined(PERL_NO_UTF16_FILTER) */
 #endif /* defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_UNIVERSAL_C)
-STATIC bool
+static bool
 S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flags);
 # define PERL_ARGS_ASSERT_ISA_LOOKUP            \
         assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(namesv || name)
 
-STATIC bool
+static bool
 S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN len, U32 flags);
 # define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SVPVN \
         assert(sv); assert(namesv || name)
 
 #endif /* defined(PERL_IN_UNIVERSAL_C) */
 #if defined(PERL_IN_UTF8_C)
-STATIC UV
+static UV
 S_check_locale_boundary_crossing(pTHX_ const U8 * const p, const UV result, U8 * const ustrp, STRLEN *lenp)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_LOCALE_BOUNDARY_CROSSING \
         assert(p); assert(ustrp); assert(lenp)
 
-STATIC HV *
+static HV *
 S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_MSG_HV            \
         assert(message)
 
-STATIC UV
+static UV
 S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Size_t *remaining_count, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal);
 # define PERL_ARGS_ASSERT_TO_CASE_CP_LIST       \
         assert(invlist); assert(invmap); assert(normal)
 
-STATIC U8
+static U8
 S_to_lower_latin1(const U8 c, U8 *p, STRLEN *lenp, const char dummy)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TO_LOWER_LATIN1
 
-STATIC UV
+static UV
 S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal);
 # define PERL_ARGS_ASSERT_TO_UTF8_CASE_         \
         assert(ustrp); assert(lenp); assert(invlist); assert(invmap); \
         assert(normal)
 
-STATIC UV
+static UV
 S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp);
 # define PERL_ARGS_ASSERT_TURKIC_FC             \
         assert(p); assert(e); assert(ustrp); assert(lenp); assert(p < e)
 
-STATIC UV
+static UV
 S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *lenp);
 # define PERL_ARGS_ASSERT_TURKIC_LC             \
         assert(p0); assert(e); assert(ustrp); assert(lenp); assert(p0 < e)
 
-STATIC UV
+static UV
 S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp);
 # define PERL_ARGS_ASSERT_TURKIC_UC             \
         assert(p); assert(e); assert(ustrp); assert(lenp); assert(p < e)
 
-STATIC char *
+static char *
 S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, const STRLEN non_cont_byte_pos, const STRLEN expect_len)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UNEXPECTED_NON_CONTINUATION_TEXT \
         assert(s)
 
 # if 0
-STATIC void
+static void
 S_warn_on_first_deprecated_use(pTHX_ U32 category, const char * const name, const char * const alternative, const bool use_locale, const char * const file, const unsigned line);
 #   define PERL_ARGS_ASSERT_WARN_ON_FIRST_DEPRECATED_USE \
         assert(name); assert(alternative); assert(file)
@@ -9726,33 +9726,33 @@ S_is_utf8_overlong(const U8 * const s, const STRLEN len)
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_UTIL_C)
-STATIC bool
+static bool
 S_ckwarn_common(pTHX_ U32 w);
 # define PERL_ARGS_ASSERT_CKWARN_COMMON
 
-STATIC SV *
+static SV *
 S_mess_alloc(pTHX);
 # define PERL_ARGS_ASSERT_MESS_ALLOC
 
-STATIC SV *
+static SV *
 S_with_queued_errors(pTHX_ SV *ex);
 # define PERL_ARGS_ASSERT_WITH_QUEUED_ERRORS    \
         assert(ex)
 
-STATIC void
+static void
 S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p, STRLEN xs_len);
 # define PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK  \
         assert(xs_p)
 
 # if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
-STATIC void
+static void
 S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const char *type_name, const SV *sv, Malloc_t oldalloc, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname);
 #   define PERL_ARGS_ASSERT_MEM_LOG_COMMON      \
         assert(type_name); assert(filename); assert(funcname)
 
 # endif
 # if defined(PERL_USES_PL_PIDSTATUS)
-STATIC void
+static void
 S_pidgone(pTHX_ Pid_t pid, int status);
 #   define PERL_ARGS_ASSERT_PIDGONE
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -223,7 +223,7 @@ dict_free(item* head)
 /* End of Dictionary Stuff */
 
 /* All calculations/work are done here */
-STATIC int
+static int
 S_edit_distance(const UV* src,
                 const UV* tgt,
                 const STRLEN x,             /* length of src[] */
@@ -1120,7 +1120,7 @@ S_compile_runtime_code(pTHX_ RExC_state_t * const pRExC_state,
 }
 
 
-STATIC bool
+static bool
 S_setup_longest(pTHX_ RExC_state_t *pRExC_state,
                       struct reg_substr_datum  *rsd,
                       struct scan_data_substrs *sub,
@@ -1174,7 +1174,7 @@ S_setup_longest(pTHX_ RExC_state_t *pRExC_state,
     return true;
 }
 
-STATIC void
+static void
 S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx)
 {
     /* Calculates and sets in the compiled pattern 'Rx' the string to compile,
@@ -1263,7 +1263,7 @@ S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx)
     SvCUR_set(Rx, p - RX_WRAPPED(Rx));
 }
 
-STATIC void
+static void
 S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc)
 {
     /* The inversion list in the SSC is marked mortal; now we need a more
@@ -1304,7 +1304,7 @@ S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc)
     assert(! (ANYOF_FLAGS(ssc) & ANYOF_LOCALE_FLAGS) || RExC_contains_locale);
 }
 
-STATIC bool
+static bool
 S_is_ssc_worth_it(const RExC_state_t * pRExC_state, const regnode_ssc * ssc)
 {
     /* The synthetic start class is used to hopefully quickly winnow down
@@ -2513,7 +2513,7 @@ Perl_reg_qr_package(pTHX_ REGEXP * const rx)
 #define REG_RSN_RETURN_NAME    1
 #define REG_RSN_RETURN_DATA    2
 
-STATIC SV*
+static SV*
 S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
 {
     PERL_ARGS_ASSERT_REG_SCAN_NAME;
@@ -2616,7 +2616,7 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
 })
 
 
-STATIC void
+static void
 S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
 {
     /* This parses the flags that are in either the '(?foo)' or '(?foo:bar)'
@@ -2885,7 +2885,7 @@ S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
  * follows makes it hard to avoid.
  */
 
-STATIC regnode_offset
+static regnode_offset
 S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state,
                              I32 *flagp,
                              char * backref_parse_start,
@@ -2958,7 +2958,7 @@ S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state,
  * any use of it would have had to be broken onto multiple lines, hence
  * the abbreviation.
  */
-STATIC regnode_offset
+static regnode_offset
 S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags,
     const char *type)
 {
@@ -3007,7 +3007,7 @@ S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags,
  * the abbreviation.
  */
 
-STATIC regnode_offset
+static regnode_offset
 S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags,
     const char *type)
 {
@@ -3089,7 +3089,7 @@ S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags,
  *                  NEED_UTF8 if the pattern needs to be upgraded to UTF-8.
  *  Otherwise would only return 0 if regbranch() returns 0, which cannot
  *  happen.  */
-STATIC regnode_offset
+static regnode_offset
 S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
     /* paren: Parenthesized? 0 = top; 1,2 = inside '(': changed to letter.
      * 2 is like 1, but indicates that nextchar() has been called to advance
@@ -4544,7 +4544,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
  * to be restarted, or'd with NEED_UTF8 if the pattern needs to be upgraded to
  * UTF-8
  */
-STATIC regnode_offset
+static regnode_offset
 S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
 {
     regnode_offset ret;
@@ -4793,7 +4793,7 @@ S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state,
  *  RESTART_PARSE   if the parse needs to be restarted, or'd with
  *                  NEED_UTF8 if the pattern needs to be upgraded to UTF-8.
  */
-STATIC regnode_offset
+static regnode_offset
 S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 {
     regnode_offset ret;
@@ -5047,7 +5047,7 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
     NOT_REACHED; /*NOTREACHED*/
 }
 
-STATIC bool
+static bool
 S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
                 regnode_offset * node_p,
                 UV * code_point_p,
@@ -5501,7 +5501,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
 }
 
 
-STATIC U8
+static U8
 S_compute_EXACTish(RExC_state_t *pRExC_state)
 {
     U8 op;
@@ -5613,7 +5613,7 @@ S_backref_value(const char *p, const char *e, char **pe)
 
 */
 
-STATIC regnode_offset
+static regnode_offset
 S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 {
     regnode_offset ret = 0;
@@ -7721,7 +7721,7 @@ Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
         return ret;                                                         \
     } STMT_END
 
-STATIC int
+static int
 S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 
     const char * const s,      /* Where the putative posix class begins.
@@ -8503,7 +8503,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 }
 #undef ADD_POSIX_WARNING
 
-STATIC unsigned  int
+static unsigned  int
 S_regex_set_precedence(const U8 my_operator) {
 
     /* Returns the precedence in the (?[...]) construct of the input operator,
@@ -8531,7 +8531,7 @@ S_regex_set_precedence(const U8 my_operator) {
     return 0;   /* Silence compiler warning */
 }
 
-STATIC regnode_offset
+static regnode_offset
 S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV** return_invlist,
                     I32 *flagp, U32 depth)
 {
@@ -9219,7 +9219,7 @@ redo_curchar:
 
 #ifdef ENABLE_REGEX_SETS_DEBUGGING
 
-STATIC void
+static void
 S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
                              AV * stack, const IV fence, AV * fence_stack)
 {   /* Dumps the stacks in handle_regex_sets() */
@@ -9365,7 +9365,7 @@ Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV** i
 #endif /* PERL_RE_BUILD_AUX */
 
 
-STATIC void
+static void
 S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV* posix_warnings)
 {
     /* Output the elements of the array given by '*posix_warnings' as REGEXP
@@ -9410,7 +9410,7 @@ S_find_first_differing_byte_pos(const U8 * s1, const U8 * s2, const Size_t max)
     return s1 - start;
 }
 
-STATIC AV *
+static AV *
 S_add_multi_match(pTHX_ AV* multi_char_matches, SV* multi_string, const STRLEN cp_count)
 {
     /* This adds the string scalar <multi_string> to the array
@@ -9479,7 +9479,7 @@ S_add_multi_match(pTHX_ AV* multi_char_matches, SV* multi_string, const STRLEN c
         }                                                               \
     } STMT_END
 
-STATIC regnode_offset
+static regnode_offset
 S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                  const bool stop_at_1,  /* Just parse the next thing, don't
                                            look for a full character class */
@@ -11344,7 +11344,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
     return ret;
 }
 
-STATIC U8
+static U8
 S_optimize_regclass(pTHX_
                     RExC_state_t *pRExC_state,
                     SV * cp_list,
@@ -12727,7 +12727,7 @@ S_reg_skipcomment(RExC_state_t *pRExC_state, char* p)
     return p;
 }
 
-STATIC void
+static void
 S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state,
                                 char ** p,
                                 const bool force_to_xmod
@@ -12794,7 +12794,7 @@ S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state,
    This is the UTF, (?#...), and /x friendly way of saying RExC_parse_inc_by(1).
 */
 
-STATIC void
+static void
 S_nextchar(pTHX_ RExC_state_t *pRExC_state)
 {
     PERL_ARGS_ASSERT_NEXTCHAR;
@@ -12811,7 +12811,7 @@ S_nextchar(pTHX_ RExC_state_t *pRExC_state)
     }
 }
 
-STATIC void
+static void
 S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size)
 {
     /* 'size' is the delta number of smallest regnode equivalents to add or
@@ -12837,7 +12837,7 @@ S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size)
     }
 }
 
-STATIC regnode_offset
+static regnode_offset
 S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
 {
     /* Allocate a regnode that is (1 + extra_size) times as big as the
@@ -12858,7 +12858,7 @@ S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
 
 #ifdef DEBUGGING
 
-STATIC regnode_offset
+static regnode_offset
 S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_size) {
     PERL_ARGS_ASSERT_REGNODE_GUTS_DEBUG;
     assert(extra_size >= REGNODE_ARG_LEN(op) || REGNODE_TYPE(op) == ANYOF);
@@ -12872,7 +12872,7 @@ S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN 
 /*
 - reg_node - emit a node
 */
-STATIC regnode_offset /* Location. */
+static regnode_offset /* Location. */
 S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
 {
     const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
@@ -12890,7 +12890,7 @@ S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
 /*
 - reg1node - emit a node with an argument
 */
-STATIC regnode_offset /* Location. */
+static regnode_offset /* Location. */
 S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
 {
     const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
@@ -12909,7 +12909,7 @@ S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
 /*
 - regpnode - emit a temporary node with a SV* argument
 */
-STATIC regnode_offset /* Location. */
+static regnode_offset /* Location. */
 S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV * arg)
 {
     const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
@@ -12922,7 +12922,7 @@ S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV * arg)
     return(ret);
 }
 
-STATIC regnode_offset
+static regnode_offset
 S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I32 arg2)
 {
     /* emit a node with U32 and I32 arguments */
@@ -12953,7 +12953,7 @@ S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I
 *
 * ALSO NOTE - FLAGS(newly-inserted-operator) will be set to 0 as well.
 */
-STATIC void
+static void
 S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
                   const regnode_offset operand, const U32 depth)
 {
@@ -13026,7 +13026,7 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
             engine is designed for.)
 - SEE ALSO: regtail_study
 */
-STATIC bool
+static bool
 S_regtail(pTHX_ RExC_state_t * pRExC_state,
                 const regnode_offset p,
                 const regnode_offset val,
@@ -13100,7 +13100,7 @@ so both currently return a pass/fail return.
 */
 /* TODO: All four parms should be const */
 
-STATIC bool
+static bool
 S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
                       const regnode_offset val, U32 depth)
 {
@@ -13865,7 +13865,7 @@ Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
 
 #endif    /* USE_ITHREADS */
 
-STATIC void
+static void
 S_re_croak(pTHX_ bool utf8, const char* pat,...)
 {
     va_list args;
@@ -14107,7 +14107,7 @@ S_get_extended_utf8_msg(pTHX_ const UV cp)
 #  endif
 #endif /* end of ! PERL_IN_XSUB_RE */
 
-STATIC REGEXP *
+static REGEXP *
 S_compile_wildcard(pTHX_ const char * subpattern, const STRLEN len,
                          const bool ignore_case)
 {
@@ -14179,7 +14179,7 @@ S_compile_wildcard(pTHX_ const char * subpattern, const STRLEN len,
     return subpattern_re;
 }
 
-STATIC I32
+static I32
 S_execute_wildcard(pTHX_ REGEXP * const prog, char* stringarg, char *strend,
          char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
 {
@@ -14522,7 +14522,7 @@ S_handle_user_defined_property(pTHX_
 #    define ORIGINAL_CONTEXT                  NULL
 #  endif
 
-STATIC void
+static void
 S_delete_recursion_entry(pTHX_ void *key)
 {
     /* Deletes the entry used to detect recursion when expanding user-defined
@@ -14550,7 +14550,7 @@ S_delete_recursion_entry(pTHX_ void *key)
     RESTORE_CONTEXT;
 }
 
-STATIC SV *
+static SV *
 S_get_fq_name(pTHX_
               const char * const name,    /* The first non-blank in the \p{}, \P{} */
               const Size_t name_len,      /* Its length in bytes, not including any trailing space */
@@ -14579,7 +14579,7 @@ S_get_fq_name(pTHX_
     return fq_name;
 }
 
-STATIC SV *
+static SV *
 S_parse_uniprop_string(pTHX_
 
     /* Parse the interior of a \p{}, \P{}.  Returns its definition if knowable
@@ -16009,7 +16009,7 @@ S_parse_uniprop_string(pTHX_
     }
 }
 
-STATIC bool
+static bool
 S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
                               const STRLEN wname_len, /* Its length */
                               SV ** prop_definition,

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -1057,7 +1057,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
 
 
 #ifdef DEBUGGING
-STATIC void
+static void
 S_put_code_point(pTHX_ SV *sv, UV c)
 {
     PERL_ARGS_ASSERT_PUT_CODE_POINT;
@@ -1082,7 +1082,7 @@ S_put_code_point(pTHX_ SV *sv, UV c)
     }
 }
 
-STATIC void
+static void
 S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
 {
     /* Appends to 'sv' a displayable version of the range of code points from
@@ -1264,7 +1264,7 @@ S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
     }
 }
 
-STATIC void
+static void
 S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV* invlist)
 {
     /* Concatenate onto the PV in 'sv' a displayable form of the inversion list
@@ -1319,7 +1319,7 @@ S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV* invlist)
     return;
 }
 
-STATIC SV*
+static SV*
 S_put_charclass_bitmap_innards_common(pTHX_
         SV* invlist,            /* The bitmap */
         SV* posixes,            /* Under /l, things like [:word:], \S */
@@ -1398,7 +1398,7 @@ S_put_charclass_bitmap_innards_common(pTHX_
     return output;
 }
 
-STATIC U8
+static U8
 S_put_charclass_bitmap_innards(pTHX_ SV *sv,
                                      char *bitmap,
                                      SV *nonbitmap_invlist,

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -1,8 +1,5 @@
 #ifndef PERL_REGCOMP_INTERNAL_H
 #define PERL_REGCOMP_INTERNAL_H
-#ifndef STATIC
-#define STATIC  static
-#endif
 #ifndef RE_OPTIMIZE_CURLYX_TO_CURLYM
 #define RE_OPTIMIZE_CURLYX_TO_CURLYM 1
 #endif

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -158,7 +158,7 @@ S_invlist_array_init_(SV* const invlist, const bool will_have_0)
     return zero_addr + *offset;
 }
 
-STATIC void
+static void
 S_invlist_replace_list_destroys_src(pTHX_ SV * dest, SV * src)
 {
     /* Replaces the inversion list in 'dest' with the one from 'src'.  It
@@ -284,7 +284,7 @@ S_invlist_max(const SV* const invlist)
            : FROM_INTERNAL_SIZE(SvLEN(invlist)) - 1;
 }
 
-STATIC void
+static void
 S_initialize_invlist_guts(pTHX_ SV* invlist, const Size_t initial_size)
 {
     PERL_ARGS_ASSERT_INITIALIZE_INVLIST_GUTS;
@@ -378,7 +378,7 @@ Perl_new_invlist_C_array_(pTHX_ const UV* const list)
     return invlist;
 }
 
-STATIC void
+static void
 S_append_range_to_invlist_(pTHX_ SV* const invlist,
                                  const UV start, const UV end)
 {

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -24,7 +24,7 @@
     SAVEFREEPV(and_withp)
 
 
-STATIC void
+static void
 S_unwind_scan_frames(pTHX_ void *p)
 {
     PERL_ARGS_ASSERT_UNWIND_SCAN_FRAMES;
@@ -39,7 +39,7 @@ S_unwind_scan_frames(pTHX_ void *p)
 /* Follow the next-chain of the current node and optimize away
    all the NOTHINGs from it.
  */
-STATIC void
+static void
 S_rck_elide_nothing(pTHX_ regnode *node)
 {
     PERL_ARGS_ASSERT_RCK_ELIDE_NOTHING;
@@ -81,7 +81,7 @@ S_rck_elide_nothing(pTHX_ regnode *node)
  * Returns the invlist as a new SV*; it is the caller's responsibility to
  * call SvREFCNT_dec() when done with it.
  */
-STATIC SV*
+static SV*
 S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
 {
     const U8 * s = (U8*)STRING(node);
@@ -300,7 +300,7 @@ Perl_scan_commit(pTHX_ const RExC_state_t *pRExC_state, scan_data_t *data,
 /* An SSC is just a regnode_charclass_posix with an extra field: the inversion
  * list that describes which code points it matches */
 
-STATIC void
+static void
 S_ssc_anything(pTHX_ regnode_ssc *ssc)
 {
     /* Set the SSC 'ssc' to match an empty string or any code point */
@@ -314,7 +314,7 @@ S_ssc_anything(pTHX_ regnode_ssc *ssc)
     ANYOF_FLAGS(ssc) |= SSC_MATCHES_EMPTY_STRING;  /* Plus matches empty */
 }
 
-STATIC int
+static int
 S_ssc_is_anything(const regnode_ssc *ssc)
 {
     /* Returns true if the SSC 'ssc' can match the empty string and any code
@@ -386,7 +386,7 @@ Perl_ssc_init(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc)
     }
 }
 
-STATIC int
+static int
 S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state,
                         const regnode_ssc *ssc)
 {
@@ -420,7 +420,7 @@ S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state,
 }
 
 
-STATIC SV*
+static SV*
 S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
                                const regnode_charclass* const node)
 {
@@ -572,7 +572,7 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
 /* 'AND' a given class with another one.  Can create false positives.  'ssc'
  * should not be inverted. */
 
-STATIC void
+static void
 S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
                 const regnode_charclass *and_with)
 {
@@ -755,7 +755,7 @@ S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
     }
 }
 
-STATIC void
+static void
 S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
                const regnode_charclass *or_with)
 {
@@ -838,7 +838,7 @@ S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
               );
 }
 
-STATIC void
+static void
 S_ssc_union(pTHX_ regnode_ssc *ssc, SV* const invlist, const bool invert2nd)
 {
     PERL_ARGS_ASSERT_SSC_UNION;
@@ -851,7 +851,7 @@ S_ssc_union(pTHX_ regnode_ssc *ssc, SV* const invlist, const bool invert2nd)
                                         &ssc->invlist);
 }
 
-STATIC void
+static void
 S_ssc_intersection(pTHX_ regnode_ssc *ssc,
                          SV* const invlist,
                          const bool invert2nd)
@@ -866,7 +866,7 @@ S_ssc_intersection(pTHX_ regnode_ssc *ssc,
                                                &ssc->invlist);
 }
 
-STATIC void
+static void
 S_ssc_add_range(pTHX_ regnode_ssc *ssc, const UV start, const UV end)
 {
     PERL_ARGS_ASSERT_SSC_ADD_RANGE;
@@ -876,7 +876,7 @@ S_ssc_add_range(pTHX_ regnode_ssc *ssc, const UV start, const UV end)
     ssc->invlist = add_range_to_invlist_(ssc->invlist, start, end);
 }
 
-STATIC void
+static void
 S_ssc_cp_and(pTHX_ regnode_ssc *ssc, const UV cp)
 {
     /* AND just the single code point 'cp' into the SSC 'ssc' */
@@ -894,7 +894,7 @@ S_ssc_cp_and(pTHX_ regnode_ssc *ssc, const UV cp)
     SvREFCNT_dec_NN(cp_list);
 }
 
-STATIC void
+static void
 S_ssc_clear_locale(regnode_ssc *ssc)
 {
     /* Set the SSC 'ssc' to not match any locale things */

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -47,7 +47,7 @@
   Used for debugging make_trie().
 */
 
-STATIC void
+static void
 S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
             AV *revcharmap, U32 depth)
 {
@@ -141,7 +141,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
   possible chars (trie->uniquecharcount) is very high.
   Used for debugging make_trie().
 */
-STATIC void
+static void
 S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
                          HV *widecharmap, AV *revcharmap, U32 next_alloc,
                          U32 depth)
@@ -201,7 +201,7 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
   twists to facilitate compression later.
   Used for debugging make_trie().
 */
-STATIC void
+static void
 S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
                           HV *widecharmap, AV *revcharmap, U32 next_alloc,
                           U32 depth)
@@ -523,7 +523,7 @@ is the recommended Unicode-aware way of saying
  * and its folded variant, and for the first byte of a variant codepoint,
  * if any */
 
-STATIC void
+static void
 S_trie_bitmap_set_folded(pTHX_ RExC_state_t *pRExC_state,
     reg_trie_data *trie, U8 ch, const U8 * folder)
 {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -2904,6 +2904,7 @@ my @unresolved_visibility_overrides = qw(
     STANDARD_C
     StashHANDLER
     Stat
+    STATIC
     Stat_t
     STATUS_ALL_FAILURE
     STATUS_ALL_SUCCESS
@@ -4068,8 +4069,8 @@ sub generate_proto_h {
             }
             else {
                 $type = {
-                    'S' => 'STATIC',
-                    's' => 'STATIC',
+                    'S' => 'static',
+                    's' => 'static',
                     'i' => 'PERL_STATIC_INLINE',
                     'I' => 'PERL_STATIC_FORCE_INLINE'
                 }->{$static_flag};

--- a/regen/genpacksizetables.pl
+++ b/regen/genpacksizetables.pl
@@ -38,7 +38,7 @@ sub make_tables {
                       $unpredictable, $nocsum, $size, $condition);
     }
 
-    my $text = "STATIC const packprops_t packprops[512] = {\n";
+    my $text = "static const packprops_t packprops[512] = {\n";
     foreach my $arrayname (qw(normal shrieking)) {
         my $array = $arrays{$arrayname} ||
             die "No defined entries in $arrayname";

--- a/regen/mph.pl
+++ b/regen/mph.pl
@@ -931,7 +931,7 @@ sub blob_as_code {
     my $blob_name= $self->{blob_name};
 
     # output the blob as C code.
-    my @code= (sprintf "STATIC const unsigned char %s[] =\n", $blob_name);
+    my @code= (sprintf "static const unsigned char %s[] =\n", $blob_name);
     my $blob_len= length $blob;
     while (length($blob)) {
         push @code, sprintf qq(    "%s"), substr($blob, 0, 65, "");
@@ -1050,13 +1050,13 @@ EOF_CODE
 
     push @code, "#define ${prefix}_RSHIFT $RSHIFT\n";
     push @code, "#define ${prefix}_BUCKETS $n\n\n";
-    push @code, sprintf "STATIC const U32 ${prefix}_SEED1 = 0x%08x;\n", $seed1;
-    push @code, sprintf "STATIC const U32 ${prefix}_FNV32_PRIME = 0x%08x;\n\n",
+    push @code, sprintf "static const U32 ${prefix}_SEED1 = 0x%08x;\n", $seed1;
+    push @code, sprintf "static const U32 ${prefix}_FNV32_PRIME = 0x%08x;\n\n",
         FNV32_PRIME;
 
     push @code, "/* The comments give the input key for the row it is in */\n";
     push @code,
-        "STATIC const struct $struct_name $table_name\[${prefix}_BUCKETS] = {\n",
+        "static const struct $struct_name $table_name\[${prefix}_BUCKETS] = {\n",
         join(",\n", @$rows_array) . "\n};\n\n";
     push @code, <<"EOF_CODE";
 ${prefix}_VALt

--- a/regexec.c
+++ b/regexec.c
@@ -120,10 +120,6 @@ static const char non_utf8_target_but_utf8_required[]
     goto target;                                                         \
 } STMT_END
 
-#ifndef STATIC
-#define STATIC  static
-#endif
-
 /*
  * Forwards.
  */
@@ -226,7 +222,7 @@ static regmatch_state * S_push_slab(pTHX);
 /* REGCP_FRAME_ELEMS are not part of the REGCP_OTHER_ELEMS and
  * are needed for the regexp context stack bookkeeping. */
 
-STATIC CHECKPOINT
+static CHECKPOINT
 S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH)
 {
     const int retval = PL_savestack_ix;
@@ -414,7 +410,7 @@ S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma
 #define CAPTURE_CLEAR(from_ix, to_ix, str)              \
     if (from_ix) capture_clear(rex,from_ix, to_ix, str)
 
-STATIC void
+static void
 S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 {
     UV i;
@@ -524,7 +520,7 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 /* restore the parens and associated vars at savestack position ix,
  * but without popping the stack */
 
-STATIC void
+static void
 S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
 {
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -547,7 +543,7 @@ S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
 }
 
 
-STATIC bool
+static bool
 S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
 {
     /* Returns a boolean as to whether or not 'character' is a member of the
@@ -623,7 +619,7 @@ S_foldEQ_latin1_s2_folded(pTHX_ const char *s1, const char *s2, I32 len)
     return 1;
 }
 
-STATIC bool
+static bool
 S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8* character, const U8* e)
 {
     /* Returns a boolean as to whether or not the (well-formed) UTF-8-encoded
@@ -661,7 +657,7 @@ S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8* character, const U8* e)
     NOT_REACHED; /* NOTREACHED */
 }
 
-STATIC U8 *
+static U8 *
 S_find_span_end(U8 * s, const U8 * send, const U8 span_byte)
 {
     PERL_ARGS_ASSERT_FIND_SPAN_END;
@@ -718,7 +714,7 @@ S_find_span_end(U8 * s, const U8 * send, const U8 span_byte)
     return s;
 }
 
-STATIC U8 *
+static U8 *
 S_find_next_masked(U8 * s, const U8 * send, const U8 byte, const U8 mask)
 {
     PERL_ARGS_ASSERT_FIND_NEXT_MASKED;
@@ -786,7 +782,7 @@ S_find_next_masked(U8 * s, const U8 * send, const U8 byte, const U8 mask)
     return s;
 }
 
-STATIC U8 *
+static U8 *
 S_find_span_end_mask(U8 * s, const U8 * send, const U8 span_byte, const U8 mask)
 {
     PERL_ARGS_ASSERT_FIND_SPAN_END_MASK;
@@ -2265,7 +2261,7 @@ S_get_break_val_cp_checked(SV* const invlist, const UV cp_in) {
 /* if reginfo->intuit, its a dryrun */
 /* annoyingly all the vars in this routine have different names from their counterparts
    in regmatch. /grrr */
-STATIC char *
+static char *
 S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
     const char *strend, regmatch_info *reginfo)
 {
@@ -4407,7 +4403,7 @@ S_set_reg_curpm(pTHX_ REGEXP *rx, regmatch_info *reginfo)
        used to detect when this has happened.
 
  */
-STATIC bool			/* 0 failure, 1 success */
+static bool			/* 0 failure, 1 success */
 S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
 {
     REGEXP *const rx = reginfo->prog;
@@ -4491,7 +4487,7 @@ Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 
 /* grab a new slab and return the first slot in it */
 
-STATIC regmatch_state *
+static regmatch_state *
 S_push_slab(pTHX)
 {
     regmatch_slab *s = PL_regmatch_slab->next;
@@ -4507,7 +4503,7 @@ S_push_slab(pTHX)
 
 #ifdef DEBUGGING
 
-STATIC void
+static void
 S_debug_start_match(pTHX_ const REGEXP *prog, const bool utf8_target,
     const char *start, const char *end, const char *blurb)
 {
@@ -4537,7 +4533,7 @@ S_debug_start_match(pTHX_ const REGEXP *prog, const bool utf8_target,
     }
 }
 
-STATIC void
+static void
 S_dump_exec_pos(pTHX_ const char *locinput,
                       const regnode *scan,
                       const char *loc_regeol,
@@ -4618,7 +4614,7 @@ S_dump_exec_pos(pTHX_ const char *locinput,
  * Returns the index of the leftmost defined buffer with the given name
  * or 0 if non of the buffers matched.
  */
-STATIC I32
+static I32
 S_reg_check_named_buff_matched(const regexp *rex, const regnode *scan)
 {
     I32 n;
@@ -5243,7 +5239,7 @@ S_test_EXACTISH_ST(const char * loc,
     return (input32 & info.mask32) == info.anded32;
 }
 
-STATIC bool
+static bool
 S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strbeg, const U8 * const curpos, const bool utf8_target)
 {
     PERL_ARGS_ASSERT_ISGCB;
@@ -5368,7 +5364,7 @@ S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strb
                       break */
 }
 
-STATIC GCB_enum
+static GCB_enum
 S_backup_one_GCB(pTHX_ const U8 * const strbeg, U8 ** curpos, const bool utf8_target)
 {
     GCB_enum gcb;
@@ -5424,7 +5420,7 @@ S_backup_one_GCB(pTHX_ const U8 * const strbeg, U8 ** curpos, const bool utf8_ta
 #define backup_one_LB_but_over_CM_ZWJ(begin, cur, utf8)                 \
                                 backup_one_LB_(begin, cur, utf8, true)
 
-STATIC bool
+static bool
 S_isLB(pTHX_ LB_enum before,
              LB_enum after,
              const U8 * const strbeg,
@@ -5744,7 +5740,7 @@ S_isLB(pTHX_ LB_enum before,
                       break */
 }
 
-STATIC LB_enum
+static LB_enum
 S_advance_one_LB(pTHX_ U8 ** curpos, const U8 * const strend, const bool utf8_target)
 {
 
@@ -5774,7 +5770,7 @@ S_advance_one_LB(pTHX_ U8 ** curpos, const U8 * const strend, const bool utf8_ta
     return lb;
 }
 
-STATIC LB_enum
+static LB_enum
 S_backup_one_LB_(pTHX_ const U8 * const strbeg,
                        U8 ** curpos,
                        const bool utf8_target,
@@ -5842,7 +5838,7 @@ S_backup_one_LB_(pTHX_ const U8 * const strbeg,
     return lb;
 }
 
-STATIC bool
+static bool
 S_isSB(pTHX_ SB_enum before,
              SB_enum after,
              const U8 * const strbeg,
@@ -6037,7 +6033,7 @@ S_isSB(pTHX_ SB_enum before,
     return false;
 }
 
-STATIC SB_enum
+static SB_enum
 S_advance_one_SB(pTHX_ U8 ** curpos, const U8 * const strend, const bool utf8_target)
 {
     SB_enum sb;
@@ -6070,7 +6066,7 @@ S_advance_one_SB(pTHX_ U8 ** curpos, const U8 * const strend, const bool utf8_ta
     return sb;
 }
 
-STATIC SB_enum
+static SB_enum
 S_backup_one_SB(pTHX_ const U8 * const strbeg, U8 ** curpos, const bool utf8_target)
 {
     SB_enum sb;
@@ -6123,7 +6119,7 @@ S_backup_one_SB(pTHX_ const U8 * const strbeg, U8 ** curpos, const bool utf8_tar
 #define advance_one_WB_but_over_Extend_FO(cur, end, utf8)               \
                                 advance_one_WB_(cur, end, utf8, true)
 
-STATIC bool
+static bool
 S_isWB(pTHX_ WB_enum previous,
              WB_enum before,
              WB_enum after,
@@ -6291,7 +6287,7 @@ S_isWB(pTHX_ WB_enum previous,
                       break */
 }
 
-STATIC WB_enum
+static WB_enum
 S_advance_one_WB_(pTHX_ U8 ** curpos,
                         const U8 * const strend,
                         const bool utf8_target,
@@ -6331,7 +6327,7 @@ S_advance_one_WB_(pTHX_ U8 ** curpos,
     return wb;
 }
 
-STATIC WB_enum
+static WB_enum
 S_backup_one_WB_but_over_Extend_FO(pTHX_ WB_enum * previous,
                                          const U8 * const strbeg,
                                          U8 ** curpos,
@@ -6636,7 +6632,7 @@ bounds of our window into the string.
 */
 
 /* returns -1 on failure, $+[0] on success */
-STATIC SSize_t
+static SSize_t
 S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 {
     const bool utf8_target = reginfo->is_utf8_target;
@@ -10431,7 +10427,7 @@ NULL
  * max       - maximum number of things to match.
  * depth     - (for debugging) backtracking depth.
  */
-STATIC I32
+static I32
 S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
             char * loceol, regmatch_info *const reginfo, I32 max comma_pDEPTH)
 {
@@ -11110,7 +11106,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
 
  */
 
-STATIC bool
+static bool
 S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const p, const U8* const p_end, const bool utf8_target)
 {
     const char flags = (inRANGE(OP(n), ANYOFH, ANYOFHs))
@@ -11326,7 +11322,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
     return (flags & ANYOF_INVERT) ^ match;
 }
 
-STATIC U8 *
+static U8 *
 S_reghop3(U8 *s, SSize_t off, const U8* lim)
 {
     /* return the position 'off' UTF-8 characters away from 's', forward if
@@ -11363,7 +11359,7 @@ S_reghop3(U8 *s, SSize_t off, const U8* lim)
 /* like reghop3, but returns NULL on overrun, rather than returning last
  * char pos */
 
-STATIC U8 *
+static U8 *
 S_reghopmaybe3(U8* s, SSize_t off, const U8* const lim)
 {
     PERL_ARGS_ASSERT_REGHOPMAYBE3;
@@ -11578,7 +11574,7 @@ S_cleanup_regmatch_info_aux(pTHX_ void *arg)
 }
 
 
-STATIC void
+static void
 S_to_utf8_substr(pTHX_ regexp *prog)
 {
     /* Converts substr fields in prog from bytes to UTF-8, calling fbm_compile
@@ -11612,7 +11608,7 @@ S_to_utf8_substr(pTHX_ regexp *prog)
     } while (i--);
 }
 
-STATIC bool
+static bool
 S_to_byte_substr(pTHX_ regexp *prog)
 {
     /* Converts substr fields in prog from UTF-8 to bytes, calling fbm_compile

--- a/scope.c
+++ b/scope.c
@@ -297,7 +297,7 @@ S<C<'local $x = $y'>>), and that will handle the magic.
 =cut
 */
 
-STATIC SV *
+static SV *
 S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
 {
     SV * osv;

--- a/sv.c
+++ b/sv.c
@@ -292,7 +292,7 @@ Perl_more_sv(pTHX)
             plant_SV(p);				\
     } STMT_END
 
-STATIC void
+static void
 S_del_sv(pTHX_ SV *p)
 {
     PERL_ARGS_ASSERT_DEL_SV;
@@ -376,7 +376,7 @@ S_sv_add_arena(pTHX_ char *const ptr, const U32 size, const U32 flags)
 /* visit(): call the named function for each non-free SV in the arenas
  * whose flags field matches the flags/mask args. */
 
-STATIC SSize_t
+static SSize_t
 S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
 {
     SV* sva;
@@ -1770,7 +1770,7 @@ Perl_sv_setrv_inc_mg(pTHX_ SV *const sv, SV *const ref)
  * The return value may be != tmpbuf.
  */
 
-STATIC const char *
+static const char *
 S_sv_display(pTHX_ SV *const sv, char *tmpbuf, STRLEN tmpbuf_size) {
     const char *pv;
 
@@ -1839,7 +1839,7 @@ S_sv_display(pTHX_ SV *const sv, char *tmpbuf, STRLEN tmpbuf_size) {
  * printable version of the offending string
  */
 
-STATIC void
+static void
 S_not_a_number(pTHX_ SV *const sv)
 {
      char tmpbuf[64];
@@ -1860,7 +1860,7 @@ S_not_a_number(pTHX_ SV *const sv)
                "Argument \"%s\" isn't numeric", pv);
 }
 
-STATIC void
+static void
 S_not_incrementable(pTHX_ SV *const sv) {
      char tmpbuf[64];
      const char *pv;
@@ -1902,7 +1902,7 @@ Perl_looks_like_number(pTHX_ SV *const sv)
     return ((numtype & IS_NUMBER_TRAILING)) ? 0 : numtype;
 }
 
-STATIC bool
+static bool
 S_glob_2number(pTHX_ GV * const gv)
 {
     PERL_ARGS_ASSERT_GLOB_2NUMBER;
@@ -2004,7 +2004,7 @@ S_glob_2number(pTHX_ GV * const gv)
 /* sv_2iuv_non_preserve(): private routine for use by sv_2iv() and sv_2uv() */
 
 /* For sv_2nv these three cases are "SvNOK and don't bother casting"  */
-STATIC int
+static int
 S_sv_2iuv_non_preserve(pTHX_ SV *const sv
 #  ifdef DEBUGGING
                        , I32 numtype
@@ -2098,7 +2098,7 @@ S_sv_setnv(pTHX_ SV* sv, int numtype)
 STATIC_ASSERT_DECL(MAX_UV_PRESERVED_IN_NV <= (UV)IV_MAX);
 #endif
 
-STATIC bool
+static bool
 S_sv_2iuv_common(pTHX_ SV *const sv)
 {
     PERL_ARGS_ASSERT_SV_2IUV_COMMON;
@@ -2914,7 +2914,7 @@ Perl_uiv_2buf(char *const buf, const IV iv, UV uv, const int is_uv, char **const
  * XXX for "Inf", "-Inf", and "NaN", we could have three read-only
  * shared string constants we point to, instead of generating a new
  * string for each instance. */
-STATIC size_t
+static size_t
 S_infnan_2pv(NV nv, char* buffer, size_t maxlen, char plus) {
     char* s = buffer;
     assert(maxlen >= 4);
@@ -7155,7 +7155,7 @@ Perl_sv_replace(pTHX_ SV *const sv, SV *const nsv)
  * If that CV will outlive us, make it anonymous (i.e. fix up its CvGV
  * field) */
 
-STATIC void
+static void
 S_anonymise_cv_maybe(pTHX_ GV *gv, CV* cv)
 {
     SV *gvname;
@@ -12199,7 +12199,7 @@ S_sv_catpvn_simple(pTHX_ SV *const sv, const char* const buf, const STRLEN len)
  * arguments should be &PL_sv_no; an undefined value would yield
  * inappropriate "use of uninit" warnings [perl #71000].
  */
-STATIC void
+static void
 S_warn_vcatpvfn_missing_argument(pTHX) {
     ck_warner(packWARN(WARN_MISSING), "Missing argument in %s",
               PL_op ? OP_DESC(PL_op) : "sv_vcatpvfn()");
@@ -12271,7 +12271,7 @@ S_sprintf_arg_num_val(pTHX_ va_list *const args, int i, SV *sv, bool *neg)
  * than 1G, which seems reasonable.
  */
 
-STATIC STRLEN
+static STRLEN
 S_expect_number(pTHX_ const char **const pattern)
 {
     STRLEN var;
@@ -12296,7 +12296,7 @@ S_expect_number(pTHX_ const char **const pattern)
  * Returns NULL if not convertible.
  */
 
-STATIC char *
+static char *
 S_F0convert(NV nv, char *const endbuf, STRLEN *const len)
 {
     const int neg = nv < 0;
@@ -12432,7 +12432,7 @@ Perl_sv_vcatpvfn(pTHX_ SV *const sv, const char *const pat, const STRLEN patlen,
  * extraction sanity checked.  On the second round the actual output
  * (the extraction of the hexadecimal values) takes place.
  * Sanity failures cause fatal failures during both rounds. */
-STATIC U8*
+static U8*
 S_hextract(pTHX_ const NV nv, int* exponent, bool *subnormal,
            U8* vhex, U8* vend)
 {
@@ -15038,7 +15038,7 @@ Perl_ptr_table_new(pTHX)
 
 /* map an existing pointer using a table */
 
-STATIC PTR_TBL_ENT_t *
+static PTR_TBL_ENT_t *
 S_ptr_table_find(PTR_TBL_t *const tbl, const void *const sv)
 {
     PTR_TBL_ENT_t *tblent;
@@ -17485,7 +17485,7 @@ Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding,
 /* Look for an entry in the hash whose value has the same SV as val;
  * If so, return a mortal copy of the key. */
 
-STATIC SV*
+static SV*
 S_find_hash_subscript(pTHX_ const HV *const hv, const SV *const val)
 {
     HE **array;
@@ -17515,7 +17515,7 @@ S_find_hash_subscript(pTHX_ const HV *const hv, const SV *const val)
 /* Look for an entry in the array whose value has the same SV as val;
  * If so, return the index, otherwise return -1. */
 
-STATIC SSize_t
+static SSize_t
 S_find_array_subscript(pTHX_ const AV *const av, const SV *const val)
 {
     PERL_ARGS_ASSERT_FIND_ARRAY_SUBSCRIPT;
@@ -17633,7 +17633,7 @@ C<PL_comppad>/C<PL_curpad> points to the currently executing pad.
 =cut
 */
 
-STATIC SV *
+static SV *
 S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                   bool match, const char **desc_p)
 {

--- a/toke.c
+++ b/toke.c
@@ -562,7 +562,7 @@ static struct debug_tokens {
 
 /* dump the returned token in rv, plus any optional arg in pl_yylval */
 
-STATIC int
+static int
 S_tokereport(pTHX_ I32 rv, const YYSTYPE* lvalp)
 {
     PERL_ARGS_ASSERT_TOKEREPORT;
@@ -627,7 +627,7 @@ S_tokereport(pTHX_ I32 rv, const YYSTYPE* lvalp)
 
 /* print the buffer with suitable escapes */
 
-STATIC void
+static void
 S_printbuf(pTHX_ const char *const fmt, const char *const s)
 {
     SV* const tmp = newSVpvs("");
@@ -649,7 +649,7 @@ S_printbuf(pTHX_ const char *const fmt, const char *const s)
  * parsed and turns it into an ASSIGNOP if it finds one.
  */
 
-STATIC int
+static int
 S_ao(pTHX_ int toketype)
 {
     if (*PL_bufptr == '=') {
@@ -684,7 +684,7 @@ S_ao(pTHX_ int toketype)
 
 #define POP_OLDBUFPTR TRUE
 
-STATIC void
+static void
 S_warn_expect_operator(pTHX_ const char *const what, char *s, I32 pop_oldbufptr)
 {
     if (PL_expect != XOPERATOR)
@@ -768,7 +768,7 @@ S_warn_expect_operator(pTHX_ const char *const what, char *s, I32 pop_oldbufptr)
  * This is fatal.
  */
 
-STATIC void
+static void
 S_missingterm(pTHX_ char *s, STRLEN len)
 {
     char tmpbuf[UTF8_MAXBYTES + 1];
@@ -809,7 +809,7 @@ S_missingterm(pTHX_ char *s, STRLEN len)
                      " anywhere before EOF", q, UTF8fARG(uni, len, s), q);
 }
 
-STATIC char *
+static char *
 S_scan_terminated(pTHX_ char *s, I32 ival) {
     s = scan_str(s,FALSE,FALSE,FALSE,NULL);
     if (!s)
@@ -822,7 +822,7 @@ S_scan_terminated(pTHX_ char *s, I32 ival) {
 
 #include "feature.h"
 
-STATIC void
+static void
 S_yyerror_non_ascii_message(pTHX_ const U8 * const s)
 {
     PERL_ARGS_ASSERT_YYERROR_NON_ASCII_MESSAGE;
@@ -837,7 +837,7 @@ S_yyerror_non_ascii_message(pTHX_ const U8 * const s)
 #  define is_ascii_string_loc(s, len, ep)                               \
                                 is_utf8_invariant_string_loc(s, len, ep)
 #else
-STATIC bool
+static bool
 S_is_ascii_string_loc(const U8 * const s0, STRLEN len, const U8 ** ep)
 {
     const U8 * s = s0;
@@ -1898,7 +1898,7 @@ Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
  * If so, it sets the current line number and file to the values in the comment.
  */
 
-STATIC void
+static void
 S_incline(pTHX_ const char *s, const char *end)
 {
     PERL_ARGS_ASSERT_INCLINE;
@@ -2020,7 +2020,7 @@ S_incline(pTHX_ const char *s, const char *end)
     CopLINE_set(PL_curcop, line_num);
 }
 
-STATIC void
+static void
 S_update_debugger_info(pTHX_ SV *orig_sv, const char *const buf, STRLEN len)
 {
     AV *av = CopFILEAVx(PL_curcop);
@@ -2091,7 +2091,7 @@ Perl_skipspace_flags(pTHX_ char *s, U32 flags)
  * the +5 is its argument.
  */
 
-STATIC void
+static void
 S_check_unary(pTHX)
 {
     const char *s;
@@ -2139,7 +2139,7 @@ S_check_unary(pTHX)
  *  - else it's a list operator
  */
 
-STATIC I32
+static I32
 S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s)
 {
     PERL_ARGS_ASSERT_LOP;
@@ -2174,7 +2174,7 @@ S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s)
  * the lexer handles the token correctly.
  */
 
-STATIC void
+static void
 S_force_next(pTHX_ I32 type)
 {
 #ifdef DEBUGGING
@@ -2249,7 +2249,7 @@ Perl_yyunlex(pTHX)
     }
 }
 
-STATIC SV *
+static SV *
 S_newSV_maybe_utf8(pTHX_ const char *const start, STRLEN len)
 {
     SV * const sv = newSVpvn_utf8(start, len,
@@ -2277,7 +2277,7 @@ S_newSV_maybe_utf8(pTHX_ const char *const start, STRLEN len)
  *       use, etc. do this)
  */
 
-STATIC char *
+static char *
 S_force_word(pTHX_ char *start, int token, U32 flags)
 {
     char *s;
@@ -2330,7 +2330,7 @@ S_force_word(pTHX_ char *start, int token, U32 flags)
  * Creates the symbol if it didn't already exist (via gv_fetchpv()).
  */
 
-STATIC void
+static void
 S_force_ident(pTHX_ const char *s, int kind)
 {
     PERL_ARGS_ASSERT_FORCE_IDENT;
@@ -2401,7 +2401,7 @@ Perl_str_to_version(pTHX_ SV *sv)
  * must use an alternative parsing method).
  */
 
-STATIC char *
+static char *
 S_force_version(pTHX_ char *s, int guessing)
 {
     OP *version = NULL;
@@ -2445,7 +2445,7 @@ S_force_version(pTHX_ char *s, int guessing)
  * Forces the next token to be a version number using strict syntax rules.
  */
 
-STATIC char *
+static char *
 S_force_strict_version(pTHX_ char *s)
 {
     OP *version = NULL;
@@ -2484,7 +2484,7 @@ S_force_strict_version(pTHX_ char *s)
  * unchanged, and a new SV containing the modified input is returned.
  */
 
-STATIC SV *
+static SV *
 S_tokeq(pTHX_ SV *sv)
 {
     char *s;
@@ -2554,7 +2554,7 @@ S_tokeq(pTHX_ SV *sv)
  * call to S_sublex_push().
  */
 
-STATIC I32
+static I32
 S_sublex_start(pTHX)
 {
     const I32 op_type = pl_yylval.ival;
@@ -2606,7 +2606,7 @@ S_sublex_start(pTHX)
  * Sets PL_lex_state to LEX_INTERPCONCAT.
  */
 
-STATIC I32
+static I32
 S_sublex_push(pTHX)
 {
     LEXSHARED *shared;
@@ -2709,7 +2709,7 @@ S_sublex_push(pTHX)
  * Restores lexer state after a S_sublex_push.
  */
 
-STATIC I32
+static I32
 S_sublex_done(pTHX)
 {
     if (!PL_lex_starts++) {
@@ -2838,7 +2838,7 @@ Perl_load_charnames(pTHX_ SV * char_name, const char * context,
     return NULL;
 }
 
-STATIC SV*
+static SV*
 S_get_and_check_backslash_N_name_wrapper(pTHX_ const char* s, const char* const e)
 {
     /* This justs wraps get_and_check_backslash_N_name() to output any error
@@ -3170,7 +3170,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
 
 */
 
-STATIC char *
+static char *
 S_scan_const(pTHX_ char *start)
 {
     const char * const send = PL_bufend;/* end of the constant */
@@ -4480,7 +4480,7 @@ S_scan_const(pTHX_ char *start)
     return s;
 }
 
-STATIC bool
+static bool
 S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8)
 {
     PERL_ARGS_ASSERT_IS_EXISTING_IDENTIFIER;
@@ -4529,7 +4529,7 @@ S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8)
 
 /* This is the one truly awful dwimmer necessary to conflate C and sed. */
 
-STATIC int
+static int
 S_intuit_more(pTHX_ char *s, char *e,
               U8 caller_context,    /* Who's calling us? basically an enum */
               char * caller_s,      /* If non-NULL, the name of the identifier
@@ -5020,7 +5020,7 @@ S_intuit_more(pTHX_ char *s, char *e,
  *   =>
  */
 
-STATIC int
+static int
 S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv)
 {
     PERL_ARGS_ASSERT_INTUIT_METHOD;
@@ -5338,7 +5338,7 @@ Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
     return ret;
 }
 
-STATIC char *
+static char *
 S_filter_gets(pTHX_ SV *sv, STRLEN append)
 {
     PERL_ARGS_ASSERT_FILTER_GETS;
@@ -5355,7 +5355,7 @@ S_filter_gets(pTHX_ SV *sv, STRLEN append)
         return (sv_gets(sv, PL_rsfp, append));
 }
 
-STATIC HV *
+static HV *
 S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
 {
     GV *gv;
@@ -5386,7 +5386,7 @@ S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
 }
 
 
-STATIC char *
+static char *
 S_tokenize_use(pTHX_ int is_use, char *s) {
     PERL_ARGS_ASSERT_TOKENIZE_USE;
 
@@ -5424,7 +5424,7 @@ S_tokenize_use(pTHX_ int is_use, char *s) {
 #endif
 
 #define word_takes_any_delimiter(p,l) S_word_takes_any_delimiter(p,l)
-STATIC bool
+static bool
 S_word_takes_any_delimiter(char *p, STRLEN len)
 {
     return (len == 1 && memCHRs("msyq", p[0]))
@@ -10386,7 +10386,7 @@ S_pending_ident(pTHX)
     return BAREWORD;
 }
 
-STATIC void
+static void
 S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
 {
     PERL_ARGS_ASSERT_CHECKCOMMA;
@@ -10456,7 +10456,7 @@ S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
    If error_msg is not NULL, *error_msg will be set to any error encountered.
    Otherwise yyerror() will be used to output it */
 
-STATIC SV *
+static SV *
 S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
                SV *sv, SV *pv, const char *type, STRLEN typelen,
                const char ** error_msg)
@@ -10564,7 +10564,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
     return SvREFCNT_inc_simple_NN(sv);
 }
 
-STATIC char *
+static char *
 S_parse_ident(pTHX_ const char *s, const char * const s_end,
                     char **d, char * const e,
                     bool is_utf8, HV** failure_details, U32 flags)
@@ -10899,7 +10899,7 @@ Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STR
  * unary operators.  This is silently overriden if CHECK_ONLY is also
  * specified.
  */
-STATIC char *
+static char *
 S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
 {
     PERL_ARGS_ASSERT_SCAN_IDENT;
@@ -11300,7 +11300,7 @@ S_pmflag(pTHX_ const char* const valid_flags, U32 * pmfl, char** s, char* charse
         return TRUE;
 }
 
-STATIC char *
+static char *
 S_scan_pat(pTHX_ char *start, I32 type)
 {
     PMOP *pm;
@@ -11376,7 +11376,7 @@ S_scan_pat(pTHX_ char *start, I32 type)
     return s;
 }
 
-STATIC char *
+static char *
 S_scan_subst(pTHX_ char *start)
 {
     char *s;
@@ -11464,7 +11464,7 @@ S_scan_subst(pTHX_ char *start)
     return s;
 }
 
-STATIC char *
+static char *
 S_scan_trans(pTHX_ char *start)
 {
     char* s;
@@ -11549,7 +11549,7 @@ S_scan_trans(pTHX_ char *start)
    Otherwise it is treated as an eval.
 */
 
-STATIC char *
+static char *
 S_scan_heredoc(pTHX_ char *s)
 {
     I32 op_type = OP_SCALAR;
@@ -12003,7 +12003,7 @@ S_scan_heredoc(pTHX_ char *s)
 
 */
 
-STATIC char *
+static char *
 S_scan_inputsymbol(pTHX_ char *start)
 {
     char *s = start;		/* current position in buffer */
@@ -13190,7 +13190,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
     return (char *)s;
 }
 
-STATIC char *
+static char *
 S_scan_formline(pTHX_ char *s)
 {
     SV * const stuff = newSVpvs("");
@@ -13336,7 +13336,7 @@ Perl_start_subparse(pTHX_ I32 is_format, U32 flags)
  * Otherwise does nothing and returns false
  */
 
-STATIC bool
+static bool
 S_apply_builtin_cv_attribute(pTHX_ CV *cv, OP *o)
 {
     assert(o->op_type == OP_CONST);
@@ -13607,7 +13607,7 @@ Perl_yyerror_pvn(pTHX_ const char *const s, STRLEN len, U32 flags)
     return 0;
 }
 
-STATIC char*
+static char*
 S_swallow_bom(pTHX_ U8 *s)
 {
     const STRLEN slen = SvCUR(PL_linestr);

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -21,7 +21,7 @@ ref length: 63248
 data size: 72380 (%64.87)
 */
 
-STATIC const unsigned char mph_blob[] =
+static const unsigned char mph_blob[] =
     "l&cwlmcmocradlmaghbahexahomarmiavstbatkbhksbuhdcakmcanschamchrscp"
     "mncprtcwucyrldsrtgonggrekgujrgukhhluwhmngzljtkawikitskndakrailaoo"
     "latnlisumedfmercmteimymrnarbnewaoryaosgeougrpcmphlpphnxqaacrjngru"
@@ -177,11 +177,11 @@ struct mph_struct {
 #define MPH_RSHIFT 8
 #define MPH_BUCKETS 7906
 
-STATIC const U32 MPH_SEED1 = 0x5065726f;
-STATIC const U32 MPH_FNV32_PRIME = 0x01000193;
+static const U32 MPH_SEED1 = 0x5065726f;
+static const U32 MPH_FNV32_PRIME = 0x01000193;
 
 /* The comments give the input key for the row it is in */
-STATIC const struct mph_struct mph_table[MPH_BUCKETS] = {
+static const struct mph_struct mph_table[MPH_BUCKETS] = {
   {     1,  1733,  6484,   4,  20, UNI_GLAGOLITICSUP }   /* blk=glagoliticsupplement */,
   {     3,  1911,  1144,   6,   5, UNI_TALU }   /* script=talu */,
   {     3,  2429,  2385,   6,  12, UNI_INTULUTIGALARI }   /* block=tulutigalari */,
@@ -8177,5 +8177,5 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * 8abaee16c84c1a61a69a77b6e8963675d99f515f3c2a34e449faeb9bfdec861a regen/mk_PL_charclass.pl
  * 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
- * d6987e01ad538d1567394851cf199f99815f7701bebd6092be4bc7a6d8f147c6 regen/mph.pl
+ * a6ce8aefad005c081d4e04523e1f1f1a5a1bed5414ca4a421b5b16b73bfce6a4 regen/mph.pl
  * ex: set ro ft=c: */

--- a/universal.c
+++ b/universal.c
@@ -39,7 +39,7 @@
  * The main guts of traverse_isa was actually copied from gv_fetchmeth
  */
 
-STATIC bool
+static bool
 S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char * name, STRLEN len, U32 flags)
 {
     PERL_ARGS_ASSERT_ISA_LOOKUP;
@@ -78,7 +78,7 @@ S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char * name, STRLEN len, U32 fla
     return FALSE;
 }
 
-STATIC bool
+static bool
 S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char * name, const STRLEN len, U32 flags)
 {
     HV* stash;
@@ -1352,7 +1352,7 @@ static const struct xsub_details these_details[] = {
     {"Tie::Hash::NamedCapture::flags", XS_NamedCapture_flags, NULL, 0 },
 };
 
-STATIC OP*
+static OP*
 optimize_out_native_convert_function(pTHX_ OP* entersubop,
                                            GV* namegv,
                                            SV* protosv)

--- a/utf8.c
+++ b/utf8.c
@@ -97,7 +97,7 @@ Perl_force_out_malformed_utf8_message_(pTHX_
     }
 }
 
-STATIC HV *
+static HV *
 S_new_msg_hv(pTHX_ const char * const message, /* The message text */
                    U32 categories,  /* Packed warning categories */
                    U32 flag)        /* Flag associated with this message */
@@ -3706,7 +3706,7 @@ Perl_to_uni_title(pTHX_ UV c, U8* p, STRLEN *lenp)
     return CALL_TITLE_CASE(c, NULL, p, lenp);
 }
 
-STATIC U8
+static U8
 S_to_lower_latin1(const U8 c, U8* p, STRLEN *lenp, const char dummy)
 {
     /* We have the latin1-range values compiled into the core, so just use
@@ -3854,7 +3854,7 @@ Perl_to_uni_fold_flags_(pTHX_ UV c, U8* p, STRLEN *lenp, U8 flags)
 #if 0	/* Not currently used, but may be needed in the future */
 PERLVAR(I, seen_deprecated_macro, HV *)
 
-STATIC void
+static void
 S_warn_on_first_deprecated_use(pTHX_ U32 category,
                                      const char * const name,
                                      const char * const alternative,
@@ -3901,7 +3901,7 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category,
 /* returns the number of bytes comprising the UTF8-encoded character that
  * starts at <p>, and extending no further than <e - 1> if it is in the
  * inversion list <invlist>; or 0 if it isn't */
-STATIC Size_t
+static Size_t
 S_is_utf8_in_invlist(pTHX_ const U8 * p, const U8 * e, SV * const invlist)
 {
     Size_t advance;
@@ -3936,7 +3936,7 @@ Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
     return S_is_utf8_in_invlist(aTHX_ p, e, PL_utf8_perl_idcont);
 }
 
-STATIC UV
+static UV
 S_to_case_cp_list(pTHX_
                   const UV original,
                   const U32 ** const remaining_list,
@@ -4033,7 +4033,7 @@ S_to_case_cp_list(pTHX_
     return (UV) aux_tables[base][0];
 }
 
-STATIC UV
+static UV
 S_to_utf8_case_(pTHX_ const UV original, const U8 *p,
                       U8* ustrp, STRLEN *lenp,
                       SV *invlist, const I32 * const invmap,
@@ -4160,7 +4160,7 @@ Perl_inverse_folds_(pTHX_ const UV cp, U32 * first_folds_to,
     return 1;
 }
 
-STATIC UV
+static UV
 S_check_locale_boundary_crossing(pTHX_ const U8* const p, const UV result,
                                        U8* const ustrp, STRLEN *lenp)
 {
@@ -4217,7 +4217,7 @@ S_check_locale_boundary_crossing(pTHX_ const U8* const p, const UV result,
     return original;
 }
 
-STATIC UV
+static UV
 S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e,
                         U8 * ustrp, STRLEN *lenp)
 {
@@ -4251,7 +4251,7 @@ S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e,
     return 0;
 }
 
-STATIC UV
+static UV
 S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e,
                         U8 * ustrp, STRLEN *lenp)
 {
@@ -4296,7 +4296,7 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e,
     return turkic_fc(p0, e, ustrp, lenp);
 }
 
-STATIC UV
+static UV
 S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e,
                         U8 * ustrp, STRLEN *lenp)
 {

--- a/util.c
+++ b/util.c
@@ -1371,7 +1371,7 @@ Perl_savesharedpvn(pTHX_ const char *const pv, const STRLEN len)
 
 /* the SV for Perl_form() and mess() is not kept in an arena */
 
-STATIC SV *
+static SV *
 S_mess_alloc(pTHX)
 {
     SV *sv;
@@ -1693,7 +1693,7 @@ Perl_write_to_stderr(pTHX_ SV* msv)
 
 /* Common code used in dieing and warning */
 
-STATIC SV *
+static SV *
 S_with_queued_errors(pTHX_ SV *ex)
 {
     PERL_ARGS_ASSERT_WITH_QUEUED_ERRORS;
@@ -5577,7 +5577,7 @@ cross platform way to prevent a SEGV.
 }
 
 
-STATIC void
+static void
 S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
                           STRLEN xs_len)
 {

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -3541,7 +3541,7 @@ win32_popenlist(const char *mode, IV narg, SV **args)
     return do_popen(mode, NULL, narg, args);
 }
 
-STATIC PerlIO*
+static PerlIO*
 do_popen(const char *mode, const char *command, IV narg, SV **args) {
     int p[2];
     int handles[3];


### PR DESCRIPTION
`STATIC` was first defined internally (as `#define STATIC static`) in `regexp.c` in [perl-2.0](https://github.com/Perl/perl5/commit/378cc40b38293ffc7298c6a7ed3cd740ad79be52), then copied to `regcomp.c` (and thence later to `regcomp_internal.h`) and `regexec.c` in [perl-3.000](https://github.com/Perl/perl5/commit/a687059cbaf2c6fdccb5e0fae2aee80ec15625a8).

In 76e3520e1f6b (1998), the `PERL_OBJECT` feature was added. It allowed for multiplicity as follows:  All global variables and functions were wrapped in a C++ class (`CPerlObj`), so all access to interpreter state implicitly went through `this->...`. Any internal function that used variables or functions of the perl interpreter had to be non-static because it was actually a member function of `CPerlObj` (and declaring member functions `static` means they don't have access to `this`). Thus all such functions were changed from `static` to `STATIC` and a conditional definition was added to `perl.h`: In normal configurations, `STATIC` would just expand to `static`, but under `PERL_OBJECT`, `STATIC` would expand to nothing.

In acfe0abcedaf (2001), `PERL_OBJECT` was removed again ("deprecated cruft", "has long since stopped working"). Ever since, `STATIC` has been unconditionally defined as `static`.

But instead of slowly getting removed over time, new uses of `STATIC` were added, even in places where it would have made no sense under `PERL_OBJECT`, such as XS modules or static variables in functions.

This PR removes all remaining uses of `STATIC` in core and changes them to `static` (except for Devel::PPPort because that module scares me).

I don't think this change requires a perldelta entry because `STATIC` has never been properly documented (except for a quick mention in perlguts, long outdated).

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
