### PR TITLE
Create a new version of MAGIC; called Magic v2

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5132,6 +5132,8 @@ ext/XS-APItest/APItest_hash.xs			XS::APItest hash-related XS split
 ext/XS-APItest/APItest_hv_macro.xs		XS::APItest HvMacro-related XS split
 ext/XS-APItest/APItest_magic.xs			XS::APItest magic-related XS split
 ext/XS-APItest/APItest_magic_hash_support.inc	XS::APItest magic/hash support include
+ext/XS-APItest/APItest_magicv2.inc		XS::APItest Magic v2 support include
+ext/XS-APItest/APItest_magicv2.xs		XS::APItest Magic v2 XS split
 ext/XS-APItest/APItest_misc_runtime.xs		XS::APItest misc runtime XS split
 ext/XS-APItest/APItest_misc_xsub_basics.xs	XS::APItest misc basic XSUB split
 ext/XS-APItest/APItest_optree_cophh.xs		XS::APItest optree and cophh XS split
@@ -5228,6 +5230,8 @@ ext/XS-APItest/t/looprest.t			test recursive descent statement-sequence parsing
 ext/XS-APItest/t/lvalue.t			Test XS lvalue functions
 ext/XS-APItest/t/magic.t			test attaching, finding, and removing magic
 ext/XS-APItest/t/magic_chain.t			test low-level MAGIC chain handling
+ext/XS-APItest/t/magicv2.t			XS::APItest: tests for Magic-v2 related APIs
+ext/XS-APItest/t/magicv2-threads.t		XS::APItest: tests for Magic-v2 related APIs across multiple threads
 ext/XS-APItest/t/Markers.pm			Helper for ./blockhooks.t
 ext/XS-APItest/t/mortal_destructor.t		Test mortal_destructor api.
 ext/XS-APItest/t/mro.t				Test mro plugin api

--- a/dump.c
+++ b/dump.c
@@ -1999,6 +1999,124 @@ Perl_gv_dump(pTHX_ GV *gv)
     dump_indent(0, Perl_debug_log, "}\n");
 }
 
+const struct flag_to_name mgv2_flags_names[] = {
+    /* MGv2 is implied */
+    {MGv2f_REFCOUNTED_AUXSV, "REFCOUNTED_AUXSV,"},
+};
+
+#define do_magicv2_dump(level, file, mg, nest, maxnest, dumpops, pvlim)  Perl_do_magicv2_dump(aTHX_ level, file, mg, nest, maxnest, dumpops, pvlim)
+static void
+Perl_do_magicv2_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
+{
+    dump_indent(level, file, "  MAGICv2 = 0x%" UVxf "\n", PTR2UV(mg));
+
+    const struct MagicFunctions *funcs = MgFUNCS(mg);
+    if(funcs->debug_name)
+        dump_indent(level, file, "    FUNCS = %s (0x%" UVxf ")\n",
+                funcs->debug_name, PTR2UV(funcs));
+    else
+        dump_indent(level, file, "    FUNCS = 0x%" UVxf "\n",
+                PTR2UV(funcs));
+
+    {
+        const char *shapename = NULL;
+        switch(funcs->shape) {
+            case MGv2s_BASE:      shapename = "BASE";      break;
+            case MGv2s_SCALARVAR: shapename = "SCALARVAR"; break;
+            case MGv2s_ARRAYVAR:  shapename = "ARRAYVAR";  break;
+            case MGv2s_HASHVAR:   shapename = "HASHVAR";   break;
+        }
+        if(shapename)
+            dump_indent(level, file, "      SHAPE = %s\n", shapename);
+        else
+            dump_indent(level, file, "      SHAPE = (%d)\n", funcs->shape);
+
+        if(funcs->free_mg)
+            dump_indent(level, file, "      FREE_MG\n");
+        if(funcs->clone_mg)
+            dump_indent(level, file, "      CLONE_MG\n");
+
+        switch(funcs->shape) {
+            case MGv2s_BASE:
+                break;
+
+            case MGv2s_SCALARVAR:
+            {
+                const struct ScalarVarMagicFunctions *funcs = MgSCALARVARFUNCS(mg);
+                if(funcs->pre_get)
+                    dump_indent(level, file, "      PRE_GET\n");
+                if(funcs->post_set)
+                    dump_indent(level, file, "      POST_SET\n");
+                break;
+            }
+
+            case MGv2s_ARRAYVAR:
+            {
+                const struct ArrayVarMagicFunctions *funcs = MgARRAYVARFUNCS(mg);
+                if(funcs->clear)
+                    dump_indent(level, file, "      CLEAR\n");
+                break;
+            }
+
+            case MGv2s_HASHVAR:
+            {
+                const struct HashVarMagicFunctions *funcs = MgHASHVARFUNCS(mg);
+                if(funcs->clear)
+                    dump_indent(level, file, "      CLEAR\n");
+                break;
+            }
+        }
+    }
+
+    {
+        /* flags will always contain at least MGf_MGv2 */
+        U16 flags = MgFLAGS(mg);
+        SV *flagsv = newSVpvs("MGv2,");
+        append_flags(flagsv, flags, mgv2_flags_names);
+        switch(flags & MGv2f_WITH_MASK) {
+            case MGv2f_WITH_KEYIV:  sv_catpvs(flagsv, "WITH_KEYIV,");  break;
+            case MGv2f_WITH_KEYHEK: sv_catpvs(flagsv, "WITH_KEYHEK,"); break;
+            case MGv2f_WITH_KEYSV:  sv_catpvs(flagsv, "WITH_KEYSV,");  break;
+        }
+        if(SvCUR(flagsv))  /* trim trailing comma */
+            SvPVX(flagsv)[SvCUR(flagsv)-1] = '\0';
+        dump_indent(level, file, "    FLAGS = (%s)\n", SvPVX(flagsv));
+    }
+
+    if(MgPRIV(mg))
+        dump_indent(level, file, "    PRIV = 0x%04" UVxf "\n", (UV)MgPRIV(mg));
+
+    if(MgAUXSV(mg)) {
+        dump_indent(level, file, "    AUXSV = 0x%" UVxf "\n", PTR2UV(MgAUXSV(mg)));
+        do_sv_dump(level+2, file, MgAUXSV(mg), nest+1, maxnest, dumpops, pvlim); /* MG is already +1 */
+    }
+
+    if(MgPTR(mg) && MgPTRLEN(mg)) {
+        size_t printlen = MgPTRLEN(mg);
+        if(printlen > 32) printlen = 32;
+        SV *tmpsv = newSVpvs_flags("", SVs_TEMP);
+        dump_indent(level, file, "    PTR = \"%s\"%s (LEN = %zd)\n",
+                generic_pv_escape(tmpsv, (char *)MgPTR(mg), printlen, 0),
+                MgPTRLEN(mg) > 32 ? "..." : "",
+                MgPTRLEN(mg));
+    }
+    else if(MgPTR(mg)) {
+        dump_indent(level, file, "    PTR = 0x%" UVxf "\n",
+                PTR2UV(MgPTR(mg)));
+    }
+    else if(MgPTRLEN(mg)) {
+        dump_indent(level, file, "    PTRLEN = %zd\n",
+                MgPTRLEN(mg));
+    }
+
+    if(MgHasKEYIV(mg)) {
+        dump_indent(level, file, "    KEYIV = %" IVdf "\n", MgKEYIV(mg));
+    }
+    else if(MgHasKEYSV(mg)) {
+        dump_indent(level, file, "    KEYSV = 0x%" UVxf "\n", PTR2UV(MgKEYSV(mg)));
+        do_sv_dump(level+2, file, MgKEYSV(mg), nest+1, maxnest, dumpops, pvlim); /* MG is already +1 */
+    }
+}
 
 /* map magic types to the symbolic names
  * (with the PERL_MAGIC_ prefixed stripped)
@@ -2016,6 +2134,11 @@ Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32
     PERL_ARGS_ASSERT_DO_MAGIC_DUMP;
 
     for (; mg; mg = mg->mg_moremagic) {
+        if (MgIsV2(mg)) {
+            do_magicv2_dump(level, file, (const MAGIC *)mg, nest, maxnest, dumpops, pvlim);
+            continue;
+        }
+
         dump_indent(level, file, "  MAGIC = 0x%" UVxf "\n", PTR2UV(mg));
         if (mg->mg_virtual) {
             const MGVTBL * const v = mg->mg_virtual;

--- a/embed.fnc
+++ b/embed.fnc
@@ -2210,6 +2210,10 @@ p	|int	|magic_setvec	|NN SV *sv				\
 				|NN MAGIC *mg
 p	|U32	|magic_sizepack |NN SV *sv				\
 				|NN MAGIC *mg
+Adp	|MAGIC *|magicv2_localize_copy					\
+				|NN SV *nsv				\
+				|NN SV *osv				\
+				|NN MAGIC *omg
 p	|int	|magic_wipepack |NN SV *sv				\
 				|NN MAGIC *mg
 
@@ -2247,6 +2251,9 @@ dp	|void	|mg_localize	|NN SV *sv				\
 				|NN SV *nsv				\
 				|bool setmagic
 ATdp	|void	|mg_magical	|NN SV *sv
+Adp	|void	|mg_ptr_store	|NN MAGIC *mg				\
+				|NULLOK const void *ptr 		\
+				|STRLEN len
 Adp	|int	|mg_set 	|NN SV *sv
 Cp	|I32	|mg_size	|NN SV *sv
 ATdp	|void	|mini_mktime	|NN struct tm *ptm
@@ -3516,6 +3523,33 @@ Adp	|MAGIC *|sv_magicext	|NN SV * const sv			\
 : exported for re.pm
 EXp	|MAGIC *|sv_magicext_mglob					\
 				|NN SV *sv
+Adpx	|MAGIC *|sv_magicv2_add |NN SV *sv				\
+				|NN const struct MagicFunctions *funcs	\
+				|U32 flags				\
+				|NULLOK SV *auxsv
+Adpx	|MAGIC *|sv_magicv2_find_by_auxsv				\
+				|NN const SV *sv			\
+				|NN const SV *auxsv
+Adpx	|MAGIC *|sv_magicv2_find_by_funcs				\
+				|NN const SV *sv			\
+				|NN const struct MagicFunctions *funcs
+Adpx	|MAGIC *|sv_magicv2_findnext_by_auxsv				\
+				|NN const SV *sv			\
+				|NN const SV *auxsv			\
+				|NN MAGIC *mg
+Adpx	|MAGIC *|sv_magicv2_findnext_by_funcs				\
+				|NN const SV *sv			\
+				|NN const struct MagicFunctions *funcs	\
+				|NN MAGIC *mg
+Adpx	|MAGIC *|sv_magicv2_find_or_add 				\
+				|NN SV *sv				\
+				|NN const struct MagicFunctions *funcs
+Adpx	|void	|sv_magicv2_remove					\
+				|NN SV *sv				\
+				|NN MAGIC *mg
+Adpx	|void	|sv_magicv2_remove_by_funcs				\
+				|NN SV *sv				\
+				|NN const struct MagicFunctions *funcs
 Adp	|SV *	|sv_2mortal	|NULLOK SV * const sv
 ARdmp	|SV *	|sv_mortalcopy	|NULLOK SV * const oldsv
 ARdp	|SV *	|sv_mortalcopy_flags					\
@@ -5090,6 +5124,12 @@ Tp	|bool	|translate_substr_offsets				\
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 p	|void	|mg_free_struct |NN SV *sv				\
 				|NN MAGIC *mg
+p	|void	|mgv2_copy	|NN const MAGIC *smg			\
+				|NN MAGIC *dmg
+p	|MAGIC *|sv_magicv2_attach					\
+				|NN SV *sv				\
+				|NN const struct MagicFunctions *funcs	\
+				|U32 flags
 #endif
 #if defined(PERL_IN_MRO_C)
 S	|void	|mro_clean_isarev					\

--- a/embed.h
+++ b/embed.h
@@ -32,6 +32,7 @@
 #   undef is_WORD_BUT_NONCONT_safe
 #   undef isFOO_or_UNDERSCORE_
 #   undef isIDCONT_lazy_if_safe
+#   undef MGv2f_WITH_KEYHEK
 #   undef new_XPV
 #   undef new_XPVIV
 #   undef pTHX_10
@@ -330,6 +331,7 @@
 # define looks_like_number(a)                   Perl_looks_like_number(aTHX_ a)
 # define lsbit_pos32                            Perl_lsbit_pos32
 # define magic_dump(a)                          Perl_magic_dump(aTHX_ a)
+# define magicv2_localize_copy(a,b,c)           Perl_magicv2_localize_copy(aTHX_ a,b,c)
 # define markstack_grow()                       Perl_markstack_grow(aTHX)
 # define mess_sv(a,b)                           Perl_mess_sv(aTHX_ a,b)
 # define mg_clear(a)                            Perl_mg_clear(aTHX_ a)
@@ -341,6 +343,7 @@
 # define mg_freeext(a,b,c)                      Perl_mg_freeext(aTHX_ a,b,c)
 # define mg_get(a)                              Perl_mg_get(aTHX_ a)
 # define mg_magical                             Perl_mg_magical
+# define mg_ptr_store(a,b,c)                    Perl_mg_ptr_store(aTHX_ a,b,c)
 # define mg_set(a)                              Perl_mg_set(aTHX_ a)
 # define mg_size(a)                             Perl_mg_size(aTHX_ a)
 # define mini_mktime                            Perl_mini_mktime
@@ -693,6 +696,14 @@
 # define sv_len_utf8_nomg(a)                    Perl_sv_len_utf8_nomg(aTHX_ a)
 # define sv_magic(a,b,c,d,e)                    Perl_sv_magic(aTHX_ a,b,c,d,e)
 # define sv_magicext(a,b,c,d,e,f)               Perl_sv_magicext(aTHX_ a,b,c,d,e,f)
+# define sv_magicv2_add(a,b,c,d)                Perl_sv_magicv2_add(aTHX_ a,b,c,d)
+# define sv_magicv2_find_by_auxsv(a,b)          Perl_sv_magicv2_find_by_auxsv(aTHX_ a,b)
+# define sv_magicv2_find_by_funcs(a,b)          Perl_sv_magicv2_find_by_funcs(aTHX_ a,b)
+# define sv_magicv2_find_or_add(a,b)            Perl_sv_magicv2_find_or_add(aTHX_ a,b)
+# define sv_magicv2_findnext_by_auxsv(a,b,c)    Perl_sv_magicv2_findnext_by_auxsv(aTHX_ a,b,c)
+# define sv_magicv2_findnext_by_funcs(a,b,c)    Perl_sv_magicv2_findnext_by_funcs(aTHX_ a,b,c)
+# define sv_magicv2_remove(a,b)                 Perl_sv_magicv2_remove(aTHX_ a,b)
+# define sv_magicv2_remove_by_funcs(a,b)        Perl_sv_magicv2_remove_by_funcs(aTHX_ a,b)
 # define sv_mortalcopy_flags(a,b)               Perl_sv_mortalcopy_flags(aTHX_ a,b)
 # define sv_newmortal()                         Perl_sv_newmortal(aTHX)
 # define sv_newref(a)                           Perl_sv_newref(aTHX_ a)
@@ -1448,6 +1459,8 @@
 #   endif
 #   if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 #     define mg_free_struct(a,b)                Perl_mg_free_struct(aTHX_ a,b)
+#     define mgv2_copy(a,b)                     Perl_mgv2_copy(aTHX_ a,b)
+#     define sv_magicv2_attach(a,b,c)           Perl_sv_magicv2_attach(aTHX_ a,b,c)
 #   endif
 #   if defined(PERL_IN_MRO_C)
 #     define mro_clean_isarev(a,b,c,d,e,f)      S_mro_clean_isarev(aTHX_ a,b,c,d,e,f)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.51';
+our $VERSION = '1.52';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -198,6 +198,8 @@ START_MY_CXT
 /* C Include Files Go Here - shared C support includes for split XS::APItest domains. */
 #include "APItest_magic_hash_support.inc"
 
