### PR TITLE
utf8_to_bytes: remove bad const from output argument

### DIFF
--- a/pp_pack.c
+++ b/pp_pack.c
@@ -276,7 +276,7 @@ utf8_to_byte(pTHX_ const char **s, const char *end, I32 datumtype)
         *(U8 *)(s)++)
 
 static bool
-S_utf8_to_bytes(pTHX_ const char **s, const char *end, const char *buf, SSize_t buf_len, I32 datumtype)
+S_utf8_to_bytes(pTHX_ const char **s, const char *end, char *buf, SSize_t buf_len, I32 datumtype)
 {
     UV val;
     STRLEN retlen;


### PR DESCRIPTION
The 'const' was added in commit f7fe979eb250 (when the function was still called uni_to_bytes()). This was an error because the function writes through buf, but it went unnoticed because the (U8 *) casts in the function body inadvertently cast away const, too.

May address the clang build warnings in #24165.


-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
