### PR TITLE
remove redundant parens around NULL

### DIFF
--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/Cwd.xs
+++ b/dist/PathTools/Cwd.xs
@@ -76,8 +76,8 @@
  * char *realpath(const char *path, char resolved[MAXPATHLEN]);
  *
  * Find the real name of path, by removing all ".", ".." and symlink
- * components.  Returns (resolved) on success, or (NULL) on failure,
- * in which case the path which caused trouble is left in (resolved).
+ * components.  Returns resolved on success, or NULL on failure,
+ * in which case the path which caused trouble is left in resolved.
  */
 static
 char *
@@ -98,20 +98,20 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
             resolved[0] = '/';
             resolved[1] = '\0';
             if (path[1] == '\0')
-                    return (resolved);
+                    return resolved;
             resolved_len = 1;
             remaining_len = my_strlcpy(remaining, path + 1, sizeof(remaining));
 	} else {
             if (getcwd(resolved, MAXPATHLEN) == NULL) {
                 my_strlcpy(resolved, ".", MAXPATHLEN);
-                return (NULL);
+                return NULL;
             }
             resolved_len = strlen(resolved);
             remaining_len = my_strlcpy(remaining, path, sizeof(remaining));
 	}
 	if (remaining_len >= sizeof(remaining) || resolved_len >= MAXPATHLEN) {
             errno = ENAMETOOLONG;
-            return (NULL);
+            return NULL;
 	}
 
 	/*
@@ -129,7 +129,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
 
             if ((STRLEN)(s - remaining) >= (STRLEN)sizeof(next_token)) {
                 errno = ENAMETOOLONG;
-                return (NULL);
+                return NULL;
             }
             memcpy(next_token, remaining, s - remaining);
             next_token[s - remaining] = '\0';
@@ -147,7 +147,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
             if (resolved[resolved_len - 1] != '/') {
                 if (resolved_len + 1 >= MAXPATHLEN) {
                     errno = ENAMETOOLONG;
-                    return (NULL);
+                    return NULL;
                 }
                 resolved[resolved_len++] = '/';
                 resolved[resolved_len] = '\0';
@@ -178,7 +178,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
             resolved_len = my_strlcat(resolved, next_token, MAXPATHLEN);
             if (resolved_len >= MAXPATHLEN) {
                 errno = ENAMETOOLONG;
-                return (NULL);
+                return NULL;
             }
 #if defined(HAS_LSTAT) && defined(HAS_READLINK) && defined(HAS_SYMLINK)
             {
@@ -186,9 +186,9 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                 if (PerlLIO_lstat(resolved, &sb) != 0) {
                     if (errno == ENOENT && p == NULL) {
                         errno = serrno;
-                        return (resolved);
+                        return resolved;
                     }
-                    return (NULL);
+                    return NULL;
                 }
                 if (S_ISLNK(sb.st_mode)) {
                     int slen;
@@ -196,11 +196,11 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
 
                     if (symlinks++ > MAXSYMLINKS) {
                         errno = ELOOP;
-                        return (NULL);
+                        return NULL;
                     }
                     slen = PerlLIO_readlink(resolved, symlink, sizeof(symlink) - 1);
                     if (slen < 0)
-                        return (NULL);
+                        return NULL;
                     symlink[slen] = '\0';
 #  ifdef OS390
                     /* Replace all instances of $SYSNAME/foo simply by /foo */
@@ -232,7 +232,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                         if (symlink[slen - 1] != '/') {
                             if ((STRLEN)(slen + 1) >= (STRLEN)sizeof(symlink)) {
                                 errno = ENAMETOOLONG;
-                                return (NULL);
+                                return NULL;
                             }
                             symlink[slen] = '/';
                             symlink[slen + 1] = 0;
@@ -240,7 +240,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                         remaining_len = my_strlcat(symlink, remaining, sizeof(symlink));
                         if (remaining_len >= sizeof(remaining)) {
                             errno = ENAMETOOLONG;
-                            return (NULL);
+                            return NULL;
                         }
                     }
                     remaining_len = my_strlcpy(remaining, symlink, sizeof(remaining));
@@ -258,7 +258,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
 	 */
 	if (resolved_len > 1 && resolved[resolved_len - 1] == '/')
             resolved[resolved_len - 1] = '\0';
