### PR TITLE
Fix popmark underflow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1018,6 +1018,7 @@ Milton L. Hankins              <mlh@swl.msd.ray.com>
 Misty De Meo                   <mistydemeo@github.com>
 Mohammad S Anwar               <Mohammad.Anwar@yahoo.com>
 Mohammed El-Afifi              <mohammed_elafifi@yahoo.com>
+Molchan Nikita Olegovich       <v.tkalin.ru@gmail.com>
 Moritz Lenz                    <moritz@casella.verplant.org>
 Moshe Kaminsky                 <kaminsky@math.huji.ac.il>
 Mottaqui Karim                 <taqqui.karim@gmail.com>

--- a/inline.h
+++ b/inline.h
@@ -404,11 +404,13 @@ Perl_TOPMARK(pTHX)
 PERL_STATIC_INLINE Stack_off_t
 Perl_POPMARK(pTHX)
 {
+    if (UNLIKELY(PL_markstack_ptr <= PL_markstack))
+        Perl_croak(aTHX_ "panic: MARK underflow");
+
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
                                  "MARK pop  %p %" IVdf "\n",
-                                  (PL_markstack_ptr-1),
-                                  (IV)*(PL_markstack_ptr-1))));
-    assert((PL_markstack_ptr > PL_markstack) || !"MARK underflow");
+                                  PL_markstack_ptr,
+                                  (IV)*PL_markstack_ptr)));
     return *PL_markstack_ptr--;
 }
 

--- a/t/op/popmark-underflow.t
+++ b/t/op/popmark-underflow.t
@@ -1,0 +1,37 @@
+#!./perl
+
+use strict;
+use warnings;
+
+require './test.pl';
+
+my $poc_min = '\(sort {0} 0, 0 .. "r")';
+
+my $poc_fuzz = <<'POC';
+\(\(\(\(\(\(\(\(sort {
+    \(\(sort {18446605494517776183;} %0, 'so'));
+} %0 = 'Ev5' .. 14))))))));
+POC
+
+my @pocs = (
+    [ 'minimal', $poc_min ],
+    [ 'fuzz',    $poc_fuzz ],
+);
+
+my $libdir = -d 'lib' ? 'lib' : '../lib';
+my $runperl_args = {
+    nolib    => 1,
+    switches => [ "-I$libdir" ],
+};
+
+for my $case (@pocs) {
+    my ($name, $poc) = @$case;
+    my $err = fresh_perl($poc, $runperl_args);
+    my $status = $?;
+
+    unlike($err, qr/Segmentation fault/, "$name: no segfault");
+    like($err, qr/\bpanic:\s+MARK underflow\b/, "$name: deterministic MARK underflow");
+
+}
+
+done_testing();


### PR DESCRIPTION
This PR addresses a memory-safety issue triggered by the PoC in GH #19790.

Problem
-------
The attached PoC reliably triggers a MARK underflow during sort execution. When asserts are
disabled, Perl_POPMARK() may read before the markstack base, which is undefined behavior.
Under ASan this manifests as a heap-buffer-overflow (READ of size 4) in inline.h:Perl_POPMARK,
with the call originating from pp_sort.c.

Reproduction
------------
On blead, build with ASan/UBSan and run:

    ./perl -Ilib poc.pl

```perl
use strict;
use warnings;

\(\(\(\(\(\(\(\(sort {
    \(\(sort {18446605494517776183;} %0, 'so'));
} %0 = 'Ev5' .. 14))))))));
```


ASan summary
------------
heap-buffer-overflow (READ 4) in Perl_POPMARK (inline.h:412) from Perl_pp_sort (pp_sort.c:698);
the read occurs 4 bytes before the allocated markstack region (MARK underflow).
Full ASan log: repro.asan.txt (attached)

Fix
---
Add an explicit bounds check in Perl_POPMARK(): if PL_markstack_ptr <= PL_markstack, croak with
"panic: MARK underflow" before any dereference. This removes the OOB/UB and makes the failure
deterministic. This PR intentionally does not attempt to fix the underlying MARK imbalance in
pp_sort; it hardens POPMARK against memory-unsafe behavior.

Testing
-------
- make test_harness
- t/porting/authors.t
- With the fix applied, the PoC no longer triggers an ASan OOB report; it now fails
  deterministically with "panic: MARK underflow".

GH #19790

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
[repro.asan.txt](https://github.com/user-attachments/files/24995493/repro.asan.txt)
