### PR TITLE
embed.pl: RXf_PMf_ symbols should be visible everywhere

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -45,8 +45,6 @@
 #     undef OPpPARAM_IF_FALSE
 #     undef OPpPARAM_IF_UNDEF
 #     undef OPpSELF_IN_PAD
-#     undef RXf_PMf_CHARSET_SHIFT_
-#     undef RXf_PMf_SHIFT_NEXT_
 #     undef utf16_to_utf8
 #     undef utf16_to_utf8_reversed
 #   endif /* !defined(PERL_EXT) */
@@ -58,9 +56,8 @@
 #     undef PARSE_IDENT_ERROR_POSITION
 #     undef PARSE_IDENT_ERROR_TEXT
 #     undef RExC_parse_advance
-#     undef RXf_PMf_SHIFT_COMPILETIME_
 #     undef WARN_HELPER_
-#   endif /* !defined(PERL_EXT_RE_BUILD) */
+#   endif
 # endif /* !defined(PERL_CORE) */
 #else /* if !defined(PERL_DO_UNDEFS) */
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3610,7 +3610,6 @@ my @needed_by_ext_re = qw(
     PARSE_IDENT_ERROR_POSITION
     PARSE_IDENT_ERROR_TEXT
     RExC_parse_advance
-    RXf_PMf_SHIFT_COMPILETIME_
     WARN_HELPER_
 );
 
@@ -3620,8 +3619,6 @@ my @needed_by_ext = qw(
     OPpPARAM_IF_FALSE
     OPpPARAM_IF_UNDEF
     OPpSELF_IN_PAD
-    RXf_PMf_CHARSET_SHIFT_
-    RXf_PMf_SHIFT_NEXT_
 );
 
 # This is a list of symbols that are needed to be visible everywhere and are
@@ -3647,6 +3644,9 @@ my @undocumented_always_visible = qw(
     MEM_WRAP_NEEDS_RUNTIME_CHECK_
     MEM_WRAP_WILL_WRAP_
     NV_BODYLESS_UNION_
+    RXf_PMf_CHARSET_SHIFT_
+    RXf_PMf_SHIFT_COMPILETIME_
+    RXf_PMf_SHIFT_NEXT_
     shifted_octet_
     STATIC_ASSERT_STRUCT_BODY_
     STATIC_ASSERT_STRUCT_NAME_

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -160,7 +160,9 @@ my %per_file_definitions = (
 # The list does not include symbols that we have documented as being reserved
 # for perl's use, namely those that match the pattern just above.
 # There are two parts of the list; the second part contains the symbols which
-# have a trailing underscore; the first part those without.
+# have a trailing underscore indicating the intent for this symbol to not be
+# directly usable by XS code.  The first part are those symbols without a
+# trailing underscore.
 #
 # For all modules that aren't deliberately using particular names, all the
 # other symbols on it are namespace pollutants.
@@ -3633,10 +3635,15 @@ my @needed_by_ext = qw(
 #
 # Typically these are symbols that are behind-the-scenes helpers whose use is
 # obvious from inspection of the things they help.
+#
+# The list has two parts, separated by a blank line.  The names in the second
+# part have a trailing underscore, indicating the intent for this symbol to
+# not be directly usable by XS code
 my @undocumented_always_visible = qw(
+    MAX_UNICODE_UTF8_BYTES
+
     EXTEND_NEEDS_GROW_
     EXTEND_SAFE_N_
-    MAX_UNICODE_UTF8_BYTES
     MEM_WRAP_NEEDS_RUNTIME_CHECK_
     MEM_WRAP_WILL_WRAP_
     NV_BODYLESS_UNION_


### PR DESCRIPTION
Fixes #24153; Fixes #24154

The spelling of various symbols changed in 5.43, to align with the C Standard.  That meant that any code using the old symbol, and which didn't get updated, would break.  Macros that used the old symbol were updated to use the new one.  Since we didn't get breakage, that meant there was no tested code that used the old spelling directly.

When I was backporting the hardening of visibility to the beginning of 5.43, I found the spelling changes.  If I didn't find a macro that used the new spelling, I concluded that this symbol wasn't used in CPAN, even indirectly.  (I grepped a snapshot of metacpan to rule out direct mentions.)

For the symbols that broke here, I did find indirect uses, but it appeared to me that these were only uses by Perl extensions.  I was clearly wrong.

This fact indicates that we can resolve these symbols; they are needed to be visible everywhere.  There's three ways to resolve such things:

1.  Document them.  I don't see any real need for code beyond the already
    existing code from needing to use them.  Their use is obvious once
    you see the pattern, so I  don't see a need for them to even be put
    in perlintern.
2.  Change their names to begin with Perl_.  This might be something to
    do at a later date, but not in the 5.43 cycle.
3.  Put them on the resolved list.  I've opted for that now.

* This set of changes does not require a perldelta entry.