-	return (resolved);
+	return resolved;
 }
 #endif
 

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -4,7 +4,7 @@ use strict;
 
 # Keep $VERSION consistent in all *.pm files in this distribution, including
 # Cwd.pm.
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 my %module = (

--- a/dist/PathTools/lib/File/Spec/AmigaOS.pm
+++ b/dist/PathTools/lib/File/Spec/AmigaOS.pm
@@ -3,7 +3,7 @@ package File::Spec::AmigaOS;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
+++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
@@ -3,7 +3,7 @@ package File::Spec::Cygwin;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Epoc.pm
+++ b/dist/PathTools/lib/File/Spec/Epoc.pm
@@ -2,7 +2,7 @@ package File::Spec::Epoc;
 
 use strict;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 require File::Spec::Unix;

--- a/dist/PathTools/lib/File/Spec/Functions.pm
+++ b/dist/PathTools/lib/File/Spec/Functions.pm
@@ -3,7 +3,7 @@ package File::Spec::Functions;
 use File::Spec;
 use strict;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/dist/PathTools/lib/File/Spec/Mac.pm
+++ b/dist/PathTools/lib/File/Spec/Mac.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Unix.pm
+++ b/dist/PathTools/lib/File/Spec/Unix.pm
@@ -3,7 +3,7 @@ package File::Spec::Unix;
 use strict;
 use Cwd ();
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 =head1 NAME

--- a/dist/PathTools/lib/File/Spec/VMS.pm
+++ b/dist/PathTools/lib/File/Spec/VMS.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Win32.pm
+++ b/dist/PathTools/lib/File/Spec/Win32.pm
@@ -5,7 +5,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -546,7 +546,7 @@ Perl_sharedsv_find(pTHX_ SV *sv)
     if (SvROK(sv) && sv_derived_from(sv, "threads::shared::tie")) {
         return (SHAREDSV_FROM_OBJ(sv));
     }
-    return (NULL);
+    return NULL;
 }
 
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -1061,7 +1061,7 @@ S_ithread_create(
             }
         }
 #endif
-        return (NULL);
+        return NULL;
     }
 
     my_pool->running_threads++;

--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -33,7 +33,7 @@ $EXPORT_TAGS{bsd_glob} = [@{$EXPORT_TAGS{glob}}];
 
 our @EXPORT_OK   = (@{$EXPORT_TAGS{'glob'}}, 'csh_glob');
 
-our $VERSION = '1.42';
+our $VERSION = '1.43';
 
 sub import {
     require Exporter;

--- a/ext/File-Glob/bsd_glob.c
+++ b/ext/File-Glob/bsd_glob.c
@@ -1019,7 +1019,7 @@ g_opendir(Char *str, glob_t *pglob)
                 my_strlcpy(buf, ".", sizeof(buf));
         } else {
                 if (g_Ctoc(str, buf, sizeof(buf)))
-                        return(NULL);
+                        return NULL;
         }
 
         if (pglob->gl_flags & GLOB_ALTDIRFUNC)
@@ -1063,7 +1063,7 @@ g_strchr(Char *str, int ch)
                 if (*str == ch)
                         return (str);
         } while (*str++);
-        return (NULL);
+        return NULL;
 }
 
 static int

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -1943,7 +1943,7 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
     case '+':
       if (!skip) {
         SvREFCNT_dec(result);
-        return (NULL);
+        return NULL;
       }
       break;
     case '0':
@@ -1966,7 +1966,7 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
       break;
     default:
       SvREFCNT_dec(result);
-      return (NULL);
+      return NULL;
     }
     s++;
   }

--- a/reginline.h
+++ b/reginline.h
@@ -11,7 +11,7 @@ Perl_regnext(pTHX_ const regnode *p)
     I32 offset;
 
     if (!p)
-        return(NULL);
+        return NULL;
 
     if (OP(p) > REGNODE_MAX) {                /* regnode.type is unsigned */
         croak("Corrupted regexp opcode %d > %d",
@@ -20,7 +20,7 @@ Perl_regnext(pTHX_ const regnode *p)
 
     offset = (REGNODE_OFF_BY_ARG(OP(p)) ? ARG1u(p) : NEXT_OFF(p));
     if (offset == 0)
-        return(NULL);
+        return NULL;
 
     return(regnode *)(p+offset);
 }


### PR DESCRIPTION
This is semantically a no-op, but it may help with broken build warnings in clang 21 `-Wimplicit-void-ptr-cast`.

Addresses #24164.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
