### PR TITLE
assorted LOGOP peephole stuff

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -1711,9 +1711,16 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
     case OP_ENTERTRY:
     case OP_ONCE:
     case OP_PARAMTEST:
+    case OP_CMPCHAIN_AND:
+    case OP_PUSHDEFER:
+    case OP_ENTERTRYCATCH:
+    case OP_HELEMEXISTSOR:
+    case OP_ANYWHILE:
+    case OP_CATCH:
         S_opdump_indent(aTHX_ o, level, bar, file, "OTHER");
         S_opdump_link(aTHX_ o, cLOGOPo->op_other, file);
         break;
+
     case OP_SPLIT:
     case OP_MATCH:
     case OP_QR:

--- a/peep.c
+++ b/peep.c
@@ -3589,9 +3589,10 @@ Perl_rpeep(pTHX_ OP *o)
         case OP_GREPWHILE:
             if ((o->op_flags & OPf_WANT) == OPf_WANT_SCALAR)
                 S_check_for_bool_cxt(o, 1, OPpTRUEBOOL, 0);
-            /* FALLTHROUGH */
+            goto generic_logop;
+
         case OP_COND_EXPR:
-            if (o->op_type == OP_COND_EXPR) {
+            {
                 OP *stub = cLOGOP->op_other;
                 OP *trueop  = OpSIBLING( cLOGOP->op_first );
                 OP *falseop = OpSIBLING(trueop);
@@ -3707,6 +3708,16 @@ Perl_rpeep(pTHX_ OP *o)
         case OP_ONCE:
         case OP_ARGDEFELEM:
         case OP_PARAMTEST:
+
+        generic_logop:
+
+            /* Handle the stuff generically needed for all LOGOPs:
+             * in particular, process op_other: strip nulls and
+             * run the peephole optimiser on it.
+             *
+             * Note that some LOGOPs, such as OP_AND, do their own
+             * specialised handling and never reach here.
+             */
             while (cLOGOP->op_other->op_type == OP_NULL)
                 cLOGOP->op_other = cLOGOP->op_other->op_next;
             DEFER(cLOGOP->op_other);

--- a/peep.c
+++ b/peep.c
@@ -3613,7 +3613,7 @@ Perl_rpeep(pTHX_ OP *o)
                         cLOGOP->op_other = stub->op_next;
                         op_sibling_splice(o, cLOGOP->op_first, 1, NULL);
                         op_free(stub);
-                        break;
+                        goto generic_logop;
                     } else if (OP_TYPE_IS(trueop, OP_SCOPE) &&
                                (stub == cUNOPx(trueop)->op_first) ) {
                         assert(!(stub->op_flags & OPf_KIDS));
@@ -3630,7 +3630,7 @@ Perl_rpeep(pTHX_ OP *o)
                             op_sibling_splice(o, cLOGOP->op_first, 1, NULL);
                             op_free(stub);
                             op_free(trueop);
-                            break;
+                            goto generic_logop;
                         } else {
                             /* Could be something like this:
                              *         -condition-

--- a/peep.c
+++ b/peep.c
@@ -3710,6 +3710,7 @@ Perl_rpeep(pTHX_ OP *o)
         case OP_PARAMTEST:
         case OP_HELEMEXISTSOR:
         case OP_ANYWHILE:
+        case OP_CATCH:
 
         generic_logop:
 
@@ -3745,10 +3746,9 @@ Perl_rpeep(pTHX_ OP *o)
             break;
 
         case OP_ENTERTRYCATCH:
-            assert(cLOGOPo->op_other->op_type == OP_CATCH);
             /* catch body is the ->op_other of the OP_CATCH */
-            DEFER(cLOGOPx(cLOGOPo->op_other)->op_other);
-            break;
+            assert(cLOGOPo->op_other->op_type == OP_CATCH);
+            goto generic_logop;
 
         case OP_SUBST:
             if ((o->op_flags & OPf_WANT) == OPf_WANT_SCALAR)

--- a/peep.c
+++ b/peep.c
@@ -3708,6 +3708,8 @@ Perl_rpeep(pTHX_ OP *o)
         case OP_ONCE:
         case OP_ARGDEFELEM:
         case OP_PARAMTEST:
+        case OP_HELEMEXISTSOR:
+        case OP_ANYWHILE:
 
         generic_logop:
 

--- a/peep.c
+++ b/peep.c
@@ -3698,8 +3698,18 @@ Perl_rpeep(pTHX_ OP *o)
                     }
                 }
 
+                goto generic_logop;
             }
