### PR TITLE
Avoid SvCUR() on an undefined scalar in PerlIOScalar_write (supplement to #24063)

### DIFF
--- a/perlio.c
+++ b/perlio.c
@@ -1269,7 +1269,7 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
         STRLEN const cur = SvOK(sv) ? SvCUR(sv) : 0;
 	if ((PerlIOBase(f)->flags) & PERLIO_F_APPEND) {
 	    dst = SvGROW(sv, cur + count + 1);
-	    offset = SvCUR(sv);
+	    offset = cur;
 	    s->posn = offset + count;
 	}
 	else {
@@ -1299,7 +1299,7 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
 	    s->posn += count;
 	}
 	Move(vbuf, dst + offset, count, char);
-	if ((STRLEN) s->posn > SvCUR(sv)) {
+	if ((STRLEN) s->posn > cur) {
 	    SvCUR_set(sv, (STRLEN)s->posn);
 	    dst[(STRLEN) s->posn] = 0;
 	}

--- a/t/io/scalar.t
+++ b/t/io/scalar.t
@@ -12,7 +12,7 @@ use strict;
 use Fcntl qw(SEEK_SET SEEK_CUR SEEK_END); # Not 0, 1, 2 everywhere.
 use Errno qw(EACCES);
 
-plan(129);
+plan(131);
 
 my $fh;
 my $var = "aaa\n";
@@ -535,4 +535,17 @@ SKIP:
     undef $str;
     print $fh "y";
     is($str, "\0\0\0\0\0y", "write to undef'ed variable");
+
+    undef $str;
+    seek $fh, 0, SEEK_SET;
+    print $fh "zz";
+    is($str, "zz", "rewind and write to undef'ed variable");
+}
+
+{
+    open my $fh, '>>', \my $str or die $!;
+    print $fh "xxxxx";
+    undef $str;
+    print $fh "y";
+    is($str, "y", "append to undef'ed variable");
 }


### PR DESCRIPTION
Even after #24063 was merged,  there were still cases where `SvCUR()` was called for an undefined SV, which used cause the newly created scalar not to be truncated or padded properly.

The symptom might be a segfault on older perl:
```
% perl -wle 'open my $fh, ">", \my $str or die; print $fh "12345"; undef $str; seek $fh, 0, 0; print $fh "67"'
Segmentation fault
```