+#include "APItest_magicv2.inc"
+
 /* indirect functions to test the [pa]MY_CXT macros */
 
 int
@@ -1044,3 +1046,5 @@ INCLUDE: APItest_global_locale.xs
 INCLUDE: APItest_savestack.xs
 
 INCLUDE: APItest_vstring.xs
+
+INCLUDE: APItest_magicv2.xs

--- a/ext/XS-APItest/APItest_magicv2.inc
+++ b/ext/XS-APItest/APItest_magicv2.inc
@@ -1,0 +1,166 @@
+/* Magic functions for XS::APItest::MagicV2 */
+
+static void
+magicfunc_grab_before_get(pTHX_ SV *sv, MAGIC *mg)
+{
+    SV *auxsv = MgAUXSV(mg);
+    sv_setsv_nomg(sv, auxsv);
+}
+
+static void
+magicfunc_inc_after_set(pTHX_ SV *sv, MAGIC *mg)
+{
+    PERL_UNUSED_ARG(sv);
+
+    SV *auxsv = MgAUXSV(mg);
+    if(auxsv)
+        sv_inc(auxsv);
+
+    /* flag to test sv_magicv2_remove during operation */
+    if(MgPRIV(mg) & 0x0001) {
+        sv_magicv2_remove(sv, mg);
+    }
+}
+
+static void
+magicfunc_inc(pTHX_ SV *sv, MAGIC *mg)
+{
+    PERL_UNUSED_ARG(sv);
+
+    SV *auxsv = MgAUXSV(mg);
+    if(auxsv)
+        sv_inc(auxsv);
+}
+
+static void
+magicfunc_inc_on_clone_clone(pTHX_ SV *nsv, MAGIC *nmg, SV *osv, MAGIC *omg, CLONE_PARAMS *params)
+{
+    PERL_UNUSED_ARG(nsv);
+    PERL_UNUSED_ARG(osv);
+    PERL_UNUSED_ARG(omg);
+    PERL_UNUSED_ARG(params);
+
+    SV *auxsv = MgAUXSV(nmg);
+    if(auxsv)
+        sv_inc(auxsv);
+}
+
+static const struct MagicFunctions magicfuncs_empty = {
+    .ver   = 2,
+    .shape = MGv2s_BASE,
+    .debug_name = "XS::APItest/empty",
+
+    /* no funcs */
+};
+
+static const struct MagicFunctions magicfuncs_weak = {
+    .ver   = 2,
+    .shape = MGv2s_BASE,
+    .flags = MGv2f_ALWAYS_WEAK_AUXSV,
+    .debug_name = "XS::APItest/weak",
+
+    /* no funcs */
+};
+
+static const struct ScalarVarMagicFunctions magicfuncs_container_empty = {
+    .ver   = 2,
+    .shape = MGv2s_SCALARVAR,
+    .debug_name = "XS::APItest/container_empty",
+
+    .localize_mg = &Perl_magicv2_localize_copy,
+};
+
+static const struct ScalarVarMagicFunctions magicfuncs_with_keyiv = {
+    .ver   = 2,
+    .shape = MGv2s_SCALARVAR,
+    .flags = MGv2f_WITH_KEYIV,
+    .debug_name = "XS::APItest/with_keyiv",
+
+    .localize_mg = &Perl_magicv2_localize_copy,
+};
+
+static const struct ScalarVarMagicFunctions magicfuncs_with_keysv = {
+    .ver   = 2,
+    .shape = MGv2s_SCALARVAR,
+    .flags = MGv2f_WITH_KEYSV,
+    .debug_name = "XS::APItest/with_keysv",
+
+    .localize_mg = &Perl_magicv2_localize_copy,
+};
+
+static const struct MagicFunctions magicfuncs_inc_on_free = {
+    .ver   = 2,
+    .shape = MGv2s_BASE,
+    .debug_name = "XS::APItest/inc_on_free",
+
+    .free_mg = &magicfunc_inc,
+};
+
+static const struct MagicFunctions magicfuncs_inc_on_clone = {
+    .ver   = 2,
+    .shape = MGv2s_BASE,
+    .debug_name = "XS::APItest/inc_on_clone",
+
+    .clone_mg = &magicfunc_inc_on_clone_clone,
+};
+
+struct TwoIVs { IV x, y; };
+static const struct ScalarVarMagicFunctions magicfuncs_userstruct = {
+    .ver   = 2,
+    .shape = MGv2s_SCALARVAR,
+    .debug_name = "XS::APItest/userstruct",
+    .user_size = sizeof(struct TwoIVs),
+
+    .localize_mg = &Perl_magicv2_localize_copy,
+};
+
+static const struct ScalarVarMagicFunctions magicfuncs_grab_before_get = {
+    .ver   = 2,
+    .shape = MGv2s_SCALARVAR,
+    .debug_name = "XS::APItest/grab_before_get",
+
+    .pre_get = &magicfunc_grab_before_get,
+};
+
+static const struct ScalarVarMagicFunctions magicfuncs_inc_after_set = {
+    .ver   = 2,
+    .shape = MGv2s_SCALARVAR,
+    .debug_name = "XS::APItest/inc_after_set",
+
+    .localize_mg = &Perl_magicv2_localize_copy,
+    .post_set = &magicfunc_inc_after_set,
+};
+
+static const struct ArrayVarMagicFunctions magicfuncs_inc_after_clear_arr = {
+    .ver   = 2,
+    .shape = MGv2s_ARRAYVAR,
+    .debug_name = "XS::APItest/inc_after_clear_arr",
+
+    .clear = &magicfunc_inc,
+};
+
+static const struct ArrayVarMagicFunctions magicfuncs_inc_after_clear_hash = {
+    .ver   = 2,
+    .shape = MGv2s_HASHVAR,
+    .debug_name = "XS::APItest/inc_after_clear_hash",
+
+    .clear = &magicfunc_inc,
+};
+
+static const struct MagicFunctions *S_magicfuncs_by_name(pTHX_ SV *name)
+{
+    char *namepv = SvPV_nolen(name);
+    if(strEQ(namepv, "empty"))           return &magicfuncs_empty;
+    if(strEQ(namepv, "weak"))            return &magicfuncs_weak;
+    if(strEQ(namepv, "container_empty")) return (struct MagicFunctions *)&magicfuncs_container_empty;
+    if(strEQ(namepv, "with_keyiv"))      return (struct MagicFunctions *)&magicfuncs_with_keyiv;
+    if(strEQ(namepv, "with_keysv"))      return (struct MagicFunctions *)&magicfuncs_with_keysv;
+    if(strEQ(namepv, "inc_on_free"))     return &magicfuncs_inc_on_free;
+    if(strEQ(namepv, "inc_on_clone"))    return &magicfuncs_inc_on_clone;
+    if(strEQ(namepv, "userstruct"))      return (struct MagicFunctions *)&magicfuncs_userstruct;
+    if(strEQ(namepv, "grab_before_get")) return (struct MagicFunctions *)&magicfuncs_grab_before_get;
+    if(strEQ(namepv, "inc_after_set"))   return (struct MagicFunctions *)&magicfuncs_inc_after_set;
+    if(strEQ(namepv, "inc_after_clear_arr"))  return (struct MagicFunctions *)&magicfuncs_inc_after_clear_arr;
+    if(strEQ(namepv, "inc_after_clear_hash")) return (struct MagicFunctions *)&magicfuncs_inc_after_clear_hash;
+    croak("Unrecognised magicfuncs name %" SVf, SVfARG(name));
+}

--- a/ext/XS-APItest/APItest_magicv2.xs
+++ b/ext/XS-APItest/APItest_magicv2.xs
@@ -1,0 +1,244 @@
+MODULE = XS::APItest            PACKAGE = XS::APItest::MagicV2
+
+void
+sv_magicv2_add(SV *sv, SV *magicname, SV *auxsvref, U16 priv = 0)
+    PROTOTYPE: \[$@%]$$;$
+    CODE:
+        const struct MagicFunctions *funcs = S_magicfuncs_by_name(aTHX_ magicname);
+        SV *auxsv = NULL;
+        if(auxsvref && SvROK(auxsvref))
+            auxsv = SvRV(auxsvref);
+
+        if(auxsv && !(funcs->flags & MGv2f_ALWAYS_WEAK_AUXSV))
+            SvREFCNT_inc(auxsv);
+
+        MAGIC *mg = sv_magicv2_add(SvRV(sv), funcs, 0, auxsv);
+
+        if(priv)
+            MgPRIV(mg) = priv;
+
+        if(funcs == (const struct MagicFunctions *)&magicfuncs_userstruct) {
+            struct TwoIVs *user = MgUSERSTRUCT(mg, struct TwoIVs *);
+            user->x = 123;
+            user->y = 456;
+        }
+
+bool
+sv_magicv2_exists(SV *sv, SV *magicname)
+    CODE:
+        RETVAL = (bool)sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+    OUTPUT:
+        RETVAL
+
+bool
+sv_magicv2_exists_by_auxsv(SV *sv, SV *auxsvref)
+    CODE:
+        RETVAL = (bool)sv_magicv2_find_by_auxsv(sv, SvRV(auxsvref));
+    OUTPUT:
+        RETVAL
+
+SV *
+MgAUXSV(SV *sv, SV *magicname)
+    // args different than the C macros
+    ALIAS:
+        MgAUXSV = 0
+        MgPRIV  = 2
+        MgKEYIV = 3
+        MgKEYSV = 4
+    CODE:
+    {
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            XSRETURN_UNDEF;
+
+        RETVAL = &PL_sv_undef;
+
+        switch(ix) {
+            case 0:
+                if(MgAUXSV(mg))
+                    RETVAL = newRV_inc(MgAUXSV(mg));
+                break;
+
+            case 2:
+                RETVAL = newSVuv(MgPRIV(mg));
+                break;
+
+            case 3:
+                if(!MgHasKEYIV(mg))
+                    croak("This Magic does not set MgKEYIV");
+                RETVAL = newSViv(MgKEYIV(mg));
+                break;
+
+            case 4:
+                if(!MgHasKEYSV(mg))
+                    croak("This Magic does not set MgKEYSV");
+                RETVAL = newSVsv(MgKEYSV(mg));
+                break;
+        }
+    }
+    OUTPUT:
+        RETVAL
+
+void
+MgAUXSV_set(SV *sv, SV *magicname, SV *newauxsvref)
+    // args different than the C macro
+    CODE:
+    {
+        const struct MagicFunctions *funcs = S_magicfuncs_by_name(aTHX_ magicname);
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, funcs);
+        if(!mg)
+            XSRETURN_EMPTY;
+
+        SV *auxsv = NULL;
+        if(newauxsvref && SvROK(newauxsvref))
+            auxsv = SvRV(newauxsvref);
+
+        if(auxsv && !MgWEAK_AUXSV(mg))
+            SvREFCNT_inc(auxsv);
+
+        MgAUXSV_set(mg, auxsv);
+    }
+
+SV *
+MgAUXSV_value(SV *sv, SV *magicname)
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            XSRETURN_UNDEF;
+
+        RETVAL = newSVsv(MgAUXSV(mg));
+    OUTPUT:
+        RETVAL
+
+void
+MgAUXSV_values(SV *sv, SV *magicname)
+    PPCODE:
+        const struct MagicFunctions *funcs;
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, (funcs = S_magicfuncs_by_name(aTHX_ magicname)));
+        if(!mg)
+            XSRETURN(0);
+
+        U32 count = 0;
+        while(mg) {
+            XPUSHs(sv_mortalcopy(MgAUXSV(mg)));
+            count++;
+
+            mg = sv_magicv2_findnext_by_funcs(sv, funcs, mg);
+        }
+
+        XSRETURN(count);
+
+void
+MgKEYIV_set(SV *sv, SV *magicname, IV newval)
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            XSRETURN_EMPTY;
+
+        if(!MgHasKEYIV(mg))
+            croak("This Magic does not set MgKEYIV");
+        MgKEYIV_set(mg, newval);
+
+void
+MgKEYSV_set(SV *sv, SV *magicname, SV *newval)
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            XSRETURN_EMPTY;
+
+        if(!MgHasKEYSV(mg))
+            croak("This Magic does not set MgKEYSV");
+        MgKEYSV_set(mg, newSVsv(newval));
+
+SV *
+MgPTR(SV *sv, SV *magicname)
+    // args different than C macro
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg || !MgPTR(mg))
+            RETVAL = &PL_sv_undef;
+        else
+            RETVAL = newSVpvn((char *)MgPTR(mg), MgPTRLEN(mg));
+    OUTPUT:
+        RETVAL
+
+void
+MgPTR_write(SV *sv, SV *magicname, SV *newval)
+    // not actual perl API but used by magicv2.t to demonstrate independence of buffers
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            XSRETURN_EMPTY;
+        if(!MgPTR(mg) || !MgPTRLEN(mg))
+            XSRETURN_EMPTY;
+
+        STRLEN len;
+        char *pv = SvPV(newval, len);
+        if(len > (STRLEN)MgPTRLEN(mg))
+            len = MgPTRLEN(mg);
+
+        Copy(pv, MgPTR(mg), len, char);
+
+STRLEN
+MgPTRLEN(SV *sv, SV *magicname)
+    // args different than C macro
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            RETVAL = -1;
+        else
+            RETVAL = MgPTRLEN(mg);
+
+    OUTPUT:
+      RETVAL
+
+void
+MgPTRLEN_set(SV *sv, SV *magicname, STRLEN len)
+    // args different than C macro
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            XSRETURN_EMPTY;
+
+        MgPTRLEN_set(mg, len);
+
+void
+mg_ptr_store(SV *sv, SV *magicname, SV *ptr)
+    // args different than C function
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));
+        if(!mg)
+            XSRETURN_EMPTY;
+
+        STRLEN len;
+        const char *pv = SvPV(ptr, len);
+        mg_ptr_store(mg, pv, len);
+
+void
+sv_magicv2_get_userstruct(SV *sv)
+    PPCODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, (const struct MagicFunctions *)&magicfuncs_userstruct);
+        if(!mg)
+            XSRETURN(0);
+
+        struct TwoIVs *user = MgUSERSTRUCT(mg, struct TwoIVs *);
+        EXTEND(SP, 2);
+        mPUSHi(user->x);
+        mPUSHi(user->y);
+        XSRETURN(2);
+
+void
+sv_magicv2_set_userstruct(SV *sv, IV x, IV y)
+    CODE:
+        MAGIC *mg = sv_magicv2_find_by_funcs(sv, (const struct MagicFunctions *)&magicfuncs_userstruct);
+        if(!mg)
+            XSRETURN_EMPTY;
+
+        struct TwoIVs *user = MgUSERSTRUCT(mg, struct TwoIVs *);
+        user->x = x;
+        user->y = y;
+
+void
+sv_magicv2_remove(SV *sv, SV *magicname)
+    CODE:
+        sv_magicv2_remove_by_funcs(sv, S_magicfuncs_by_name(aTHX_ magicname));

