### PR TITLE
Remove PERL_CREATE_GVSV

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1636,6 +1636,7 @@ Adp	|HV *	|gv_stashpvn	|NN const char *name			\
 				|I32 flags
 Adp	|HV *	|gv_stashsv	|NN SV *sv				\
 				|I32 flags
+Admp	|GV *	|gv_SVadd	|NULLOK GV *gv
 Xdpx	|void	|gv_try_downgrade					\
 				|NN GV *gv
 op	|struct xpvhv_aux *|hv_auxalloc 				\
@@ -4416,9 +4417,6 @@ eopx	|OP *	|op_refcnt_inc	|NULLOK OP *o
 Mp	|bool	|do_exec	|NN const char *cmd
 #else
 p	|bool	|do_exec	|NN const char *cmd
-#endif
-#if defined(PERL_DONT_CREATE_GVSV)
-Admp	|GV *	|gv_SVadd	|NULLOK GV *gv
 #endif
 #if defined(PERL_IMPLICIT_SYS)
 CTo	|PerlInterpreter *|perl_alloc_using				\

--- a/embed.h
+++ b/embed.h
@@ -2321,6 +2321,7 @@
 #   define Perl_gv_AVadd                        gv_AVadd
 #   define Perl_gv_HVadd                        gv_HVadd
 #   define Perl_gv_IOadd                        gv_IOadd
+#   define Perl_gv_SVadd                        gv_SVadd
 #   define Perl_gv_efullname3                   gv_efullname3
 #   define Perl_gv_fetchmeth                    gv_fetchmeth
 #   define Perl_gv_fetchmeth_autoload           gv_fetchmeth_autoload
@@ -2415,9 +2416,6 @@
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 #     define Perl_utf16_to_utf8                 utf16_to_utf8
 #     define Perl_utf16_to_utf8_reversed        utf16_to_utf8_reversed
-#   endif
-#   if defined(PERL_DONT_CREATE_GVSV)
-#     define Perl_gv_SVadd                      gv_SVadd
 #   endif
 #   if !defined(USE_ITHREADS)
 #     define Perl_CopFILEGV_set                 CopFILEGV_set

--- a/gv.c
+++ b/gv.c
@@ -160,11 +160,7 @@ Perl_gv_fetchfile_flags(pTHX_ const char *const name, const STRLEN namelen,
         gv = *gvp;
         if (!isGV(gv)) {
             gv_init(gv, PL_defstash, tmpbuf, tmplen, FALSE);
-#ifdef PERL_DONT_CREATE_GVSV
             GvSV(gv) = newSVpvn(name, namelen);
-#else
-            sv_setpvn(GvSV(gv), name, namelen);
-#endif
         }
         if (PERLDB_LINE_OR_SAVESRC && !GvAV(gv))
             hv_magic(GvHVn(gv), GvAVn(gv), PERL_MAGIC_dbfile);
@@ -210,9 +206,6 @@ Perl_newGP(pTHX_ GV *const gv)
     PERL_ARGS_ASSERT_NEWGP;
     Newxz(gp, 1, GP);
     gp->gp_egv = gv; /* allow compiler to reuse gv after this */
-#ifndef PERL_DONT_CREATE_GVSV
-    gp->gp_sv = newSV_type(SVt_NULL);
-#endif
 
     /* PL_curcop may be null here.  E.g.,
         INIT { bless {} and exit }
@@ -580,7 +573,6 @@ S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type)
     case SVt_PVHV:
         (void)GvHVn(gv);
         break;
-#ifdef PERL_DONT_CREATE_GVSV
     case SVt_NULL:
     case SVt_PVCV:
     case SVt_PVFM:
@@ -592,7 +584,6 @@ S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type)
                If we just cast GvSVn(gv) to void, it ignores evaluating it for
                its side effect */
         }
-#endif
     }
 }
 
@@ -1485,9 +1476,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
 
     if (!isGV(vargv)) {
         gv_init_pvn(vargv, varstash, S_autoload, S_autolen, 0);
-#ifdef PERL_DONT_CREATE_GVSV
         GvSV(vargv) = newSV_type(SVt_NULL);
-#endif
     }
     LEAVE;
     varsv = GvSVn(vargv);
@@ -3178,11 +3167,9 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
       if (!gv_fetchmeth_pvn(stash, "((", 2, -1, 0))
         goto no_table;
     }
-#ifdef PERL_DONT_CREATE_GVSV
     else if (!sv) {
         NOOP;   /* Equivalent to !SvTRUE and !SvOK  */
     }
-#endif
     else if (SvTRUE(sv))
         /* don't need to set overloading here because fallback => 1
          * is the default setting for classes without overloading */

--- a/gv.h
+++ b/gv.h
@@ -94,9 +94,8 @@ the need to cast the result to the appropriate type.
 
 Return the SV from the GV.
 
-Prior to Perl v5.9.3, this would add a scalar if none existed.  Nowadays, use
-C<L</GvSVn>> for that, or compile perl with S<C<-DPERL_CREATE_GVSV>>.  See
-L<perl5100delta>.
+Use C<L</GvSVn>> if you wish to create an empty scalar when the SV slot is
+empty.
 
 =for apidoc Am|SV*|GvSVn|GV* gv
 Like C<L</GvSV>>, but creates an empty scalar if none already exists.
@@ -117,13 +116,9 @@ Return the CV from the GV.
 */
 
 #define GvSV(gv)	(GvGP(gv)->gp_sv)
-#ifdef PERL_DONT_CREATE_GVSV
 #define GvSVn(gv)	(*(GvGP(gv)->gp_sv ? \
                          &(GvGP(gv)->gp_sv) : \
                          &(GvGP(gv_SVadd(gv))->gp_sv)))
