### PR TITLE
Perl_hv_common - don't call share_hek_flags when (keysv_hek != NULL)

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -995,7 +995,11 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
        bad API design.  */
     if (LIKELY(HvSHAREKEYS(hv))) {
         entry = new_HE();
-        HeKEY_hek(entry) = share_hek_flags(key, klen, hash, flags);
+        if (keysv_hek) {
+            HeKEY_hek(entry) = share_hek_hek(keysv_hek);
+        } else {
+            HeKEY_hek(entry) = share_hek_flags(key, klen, hash, flags);
+        }
     }
     else if (UNLIKELY(hv == PL_strtab)) {
         /* PL_strtab is usually the only hash without HvSHAREKEYS, so putting


### PR DESCRIPTION
When creating a new `HE` for insertion into a hash that supports shared keys, `Perl_hv_common` always achieves this via `S_share_hek_flags`.

`S_share_hek_flags` searches the shared string table - `PL_strtab` - for a matching entry and inserts one if needs be, returning the relevant `HEK*`.

However, if `Perl_hv_common`'s `keysv` is a "HEK in disguise" to begin with, `keysv_hek` _already_ contains the resulting `HEK*` - and we are able to bump the refcount on it. So this commit checks for that case and branches accordingly.

gcov counts from a perl build and test_harness run suggest that having a valid `keysv_hek` is already very common.

```
129097943:  996:    if (LIKELY(HvSHAREKEYS(hv))) {
129097941:  997:        entry = new_HE();
129097941:  998:        if (keysv_hek) {
 50255991:  999:            HeKEY_hek(entry) = keysv_hek;
 50255991: 1000:            share_hek_hek(keysv_hek);
        -: 1001:        } else {
 78841950: 1002:            HeKEY_hek(entry) = share_hek_flags(key, klen, hash, flags);
        -: 1003:        }
        -: 1004:    }
```

If greater use is made of `PL_strtab` in the future, such as for OP_CONST SVs, the `keysv_hek` is likely to become correspondingly hotter.

(If someone points out a compelling reason why this isn't already done, I'll add comments to that effect instead.)

-------------------------------------------------------------------------------
* I haven't benchmarked yet to see if this change is likely to be noticeable. It may warrant a perldelta entry.
