### PR TITLE
perlapi: Tabularize display of config.h symbols

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -562,6 +562,20 @@ sub where_from_string ($file, $line_num = 0) {
     return "at $file, line $line_num";
 }
 
+sub make_verbatim_list(@entries) {
+
+    # This takes a list and creates an alphabetized verbatim table of its
+    # entries for convenient display
+
+    my @list = sort dictionary_order @entries;
+
+    # Give the table a width one less than you might expect, as we indent each
+    # line by one, to mark it as verbatim.
+    my $table = columnarize_list(\@list, $max_width - 1);
+
+    return $table =~ s/^/ /gmr;
+}
+
 sub check_and_add_proto_defn {
     my ($element, $file, $line_num, $raw_flags, $ret_type, $args_ref,
         $definition_type
@@ -2297,13 +2311,8 @@ sub construct_missings_section ($missings_hdr, $missings_ref) {
     # Sort the elements.
     my @missings = sort dictionary_order $missings_ref->@*;
 
-    # Make a table of the missings in columns.  Give the subroutine a width
-    # one less than you might expect, as we indent each line by one, to mark
-    # it as verbatim.
-    my $table .= columnarize_list(\@missings, $max_width - 1);
-    $table =~ s/^/ /gm;
-
-    return $text . "\n\n" . $table;
+    # Make a table of the missings in columns.
+    return $text . "\n\n" . make_verbatim_list(@missings);
 }
 
 sub dictionary_order {

--- a/autodoc.pl
+++ b/autodoc.pl
@@ -2868,13 +2868,7 @@ my $places_other_than_api = join ", ",
 
 
 foreach my $name (keys %list_only) {
-    my @this_list = $list_only{$name}{list}->@*;
-    my $text = "";
-    foreach my $entry (sort dictionary_order @this_list) {
-        $text .= ",S< > " if $text; # The S< > makes things less densely
-                                    # packed, hence more readable
-        $text .= "C<$entry>";
-    }
+    my $text = make_verbatim_list($list_only{$name}{list}->@*);
     $valid_sections{$genconfig_scn}{footer}
                                     =~ s/$list_only{$name}{placement}/$text/;
 }


### PR DESCRIPTION
Certain symbols in config.h have been displayed with no addtional information.  The lack of information is because the symbol's name says it all. For example HAS_SETENV is a boolean indicating if setenv() is available on the platform.  No further explanation is needed than the introductory paragraph at the beginning of the section.

Prior to this commit, these symbols were displayed as a comma separated list wrapping across multiple lines.

This commit organizes them into a table with columns, making them much easier to read.