--- a/ext/XS-APItest/t/magicv2-threads.t
+++ b/ext/XS-APItest/t/magicv2-threads.t
@@ -1,0 +1,113 @@
+use strict;
+use warnings;
+use Config;
+
+BEGIN {
+    if( !$Config{usethreads} ) {
+        require Test::More;
+        Test::More::plan( skip_all => "No threads" );
+    }
+}
+
+use XS::APItest;
+
+# We must 'use threads' before 'use Test::More' so the test count sync works
+use threads;
+use Test::More;
+
+# MgAUXSV cloning into thread
+{
+    my $sv;
+    sv_magicv2_add($sv, empty => \(my $tmp = "orig-data"));
+
+    threads->create(sub {
+        my $auxsvref = MgAUXSV($sv, 'empty');
+        is($$auxsvref, "orig-data", 'sv_magicv2_find_by_funcs sees auxsv inside thread');
+        $$auxsvref = "new-data";
+        is($$auxsvref, "new-data", 'can modify data inside thread');
+    })->join;
+
+    my $auxsvref = MgAUXSV($sv, 'empty');
+    is($$auxsvref, "orig-data", 'sv_magicv2_find_by_funcs sees original auxsv in main');
+}
+
+# MgPTR cloning into thread
+{
+    my $sv;
+    sv_magicv2_add($sv, empty => undef);
+    mg_ptr_store($sv, 'empty', "ABCDE");
+
+    threads->create(sub {
+        is(MgPTR($sv, 'empty'), "ABCDE", 'sv_magicv2_find_by_funcs sees MgPTR cloned inside thread');
+
+        MgPTR_write($sv, 'empty', "ZYXWV");
+        is(MgPTR($sv, 'empty'), "ZYXWV", 'MgPTR can be updated inside thread');
+    })->join;
+
+    is(MgPTR($sv, 'empty'), "ABCDE", 'Original MgPTR is retained');
+}
+
+# MgKEYIV cloning into thread
+{
+    my $sv;
+    sv_magicv2_add($sv, with_keyiv => undef);
+    MgKEYIV_set($sv, with_keyiv => 12345);
+
+    threads->create(sub {
+        is(MgKEYIV($sv, 'with_keyiv'), 12345, 'MgKEYIV is set inside thread');
+
+        MgKEYIV_set($sv, with_keyiv => 54321);
+        is(MgKEYIV($sv, 'with_keyiv'), 54321, 'MgKEYIV can be updated inside thread');
+    })->join;
+
+    is(MgKEYIV($sv, 'with_keyiv'), 12345, 'Original MgKEYIV is retained');
+}
+
+# MgKEYSV cloning into thread
+{
+    my $sv;
+    sv_magicv2_add($sv, with_keysv => undef);
+    MgKEYSV_set($sv, with_keysv => "XYZ");
+
+    threads->create(sub {
+        is(MgKEYSV($sv, 'with_keysv'), "XYZ", 'MgKEYSV is set inside thread');
+
+        MgKEYSV_set($sv, with_keysv => "ZYX");
+        is(MgKEYSV($sv, 'with_keysv'), "ZYX", 'MgKEYSV can be updated inside thread');
+    })->join;
+
+    is(MgKEYSV($sv, 'with_keysv'), "XYZ", 'Original MgKEYSV is retained');
+}
+
+# MgUSERSTRUCT cloning into thread
+{
+    my $sv;
+    sv_magicv2_add($sv, userstruct => undef);
+    sv_magicv2_set_userstruct($sv, 76, 54);
+
+    threads->create(sub {
+        is_deeply([sv_magicv2_get_userstruct($sv)], [76, 54],
+            'Userstruct data copied into thread');
+
+        sv_magicv2_set_userstruct($sv, 87, 65);
+        is_deeply([sv_magicv2_get_userstruct($sv)], [87, 65],
+            'Userstruct data can be updated inside thread');
+    })->join;
+
+    is_deeply([sv_magicv2_get_userstruct($sv)], [76, 54],
+        'Original userstruct data is retained');
+}
+
+# clone trigger is invoked
+{
+    my $sv;
+    sv_magicv2_add($sv, inc_on_clone => \(my $counter = 1));
+
+    threads->create(sub {
+        is($counter, 2, '$counter is 2 inside thread');
+    })->join;
+
+    is($counter, 1, '$counter remains 1 in main');
+}
+
+done_testing();

--- a/ext/XS-APItest/t/magicv2.t
+++ b/ext/XS-APItest/t/magicv2.t
@@ -1,0 +1,366 @@
+use strict;
+use warnings;
+use Test::More;
+
+use XS::APItest;
+
+# MgPRIV storage
+{
+    my $sv;
+    sv_magicv2_add($sv, empty => undef, 1234);
+    is(MgPRIV($sv, 'empty'), 1234, 'sv_magicv2_find retrieves MgPRIV value');
+}
+
+# MgAUXSV refcounting
+{
+    my $auxsv;
+    {
+        my $sv;
+        sv_magicv2_add($sv, empty => \$auxsv);
+
+        ok(sv_magicv2_exists($sv, 'empty'), 'sv_magicv2_exists finds empty magic');
+
+        is(Internals::SvREFCNT($auxsv), 2, '$auxsv has refcount 2 before drop');
+
+        ok(sv_magicv2_exists_by_auxsv($sv, \$auxsv), 'sv_magicv2_exists_by_auxsv finds magic');
+    }
+    is(Internals::SvREFCNT($auxsv), 1, '$auxsv has refcount 1 after drop');
+
+    # MgAUXSV_set can replace it
+    {
+        my $sv;
+        sv_magicv2_add($sv, empty => \$auxsv);
+
+        is(Internals::SvREFCNT($auxsv), 2, '$auxsv has refcount 2 before MgAUXSV_set');
+
+        MgAUXSV_set($sv, empty => my $arr = []);
+
+        is(MgAUXSV($sv, 'empty'), $arr, 'MgAUXSV_set has replaced aux SV');
+        is(Internals::SvREFCNT($auxsv), 1, '$auxsv has refcount 1 after MgAUXSV_set');
+        is(Internals::SvREFCNT(@$arr), 2, '@$arr has refcount 2 after MgAUXSV_set');
+    }
+}
+
+# MgAUXSV with WEAK_AUXSV
+{
+    my $auxsv;
+    {
+        my $sv;
+        sv_magicv2_add($sv, weak => \$auxsv);
+
+        ok(sv_magicv2_exists($sv, 'weak'), 'sv_magicv2_exists finds weak magic');
+
+        is(Internals::SvREFCNT($auxsv), 1, '$auxsv has refcount 2 before drop');
+    }
+    is(Internals::SvREFCNT($auxsv), 1, '$auxsv has refcount 1 after drop');
+
+    # MgAUXSV_set can replace it
+    {
+        my $sv;
+        sv_magicv2_add($sv, weak => \$auxsv);
+
+        is(Internals::SvREFCNT($auxsv), 1, '$auxsv has refcount 1 before MgAUXSV_set');
+
+        MgAUXSV_set($sv, weak => my $arr = []);
+
+        is(MgAUXSV($sv, 'weak'), $arr, 'MgAUXSV_set has replaced aux SV');
+        is(Internals::SvREFCNT($auxsv), 1, '$auxsv has refcount 1 after MgAUXSV_set');
+        is(Internals::SvREFCNT(@$arr), 1, '@$arr has refcount 1 after MgAUXSV_set');
+    }
+}
+
+# MgPTR can store a byte buffer
+{
+    my $sv;
+    sv_magicv2_add($sv, empty => undef);
+    mg_ptr_store($sv, 'empty', "ABCDE");
+
+    is(MgPTR($sv, 'empty'), "ABCDE", 'MgPTR can store a byte buffer');
+}
+
+# MgPTRLEN is usable on its own
+{
+    my $sv;
+    sv_magicv2_add($sv, empty => undef);
+
+    MgPTRLEN_set($sv, 'empty', 123456);
+    is(MgPTRLEN($sv, 'empty'), 123456, 'MgPTRLEN is usable on its own');
+}
+
+# MgKEYIV
+{
+    my $sv;
+    sv_magicv2_add($sv, with_keyiv => undef);
+
+    is(MgKEYIV($sv, 'with_keyiv'), 0, 'MgKEYIV is zero initially');
+
+    MgKEYIV_set($sv, with_keyiv => 12345);
+    is(MgKEYIV($sv, 'with_keyiv'), 12345, 'MgKEYIV can be set to a value');
+}
+
+# MgKEYSV
+{
+    my $sv;
+    sv_magicv2_add($sv, with_keysv => undef);
+
+    is(MgKEYSV($sv, 'with_keysv'), undef, 'MgKEYSV is zero initially');
+
+    MgKEYSV_set($sv, with_keysv => "XYZ");
+    is(MgKEYSV($sv, 'with_keysv'), "XYZ", 'MgKEYSV can be set to a value');
+}
+
+# sv_magicv2_find
+{
+    my $sv;
+    sv_magicv2_add($sv, empty => \"the auxsv data");
+    my $auxsvref = MgAUXSV($sv, 'empty');
+    is($$auxsvref, "the auxsv data", 'sv_magicv2_find can find magic structure');
+    is(MgAUXSV_value($sv, 'empty'), "the auxsv data", 'MgAUXSV_value works');
+    ok(!defined MgAUXSV($sv, 'inc_on_free'), 'sv_magicv2_find does not see wrong magic');
+}
+
+# Can add the same magic multiple times
+{
+    my $sv;
+    sv_magicv2_add($sv, empty => \"data 1");
+    sv_magicv2_add($sv, empty => \"data 2");
+    # We don't guarantee what the order will be
+    is_deeply([sort +MgAUXSV_values($sv, 'empty')], ["data 1", "data 2"],
+        "MgAUXSV_values can see multiple auxsv");
+}
+
+# free trigger is invoked
+{
+    my $counter;
+    {
+        my $sv = 123;
+        sv_magicv2_add($sv, inc_on_free => \$counter);
+    }
+    is $counter, 1, '$counter is now 1 after SV free';
+}
+
+# MgUSERSTRUCT can store more data
+{
+    my $sv;
+    sv_magicv2_add($sv, userstruct => undef);
+
+    is_deeply([sv_magicv2_get_userstruct($sv)], [123, 456],
+        'Magic gets initialised with userstruct data');
+
+    sv_magicv2_set_userstruct($sv, 987, 654);
+    is_deeply([sv_magicv2_get_userstruct($sv)], [987, 654],
+        'Userstruct data can be modified');
+}
+
+# Magic can be removed
+{
+    my $counter;
+    my $sv = 123;
+    sv_magicv2_add($sv, inc_on_free => \$counter);
+    sv_magicv2_remove($sv, 'inc_on_free');
+    is($counter, 1, '$counter is now 1 after sv_magicv2_remove');
+}
+
+# Removed magics don't disturb others
+{
+    my $counterA;
+    my $counterB;
+    {
+        my $sv;
+        sv_magicv2_add($sv, inc_on_free => \$counterA);
+        sv_magicv2_add($sv, empty => \undef);
+        sv_magicv2_add($sv, inc_on_free => \$counterB);
+
+        sv_magicv2_remove($sv, 'empty');
+    }
+    is($counterA, 1, 'first inc_on_free trigger invoked after empty magic removed');
+    is($counterB, 1, 'second inc_on_free trigger invoked after empty magic removed');
+}
+
+# Non-container magics do not persist through `local`
+{
+    my $auxsv;
+    # we can't local'ise a lexical var
+    my @var = (undef);
+    sv_magicv2_add($var[0], empty => \$auxsv);
+
+    {
+        local $var[0];
+        is(MgAUXSV($var[0], 'empty'), undef, 'sv_magicv2_find sees nothing while localised');
+    }
+
+    is(MgAUXSV($var[0], 'empty'), \$auxsv, 'sv_magicv2_find after SV restored');
+}
+
+# Container magics keep MgAUXSV across `local`
+{
+    my $auxsv;
+    # we can't local'ise a lexical var
+    my @var = (undef);
+    sv_magicv2_add($var[0], container_empty => \$auxsv);
+
+    {
+        local $var[0];
+        is(MgAUXSV($var[0], 'container_empty'), \$auxsv, 'sv_magicv2_find sees auxsv localised');
+        is(Internals::SvREFCNT($auxsv), 3, '$auxsv has refcount 3 after local');
+    }
+
+    is(MgAUXSV($var[0], 'container_empty'), \$auxsv, 'sv_magicv2_find after SV restored');
+}
+
+# Container magics keep MgPTR across `local`
+{
+    # we can't local'ise a lexical var
+    my @var = (undef);
+    sv_magicv2_add($var[0], container_empty => undef);
+    mg_ptr_store($var[0], 'container_empty' => "ABCDE");
+
+    {
+        local $var[0];
+        is(MgPTR($var[0], 'container_empty'), "ABCDE", 'MgPTR copied on local');
+
+        MgPTR_write($var[0], 'container_empty', "ZYXWV");
+        is(MgPTR($var[0], 'container_empty'), "ZYXWV", 'MgPTR can be updated');
+    }
+
+    is(MgPTR($var[0], 'container_empty'), "ABCDE", 'Original MgPTR is retained');
+}
+
+# Container magics keep MgPTRLEN across `local`
+{
+    # we can't local'ise a lexical var
+    my @var = (undef);
+    sv_magicv2_add($var[0], container_empty => undef);
+    MgPTRLEN_set($var[0], 'container_empty', 7654);
+
+    {
+        local $var[0];
+        is(MgPTRLEN($var[0], 'container_empty'), 7654, 'MgPTRLEN copied on local');
+    }
+}
+
+# Container magics keep MgKEYIV across `local`
+{
+    # we can't local'ise a lexical var
+    my @var = (undef);
+    sv_magicv2_add($var[0], with_keyiv => undef);
+    MgKEYIV_set($var[0], 'with_keyiv', 7654);
+
+    {
+        local $var[0];
+        is(MgKEYIV($var[0], 'with_keyiv'), 7654, 'MgKEYIV copied on local');
+    }
+}
+
+# Container magics keep MgKEYSV across `local`
+{
+    # we can't local'ise a lexical var
+    my @var = (undef);
+    sv_magicv2_add($var[0], with_keysv => undef);
+    MgKEYSV_set($var[0], 'with_keysv', "EFGH");
+
+    {
+        local $var[0];
+        is(MgKEYSV($var[0], 'with_keysv'), "EFGH", 'MgKEYSV copied on local');
+    }
+}
+
+# Container magics keep MgUSERSTRUCT across `local`
+{
+    # we can't local'ise a lexical var
+    my @var = (undef);
+    sv_magicv2_add($var[0], userstruct => undef);
+    sv_magicv2_set_userstruct($var[0], 55, 66);
+
+    {
+        local $var[0];
+        is_deeply([sv_magicv2_get_userstruct($var[0])], [55, 66],
+            'Userstruct data copied on local');
+    }
+}
+
+# Scalar Variable magics with 'post_set' function
+{
+    my $counter;
+    my $sv = 123;
+    sv_magicv2_add($sv, inc_after_set => \$counter);
+    is $counter, undef, '$counter before SV modify';
+
+    $sv = 456;
+    is $counter, 1, '$counter after SV modify';
+
+    undef $sv;
+    is $counter, 2, '$counter after SV undef';
+
+    my $counter2;
+    sv_magicv2_add($sv, inc_after_set => \$counter2);
+    $sv = 789;
+
+    is $counter,  3, '$counter after SV modify';
+    is $counter2, 1, '$counter2 after SV modify';
+}
+
+# Scalar Variable magics with 'pre_get' function
+{
+    my $shadow = 456;
+    my $sv = 123;
+    sv_magicv2_add($sv, grab_before_get => \$shadow);
+    is $sv+0, 456, '$sv appears as a copy of $shadow';
+
+    # length is weird in magic
+    $shadow = "x" x 100;
+    is length($sv), 100, 'length($sv) from shadow';
+}
+
+# Scalar Variable magics persist through `local`
+{
+    my $counter;
+    # we can't local'ise a lexical var
+    my @var = ( "a" );
+    sv_magicv2_add($var[0], inc_after_set => \$counter);
+    {
+        local $var[0] = "b";
+        # local + assign has bumped the counter twice
+        is $counter, 2, '$counter after SV localised';
+
+        $var[0] = "c";
+        is $counter, 3, '$counter after SV modify when localised';
+    }
+
+    is $counter, 4, '$counter after SV restored';
+}
+
+# Variable magic can be removed while it is running
+{
+    my $counter;
+    my $sv;
+    sv_magicv2_add($sv, inc_after_set => \$counter, 1);
+
+    $sv = 123;
+    is $counter, 1, '$counter after SV modify with dispel';
+
+    $sv = 456;
+    is $counter, 1, '$counter after SV modify unchanged after dispel';
+}
+
+# Array Variable magics with 'clear' function
+{
+    my $counter;
+    my @arr;
+    sv_magicv2_add(@arr, inc_after_clear_arr => \$counter);
+
+    undef @arr;
+    is $counter, 1, '$counter after AV clear with undef';
+}
+
+# Hash Variable magics with 'clear' function
+{
+    my $counter;
+    my %hash;
+    sv_magicv2_add(%hash, inc_after_clear_hash => \$counter);
+
+    undef %hash;
+    is $counter, 1, '$counter after HV clear with undef';
+}
+
+done_testing;

