### PR TITLE
Fix clang21 implicit-void-ptr-cast build-time warnings

### DIFF
--- a/cpan/Digest-SHA/SHA.xs
+++ b/cpan/Digest-SHA/SHA.xs
@@ -48,7 +48,7 @@ static const int ix2alg[] =
 static SHA *getSHA(pTHX_ SV *self)
 {
 	if (!sv_isobject(self) || !sv_derived_from(self, "Digest::SHA"))
-		return(NULL);
+		return NULL;
 	return INT2PTR(SHA *, SvIV(SvRV(self)));
 }
 

--- a/cpan/Digest-SHA/lib/Digest/SHA.pm
+++ b/cpan/Digest-SHA/lib/Digest/SHA.pm
@@ -9,7 +9,7 @@ use Fcntl qw(O_RDONLY O_RDWR);
 use Cwd qw(getcwd);
 use integer;
 
-$VERSION = '6.04';
+$VERSION = '6.04_001';
 
 require Exporter;
 @ISA = qw(Exporter);

--- a/cpan/Digest-SHA/src/sha.c
+++ b/cpan/Digest-SHA/src/sha.c
@@ -485,14 +485,14 @@ static HMAC *hmacinit(HMAC *h, int alg, UCHR *key, UINT keylen)
 
 	Zero(h, 1, HMAC);
 	if (!shainit(&h->isha, alg))
-		return(NULL);
+		return NULL;
 	if (!shainit(&h->osha, alg))
-		return(NULL);
+		return NULL;
 	if (keylen <= h->osha.blocksize / 8)
 		Copy(key, h->key, keylen, char);
 	else {
 		if (!shainit(&ksha, alg))
-			return(NULL);
+			return NULL;
 		shawrite(key, keylen * 8, &ksha);
 		shafinish(&ksha);
 		Copy(digcpy(&ksha), h->key, ksha.digestlen, char);

--- a/dist/PathTools/Cwd.pm
+++ b/dist/PathTools/Cwd.pm
@@ -3,7 +3,7 @@ use strict;
 use Exporter;
 
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 my $xs_version = $VERSION;
 $VERSION =~ tr/_//d;
 

--- a/dist/PathTools/Cwd.xs
+++ b/dist/PathTools/Cwd.xs
@@ -104,14 +104,14 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
 	} else {
             if (getcwd(resolved, MAXPATHLEN) == NULL) {
                 my_strlcpy(resolved, ".", MAXPATHLEN);
-                return (NULL);
+                return NULL;
             }
             resolved_len = strlen(resolved);
             remaining_len = my_strlcpy(remaining, path, sizeof(remaining));
 	}
 	if (remaining_len >= sizeof(remaining) || resolved_len >= MAXPATHLEN) {
             errno = ENAMETOOLONG;
-            return (NULL);
+            return NULL;
 	}
 
 	/*
@@ -129,7 +129,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
 
             if ((STRLEN)(s - remaining) >= (STRLEN)sizeof(next_token)) {
                 errno = ENAMETOOLONG;
-                return (NULL);
+                return NULL;
             }
             memcpy(next_token, remaining, s - remaining);
             next_token[s - remaining] = '\0';
@@ -147,7 +147,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
             if (resolved[resolved_len - 1] != '/') {
                 if (resolved_len + 1 >= MAXPATHLEN) {
                     errno = ENAMETOOLONG;
-                    return (NULL);
+                    return NULL;
                 }
                 resolved[resolved_len++] = '/';
                 resolved[resolved_len] = '\0';
@@ -178,7 +178,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
             resolved_len = my_strlcat(resolved, next_token, MAXPATHLEN);
             if (resolved_len >= MAXPATHLEN) {
                 errno = ENAMETOOLONG;
-                return (NULL);
+                return NULL;
             }
 #if defined(HAS_LSTAT) && defined(HAS_READLINK) && defined(HAS_SYMLINK)
             {
@@ -188,7 +188,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                         errno = serrno;
                         return (resolved);
                     }
-                    return (NULL);
+                    return NULL;
                 }
                 if (S_ISLNK(sb.st_mode)) {
                     int slen;
@@ -196,11 +196,11 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
 
                     if (symlinks++ > MAXSYMLINKS) {
                         errno = ELOOP;
-                        return (NULL);
+                        return NULL;
                     }
                     slen = PerlLIO_readlink(resolved, symlink, sizeof(symlink) - 1);
                     if (slen < 0)
-                        return (NULL);
+                        return NULL;
                     symlink[slen] = '\0';
 #  ifdef OS390
                     /* Replace all instances of $SYSNAME/foo simply by /foo */
@@ -232,7 +232,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                         if (symlink[slen - 1] != '/') {
                             if ((STRLEN)(slen + 1) >= (STRLEN)sizeof(symlink)) {
                                 errno = ENAMETOOLONG;
-                                return (NULL);
+                                return NULL;
                             }
                             symlink[slen] = '/';
                             symlink[slen + 1] = 0;
@@ -240,7 +240,7 @@ bsd_realpath(const char *path, char resolved[MAXPATHLEN])
                         remaining_len = my_strlcat(symlink, remaining, sizeof(symlink));
                         if (remaining_len >= sizeof(remaining)) {
                             errno = ENAMETOOLONG;
-                            return (NULL);
+                            return NULL;
                         }
                     }
                     remaining_len = my_strlcpy(remaining, symlink, sizeof(remaining));