-#else
-#define GvSVn(gv)	GvSV(gv)
-#endif
 
 #define GvREFCNT(gv)	(GvGP(gv)->gp_refcnt)
 #define GvIO(gv)                         \

--- a/long_names.c
+++ b/long_names.c
@@ -95,7 +95,6 @@ Perl_gv_IOadd(pTHX_ GV *gv)
     return gv_IOadd(gv);
 }
 
-#if defined(PERL_DONT_CREATE_GVSV)
 GV *
 Perl_gv_SVadd(pTHX_ GV *gv)
 {
@@ -103,7 +102,6 @@ Perl_gv_SVadd(pTHX_ GV *gv)
 
     return gv_SVadd(gv);
 }
-#endif
 
 void
 Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)

--- a/perl.c
+++ b/perl.c
@@ -2022,9 +2022,6 @@ S_Internals_V(pTHX_ CV *cv)
 #  ifdef PERL_DISABLE_PMC
                              " PERL_DISABLE_PMC"
 #  endif
-#  ifdef PERL_DONT_CREATE_GVSV
-                             " PERL_DONT_CREATE_GVSV"
-#  endif
 #  ifdef PERL_EXTERNAL_GLOB
                              " PERL_EXTERNAL_GLOB"
 #  endif
@@ -4162,9 +4159,7 @@ S_init_main_stash(pTHX)
     SvREFCNT_inc_simple_void(PL_replgv);
     GvMULTI_on(PL_replgv);
     (void)form("%240s","");	/* Preallocate temp - for immediate signals. */
-#ifdef PERL_DONT_CREATE_GVSV
     (void)gv_SVadd(PL_errgv);
-#endif
     sv_grow(ERRSV, 240);	/* Preallocate - for immediate signals. */
     CLEAR_ERRSV();
     CopSTASH_set(&PL_compiling, PL_defstash);

--- a/perl.h
+++ b/perl.h
@@ -1556,14 +1556,6 @@ Use L</UV> to declare variables of the maximum usable size on this platform.
 #define PERL_MULTICONCAT_HEADER_SIZE  8 /* The number of fields of a
                                            multiconcat header */
 
-/* We no longer default to creating a new SV for GvSV.
-   Do this before embed.  */
-#ifndef PERL_CREATE_GVSV
-#  ifndef PERL_DONT_CREATE_GVSV
-#    define PERL_DONT_CREATE_GVSV
-#  endif
-#endif
-
 #if !defined(HAS_WAITPID) && !defined(HAS_WAIT4) || defined(HAS_WAITPID_RUNTIME)
 #define PERL_USES_PL_PIDSTATUS
 #endif

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -355,6 +355,12 @@ then run it on the target machine, and then pass the values it outputs
 to F<Configure> on the other machine.  F<Porting/Glossary> has examples.
 [GH #22992]
 
+=item *
+
+The C<PERL_CREATE_GVSV> configuration macro has been removed. It was almost
+undocumented and it has been disabled by default since Perl 5.10.0. Its purpose
+was to force all GVs to initialize their SV slot on creation. [GH #24177]
+
 =back
 
 =head1 Testing

--- a/pp.c
+++ b/pp.c
@@ -1009,9 +1009,6 @@ PP(pp_undef)
             gp_free(MUTABLE_GV(sv));
             Newxz(gp, 1, GP);
             GvGP_set(sv, gp_ref(gp));
-#ifndef PERL_DONT_CREATE_GVSV
-            GvSV(sv) = newSV_type(SVt_NULL);
-#endif
             GvLINE(sv) = CopLINE(PL_curcop);
             GvEGV(sv) = MUTABLE_GV(sv);
             GvMULTI_on(sv);

--- a/proto.h
+++ b/proto.h
@@ -1733,6 +1733,11 @@ Perl_gv_IOadd(pTHX_ GV *gv)
 #define PERL_ARGS_ASSERT_GV_IOADD
 
 PERL_CALLCONV GV *
+Perl_gv_SVadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX_;
+#define PERL_ARGS_ASSERT_GV_SVADD
+
+PERL_CALLCONV GV *
 Perl_gv_add_by_type(pTHX_ GV *gv, svtype type)
         Perl_attribute_nonnull_aTHX_;
 #define PERL_ARGS_ASSERT_GV_ADD_BY_TYPE
@@ -8852,13 +8857,6 @@ Perl_do_exec(pTHX_ const char *cmd)
         assert(cmd)
 
 #endif /* !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
-#if defined(PERL_DONT_CREATE_GVSV)
-PERL_CALLCONV GV *
-Perl_gv_SVadd(pTHX_ GV *gv)
-        Perl_attribute_nonnull_aTHX_;
-# define PERL_ARGS_ASSERT_GV_SVADD
-
-#endif
 #if defined(PERL_IMPLICIT_SYS)
 PERL_CALLCONV PerlInterpreter *
 perl_alloc_using(const struct IPerlMem **ipM, const struct IPerlMem **ipMS, const struct IPerlMem **ipMP, const struct IPerlEnv **ipE, const struct IPerlStdIO **ipStd, const struct IPerlLIO **ipLIO, const struct IPerlDir **ipD, const struct IPerlSock **ipS, const struct IPerlProc **ipP)


### PR DESCRIPTION
`PERL_DONT_CREATE_GVSV` has been the default for more than 20 years now (since bdf3085f9fca00a6148ef3f26060d442844b64bd).

There's no real reason to enable `PERL_CREATE_GVSV` and it's almost undocumented, perlapi mentions it once in passing. It doesn't seem that any code on CPAN checks for `PERL_CREATE_GVSV` or `PERL_DONT_CREATE_GVSV`.

This set of changes does not require a perldelta entry.