--- a/mg.c
+++ b/mg.c
@@ -34,6 +34,291 @@ plus space for some flags and pointers.  For example, a tied variable has
 a MAGIC structure that contains a pointer to the object associated with the
 tie.
 
+=head2 Magic v2
+
+Magic v2 is currently considered B<experimental>.
+
+New in Perl version 5.45.2, the Magic system has been greatly extended by
+defining an entire new version. This "Magic v2" brings new data structures
+which define the sets of trigger functions and other metadata associated with
+that kind of magic, and new data structures, functions, and macros to use to
+attach them to SVs and manage those attachments.
+
+Whereas in the original (version 1) definition, user code was expected to
+directly access fields of the MAGIC structure attached to individual SVs, the
+data structure used by version 2 is considered opaque, and should only be
+manipulated via the various C<Mg...> named macros.
+
+The principal improvement is the addition of the C<struct MagicFunctions>
+structure to replace the previous C<struct MGVTBL>. It fills a similar role
+in that it provides pointers to various "trigger functions" (i.e. definitions
+of the new behaviour that the magic wishes to add), but also provides a number
+of metadata fields that were missing from the first version and couldn't
+easily be added. These metadata fields provide extra information about the
+overall kind of magic (as opposed to being about any particular SV
+attachment), as well as a version number to greatly simplify any future
+extensions of the structure to address any shortcomings from here onwards.
+
+=for apidoc Ay||struct MagicFunctions
+=for apidoc_flag MGv2f_WITH_KEYIV
+=for apidoc_flag MGv2f_WITH_KEYSV
+=for apidoc_flag MGv2f_ALWAYS_WEAK_AUXSV
+
+The base structure definition used by Magic v2 to store metadata and common
+functions for any magic definition. This can be considered as if it were a
+C<struct> having the following definition:
+
+    struct MagicFunctions {
+        U32 ver;
+        enum MagicShape shape;
+        U32 flags;
+        const char *debug_name;
+        size_t user_size;
+
+        void (*free_mg) (pTHX_ SV *sv, MAGIC *mg);
+        void (*clone_mg)(pTHX_ SV *nsv, MAGIC *nmg,
+                         SV *osv, MAGIC *omg, CLONE_PARAMS *params);
+    };
+
+In practice, you should always use C99-style named initialiser syntax to set
+the values of any of these fields when declaring a
+S<C<const struct MagicFunctions>> in your code, as for internal
+implementation reasons the C<ver> field is not actually the first field in
+the structure. Attempting to initialise these by positional index alone will
+result in the wrong fields receiving the values, and likely cause a
+compiletime error, if not a runtime crash.
+
+=over 4
+
+=item C<ver> field
+
+Gives the version number of "Magic" for this structure. The API described here
+is numbered version 2. All magic functions structures must set this field to
+this number. 
+
+Later versions of this API may increase the number. This field allows the
+interpreter to detect which version of the structure this is, and so access
+the fields appropriately. It gives a way to change the structure in future
+versions without breaking existing source code.
+
+=item C<shape> field
+
+Describes what kind of functions structure this actually is. This is an
+enumeration of one of the C<enum MagicShape> constants. For the basic
+functions structure the value is C<MGv2s_BASE>. Other structure shapes are
+described below; each having its own corresponding constant for this field.
+
+=over 4
+
+=item C<MGv2s_BASE>
+
+Indicates that this structure is the basic version without additional
+extensions.
+
+=item C<MGv2s_SCALARVAR>
+
+Indicates that the structure is in fact of type
+S<C<struct ScalarVarMagicFunctions>>.
+
+=item C<MGv2s_ARRAYVAR>
+
+Indicates that the structure is in fact of type
+S<C<struct ArrayVarMagicFunctions>>.
+
+=item C<MGv2s_HASHVAR>
+
+Indicates that the structure is in fact of type
+S<C<struct HashVarMagicFunctions>>.
+
+=back
+
+When attaching this magic structure to a specific SV, the L</SvTYPE> of the
+SV is checked to see if it is compatible with the shape given by the magic
+functions.
+
+=item C<flags> field
+
+A bitfield containing flags that provide minor adjustments to the specific
+behaviour of the magic definition. The particular constants are described
+below, having names beginning C<MGv2f_...>.
+
+=over 4
+
+=item C<MGv2f_WITH_KEYIV>
+
+Presence of this flag allows use of the C<MgKEYIV> field accessor, causing
+magic attachment structures to be allocated with enough storage space to store
+it.
+
+=item C<MGv2f_WITH_KEYSV>
+
+Presence of this flag allows use of the C<MgKEYSV> field accessor, causing
+magic attachment structures to be allocated with enough storage space to store
+it.
+
+=item C<MGv2f_ALWAYS_WEAK_AUXSV>
+
+This flag implies that every attachment of this magic will set the
+C<MgWEAK_AUXSV> flag.
+
+=back
+
+=item C<debug_name> field
+
+An optional string pointer that may be used by C<sv_dump()> when printing
+details about a magic attachment that uses this functions structure. This is
+purely of interest to human readers when debugging; perl will not otherwise
+use this field for any purpose.
+
+=item C<user_size> field
+
+An optional size in bytes that increases the memory allocation for every
+C<MAGIC> structure allocated for this set of functions when attached to an
+SV. This area can be accessed by the L</MgUSERSTRUCT> macro.
+
+=item C<free_mg> trigger function
+
+An optional pointer to a function to be invoked at the time the magic
+attachment is destroyed. This is usually at the time the SV itself is
+destroyed (likely by a call to L</SvREFCNT_dec> or similar); but could also
+happen earlier by a specific call to L</sv_magicv2_remove>.
+
+=item C<clone_mg> trigger function
+
+An optional pointer to a function to be invoked during the interpreter
+cloning process for creating a new thread. This is invoked just after the
+magic structure has been copied to the new SV in the new interpreter, after
+any L</MgAUXSV> or L</MgKEYSV> pointers have been cloned.
+
+=back
+
+In addition to this basic functions structure, the design of Magic v2 allows
+for "subtypes" of function structure to be defined. Each type of magic is
+likely using one of these extended types, which allows it to provide specific
+trigger functions for specific situations that may occur to the kind of SV it
+is attached to.
+
+=for apidoc Ay||struct ScalarVarMagicFunctions
+
+This structure extends the basic C<struct MagicFunctions> by adding the
+following fields to store more trigger functions. It may only be applied to
+SVs that represent scalar values - i.e. whose type is C<SVt_PVMG> or below,
+or the special C<SVt_PVLV>.
+
+    struct ScalarVarMagicFunctions {
+        ...
+
+        void (*localize_mg)(pTHX_ SV *nsv, SV *osv, MAGIC *omg);
+        void (*pre_get) (pTHX_ SV *sv, MAGIC *mg);
+        void (*post_set)(pTHX_ SV *sv, MAGIC *mg);
+    };
+
+For this structure, the C<shape> field takes the value C<MGv2s_SCALARVAR>.
+
+=over 4
+
+=item C<localize_mg> trigger function
+
+An optional pointer to a function to be invoked as part of a C<local>
+operation on a variable with this magic attached. It is passed a pointer to
+the new SV that was created as part of the localisation operation. If it
+wishes the magic to also apply to the new SV it can copy itself there.
+
+A convenient API function, L</magicv2_localize_copy>, is provided to cover
+simple cases. It may be sufficient simply to use this function directly
+(remember to include the C<Perl_> prefix on its name):
+
+    .localize_mg = &Perl_magicv2_localize_copy,
+
+If more complex behaviour is required, provide your own function here. You
+may call the provided function to perform the basic copy operation first,
+before customising its result afterwards.
+
+If the trigger function is absent, it indicates that the magic should be
+considered not to be relevant to the variable, but only to its current value.
+After the SV is saved away as part of a C<local> expression, the magic
+attachment is not applied to the new SV that is placed into that variable.
+
+=item C<pre_get> trigger function
+
+An optional pointer to a function to be invoked just before a read-like
+operation on the SV, such as a call to C<SvIV> or C<SvPV>.
+
+As this operation runs before a value is read from the SV and returned to
+the caller, this trigger function has the opportunity to set whatever result
+it wishes the caller to observe into the SV, by using the various
+C<sv_setfoo()> API functions.
+
+=item C<post_set> trigger function
+
+An optional pointer to a function to be invoked just after a write-like
+operation on the SV, such as a call to C<sv_setiv_mg()> or C<sv_setpvn_mg()>.
+
+As this operation runs after the new value is written into the SV, this
+trigger function can inspect the updated contents of the SV to find out what
+new value was written. It should use the various C<_nomg>-suffixed versions
+of the accessor macros, to ensure it reads the actual stored value and does
+not inadvertently invoke "get" magic v1 or "pre_get" magic v2 functions on the
+SV.
+
+=back
+
+=for apidoc Ay||struct ArrayVarMagicFunctions
+
+This structure extends the basic C<struct MagicFunctions> by adding the
+following fields to store more trigger functions. It may only be applied to
+array variables - i.e. those whose type is C<SVt_PVAV>.
+
+    struct ArrayVarMagicFunctions {
+        ...
+
+        void (*localize_mg)(pTHX_ SV *nsv, SV *osv, MAGIC *omg);
+        void (*clear)(pTHX_ SV *sv, MAGIC *mg);
+    };
+
+For this structure, the C<shape> field takes the value C<MGv2s_ARRAYVAR>.
+
+=over 4
+
+=item C<localize_mg> trigger function
+
+Performs the same as for C<struct ScalarVarMagicFunctions>.
+
+=item C<clear> trigger function
+
+An optional pointer to a function to be invoked just after an operation that
+clears the array, such as C<undef @array>.
+
+=back
+
+=for apidoc Ay||struct HashVarMagicFunctions
+
+This structure extends the basic C<struct MagicFunctions> by adding the
+following fields to store more trigger functions. It may only be applied to
+hash variables - i.e. those whose type is C<SVt_PVHV>.
+
+    struct HashVarMagicFunctions {
+        ...
+
+        void (*localize_mg)(pTHX_ SV *nsv, SV *osv, MAGIC *omg);
+        void (*clear)(pTHX_ SV *sv, MAGIC *mg);
+    };
+
+For this structure, the C<shape> field takes the value C<MGv2s_HASHVAR>.
+
+=over 4
+
+=item C<localize_mg> trigger function
+
+Performs the same as for C<struct ScalarVarMagicFunctions>.
+
+=item C<clear> trigger function
+
+An optional pointer to a function to be invoked just after an operation that
+clears the hash, such as C<undef %hash>.
+
+=back
+
 =for apidoc Ayh||MAGIC
 
 =cut