--- a/dist/PathTools/lib/File/Spec.pm
+++ b/dist/PathTools/lib/File/Spec.pm
@@ -4,7 +4,7 @@ use strict;
 
 # Keep $VERSION consistent in all *.pm files in this distribution, including
 # Cwd.pm.
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 my %module = (

--- a/dist/PathTools/lib/File/Spec/AmigaOS.pm
+++ b/dist/PathTools/lib/File/Spec/AmigaOS.pm
@@ -3,7 +3,7 @@ package File::Spec::AmigaOS;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Cygwin.pm
+++ b/dist/PathTools/lib/File/Spec/Cygwin.pm
@@ -3,7 +3,7 @@ package File::Spec::Cygwin;
 use strict;
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Epoc.pm
+++ b/dist/PathTools/lib/File/Spec/Epoc.pm
@@ -2,7 +2,7 @@ package File::Spec::Epoc;
 
 use strict;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 require File::Spec::Unix;

--- a/dist/PathTools/lib/File/Spec/Functions.pm
+++ b/dist/PathTools/lib/File/Spec/Functions.pm
@@ -3,7 +3,7 @@ package File::Spec::Functions;
 use File::Spec;
 use strict;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 require Exporter;

--- a/dist/PathTools/lib/File/Spec/Mac.pm
+++ b/dist/PathTools/lib/File/Spec/Mac.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/OS2.pm
+++ b/dist/PathTools/lib/File/Spec/OS2.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Unix.pm
+++ b/dist/PathTools/lib/File/Spec/Unix.pm
@@ -3,7 +3,7 @@ package File::Spec::Unix;
 use strict;
 use Cwd ();
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 =head1 NAME

--- a/dist/PathTools/lib/File/Spec/VMS.pm
+++ b/dist/PathTools/lib/File/Spec/VMS.pm
@@ -4,7 +4,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/PathTools/lib/File/Spec/Win32.pm
+++ b/dist/PathTools/lib/File/Spec/Win32.pm
@@ -5,7 +5,7 @@ use strict;
 use Cwd ();
 require File::Spec::Unix;
 
-our $VERSION = '3.94';
+our $VERSION = '3.95';
 $VERSION =~ tr/_//d;
 
 our @ISA = qw(File::Spec::Unix);

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.72'; # Please update the pod, too.
+our $VERSION = '1.73'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.72
+This document describes threads::shared version 1.73
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -546,7 +546,7 @@ Perl_sharedsv_find(pTHX_ SV *sv)
     if (SvROK(sv) && sv_derived_from(sv, "threads::shared::tie")) {
         return (SHAREDSV_FROM_OBJ(sv));
     }
-    return (NULL);
+    return NULL;
 }
 
 

--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.44';      # remember to update version in POD!
+our $VERSION = '2.45';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 #$VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.44
+This document describes threads version 2.45
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -1061,7 +1061,7 @@ S_ithread_create(
             }
         }
 #endif
-        return (NULL);
+        return NULL;
     }
 
     my_pool->running_threads++;

--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -33,7 +33,7 @@ $EXPORT_TAGS{bsd_glob} = [@{$EXPORT_TAGS{glob}}];
 
 our @EXPORT_OK   = (@{$EXPORT_TAGS{'glob'}}, 'csh_glob');
 
-our $VERSION = '1.42';
+our $VERSION = '1.43';
 
 sub import {
     require Exporter;

--- a/ext/File-Glob/bsd_glob.c
+++ b/ext/File-Glob/bsd_glob.c
@@ -1019,7 +1019,7 @@ g_opendir(Char *str, glob_t *pglob)
                 my_strlcpy(buf, ".", sizeof(buf));
         } else {
                 if (g_Ctoc(str, buf, sizeof(buf)))
-                        return(NULL);
+                        return NULL;
         }
 
         if (pglob->gl_flags & GLOB_ALTDIRFUNC)
@@ -1063,7 +1063,7 @@ g_strchr(Char *str, int ch)
                 if (*str == ch)
                         return (str);
         } while (*str++);
-        return (NULL);
+        return NULL;
 }
 
 static int

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -1943,7 +1943,7 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
     case '+':
       if (!skip) {
         SvREFCNT_dec(result);
-        return (NULL);
+        return NULL;
       }
       break;
     case '0':
@@ -1966,7 +1966,7 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
       break;
     default:
       SvREFCNT_dec(result);
-      return (NULL);
+      return NULL;
     }
     s++;
   }

--- a/reginline.h
+++ b/reginline.h
@@ -11,7 +11,7 @@ Perl_regnext(pTHX_ const regnode *p)
     I32 offset;
 
     if (!p)
-        return(NULL);
+        return NULL;
 
     if (OP(p) > REGNODE_MAX) {                /* regnode.type is unsigned */
         croak("Corrupted regexp opcode %d > %d",
@@ -20,7 +20,7 @@ Perl_regnext(pTHX_ const regnode *p)
 
     offset = (REGNODE_OFF_BY_ARG(OP(p)) ? ARG1u(p) : NEXT_OFF(p));
     if (offset == 0)
-        return(NULL);
+        return NULL;
 
     return(regnode *)(p+offset);
 }


### PR DESCRIPTION
This p.r. addresses the `-Wimplicit-void-ptr-cast warnings` reported in #24164.  Developed and tested with `clang21` on the box from which that bug ticket was reported.

* This set of changes does not require a perldelta entry.
