### PR TITLE
release_schedule.pod - RL will do 5.43.8

### DIFF
--- a/Porting/release_schedule.pod
+++ b/Porting/release_schedule.pod
@@ -50,7 +50,7 @@ you should reset the version numbers to the next blead series.
   2025-11-20  5.43.5  ✓       Thibault Duponchelle
   2025-12-20  5.43.6  ✓       Steve Hay
   2026-01-19  5.43.7  ✓       Max Maischein
-  2026-02-20  5.43.8                            Contentious changes freeze
+  2026-02-20  5.43.8          Richard Leach     Contentious changes freeze
   2026-03-20  5.43.9                            User-visible changes to
                                                 correctly functioning
                                                 programs freeze


### PR DESCRIPTION
Volunteering for the 5.43.8 release later this month.

Happy to do at least one release per dev cycle. Steering Council happy for me to be added to the `VICTIMS` list in this file?

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