@@ -139,14 +424,48 @@ Perl_mg_magical(SV *sv)
     SvMAGICAL_off(sv);
     if ((mg = SvMAGIC(sv))) {
         do {
-            const MGVTBL* const vtbl = mg->mg_virtual;
-            if (vtbl) {
-                if (vtbl->svt_get && !(mg->mg_flags & MGf_GSKIP))
-                    SvGMAGICAL_on(sv);
-                if (vtbl->svt_set)
-                    SvSMAGICAL_on(sv);
-                if (vtbl->svt_clear)
-                    SvRMAGICAL_on(sv);
+            if (MgIsV2(mg)) {
+                switch (MgFUNCS(mg)->shape) {
+                    case MGv2s_BASE:
+                        break;
+
+                    case MGv2s_SCALARVAR:
+                    {
+                        const struct ScalarVarMagicFunctions *funcs = MgSCALARVARFUNCS(mg);
+                        if (funcs->pre_get)
+                            SvGMAGICAL_on(sv);
+                        if (funcs->post_set)
+                            SvSMAGICAL_on(sv);
+                        break;
+                    }
+
+                    case MGv2s_ARRAYVAR:
+                    {
+                        const struct ArrayVarMagicFunctions *funcs = MgARRAYVARFUNCS(mg);
+                        if (funcs->clear)
+                            SvRMAGICAL_on(sv);
+                        break;
+                    }
+
+                    case MGv2s_HASHVAR:
+                    {
+                        const struct HashVarMagicFunctions *funcs = MgHASHVARFUNCS(mg);
+                        if (funcs->clear)
+                            SvRMAGICAL_on(sv);
+                        break;
+                    }
+                }
+            }
+            else {
+                const MGVTBL* const vtbl = mg->mg_virtual;
+                if (vtbl) {
+                    if (vtbl->svt_get && !(mg->mg_flags & MGf_GSKIP))
+                        SvGMAGICAL_on(sv);
+                    if (vtbl->svt_set)
+                        SvSMAGICAL_on(sv);
+                    if (vtbl->svt_clear)
+                        SvRMAGICAL_on(sv);
+                }
             }
         } while ((mg = mg->mg_moremagic));
         if (!(SvFLAGS(sv) & (SVs_GMG|SVs_SMG)))
@@ -185,7 +504,15 @@ Perl_mg_get(pTHX_ SV *sv)
         const MGVTBL * const vtbl = mg->mg_virtual;
         MAGIC * const nextmg = mg->mg_moremagic;	/* it may delete itself */
 
-        if (!(mg->mg_flags & MGf_GSKIP) && vtbl && vtbl->svt_get) {
+        if (MgIsV2(mg)) {
+            if (MgFUNCS(mg)->shape == MGv2s_SCALARVAR) {
+                const struct ScalarVarMagicFunctions *funcs = MgSCALARVARFUNCS(mg);
+
+                if (funcs->pre_get)
+                    funcs->pre_get(aTHX_ sv, mg);
+            }
+        }
+        else if (!(mg->mg_flags & MGf_GSKIP) && vtbl && vtbl->svt_get) {
 
             /* taint's mg get is so dumb it doesn't need flag saving */
             if (mg->mg_type != PERL_MAGIC_taint) {
@@ -290,7 +617,16 @@ Perl_mg_set(pTHX_ SV *sv)
         if (PL_localizing == 2
             && PERL_MAGIC_TYPE_IS_VALUE_MAGIC(mg->mg_type))
             continue;
-        if (vtbl && vtbl->svt_set)
+
+        if (MgIsV2(mg)) {
+            if (MgFUNCS(mg)->shape == MGv2s_SCALARVAR) {
+                const struct ScalarVarMagicFunctions *funcs = MgSCALARVARFUNCS(mg);
+
+                if (funcs->post_set)
+                    funcs->post_set(aTHX_ sv, mg);
+            }
+        }
+        else if (vtbl && vtbl->svt_set)
             vtbl->svt_set(aTHX_ sv, mg);
     }
 
@@ -355,7 +691,19 @@ Perl_mg_clear(pTHX_ SV *sv)
 
         nextmg = mg->mg_moremagic; /* it may delete itself */
 
-        if (vtbl && vtbl->svt_clear)
+        if (MgIsV2(mg)) {
+            if (MgFUNCS(mg)->shape == MGv2s_ARRAYVAR) {
+                const struct ArrayVarMagicFunctions *funcs = MgARRAYVARFUNCS(mg);
+                if (funcs->clear)
+                    funcs->clear(aTHX_ sv, mg);
+            }
+            else if (MgFUNCS(mg)->shape == MGv2s_HASHVAR) {
+                const struct HashVarMagicFunctions *funcs = MgHASHVARFUNCS(mg);
+                if (funcs->clear)
+                    funcs->clear(aTHX_ sv, mg);
+            }
+        }
+        else if (vtbl && vtbl->svt_clear)
             vtbl->svt_clear(aTHX_ sv, mg);
     }
 
@@ -491,18 +839,43 @@ Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
         return;
 
     for (mg = SvMAGIC(sv); mg; mg = mg->mg_moremagic) {
-        const MGVTBL* const vtbl = mg->mg_virtual;
-        if (PERL_MAGIC_TYPE_IS_VALUE_MAGIC(mg->mg_type))
-            continue;
-                
-        if ((mg->mg_flags & MGf_LOCAL) && vtbl->svt_local)
-            (void)vtbl->svt_local(aTHX_ nsv, mg);
-        else
-            sv_magicext(nsv, mg->mg_obj, mg->mg_type, vtbl,
-                            mg->mg_ptr, mg->mg_len);
+        if (MgIsV2(mg)) {
+            switch(MgFUNCS(mg)->shape) {
+                case MGv2s_BASE:
+                    /* does not support localisation */
+                    break;
 
-        /* container types should remain read-only across localization */
-        SvFLAGS(nsv) |= SvREADONLY(sv);
+                case MGv2s_SCALARVAR:
+                    if(MgSCALARVARFUNCS(mg)->localize_mg)
+                        (*MgSCALARVARFUNCS(mg)->localize_mg)(aTHX_ nsv, sv, mg);
+                    break;
+
+                case MGv2s_ARRAYVAR:
+                    if(MgARRAYVARFUNCS(mg)->localize_mg)
+                        (*MgARRAYVARFUNCS(mg)->localize_mg)(aTHX_ nsv, sv, mg);
+                    break;
+
+                case MGv2s_HASHVAR:
+                    if(MgHASHVARFUNCS(mg)->localize_mg)
+                        (*MgHASHVARFUNCS(mg)->localize_mg)(aTHX_ nsv, sv, mg);
+                    break;
+            }
+        }
+        else {
+            /* legacy v1 magic */
+            if (PERL_MAGIC_TYPE_IS_VALUE_MAGIC(mg->mg_type))
+                continue;
+
+            const MGVTBL* const vtbl = mg->mg_virtual;
+            if ((mg->mg_flags & MGf_LOCAL) && vtbl->svt_local)
+                (void)vtbl->svt_local(aTHX_ nsv, mg);
+            else
+                sv_magicext(nsv, mg->mg_obj, mg->mg_type, vtbl,
+                                mg->mg_ptr, mg->mg_len);
+
+            /* container types should remain read-only across localization */
+            SvFLAGS(nsv) |= SvREADONLY(sv);
+        }
     }
 
     if (SvTYPE(nsv) >= SVt_PVMG && SvMAGIC(nsv)) {
@@ -515,28 +888,102 @@ Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
     }	    
 }
 
+/*
+=for apidoc magicv2_localize_copy
+
+Intended to be called as the C<localize_mg> trigger function of a
+C<ScalarVarMagicFunctions>, C<ArrayVarMagicFunctions> or
+C<HashVarMagicFunctions>. This function will attach the same Magic v2
+functions and flags as given in the original magic in I<omg>, onto the new
+SV in I<nsv>. It then copies a variety of fields from the original into
+the new magic, taking care to maintain reference counts if appropriate. A
+pointer to the newly-added magic is returned.
+
+=over 4
+
+=item *
+
+C<MgPRIV> is copied.
+
+=item *
+
+C<MgAUXSV> is copied, with an incremented reference count if C<MgWEAK_AUXSV>
+is not set.
+
+=item *
+
+If both C<MgPTR> and C<MgPTRLEN> are set, a new structure area is allocated of
+the same size in I<nmg> and the contents of the old one are bytewise copied.
+If only one of these two fields is set, its value is copied without further
+modification.
+
+=item *
+
+If C<MgKEYIV> is valid its value is copied. If C<MgKEYSV> is valid its value
+is copied with an incremented reference count.
+
+=item *
+
+If the magic functions structure indicates a non-zero C<.user_size> size, this
+area is bytewise copied.
+
+=back
+
+=cut
+*/
+
+MAGIC *
+Perl_magicv2_localize_copy(pTHX_ SV *nsv, SV *osv, MAGIC *omg)
+{
+    PERL_ARGS_ASSERT_MAGICV2_LOCALIZE_COPY;
+
+    MAGIC *nmg = sv_magicv2_attach(nsv, MgFUNCS(omg), MgFLAGS(omg));
+    mgv2_copy(omg, nmg);
+
+    return nmg;
+}
+
 void
 Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
 {
     PERL_ARGS_ASSERT_MG_FREE_STRUCT;
 
-    const MGVTBL* const vtbl = mg->mg_virtual;
-    if (vtbl && vtbl->svt_free)
-        vtbl->svt_free(aTHX_ sv, mg);
+    if(MgIsV2(mg)) {
+        const struct MagicFunctions *funcs = MgFUNCS(mg);
+        if (funcs->free_mg)
+            funcs->free_mg(aTHX_ sv, mg);
 
-    if(mg->mg_ptr) {
-        if (mg->mg_type == PERL_MAGIC_regex_global)
-            NOOP;
-        else if (mg->mg_len > 0)
-            Safefree(mg->mg_ptr);
-        else if (mg->mg_len == HEf_SVKEY)
-            SvREFCNT_dec(MUTABLE_SV(mg->mg_ptr));
-        else if (mg->mg_type == PERL_MAGIC_utf8)
-            Safefree(mg->mg_ptr);
+        if(MgHasKEYSV(mg))
+            SvREFCNT_dec(MgKEYSV(mg));
+
+        if(MgPTR(mg) && MgPTRLEN(mg)) {
+            Safefree(MgPTR(mg));
+        }
+
+        if(MgAUXSV(mg) && !MgWEAK_AUXSV(mg)) {
+            SvREFCNT_dec(MgAUXSV(mg));
+        }
+    }
+    else {
+        const MGVTBL* const vtbl = mg->mg_virtual;
+        if (vtbl && vtbl->svt_free)
+            vtbl->svt_free(aTHX_ sv, mg);
+
+        if(mg->mg_ptr) {
+            if (mg->mg_type == PERL_MAGIC_regex_global)
+                NOOP;
+            else if (mg->mg_len > 0)
+                Safefree(mg->mg_ptr);
+            else if (mg->mg_len == HEf_SVKEY)
+                SvREFCNT_dec(MUTABLE_SV(mg->mg_ptr));
+            else if (mg->mg_type == PERL_MAGIC_utf8)
+                Safefree(mg->mg_ptr);
+        }
+
+        if (mg->mg_flags & MGf_REFCOUNTED)
+            SvREFCNT_dec(mg->mg_obj);
     }
 
-    if (mg->mg_flags & MGf_REFCOUNTED)
-        SvREFCNT_dec(mg->mg_obj);
     Safefree(mg);
 }
 

--- a/mg.h
+++ b/mg.h
@@ -31,6 +31,10 @@ struct magic {
     char*	mg_ptr;
 };
 
+/* Flag bit for mg_flags and MgFLAGS */
+#define MGf_MGv2    0x80        /* mg_virtual points at a Magic v2 structure */
+
+/* If MGf_MGv2 is not set, this is a MAGIC v1 structure */
 #define MGf_TAINTEDDIR 1        /* PERL_MAGIC_envelem only */
 #define MGf_MINMATCH   1        /* PERL_MAGIC_regex_global only */
 #define MGf_REQUIRE_GV 1        /* PERL_MAGIC_checkcall only */
@@ -82,6 +86,313 @@ struct magic {
 #endif
 
 #define whichsig(pv) whichsig_pv(pv)
+
+/* Magic v2
+ * Was called "hooks" during development; there may still be remnants of that
+ * name, or various prefixes like "HK..." or "Hk..." hanging around in code.
+ */
+
+/*
+=for apidoc_section $magic
+
+=for apidoc Am|bool|MgIsV2|MAGIC *mg
+Returns true if the given magic structure is using Magic v2. This is the only
+macro defined as part of Magic v2 that is safe to call on any magic structure.
+All other macros must only be used on structures known to be Magic v2.
+
+=cut
+*/
+
+#define MgIsV2(mg)  (mg->mg_flags & MGf_MGv2)
+
+/* Flag constants used by MgFLAGS() */
+#define MGv2f_REFCOUNTED_AUXSV  (1<<1)   /* must match MGf_REFCOUNTED */
+#define MGv2f_WITH_MASK         (3<<3)   /* aligned with MGf_COPY|MGf_DUP */
+#define   MGv2f_WITH_KEYIV      (1<<3)
+#define   MGv2f_WITH_KEYHEK     (2<<3)   /* unimplemented */
+#define   MGv2f_WITH_KEYSV      (3<<3)
+
+enum MagicShape {
+    MGv2s_BASE,
+    MGv2s_SCALARVAR,
+    MGv2s_ARRAYVAR,
+    MGv2s_HASHVAR,
+};
+
+/* Flag constants stored in MagicFunctions flags field. Defined so they don't
+ * overlap with the set above. */
+#define MGv2f_ALWAYS_WEAK_AUXSV (1<<17)
+
+/*
+=for apidoc Am|U8|MgFLAGS|MAGIC *mg
+Returns the flags bitfield from the given Magic v2 instance. This must only be
+called on known Magic v2 structures; those for which L</MgIsV2> is true.
+
+=cut
+*/
+
+#define MgFLAGS(mg)  *(assert(MgIsV2(mg)), &(mg)->mg_flags)
+
+/*
+=for apidoc Am|const struct MagicFunctions *|MgFUNCS|MAGIC *mg
+Returns a pointer to the magic functions structure of the given Magic v2
+instance. This must only be called on known Magic v2 structures; those for
+which L</MgIsV2> is true.
+
+=cut
+*/
+#define MgFUNCS(mg)  (assert(MgIsV2(mg)), \
+    (const struct MagicFunctions *)((mg)->mg_virtual))
+
+#define MGv2_ASSERT_AND_CAST_FUNCS_(mg, want_shape, type) \
+    (assert(MgFUNCS(mg)->shape == want_shape),           \
+      ((const type *)MgFUNCS(mg)))
+
+/* common to all magic v2 function structs */
+
+/* We'd love to name the free function simply `free`, but because
+ * win32/win32iop.h has a line `#define free win32_free`, we can't do that
+ * or all sorts of breakage happens :(
+ */
+#define _PERL_MAGICFUNCTIONS_COMMON_FIELDS  \
+    MGVTBL _v1_vtbl; /* reserve space */   \
+    U32 ver;                               \
+    enum MagicShape shape;                 \
+    U32 flags;                             \
+    const char *debug_name;                \
+    size_t user_size;                      \
+    void (*free_mg) (pTHX_ SV *sv, MAGIC *mg); \
+    void (*clone_mg)(pTHX_ SV *nsv, MAGIC *nmg, SV *osv, MAGIC *omg, CLONE_PARAMS *params)
+
+struct MagicFunctions {
+    _PERL_MAGICFUNCTIONS_COMMON_FIELDS;
+};
+
+struct ScalarVarMagicFunctions {
+    _PERL_MAGICFUNCTIONS_COMMON_FIELDS;
+
+    MAGIC *(*localize_mg)(pTHX_ SV *nsv, SV *osv, MAGIC *omg);
+    void (*pre_get) (pTHX_ SV *sv, MAGIC *mg);
+    void (*post_set)(pTHX_ SV *sv, MAGIC *mg);
+};
+
+#define MgSCALARVARFUNCS(mg)  MGv2_ASSERT_AND_CAST_FUNCS_(mg, MGv2s_SCALARVAR, struct ScalarVarMagicFunctions)
+
+struct ArrayVarMagicFunctions {
+    _PERL_MAGICFUNCTIONS_COMMON_FIELDS;
+
+    MAGIC *(*localize_mg)(pTHX_ SV *nsv, SV *osv, MAGIC *omg);
+    void (*clear)(pTHX_ SV *sv, MAGIC *mg);
+};
+
+#define MgARRAYVARFUNCS(mg)  MGv2_ASSERT_AND_CAST_FUNCS_(mg, MGv2s_ARRAYVAR, struct ArrayVarMagicFunctions)
+
+struct HashVarMagicFunctions {
+    _PERL_MAGICFUNCTIONS_COMMON_FIELDS;
+
+    MAGIC *(*localize_mg)(pTHX_ SV *nsv, SV *osv, MAGIC *omg);
+    void (*clear)(pTHX_ SV *sv, MAGIC *mg);
+};
+
+#define MgHASHVARFUNCS(mg)  MGv2_ASSERT_AND_CAST_FUNCS_(mg, MGv2s_HASHVAR, struct HashVarMagicFunctions)
+
+typedef struct {
+    MAGIC  _magic;
+    IV     keyiv;
+} MAGICWithKeyIV;
+
+typedef struct {
+    MAGIC  _magic;
+    SV    *keysv;
+} MAGICWithKeySV;
+
+#define MGv2_SIZEOF_FLAGS_(flags)  \
+    (((flags) & MGv2f_WITH_MASK) == MGv2f_WITH_KEYIV ? sizeof(MAGICWithKeyIV) : \
+     ((flags) & MGv2f_WITH_MASK) == MGv2f_WITH_KEYSV ? sizeof(MAGICWithKeySV) : \
+                                                       sizeof(MAGIC))
+#define MgSIZEOF(mg)  MGv2_SIZEOF_FLAGS_(MgFLAGS(mg))
+
+/*
+=for apidoc Am|U16|MgPRIV|MAGIC *mg
+Wraps a U16 field in the Magic v2 structure that is otherwise unused by the
+magic system itself. It is provided for specific instances of Magic v2 to use
+for their own purposes; typically storing a small enumeration or set of flags
+bits.
+
+This macro may be used as an lvalue.
+
+=cut
+*/
+#define MgPRIV(mg)   ((mg)->mg_private)
+
+/*
+=for apidoc Am|SV *|MgAUXSV|MAGIC *mg
+Returns the value of the stored auxilliary SV pointer from the Magic v2
+structure. This macro should not be used as an lvalue; to set a new value see
+L</MgAUXSV_set>.
+
+=cut
+*/
+#define MgAUXSV(mg)  ((mg)->mg_obj)
+
+/*
+=for apidoc Am|bool|MgWEAK_AUXSV|MAGIC *mg
+Returns true if the L</MgAUXSV> field should be considered as a weak pointer.
+If so, it will not have its reference count decremented when the structure is
+destroyed or a new value is set.
+
+=for apidoc      Am|void|MgWEAK_AUXSV_on|MAGIC *mg
+=for apidoc_item   |void|MgWEAK_AUXSV_off|MAGIC *mg
+Mutator macros to turn on or off the L</MgWEAK_AUXSV> flag.
+
+=cut
+*/
+// WEAK_AUXSV is really !MGv2f_REFCOUNTED_AUXSV
+#define MgWEAK_AUXSV(mg)      (!(MgFLAGS(mg) & MGv2f_REFCOUNTED_AUXSV))
+#define MgWEAK_AUXSV_on(mg)   (MgFLAGS(mg) &= ~MGv2f_REFCOUNTED_AUXSV)
+#define MgWEAK_AUXSV_off(mg)  (MgFLAGS(mg) |=  MGv2f_REFCOUNTED_AUXSV)
+
+/*
+=for apidoc Am|void|MgAUXSV_set|MAGIC *mg|SV *auxsv
+Sets a new value of the stored auxilliary SV pointer in the Magic v2
+structure. This does I<not> increment the reference count of the new value.
+It will decrement the count from the old value, if the L</MgWEAK_AUXSV> flag is
+not set.
+
+=cut
+*/
+#define MgAUXSV_set(mg, sv) \
+    STMT_START { \
+        MAGIC *mg_ = mg; \
+        if(MgAUXSV(mg_) && !MgWEAK_AUXSV(mg_)) SvREFCNT_dec(MgAUXSV(mg_)); \
+        (mg_)->mg_obj = sv; \
+    } STMT_END
+
+/*
+=for apidoc      Am|void *|MgPTR|MAGIC *mg
+=for apidoc_item   |STRLEN|MgPTRLEN|MAGIC *mg
+
+The L</MgPTR> macro gives access to a pointer value stored by a Magic v2
+structure, and L</MgPTRLEN> gives an associated length for it. 
+
+If L</MgPTR> is C<NULL>, the magic code may use L</MgPTRLEN> for its own
+purposes. The value will be copied on C<local> operations, thread cloning,
+and similar, but will not otherwise be used.
+
+If L</MgPTRLEN> is zero, the magic code may use L</MgPTR> for its own purposes.
+The value will be copied on C<local> operations, thread cloning and similar,
+but will not otherwise be used.
+
+When used together, these macros create a storage area where the magic code
+can store arbitrary bytes. If L</MgPTR> is non-C<NULL> and L</MgPTRLEN> is
+non-zero when the magic is copied onto a new SV (because of C<local>
+operations, thread cloning, or similar) a new buffer is allocated of the
+given size, whose contents are initialised by taking a copy of the original.
+A buffer allocated in this manner will be automatically released when the
+magic structure is destroyed.
+
+=for apidoc      Am|void|MgPTR_set|MAGIC *mg|void *ptr
+=for apidoc_item   |void|MgPTRLEN_set|MAGIC *mg|STRLEN len
+
+These macros set new values for the L</MgPTR> and L</MgPTRLEN> values stored
+in the magic structure. If both the pointer and length values are being used
+to create an allocated buffer, it is better to use the L</mg_ptr_store>
+function to allocate a new buffer and update the storage.
+
+=cut
+*/
+// PTR just steals magic's mg_ptr field. Though we pretend it's a void *
+#define MgPTR(mg)           ((void *)(mg)->mg_ptr)
+#define MgPTR_set(mg, ptr)  ((mg)->mg_ptr = (char *)(ptr))
+
+// PTRLEN just steals magic's mg_len field.
+// TODO: SSize_t vs STRLEN 
+#define MgPTRLEN(mg)           ((mg)->mg_len)
+#define MgPTRLEN_set(mg, len)  ((mg)->mg_len = (len))
+
+/*
+=for apidoc      Am|bool|MgHasKEYIV|MAGIC *mg
+=for apidoc_item   |bool|MgHasKEYSV|MAGIC *mg
+
+Returns true if the Magic v2 structure is declared as using either a key IV
+or key SV. If this is the case, then the structure will be allocated with
+enough extra storage for the field accessor macros to be used.
+
+At most one of these macros will be true at any one time; no magic structure
+is able to use both at once.
+
+=for apidoc Am|IV|MgKEYIV|MAGIC *mg
+
+If L</MgHasKEYIV> is true, then this macro may be used as either an rvalue or
+lvalue to access the key IV in the structure. If not, then this macro must not
+be called. On debugging builds, an assertion is generated if the macro is
+called on a structure without the flag.
+
+Typically this field is used to store an array index or pad offset value.
+
+=for apidoc Am|void|MgKEYIV_set|MAGIC *mg|IV iv
+
+If L</MgHasKEYIV> is true, then this macro may be used to set the value of the
+key IV in the structure. It behaves the same as assigning directly into the
+L</MgKEYIV> macro when used as an lvalue, it is just provided for
+completeness.
+
+=for apidoc Am|SV|MgKEYSV|MAGIC *mg
+
+If L</MgHasKEYSV> is true, then this macro may be used as either an rvalue or
+lvalue to access the key SV in the structure. If not, then this macro must not
+be called. On debugging builds, an assertion is generated if the macro is
+called on a structure without the flag.
+
+Typically this field is used to store a hash key value. If a value is set then
+it is cloned during thread cloning, and its reference count is automatically
+adjusted as part of localisation and destruction operations.
+
+=for apidoc Am|void|MgKEYSV_set|MAGIC *mg|SV *sv
+
+If L</MgHasKEYSV> is true, then this macro may be used to set the value of
+the key SV in the structure. In addition to assigning the new pointer value
+into the structure, it will also call L</SvREFCNT_dec> on a previous value
+if present.
+
+=cut
+*/
+#define MgHasKEYIV(mg)  ((MgFLAGS(mg) & MGv2f_WITH_MASK) == MGv2f_WITH_KEYIV)
+#define MgHasKEYSV(mg)  ((MgFLAGS(mg) & MGv2f_WITH_MASK) == MGv2f_WITH_KEYSV)
+
+// These macros need to be usable as lvalues
+#define MgKEYIV(mg)     (*(assert(MgHasKEYIV(mg)), &((MAGICWithKeyIV *)mg)->keyiv))
+#define MgKEYSV(mg)     (*(assert(MgHasKEYSV(mg)), &((MAGICWithKeySV *)mg)->keysv))
+
+#define MgKEYIV_set(mg, iv)                   \
+    STMT_START {                              \
+        assert(MgHasKEYIV(mg));               \
+        ((MAGICWithKeyIV *)mg)->keyiv = (iv); \
+    } STMT_END
+
+#define MgKEYSV_set(mg, sv)                   \
+    STMT_START {                              \
+        assert(MgHasKEYSV(mg));               \
+        if(MgKEYSV(mg))                       \
+            SvREFCNT_dec(MgKEYSV(mg));        \
+        ((MAGICWithKeySV *)mg)->keysv = (sv); \
+    } STMT_END
+
+/*
+=for apidoc Am|type|MgUSERSTRUCT|MAGIC *mg|type
+
+Returns a pointer to the "user structure" storage area of the given Magic v2
+structure. This is extra memory allocated within the structure itself, to the
+size given by the C<user_size> field in the magic functions structure. This
+pointer is cast to the given type.
+
+Typically this would be used by magic functions that have more complex data
+storage requirements than can be satisfied by use of the L</MgAUXSV>, L</MgPTR>,
+L</MgKEYIV> or L</MgKEYSV> fields, and wish to manage their own storage.
+
+=cut
+*/
+#define MgUSERSTRUCT(mg, type)  ((type)(((char *)mg) + MgSIZEOF(mg)))
 
 /*
  * ex: set ts=8 sts=4 sw=4 et:

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -27,6 +27,22 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Magic v2
+
+This version introduces a whole new set of API functions, data structures, and
+related items that provides a new kind of variable magic; providing the
+ability to attach user-supplied trigger functions to behaviours on existing
+variables.
+
+The eventual intention of this new version is to extend magic with new trigger
+functions that can apply at different times to those currently supported, and
+to allow magic to be attached to new kinds of items than are currently
+permitted. Right now as of this iteration, it does not offer any new abilities
+but simply changes the shape and structure of existing things to allow space
+for those extensions to be made at a later date.
+
+For more details, see L<perlguts/Magic v2>.
+
 =head1 Security
 
 XXX Any security-related notices go here. In particular, any security

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -737,6 +737,11 @@ not a scalar (i.e. an array or hash).  At the present version, these are only
 permitted on scalar fields.  You will have to manually create a writer
 accessor method yourself.
 
+=item Cannot apply magicfuncs shape %d to SV type %d
+
+(F) An XS module attempted to attach a Magic v2 structure to an SV, but the
+value of its C<shape> field is not compatible with the type of the SV.
+
 =item Cannot assign :param(%s) to field %s because that name is already in use
 
 (F) An attempt was made to apply a parameter name to a field, when the name
@@ -7617,6 +7622,12 @@ whereabouts in the regular expression the escape was discovered.
 (F) You attempted to add a named attribute to a C<field> definition, but
 perl does not recognise the name of the requested attribute.
 
+=item Unrecognized magicfuncs->shape value %d
+
+(F) An XS module attempted to attach a Magic v2 structure to an SV, but the
+value of its C<shape> field is not one of the recognised constants. This must
+take one of the C<MGv2s_*> values listed in L<perlapi>.
+
 =item Unrecognized named parameter '%s' to subroutine '%s'
 
 =item Unrecognized named parameters '%s' to subroutine '%s'
@@ -7669,6 +7680,16 @@ At least, Configure doesn't think so.
 Note that under some systems, like OS/2, there may be different flavors
 of Perl executables, some of which may support fork, some not.  Try
 changing the name you call Perl by to C<perl_>, C<perl__>, and so on.
+
+=item Unsupported MagicFunctions->ver value of %u
+
+(F) An XS module attempted to attach a Magic v2 structure to an SV, but the
+value of its C<ver> field is not supported as a valid version.
+
+If the reported value is zero, it is likely the author forgot to initialise
+that field of the structure. If the number is larger than 2, it likely means
+the XS module is written for a later version of Magic than this version of
+perl can support.
 
 =item Unsupported script encoding %s
 

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -1437,6 +1437,18 @@ macro C<SvPOK_on> would need to be called instead of C<SvIOK_on>.
 
 =head2 Magic Variables
 
+Perl version 5.43.8 added a new set of structures, functions, and related
+infrastructure currently called "Magic v2", intended as an overhaul of the
+original MAGIC system that had been in place beforehand. This section of
+the document is now split into two parts, one for each version.
+
+Firstly we'll describe the original system, partly for historical interest
+and to explain how existing code works. Afterwards, we will introduce the
+newer "Magic v2" by contrasting with the original and explaining what is new
+and why it was added, as well as how to use it.
+
+=head2 Original MAGIC
+
 [This section still under construction.  Ignore everything here.  Post no
 bills.  Everything not permitted is forbidden.]
 
@@ -1457,7 +1469,7 @@ linked list of C<struct magic>'s, typedef'ed to C<MAGIC>.
 
 Note this is current as of patchlevel 0, and could change at any time.
 
-=head2 Assigning Magic
+=head3 Assigning Magic
 
 Perl adds magic to an SV using the sv_magic function:
 
@@ -1522,7 +1534,7 @@ virtual table, use C<sv_unmagicext> instead:
 
     int sv_unmagicext(SV *sv, int type, MGVTBL *vtbl);
 
-=head2 Magic Virtual Tables
+=head3 Magic Virtual Tables
 
 The C<mg_virtual> field in the C<MAGIC> structure is a pointer to an
 C<MGVTBL>, which is a structure of function pointers and stands for
@@ -1805,7 +1817,7 @@ For example, calls to the C<sv_cat*()> functions typically need to be
 followed by C<SvSETMAGIC()>, but they don't need a prior C<SvGETMAGIC()>
 since their implementation handles 'get' magic.
 
-=head2 Finding Magic
+=head3 Finding Magic
 
     MAGIC *mg_find(SV *sv, int type); /* Finds the magic pointer of that
                                        * type */
@@ -1829,7 +1841,7 @@ This routine checks to see what types of magic C<sv> has.  If the mg_type
 field is an uppercase letter, then the mg_obj is copied to C<nsv>, but
 the mg_type field is changed to be the lowercase letter.
 
-=head2 Understanding the Magic of Tied Hashes and Arrays
+=head3 Understanding the Magic of Tied Hashes and Arrays
 
 Tied hashes and arrays are magical beasts of the C<PERL_MAGIC_tied>
 magic type.
@@ -1916,6 +1928,263 @@ the creation of all the mortal variables required to invoke the methods).
 This overhead will be comparatively small if the TIE methods are themselves
 substantial, but if they are only a few statements long, the overhead
 will not be insignificant.
+
+=head2 Magic v2
+
+The entire section above has explained the "historic" original MAGIC system,
+so now we will move on to the newer "Magic v2".
+
+"Magic v2" follows a broadly similar design to original MAGIC, in that it
+permits specific I<kinds> of behaviour to be specified in terms of trigger
+functions that are invoked at various times. Pointers to these functions are
+stored in a structure, this time called C<struct MagicFunctions>, and it is
+this structure which is pointed to by attachments made on individual target
+SVs. Like with original MAGIC, these attachments can also store additional
+data that the magic trigger functions can make use of alongside that target
+SV.
+
+The C<struct MagicFunctions> structure can be thought of as being like a
+class definition, in that it describes a set of behaviours in general. It
+should be declared C<static const> in a module that provides it, as it won't
+need to be visible to any other code, and it won't be modified during
+runtime.
+
+Owing to its development history, original MAGIC has a two-level arrangement
+for identifying different kinds of magic, with many internally-defined tables
+having API-level visible identities that can be identified by the I<mg_type>
+field of the MAGIC structure or the I<how> parameter to several of the API
+functions. If that type is C<PERL_MAGIC_ext> or similar, the additional
+virtual functions pointer identifies the particular magic involved. Magic v2
+is much simpler here, lacking that first-level "type" distinction. Various
+kinds of v2 magic are entirely identified by a pointer to the functions
+structure, and generally even most internally-defined structures are not
+exposed as API-level names.
+
+The central design of the original MGVTBL did not leave any room for
+versioning or metadata, or any way to be able to extend the structure in
+future. The C<MGf_COPY>, C<MGf_DUP> and C<MGf_LOCAL> flags already illustrate
+the limitation of that approach. Therefore, the C<struct MagicFunctions>
+structure begins with two fields, called I<ver> and I<shape>, that between
+them aim to describe exactly what sort of structure it is, as well as provide
+ability to extend and change that structure in future versions of perl, when
+new abilities are added.
+
+=head3 Attaching Magic
+
+Magic v2 is attached to an SV using a similar function than original MAGIC:
+
+    MAGIC *sv_magicv2_add(SV *sv, struct MagicFunctions *funcs,
+                          U32 flags, SV *auxsv);
+
+This creates a new instance of a magic structure associated with the given
+functions structure and stores it in the SV. For a more detailed description
+of the arguments and flags to this function see its entry in L<perlapi>.
+
+Often the behaviour added by magic requires storing extra data in the
+attachment to each SV. The Magic v2 mechanism provides four ways this can be
+achieved, offering various tradeoffs of simplicity of use vs flexibility.
+Magic can store data in an SV pointer in C<MgAUXSV>, the storage provided
+by either C<MgKEYIV> or C<MgKEYSV>, the storage provided by C<MgPTR> and
+C<MgPTRLEN>, and and the extra storage offered by C<user_size> and
+C<MgUSERSTRUCT>. These four features are not alternatives to each other;
+each can be used independently of the others, or in combination, to achieve
+the desired effect.
+
+=head3 Storing an SV in C<MgAUXSV>
+
+The simplest way to store extra data in a magic attachment on an SV is to put
+that data into another SV, and store that second SV in the "aux SV" area.
+This is initially set by using the C<auxsv> parameter to the
+C<sv_magicv2_add()> function, and thereafter accessed by the C<MgAUXSV> macro
+on the Magic structure. Any kind of SV can be used for this purpose.
+
+    SV *more_data = newSVpvs("here is my extra data");
+    MAGIC *mg = sv_magicv2_add(target_sv, &my_magic_funcs, 0, more_data);
+
+    warn("The extra data is %" SVf, SVfARG(MgAUXSV(mg)));
+
+When cloning the interpreter for a new thread, Perl will automatically clone
+the aux SV as well, storing the updated pointer in the magic structure in the
+new thread. When destroying the magic attachment it will automatically
+decrement the reference count in the referred SV, reclaiming it if necessary.
+This usually means the user code does not need to take any additional steps
+when using this method of storing data.
+
+=head3 Using the C<MgKEYIV> or C<MgKEYSV>
+
+If the magic attachment relates to a specific element of an AV or HV, it can
+be necessary or useful to additionally store the index or key of that element
+with the magic structure. This is the intended purpose of the C<MgKEYIV> and
+C<MgKEYSV> macros, and their corresponding C<MgKEYIV_set> and C<MgKEYSV_set>
+mutators.
+
+To use these, the C<MGv2f_WITH_KEYIV> or C<MGv2f_WITH_KEYSV> flag needs to be
+present, either passed to the C<sv_magicv2_add> function call, or set in the
+C<flags> field of the C<struct MagicFunctions> structure. Once the magic
+attachment structure is created, the relevant field access macro can be used
+as an lvalue to set it, or the corresponding C<_set> variant can be passed a
+new value.
+
+    MAGIC *mg = sv_magicv2_add(target_sv, &my_magic_funcs,
+                               MGv2f_WITH_KEYIV, NULL);
+    /* the following two lines are equivalent; you may use either style */
+    MgKEYIV(mg) = idx;
+    MgKEYIV_set(mg, idx);
+
+    warn("The element index is %" IVdf, MgKEYIV(mg));
+
+When using a SV pointer as a key argument, remember that the key is shared by
+any C<local>'ized copies of the containing variable, so it should not be
+modified once created. As it is intended to set this field initially when the
+magic is created and then leave it unmodified, using the C<MgKEYSV> macro as
+an lvalue to set its value will I<not> decrement the reference count of a
+previous SV referred there. If you are replacing the SV pointer, you must
+remember to do this manually.
+
+    if(MgKEYSV(mg))
+        SvREFCNT_dec(MgKEYSV(mg));
+
+    MgKEYSV(mg) = newSVsv(newkey);
+
+Alternatively, this is made simpler by using the C<MgKEYSV_set> macro, which
+handles this for you.
+
+    MgKEYSV_set(mg, newSVsv(newkey));
+
+=head3 Using the C<MgPTR> and C<MgPTRLEN>
+
+Each of these first two methods of storing extra data allow one additional
+value to be stored in the magic structure - either in the C<MgAUXSV> pointer,
+or one of the C<MgKEYIV> or C<MgKEYSV> fields. If the user code needs to store
+more different fields of data than this, it has a number of options. It could
+use some sort of aggregate data structure at the SV level (such as an AV or
+HV) to store multiple elements, but this consumes more memory and requires
+more indirect pointer accesses, impacting its performance. There are two
+further ways to add extra data in the form of an arbitrary C-level data
+structure; which could contain a C<struct> of the user's design.
+
+The C<MgPTR_set> and C<MgPTRLEN_set> macros can be used together to set the
+pointer and corresponding length values in the magic structure itself, to
+manage an allocated buffer:
+
+    struct MyExtraData {
+        int x;
+        UV y;
+        size_t len;
+        char **many_ptrs;
+    };
+
+    MAGIC *mg = sv_magicv2_add(target_sv, &my_magic_funcs, 0, NULL);
+
+    struct MyExtraData *dat;
+    Newx(dat, struct MyExtraData, 1);
+    *dat = ...;
+
+    MgPTR_set(mg, dat);
+    MgPTRLEN_set(mg, sizeof(*dat));
+
+    ((struct MyExtraData *)MgPTR(mg))->y = 1234;
+
+Alternatively, the C<mg_ptr_store> function will allocate a buffer of
+arbitrary size and place its pointer and length into the structure. The user
+code can then use C<MgPTR>, suitably cast, to access this buffer for its own
+purposes. Passing in a NULL pointer to C<mg_ptr_store> causes it to allocate a
+new uninitialised buffer without copying existing data into it.
+
+    struct MyExtraData {
+        int x;
+        UV y;
+        size_t len;
+        char **many_ptrs;
+    };
+
+    MAGIC *mg = sv_magicv2_add(target_sv, &my_magic_funcs, 0, NULL);
+    mg_ptr_store(mg, NULL, sizeof(struct MyExtraData));
+
+    ((struct MyExtraData *)MgPTR(mg))->y = 1234;
+
+=head3 Using C<.user_size> and C<MgUSERSTRUCT>
+
+While the C<MgPTR> area is a useful place to store some arbitrary C-level
+pointer in the magic attachment, it is not in fact ideal if the user code is
+simply using this as a buffer to store its own structural data. It involves
+an additional level of pointer access, which affects CPU performance and cache
+efficiency. It also involves making two separate memory allocations, doubling
+the C<malloc> overhead involved.
+
+Instead of this, the user code can ask the magic system to over-allocate its
+own structure and dedicate those spare bytes of storage to the user code,
+keeping the entire thing in one place in memory.
+
+When the C<user_size> field of the magic functions structure is given a
+non-zero value, any time the magic internals needs to allocate a structure, it
+will add this number of extra bytes. Being a structure of a size given by the
+user code means it can be sized sufficiently for whatever the user code wishes
+to store there (provided that is a single fixed size).
+
+Note however, that due to possible alignment limitations, the user code must
+not use any type in this structure which requires an alignment of larger
+granularity than a regular data pointer, as perl may not be able to guarantee
+correct alignment. If that is required, the user code must allocate its own
+structures and store pointers using the C<MgPTR> technique above.
+
+    struct MyExtraData {
+        int x;
+        UV y;
+        size_t len;
+        char **many_ptrs;
+    };
+    struct MagicFunctions my_magic_funcs = {
+        ...
+        .user_size = sizeof(struct MyExtraData),
+    };
+
+    MAGIC *mg = sv_magicv2_add(target_sv, &my_magic_funcs, 0, NULL);
+
+    MgUSERSTRUCT(mg, struct MyExtraData)->y = 1234;
+
+When freeing the structure or cloning it for a new interpreter thread, this
+extra storage area is accounted for and copied if necessary, so user code may
+not be required to handle basic structures that do not refer to other
+allocated memory. If other memory is allocated and stored in the structure,
+make sure to handle it correctly by providing the C<free_mg> and C<clone_mg>
+trigger functions.
+
+=head3 Handling Localization In Magic
+
+By default, Perl will not perform any extra work when C<local> is applied to a
+variable with magic annotations on it. Behaviour can be added by use of the
+C<localize_mg> trigger function on the C<ScalarVarMagicFunctions>,
+C<ArrayVarMagicFunctions> and C<HashVarMagicFunctions> structures.
+
+In many cases, it is entirely sufficient for localisation purposes to call the
+the L<perlapi/magicv2_localize_copy> function. You can use this function
+directly in your magic functions structure by setting its address as that of
+the C<localize_mg> trigger. Remember that it needs to point to the actual
+function and not the API compatibility wrapper macro, so remember to include
+the leading C<Perl_...> prefix on its name:
+
+    const struct ScalarVarMagicFunctions magic_funcs = {
+        ...,
+        .localize_mg = &Perl_magicv2_localize_copy,
+    };
+
+If your magic makes use of the pointer area or the C<MgUSERSTRUCT> area to
+store additional pointers that require further memory management, you will
+have to account for these yourself. However, you can still call this function
+at the start of your own handler function, before performing any extra work
+yourself that may be required, such as calling C<SvREFCNT_inc> on your own
+stored pointers.
+
+    static MAGIC *
+    S_magic_localize(pTHX_ SV *nsv, SV *osv, MAGIC *omg)
+    {
+	MAGIC *nmg = magicv2_localize_copy(nsv, osv, omg);
+
+	SvREFCNT_inc(MgUSERSTRUCT(mg, struct MyExtraData)->othersv);
+
+	return nmg;
+    }
 
 =head2 Localizing changes
 

--- a/proto.h
+++ b/proto.h
@@ -3620,6 +3620,15 @@ Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
 #define PERL_ARGS_ASSERT_MAGIC_WIPEPACK         \
         Perl_assert_aTHX; assert(sv); assert(mg)
 
+PERL_CALLCONV MAGIC *
+Perl_magicv2_localize_copy(pTHX_ SV *nsv, SV *osv, MAGIC *omg)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        Perl_attribute_nonnull(pTHX_3);
+#define PERL_ARGS_ASSERT_MAGICV2_LOCALIZE_COPY  \
+        Perl_assert_aTHX; assert(nsv); assert(osv); assert(omg)
+
 PERL_CALLCONV Malloc_t
 Perl_malloc(MEM_SIZE nbytes)
         __attribute__malloc__
@@ -3732,6 +3741,13 @@ Perl_mg_magical(SV *sv)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_MG_MAGICAL             \
         assert(sv)
+
+PERL_CALLCONV void
+Perl_mg_ptr_store(pTHX_ MAGIC *mg, const void *ptr, STRLEN len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_MG_PTR_STORE           \
+        Perl_assert_aTHX; assert(mg)
 
 PERL_CALLCONV int
 Perl_mg_set(pTHX_ SV *sv)
@@ -7151,6 +7167,72 @@ Perl_sv_magicext_mglob(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGICEXT_MGLOB      \
         Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV MAGIC *
+Perl_sv_magicv2_add(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 flags, SV *auxsv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_ADD         \
+        Perl_assert_aTHX; assert(sv); assert(funcs)
+
+PERL_CALLCONV MAGIC *
+Perl_sv_magicv2_find_by_auxsv(pTHX_ const SV *sv, const SV *auxsv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_FIND_BY_AUXSV \
+        Perl_assert_aTHX; assert(sv); assert(auxsv)
+
+PERL_CALLCONV MAGIC *
+Perl_sv_magicv2_find_by_funcs(pTHX_ const SV *sv, const struct MagicFunctions *funcs)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_FIND_BY_FUNCS \
+        Perl_assert_aTHX; assert(sv); assert(funcs)
+
+PERL_CALLCONV MAGIC *
+Perl_sv_magicv2_find_or_add(pTHX_ SV *sv, const struct MagicFunctions *funcs)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_FIND_OR_ADD \
+        Perl_assert_aTHX; assert(sv); assert(funcs)
+
+PERL_CALLCONV MAGIC *
+Perl_sv_magicv2_findnext_by_auxsv(pTHX_ const SV *sv, const SV *auxsv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        Perl_attribute_nonnull(pTHX_3);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_FINDNEXT_BY_AUXSV \
+        Perl_assert_aTHX; assert(sv); assert(auxsv); assert(mg)
+
+PERL_CALLCONV MAGIC *
+Perl_sv_magicv2_findnext_by_funcs(pTHX_ const SV *sv, const struct MagicFunctions *funcs, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        Perl_attribute_nonnull(pTHX_3);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_FINDNEXT_BY_FUNCS \
+        Perl_assert_aTHX; assert(sv); assert(funcs); assert(mg)
+
+PERL_CALLCONV void
+Perl_sv_magicv2_remove(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_REMOVE      \
+        Perl_assert_aTHX; assert(sv); assert(mg)
+
+PERL_CALLCONV void
+Perl_sv_magicv2_remove_by_funcs(pTHX_ SV *sv, const struct MagicFunctions *funcs)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_MAGICV2_REMOVE_BY_FUNCS \
+        Perl_assert_aTHX; assert(sv); assert(funcs)
 
 PERL_CALLCONV SV *
 Perl_sv_mortalcopy(pTHX_ SV * const oldsv)
@@ -10869,6 +10951,24 @@ Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MG_FREE_STRUCT        \
         Perl_assert_aTHX; assert(sv); assert(mg)
+
+PERL_CALLCONV void
+Perl_mgv2_copy(pTHX_ const MAGIC *smg, MAGIC *dmg)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        __attribute__visibility__("hidden");
+# define PERL_ARGS_ASSERT_MGV2_COPY             \
+        Perl_assert_aTHX; assert(smg); assert(dmg)
+
+PERL_CALLCONV MAGIC *
+Perl_sv_magicv2_attach(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 flags)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        __attribute__visibility__("hidden");
+# define PERL_ARGS_ASSERT_SV_MAGICV2_ATTACH     \
+        Perl_assert_aTHX; assert(sv); assert(funcs)
 
 #endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_MRO_C)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1755,6 +1755,12 @@ my @unresolved_visibility_overrides = qw(
     MgTAINTEDDIR
     MgTAINTEDDIR_off
     MgTAINTEDDIR_on
+    MgARRAYVARFUNCS
+    MgHASHVARFUNCS
+    MgSCALARVARFUNCS
+    MgSIZEOF
+    MGv2f_REFCOUNTED_AUXSV
+    MGv2f_WITH_MASK
     MICRO_SIGN
     MICRO_SIGN_NATIVE
     MICRO_SIGN_UTF8
@@ -3628,6 +3634,7 @@ my @undocumented_always_visible = qw(
     DEBUG_yv
     DEBUG_yv_TEST
     MAX_UNICODE_UTF8_BYTES
+    MGf_MGv2
 
     assert_scalar_or_IO_
     DEBUG__
@@ -3672,6 +3679,8 @@ my @undocumented_always_visible = qw(
     EXTEND_SAFE_N_
     MEM_WRAP_NEEDS_RUNTIME_CHECK_
     MEM_WRAP_WILL_WRAP_
+    MGv2_ASSERT_AND_CAST_FUNCS_
+    MGv2_SIZEOF_FLAGS_
     NV_BODYLESS_UNION_
     RXf_PMf_CHARSET_SHIFT_
     RXf_PMf_SHIFT_COMPILETIME_

--- a/sv.c
+++ b/sv.c
@@ -6483,6 +6483,386 @@ Perl_sv_magicext(pTHX_ SV *const sv, SV *const obj, const int how,
     return mg;
 }
 
+/* Magic v2 */
+
+/*
+=for apidoc sv_magicv2_add
+
+Adds a Magic (of version 2) to an SV, upgrading it if necessary to being of
+type C<SVt_PVMG>.
+
+If C<auxsv> is non-NULL it should point to a different SV than C<sv>.  It will
+be stored in the MAGIC structure as C<MgAUXSV>, without incrementing the
+refcount.  The reference count will be automatically decremented when the
+magic is destroyed, unless the C<MgWEAK_AUXSV> flag is set.
+
+Returns a pointer to the newly-added MAGIC structure, in case the caller
+wishes to adjust its fields with the various structure access macros, or store
+it for some other purpose. This is optional; the structure is retained by the
+SV itself so it is fine for the caller to ignore the return value.
+
+=cut
+*/
+
+/* behaviour shared by sv_magicv2_add and mg_localize */
+MAGIC *
+Perl_sv_magicv2_attach(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 flags)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_ATTACH;
+
+    SvUPGRADE(sv, SVt_PVMG);
+
+    MAGIC *mg = (MAGIC *)safecalloc(1, MGv2_SIZEOF_FLAGS_(flags) + funcs->user_size);
+    mg->mg_moremagic = SvMAGIC(sv);
+    SvMAGIC_set(sv, mg);
+
+    /* The choice of ext vs extvalue isn't significant here, as mg_localize()
+     * will have its own behaviour for Magic v2 anyway
+     */
+    mg->mg_type = PERL_MAGIC_ext;
+    mg->mg_virtual = (MGVTBL *)funcs;
+    mg->mg_len = 0;
+    mg->mg_ptr = NULL;
+    mg->mg_flags |= MGf_MGv2 | (flags & MGv2f_WITH_MASK);
+
+    mg_magical(sv);
+
+    return mg;
+}
+
+MAGIC *
+Perl_sv_magicv2_add(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 flags, SV *auxsv)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_ADD;
+    U8 svt = SvTYPE(sv);
+
+    if(funcs->ver != 2)
+        croak("Unsupported MagicFunctions->ver value of %u", (unsigned int)funcs->ver);
+
+    switch(funcs->shape) {
+        case MGv2s_BASE:
+            /* valid on any kind of SV */
+            break;
+
+        case MGv2s_SCALARVAR:
+            if(svt > SVt_PVMG && svt != SVt_PVLV)
+                goto bad_shape;
+            break;
+
+        case MGv2s_ARRAYVAR:
+            if(svt != SVt_PVAV)
+                goto bad_shape;
+            break;
+
+        case MGv2s_HASHVAR:
+            if(svt != SVt_PVHV)
+                goto bad_shape;
+            break;
+
+        default:
+            croak("Unrecognized magicfuncs->shape value %d", funcs->shape);
+bad_shape:
+            croak("Cannot apply magicfuncs shape %d to SV type %d", funcs->shape, SvTYPE(sv));
+    }
+
+    MAGIC *mg = sv_magicv2_attach(sv, funcs, flags | funcs->flags);
+
+    mg->mg_obj = auxsv; /* do not bump refcount */
+
+    MgPRIV(mg)  = 0;
+
+    if(!(funcs->flags & MGv2f_ALWAYS_WEAK_AUXSV))
+        MgFLAGS(mg) |= MGv2f_REFCOUNTED_AUXSV;
+
+    return mg;
+}
+
+void
+Perl_mgv2_copy(pTHX_ const MAGIC *smg, MAGIC *dmg)
+{
+    PERL_ARGS_ASSERT_MGV2_COPY;
+
+    MgFLAGS(dmg) = MgFLAGS(smg);
+    MgPRIV(dmg)  = MgPRIV(smg);
+    MgAUXSV_set(dmg, MgAUXSV(smg));
+
+    void *sptr = MgPTR(smg);
+    STRLEN slen = MgPTRLEN(smg);
+    if(sptr && slen)
+        mg_ptr_store(dmg, sptr, slen);
+    else if(sptr)
+        MgPTR_set(dmg, sptr);
+    else if(slen)
+        MgPTRLEN_set(dmg, slen);
+
+    if(!MgWEAK_AUXSV(smg))
+        MgWEAK_AUXSV_off(dmg);
+
+    if(MgAUXSV(dmg) && !MgWEAK_AUXSV(dmg))
+        SvREFCNT_inc_void_NN(MgAUXSV(dmg));
+
+    switch(MgFLAGS(smg) & MGv2f_WITH_MASK) {
+        case 0:
+            break;
+
+        case MGv2f_WITH_KEYIV:
+            MgKEYIV(dmg) = MgKEYIV(smg);
+            break;
+
+        case MGv2f_WITH_KEYSV:
+            MgKEYSV(dmg) = SvREFCNT_inc(MgKEYSV(smg));
+            break;
+    }
+
+    size_t usersize = MgFUNCS(smg)->user_size;
+    if(usersize)
+        Copy(MgUSERSTRUCT(smg, void *), MgUSERSTRUCT(dmg, void *), usersize, char);
+}
+
+/*
+=for apidoc mg_ptr_store
+
+Helper function to manage the buffer storage area used by C<MgPTR> and
+C<MgPTRLEN>. A new buffer is allocated of C<len> bytes long. If C<ptr>
+is not NULL the buffer is then initialised by a copy of that length of bytes
+from C<ptr>. This buffer pointer is stored in the magic structure, to be
+accessed by C<MgPTR> and length C<MgPTRLEN>. If a prior buffer was already in
+place, it is deallocated afterwards.
+
+Because the new buffer is allocated and copied before the old buffer is
+deallocated, it is safe to use this function to grow or shrink that buffer by
+taking a copy of its existing contents; e.g. by passing the current value of
+C<MgPTR> as the C<ptr> argument.
+
+=cut
+*/
+
+void
+Perl_mg_ptr_store(pTHX_ MAGIC *mg, const void *ptr, STRLEN len)
+{
+    PERL_ARGS_ASSERT_MG_PTR_STORE;
+
+    void *was_ptr = MgPTR(mg);
+    STRLEN was_len = MgPTRLEN(mg);
+
+    /* Copy it before releasing the old value, in case of
+     * memmove-style overlaps */
+    void *new_ptr = ptr ? savepvn((const char *)ptr, len)
+                        : safemalloc(len);
+    MgPTR_set(mg, new_ptr);
+    MgPTRLEN_set(mg, len);
+
+    if(was_ptr && was_len)
+        Safefree(was_ptr);
+}
+
+static MAGIC *
+S_sv_magicv2_find(pTHX_ const SV *sv, bool (*filter)(pTHX_ MAGIC *mg, const void *key), const void *key, MAGIC *mg)
+{
+    if(SvTYPE(sv) < SVt_PVMG || !SvMAGICAL(sv))
+        return NULL;
+
+    if(mg)
+        mg = mg->mg_moremagic;
+    else
+        mg = SvMAGIC(sv);
+    for(/**/; mg; mg = mg->mg_moremagic) {
+        /* Don't really need to look at mg->mg_type since we're going to
+         * filter on the virtual table anyway
+         */
+        if(!MgIsV2(mg))
+            continue;
+
+        if((*filter)(aTHX_ (MAGIC *)mg, key))
+            return (MAGIC *)mg;
+    }
+
+    return NULL;
+}
+
+static bool
+S_filter_mgv2_hk      (pTHX_ MAGIC *mg, const void *key) { return mg == key; }
+
+static bool
+S_filter_mgv2_by_funcs(pTHX_ MAGIC *mg, const void *key) { return MgFUNCS(mg) == key; }
+
+/*
+=for apidoc sv_magicv2_find_by_funcs
+
+Finds the MAGIC pointer on the SV for the first magic using the functions
+structure given by C<funcs>.  Returns C<NULL> if no such MAGIC is found.
+
+=cut
+*/
+
+MAGIC *
+Perl_sv_magicv2_find_by_funcs(pTHX_ const SV *sv, const struct MagicFunctions *funcs)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_FIND_BY_FUNCS;
+    return S_sv_magicv2_find(aTHX_ sv, &S_filter_mgv2_by_funcs, funcs, NULL);
+}
+
+/*
+=for apidoc sv_magicv2_findnext_by_funcs
+
+Finds the MAGIC pointer on the SV for the next magic using the functions
+structure given by C<funcs>, presuming that C<mg> already points at the
+previous one (as found by a previous call to this function, or
+C<sv_magicv2_find_by_funcs>).  Returns C<NULL> if no such magic is found.
+
+Note that it is B<not> safe to remove magic attachments from the SV while
+iterating them in a loop using this function.
+
+=cut
+*/
+
+MAGIC *
+Perl_sv_magicv2_findnext_by_funcs(pTHX_ const SV *sv, const struct MagicFunctions *funcs, MAGIC *mg)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_FINDNEXT_BY_FUNCS;
+    return S_sv_magicv2_find(aTHX_ sv, &S_filter_mgv2_by_funcs, funcs, mg);
+}
+
+static bool
+S_filter_mgv2_by_auxsv(pTHX_ MAGIC *mg, const void *key) { return MgAUXSV(mg) == key; }
+
+/*
+=for apidoc sv_magicv2_find_by_auxsv
+
+Finds the MAGIC pointer on the SV for the first magic whose C<MgAUXSV> pointer
+is equal to that given by C<auxsv>.  Returns C<NULL> if no such MAGIC is found.
+
+=cut
+*/
+
+MAGIC *
+Perl_sv_magicv2_find_by_auxsv(pTHX_ const SV *sv, const SV *auxsv)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_FIND_BY_AUXSV;
+    return S_sv_magicv2_find(aTHX_ sv, &S_filter_mgv2_by_auxsv, auxsv, NULL);
+}
+
+/*
+=for apidoc sv_magicv2_findnext_by_auxsv
+
+Finds the MAGIC pointer on the SV for the next magic whose C<MgAUXSV> pointer
+is equal to that given by C<auxsv>, presuming that C<mg> already points at the
+previous one (as found by a previous call to this function, or
+C<sv_magicv2_find_by_auxsv>).  Returns C<NULL> if no such magic is found.
+
+Note that it is B<not> safe to remove magic attachments from the SV while
+iterating them in a loop using this function.
+
+=cut
+*/
+
+MAGIC *
+Perl_sv_magicv2_findnext_by_auxsv(pTHX_ const SV *sv, const SV *auxsv, MAGIC *mg)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_FINDNEXT_BY_AUXSV;
+    return S_sv_magicv2_find(aTHX_ sv, &S_filter_mgv2_by_auxsv, auxsv, mg);
+}
+
+static void
+S_sv_magicv2_remove(pTHX_ SV *sv, bool (*filter)(pTHX_ MAGIC *mg, const void *key), const void *key)
+{
+    /* Don't check SvMAGICAL as that is temporarily switched off while magic
+     * functions are running. This permits us to remove the very magic that
+     * is actively running, allowing magics to remove themselves
+     */
+    if(SvTYPE(sv) < SVt_PVMG)
+        return;
+
+    bool mg_magical_again = false;
+
+    MAGIC *prevmg = NULL, *nextmg;
+    for(MAGIC *mg = SvMAGIC(sv); mg; prevmg = mg, mg = nextmg) {
+        nextmg = mg->mg_moremagic;
+        if(!MgIsV2(mg))
+            continue;
+
+        if(!(*filter)(aTHX_ (MAGIC *)mg, key))
+            continue;
+
+        if(prevmg)
+            prevmg->mg_moremagic = nextmg;
+        else
+            SvMAGIC_set(sv, nextmg);
+        mg->mg_moremagic = NULL;
+        mg_magical_again = true;
+
+        mg_free_struct(sv, mg);
+        mg = prevmg;
+    }
+
+    if(mg_magical_again)
+        mg_magical(sv);
+}
+
+/*
+=for apidoc sv_magicv2_find_or_add
+
+A shortcut for the common behaviour of first attempting to find an existing
+MAGIC on an SV, or creating one if it does not exist.
+
+If adding a new magic structure, this will be created with no aux SV, and zero
+flags.
+
+=cut
+*/
+
+MAGIC *
+Perl_sv_magicv2_find_or_add(pTHX_ SV *sv, const struct MagicFunctions *funcs)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_FIND_OR_ADD;
+
+    MAGIC *mg = sv_magicv2_find_by_funcs(sv, funcs);
+    if(!mg)
+        mg = sv_magicv2_add(sv, funcs, 0, NULL);
+
+    return mg;
+}
+
+/*
+=for apidoc sv_magicv2_remove
+
+Removes a single instance of a MAGIC from the SV.
+
+It is safe to call this from within a magic trigger function, to allow a magic
+structure to remove itself from the SV.
+
+If the associated magic functions structure has a C<free> trigger function, it
+will be invoked as part of this call. The reference count of a stored
+C<MgAUXSV> is decremented, unless the C<MgWEAK_AUXSV> flag is set.
+
+=cut
+*/
+
+void
+Perl_sv_magicv2_remove(pTHX_ SV *sv, MAGIC *mg)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_REMOVE;
+    S_sv_magicv2_remove(aTHX_ sv, &S_filter_mgv2_hk, mg);
+}
+
+/*
+=for apidoc sv_magicv2_remove_by_funcs
+
+Removes every magic attachment on the SV whose functions structure is given by
+C<funcs>. This is equivalent to calling C<sv_magicv2_remove> on each of them
+in turn, invoking any C<free> trigger functions and decrementing any
+associated SV refcounts.
+
+=cut
+*/
+
+void
+Perl_sv_magicv2_remove_by_funcs(pTHX_ SV *sv, const struct MagicFunctions *funcs)
+{
+    PERL_ARGS_ASSERT_SV_MAGICV2_REMOVE_BY_FUNCS;
+    S_sv_magicv2_remove(aTHX_ sv, &S_filter_mgv2_by_funcs, funcs);
+}
+
 MAGIC *
 Perl_sv_magicext_mglob(pTHX_ SV *sv)
 {
@@ -15091,6 +15471,44 @@ Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS *const param)
             /* when joining, we let the individual SVs add themselves to
              * backref as needed. */
             continue;
+
+        if (MgIsV2(mg)) {
+            const struct MagicFunctions *funcs = MgFUNCS(mg);
+            size_t mgsize = MgSIZEOF(mg) + funcs->user_size;
+
+            MAGIC *nmg = (MAGIC *)safecalloc(1, mgsize);
+            *mgprev_p = (MAGIC *)nmg;
+            mgprev_p = &(nmg->mg_moremagic);
+
+            Copy(mg, nmg, mgsize, char); /* copy the entire structure including user data */
+
+            void *optr  = MgPTR(mg);
+            STRLEN olen = MgPTRLEN(mg);
+            if(optr && olen) {
+                MgPTR_set(nmg, savepvn((char *)optr, olen));
+            }
+
+            if(MgAUXSV(nmg)) {
+                if(MgWEAK_AUXSV(nmg))
+                    nmg->mg_obj = sv_dup    (MgAUXSV(nmg), param);
+                else
+                    nmg->mg_obj = sv_dup_inc(MgAUXSV(nmg), param);
+            }
+
+            if(MgHasKEYSV(nmg)) {
+                MgKEYSV(nmg) = sv_dup_inc(MgKEYSV(nmg), param);
+            }
+
+            if(funcs->clone_mg) {
+                /* TODO: Once we are no longer layered on top of MAGIC, then we should
+                 * have direct access to the osv and nsv values. For now we will just
+                 * pass them in as NULL
+                 */
+                (*funcs->clone_mg)(aTHX_ /* nsv = */ NULL, nmg, /* osv = */ NULL, mg, param);
+            }
+
+            continue;
+        }
 
         Newx(nmg, 1, MAGIC);
         *mgprev_p = nmg;


### PR DESCRIPTION
The existing `MAGIC` and `MGVTBL` structures are insufficiently extensible, because they lack any embedded type information, or any version numbering by which new abilities can be added in a backwards-compatible way. Commit 6d97c8623f managed to free a single bit in the `mg_flags` field; it is this bit that we use to indicate that the `MAGIC` structure refers to version 2 of Magic.

The new structures are defined in a way that should be much easier to permit updates in future; adding new structure shapes as well as new trigger functions to the various shapes entirely. In this way, we hope to be able to extend the abilities of magic in the future.

--

This PR is verymuch in "first stage" development, as I'm sure there's plenty of things that need discussion and adjustment before we want to actually merge it.

* This set of changes requires a perldelta entry, and I need help writing it.