-            /* FALLTHROUGH */
+
+        case OP_ENTERTRY:
+            assert(cLOGOPo->op_other->op_type == OP_LEAVETRY);
+            goto generic_logop;
+
+        case OP_ENTERTRYCATCH:
+            /* catch body is the ->op_other of the OP_CATCH */
+            assert(cLOGOPo->op_other->op_type == OP_CATCH);
+            goto generic_logop;
+
         case OP_MAPWHILE:
         case OP_ANDASSIGN:
         case OP_ORASSIGN:
@@ -3739,16 +3749,6 @@ Perl_rpeep(pTHX_ OP *o)
              * process the rest of the code */
             DEFER(cLOOP->op_lastop);
             break;
-
-        case OP_ENTERTRY:
-            assert(cLOGOPo->op_other->op_type == OP_LEAVETRY);
-            DEFER(cLOGOPo->op_other);
-            break;
-
-        case OP_ENTERTRYCATCH:
-            /* catch body is the ->op_other of the OP_CATCH */
-            assert(cLOGOPo->op_other->op_type == OP_CATCH);
-            goto generic_logop;
 
         case OP_SUBST:
             if ((o->op_flags & OPf_WANT) == OPf_WANT_SCALAR)

--- a/peep.c
+++ b/peep.c
@@ -3710,6 +3710,32 @@ Perl_rpeep(pTHX_ OP *o)
             assert(cLOGOPo->op_other->op_type == OP_CATCH);
             goto generic_logop;
 
+        /* these LOGOPs' op_other always go to a known op which has alrady
+         * been processed and so don't need to run the peephole optimiser
+         * on it. They are included here for completeness.
+         * If any of the asserts fail then this assumption should be
+         * reconsidered.
+         * */
+
+        case OP_SUBSTCONT:
+            assert(cLOGOPo->op_other->op_type == OP_SUBST);
+            break;
+
+        case OP_REGCOMP:
+            assert((PL_opargs[cLOGOPo->op_other->op_type] & OA_CLASS_MASK)
+                    == OA_PMOP);
+            break;
+
+        case OP_ENTERGIVEN:
+            assert(cLOGOPo->op_other->op_type == OP_LEAVEGIVEN);
+            break;
+
+        case OP_ENTERWHEN:
+            assert(cLOGOPo->op_other->op_type == OP_LEAVEWHEN);
+            break;
+
+        /* general LOGOPs */
+
         case OP_MAPWHILE:
         case OP_ANDASSIGN:
         case OP_ORASSIGN:

--- a/peep.c
+++ b/peep.c
@@ -3583,7 +3583,6 @@ Perl_rpeep(pTHX_ OP *o)
                 o->op_next = cLOGOPx(o->op_next)->op_other;
             }
             DEFER(cLOGOP->op_other);
-            o->op_opt = 1;
             break;
 
         case OP_GREPWHILE:

--- a/peep.c
+++ b/peep.c
@@ -3593,57 +3593,49 @@ Perl_rpeep(pTHX_ OP *o)
 
         case OP_COND_EXPR:
             {
+                /* A cond_expr op will usually have three children (all of
+                 * which are sub-trees):
+                 *     cond_expr
+                 *         -condition-
+                 *         -true-
+                 *         -false-
+                 *  with op_other pointing to the start op within the
+                 *  true subtree and op_next to the start op within the
+                 *  false subtree.
+                 *
+                 *  The code in this block looks for stub subtrees
+                 *  (either a single stub op, or far more likely,
+                 *  a stub op as part of an empty scope or entry/leave
+                 *  subtree). If found, the subtree is deleted (so the
+                 *  cond_expr only has two children) and the
+                 *  op_next/op_other as appropriate is made to point to
+                 *  the op following the cond_expr op.
+                 */
+
                 OP *stub = cLOGOP->op_other;
                 OP *trueop  = OpSIBLING( cLOGOP->op_first );
                 OP *falseop = OpSIBLING(trueop);
 
                 /* Is there an empty "if" block or ternary true branch?
                    If so, optimise away the OP_STUB if safe to do so. */
-                if (stub->op_type == OP_STUB &&
-                    ((stub->op_flags & OPf_WANT) != OPf_WANT_SCALAR)
+                if (   stub->op_type == OP_STUB
+                    && ((stub->op_flags & OPf_WANT) != OPf_WANT_SCALAR)
+                    && (
+                            /* bare stub */
+                            (stub == trueop)
+                            /* stub in scope/enter */
+                        || (   OP_TYPE_IS(trueop, OP_SCOPE)
+                            && stub == cUNOPx(trueop)->op_first
+                               /* doesn't yet handle trailing nulls */
+                            && !OpSIBLING(stub)
+                            )
+                        )
                 ) {
-                    if (stub == trueop) {
-                        /* This is very unlikely:
-                         *     cond_expr
-                         *         -condition-
-                         *         stub
-                         *         -else-
-                         */
                         assert(!(stub->op_flags & OPf_KIDS));
-                        cLOGOP->op_other = stub->op_next;
+                        cLOGOP->op_other = trueop->op_next;
                         op_sibling_splice(o, cLOGOP->op_first, 1, NULL);
-                        op_free(stub);
+                        op_free(trueop);
                         goto generic_logop;
-                    } else if (OP_TYPE_IS(trueop, OP_SCOPE) &&
-                               (stub == cUNOPx(trueop)->op_first) ) {
-                        assert(!(stub->op_flags & OPf_KIDS));
-
-                        OP *stubsib = OpSIBLING(stub);
-                        if (!stubsib) {
-                        /*     cond_expr
-                         *         -condition-
-                         *         scope
-                         *             stub
-                         *         -else-
-                         */
-                            cLOGOP->op_other = trueop->op_next;
-                            op_sibling_splice(o, cLOGOP->op_first, 1, NULL);
-                            op_free(stub);
-                            op_free(trueop);
-                            goto generic_logop;
-                        } else {
-                            /* Could be something like this:
-                             *         -condition-
-                             *         scope
-                             *             stub
-                             *             null
-                             *         -else-
-                             * But it may be more desirable (but is less
-                             * straightforward) to transform this earlier
-                             * in the compiler. Ignoring it for now,
-                             * pending further exploration. */
-                        }
-                    }
                 }
 
                 /* Is there an empty "else" block or ternary false branch?

--- a/t/perf/benchmarks
+++ b/t/perf/benchmarks
@@ -1539,6 +1539,49 @@
         code    => 's/(.)/$1-$1-$1/g',
     },
 
+    # Conditional operator, (... ? .... : ... )
+
+    'expr::cond::scalar_lll_true' => {
+        setup   => 'my ($c, $t, $f, $res)  = (1, 111, 222, 0);',
+        code    => '$res = $c ? $t : $f',
+    },
+
+    'expr::cond::scalar_lll_false' => {
+        setup   => 'my ($c, $t, $f, $res)  = (0, 111, 222, 0);',
+        code    => '$res = $c ? $t : $f',
+    },
+
+    'expr::cond::list_lll_true' => {
+        setup   => 'my $c = 1; my @t = 111; my @f = 222; my @res;',
+        code    => '@res = $c ? @t : @f',
+    },
+
+    'expr::cond::list_lll_false' => {
+        setup   => 'my $c = 0; my @t = 111; my @f = 222; my @res;',
+        code    => '@res = $c ? @t : @f',
+    },
+
+    'expr::cond::list_l0l_true' => {
+        setup   => 'my $c = 1; my @f = 222; my @res;',
+        code    => '@res = $c ? () : @f',
+    },
+
+    'expr::cond::list_l0l_false' => {
+        setup   => 'my $c = 0; my @f = 222; my @res;',
+        code    => '@res = $c ? () : @f',
+    },
+
+    'expr::cond::list_ll0_true' => {
+        setup   => 'my $c = 1; my @t = 111; my @res;',
+        code    => '@res = $c ? @t : ()',
+    },
+
+    'expr::cond::list_ll0_false' => {
+        setup   => 'my $c = 0; my @t = 111; my @res;',
+        code    => '@res = $c ? @t : ()',
+    },
+
+
 
 
     # scalar assign, OP_SASSIGN

--- a/t/perf/opcount.t
+++ b/t/perf/opcount.t
@@ -1315,4 +1315,21 @@ test_opcount(0, "Empty ternary false blocks are optimised away",
                     stub => 0
                 });
 
+# make sure the code block for an any/all gets optimised
+
+test_opcount(0, "basic any/all",
+                sub {
+                    use feature      'keyword_any', 'keyword_all';
+                    use experimental 'keyword_any', 'keyword_all';
+                    my (@a, @x, @b);
+                    @a = any { $x[0] } @b;
+                    @a = all { $x[0] } @b;
+                },
+                {
+                    aelem          => 0,
+                    aelemfast_lex  => 2,
+                    'ex-aelem'     => 2,
+                }
+            );
+
 done_testing();


### PR DESCRIPTION
Assorted commits fixing performance regressions and refactoring of LOGOPs in the peephole optimiser. In particular, @res = $c ? () : @f had a very slight regression - it should have got faster recently, but actually got slightly slower. It's now fast again.

* This set of changes does not require a perldelta entry.
