### PR TITLE
embed.fnc: Add re_intuit_start end string arg assert

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2948,7 +2948,7 @@ Cp	|char * |re_intuit_start|NN REGEXP * const rx			\
 				|NULLOK SV *sv				\
 				|SPTR const char * const strbeg 	\
 				|MPTR char *strpos			\
-				|NN char *strend			\
+				|EPTRge char *strend			\
 				|const U32 flags			\
 				|NULLOK re_scream_pos_data *data
 Cp	|SV *	|re_intuit_string					\

--- a/proto.h
+++ b/proto.h
@@ -3680,7 +3680,7 @@ PERL_CALLCONV char *
 Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg, char *strpos, char *strend, const U32 flags, re_scream_pos_data *data);
 #define PERL_ARGS_ASSERT_RE_INTUIT_START        \
         assert(rx); assert(strbeg); assert(strpos); assert(strend); \
-        assert(strbeg <= strpos)
+        assert(strbeg <= strpos); assert(strpos <= strend)
 
 PERL_CALLCONV SV *
 Perl_re_intuit_string(pTHX_ REGEXP * const r);

--- a/regexec.c
+++ b/regexec.c
@@ -875,7 +875,8 @@ Perl_pregexec(pTHX_ REGEXP * const prog, char* stringarg, char *strend,
  *           the SV itself.
  *   strbeg: real beginning of string
  *   strpos: the point in the string at which to begin matching
- *   strend: pointer to the byte following the last char of the string
+ *   strend: pointer to the byte following the last char of the string, or to
+ *           'strpos' if there is nothing left to match.
  *   flags   currently unused; set to 0
  *   data:   currently unused; set to NULL
  *


### PR DESCRIPTION
It properly handles an empty string input.  Correct the comments inside it.


* This set of changes does not require a perldelta entry.
