### PR TITLE
Net::Ping: silence stderr noise in 000_load.t

### DIFF
--- a/dist/Net-Ping/t/000_load.t
+++ b/dist/Net-Ping/t/000_load.t
@@ -12,5 +12,5 @@ BEGIN {
     use_ok( 'Net::Ping' )   || print "No Net::Ping!\n";
 }
 
-diag( "Testing Net::Ping $Net::Ping::VERSION, Perl $] on $^O, $^X" );
+note( "Testing Net::Ping $Net::Ping::VERSION, Perl $] on $^O, $^X" );
 


### PR DESCRIPTION
Change the diag() call to a note() call so that the info about which platform and version the test is running under doesn't appear on STDERR, which should be reserved for errors.

This is a partial re-application of my commit v5.25.6-83-g0fc44d0a18 from 2016.

* This set of changes does not require a perldelta entry.
