### PR TITLE
embed.pl: Restrict and document non-API names reserved for Perl

### DIFF
--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -129,6 +129,8 @@ my $names_reserved_for_perl_use_re =
 
                               # This is for obsolete and deprecated uses
                             | ( _ | \b ) CPERL (arg | scope) ( _ | \b )
+
+                            | _ (?: pl | PL) _ \b
                           /x;
 
 # This program looks at C preprocessor conditional expressions.  It turns out


### PR DESCRIPTION
Perl regularly adds new API elements for XS writers to use.  These names could conflict with already existing names the XS has.  We have long assumed that XS doesn't use names beginning with `PL_` or containing `m/\bperl\b/i` .   Effectively such names are reserved for perl's use, though this isn't documented.  (Also, in the pattern, `\b` just gives you the idea, its rules are more complicated than plain `\b`.)   

This PR now documents that we reserve such symbols.

So, to avoid name conflicts with functions, XS code could always call it with its long form beginning with `Perl_`.   Infrastructure has recently been added for us to trivially create synonyms for nearly any macro element, so that each synonym begins with `Perl_`, and #24224 proposes further enhancements.   (This infrastructure does not apply to things likes typedefs, structs, and enums.)

This PR is not about API elements.

It is often convenient to have other elements visible to XS code that aren't intended for its direct use.  This PR is about these, which are usually helpers that the API elements use.  C and POSIX publish certain syntaxes that new non-API visible symbols they create will  conform to.  This PR does the same for us.

In particular, there are several hundred XS-visible symbols whose names end with an  underscore, and the assumption has been that these  will not conflict with any names XS code might use, and so is safe for us to.  This has never been documented.  XS projects could make similar assumptions, and we end up with conflicts.

We should generally not be creating new names that make this undocumented assumption.  One exception would be where such names follow an existing paradigm, such as adding a flag whose name parallels existing ones.  There is no strict enforcement proposed here, so each exception would be on a case-by-case basis.

One reason the trailing underscore paradigm tends to get used is that it unobtrusively modifies the name.  It's the same reason the Perl language has constructs like

    $a += 5 if foo

using postfix "if".  The important part is first with the qualifier last.

Names like "Perl_foo" or "PL_bar" are just the opposite.  The important part is the "foo" or "bar", which describe the action.  "Perl_" and "PL_" are syntactic anti-sugar.  They are necessary but slow down comprehension of what is intended.

I'm proposing to add and document two postfix modifiers for symbols that are visible to XS code but undocumented by us.  New code should use these; existing code can be gradually converted.

I'm proposing suffixes

```
_pl_
_PL_
```

that we document as being reserved for perl use.  That carves out a relatively small (but still infinite) portion for our use of the universe of names that end in underscore.  It paradoxically both restricts what we can use, and extends the unwritten understanding of what is reserved.

There are no spellings like this in metacpan.

This replaces #24003
