### PR TITLE
perlmodlib.PL: handle C<...> around module names

### DIFF
--- a/pod/perlmodlib.PL
+++ b/pod/perlmodlib.PL
@@ -83,6 +83,10 @@ for my $filename (@files) {
 	next;
     }
 
+    # unwrap C<...> around module name
+    if ($name =~ /^C<([A-Za-z0-9_:]+)>/) {
+        $name = $1;
+    }
     $name =~ s/[^A-Za-z0-9_:\$<>].*//;
     $name = $exceptions{$name} || $name;
     $thing =~ s/^perl pragma to //i;

--- a/pod/perlmodlib.PL
+++ b/pod/perlmodlib.PL
@@ -18,15 +18,15 @@ require './regen/regen_lib.pl';
 # MANIFEST itself is Unix style filenames, so we have to assume that Unix style
 # filenames will work.
 
-open MANIFEST, '<', 'MANIFEST'
+open my $manifest_fh, '<', 'MANIFEST'
     or die "Can't open MANIFEST: $!";
 my @files =
     grep !m#/perl.*\.pod#,
     grep m#(?:\.pm|\.pod|_pm\.PL)#,
     map {s/\s.*//s; $_}
     grep { m#^(lib|ext|dist|cpan)/# && !m#/(?:t|demo|corpus)/# }
-    <MANIFEST>;
-close MANIFEST
+    readline $manifest_fh;
+close $manifest_fh
     or die "$0: failed to close MANIFEST: $!";
 
 my $out = open_new('pod/perlmodlib.pod', undef,
@@ -44,7 +44,8 @@ my %exceptions = (
 my (@pragma, @mod);
 
 for my $filename (@files) {
-    unless (open MOD, '<', $filename) {
+    my $mod_fh;
+    unless (open $mod_fh, '<', $filename) {
         warn "Couldn't open $filename: $!";
 	next;
     }
@@ -53,7 +54,7 @@ for my $filename (@files) {
     my $foundit = 0;
     {
 	local $/ = "";
-	while (<MOD>) {
+	while (readline $mod_fh) {
 	    next unless /^=head1 NAME/;
 	    $foundit++;
 	    last;
@@ -69,9 +70,9 @@ for my $filename (@files) {
         warn "$filename missing =head1 NAME\n" unless $Quiet;
 	next;
     }
-    my $title = <MOD>;
+    my $title = readline $mod_fh;
     chomp $title;
-    close MOD
+    close $mod_fh
         or die "Error closing $filename: $!";
 
     ($name, $thing) = split /\s+--?\s+/, $title, 2;


### PR DESCRIPTION
Consider a module like IO::Socket::IP, which has this POD:

    =head1 NAME

    C<IO::Socket::IP> - Family-neutral IP socket supporting both IPv4 and IPv6

If we don't extract the `IO::Socket::IP` part from its `C<...>` wrapper, it will be sorted somewhere between "Benchmark" and "CORE" in perlmodlib, not after "IO::Socket" where it belongs.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
