### PR TITLE
Eliminate duplicated code in `PerlIOScalar_write`

### DIFF
--- a/perlio.c
+++ b/perlio.c
@@ -1268,9 +1268,7 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
         /* Avoid calling SvCUR() on undef'ed SVs */
         STRLEN const cur = SvOK(sv) ? SvCUR(sv) : 0;
 	if ((PerlIOBase(f)->flags) & PERLIO_F_APPEND) {
-	    dst = SvGROW(sv, cur + count + 1);
 	    offset = cur;
-	    s->posn = offset + count;
 	}
 	else {
             /* ensure we don't try to create ridiculously large
@@ -1287,17 +1285,12 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
             }
 #endif
 
-	    if ((STRLEN)s->posn > cur) {
-		dst = SvGROW(sv, (STRLEN)s->posn + count + 1);
-		Zero(SvPVX(sv) + cur, (STRLEN)s->posn - cur, char);
-	    }
-	    else if ((s->posn + count) >= cur)
-		dst = SvGROW(sv, (STRLEN)s->posn + count + 1);
-	    else
-		dst = SvPVX(sv);
 	    offset = s->posn;
-	    s->posn += count;
 	}
+        dst = SvGROW(sv, (STRLEN)offset + count + 1);
+        if ((STRLEN)offset > cur)
+            Zero(dst + cur, (STRLEN)offset - cur, char);
+        s->posn = offset + count;
 	Move(vbuf, dst + offset, count, char);
 	if ((STRLEN) s->posn > cur) {
 	    SvCUR_set(sv, (STRLEN)s->posn);

--- a/t/io/scalar.t
+++ b/t/io/scalar.t
@@ -12,7 +12,7 @@ use strict;
 use Fcntl qw(SEEK_SET SEEK_CUR SEEK_END); # Not 0, 1, 2 everywhere.
 use Errno qw(EACCES);
 
-plan(131);
+plan(133);
 
 my $fh;
 my $var = "aaa\n";
@@ -540,6 +540,11 @@ SKIP:
     seek $fh, 0, SEEK_SET;
     print $fh "zz";
     is($str, "zz", "rewind and write to undef'ed variable");
+
+    print $fh "aaaaa";
+    substr($str, 3) = '';
+    print $fh "b";
+    is($str, "zza\0\0\0\0b", "truncate string while writing");
 }
 
 {
@@ -548,4 +553,9 @@ SKIP:
     undef $str;
     print $fh "y";
     is($str, "y", "append to undef'ed variable");
+
+    print $fh "ccccc";
+    substr($str, 3) = '';
+    print $fh "d";
+    is($str, "yccd", "truncate string while appending");
 }


### PR DESCRIPTION
In connection with #24162 and #24063, I found that in `PerlIOScalar_write` the code to extend the SV had been almost duplicated for append mode and non-append mode, so the common code can be pulled out to reduce the code size.

This change should not affect the behavior, so I think:

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
