### PR TITLE
Bugfix for `PadnameFIELDINFO` on thread cloning

### DIFF
--- a/class.c
+++ b/class.c
@@ -1059,12 +1059,15 @@ Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
     PADOFFSET fieldix = aux->xhv_class_next_fieldix;
     aux->xhv_class_next_fieldix++;
 
-    Newxz(PadnameFIELDINFO(pn), 1, struct padname_fieldinfo);
-    PadnameFLAGS(pn) |= PADNAMEf_FIELD;
+    struct padname_fieldinfo *fieldinfo;
+    Newxz(fieldinfo, 1, struct padname_fieldinfo);
 
-    PadnameFIELDINFO(pn)->refcount = 1;
-    PadnameFIELDINFO(pn)->fieldix = fieldix;
-    PadnameFIELDINFO(pn)->fieldstash = (HV *)SvREFCNT_inc(stash);
+    fieldinfo->refcount = 1;
+    fieldinfo->fieldix = fieldix;
+    fieldinfo->fieldstash = HvREFCNT_inc(stash);
+
+    PadnameFIELDINFO(pn) = fieldinfo;
+    PadnameFLAGS(pn) |= PADNAMEf_FIELD;
 
     if(!aux->xhv_class_fields)
         aux->xhv_class_fields = newPADNAMELIST(0);

--- a/pad.c
+++ b/pad.c
@@ -2905,7 +2905,7 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
     if(PadnameIsFIELD(src)) {
         assert(PadnameFIELDINFO(src));
         struct padname_fieldinfo *sinfo = PadnameFIELDINFO(src);
-        struct padname_fieldinfo *dinfo = (struct padname_fieldinfo *)ptr_table_fetch(PL_ptr_table, src);
+        struct padname_fieldinfo *dinfo = (struct padname_fieldinfo *)ptr_table_fetch(PL_ptr_table, sinfo);
         if (dinfo)
             PadnameFIELDINFO(dst) = dinfo;
         else {

--- a/t/class/threads.t
+++ b/t/class/threads.t
@@ -42,6 +42,17 @@ class WithNoFields {
     next_test(); # account for is() inside thread
 }
 
+class WithTwoMethods {
+    # a class with two methods sharing the same field, in order to test [GH24150]
+    # We don't even need to create any instances; the mere presence of this
+    # class at compiletime would crash a thread join operation if the bug is
+    # present. If this .t file succeeds to the end without crashing it
+    # demonstrates this bug is fixed.
+    field $xxx :param;
+    method xxy { $xxx; }
+    method xxz { $xxx; }
+}
+
 threads->create(sub {
     my $obj = Testcase1->new(x => 20);
     is($obj->x, 20, '$obj->x created inside thread');


### PR DESCRIPTION
Fixes #24150

Much thanks to @nwc10 and @wolfsage on IRC who helped find this.

The change in `pad.c` is the actual bugfix. The change in `class.c` was related to debugging while I was working on it.