### PR TITLE
remove duplicated OS_ERROR/ERRNO lines from English.pm

### DIFF
--- a/lib/English.pm
+++ b/lib/English.pm
@@ -1,6 +1,6 @@
 package English;
 
-our $VERSION = '1.11';
+our $VERSION = '1.12';
 
 require Exporter;
 @ISA = qw(Exporter);
@@ -191,8 +191,6 @@ sub import {
 # Error status.
 
 	*CHILD_ERROR				= *?	;
-	*OS_ERROR				= *!	;
-	    *ERRNO				= *!	;
 	*OS_ERROR				= *!	;
 	    *ERRNO				= *!	;
 	*EXTENDED_OS_ERROR			= *^E	;


### PR DESCRIPTION
Back in September 2001, be154528f7e7dc31589b7b72d4e03f88d8751799 and ab063544b9b830d646a880f1404f8327afb8f9c6 aliased the individual slots (scalar, array, hash) to the corresponding English names. `OS_ERROR` (and `ERRNO`) showed up twice: once for `$!` and once for `%!`.

In December 2002, the a33bf49bf7b1088ee6ac580e9e39716ad87ae72a bug fix restored full glob aliasing on most English name variables, leaving two statements for `OS_ERROR`/`ERRNO`.

This patch removes the duplicated lines.

* This set of changes does not require a perldelta entry.
