### PR TITLE
dist/IO: Do not require peer for Unix sockets in send()

### DIFF
--- a/Porting/exclude_contrib.txt
+++ b/Porting/exclude_contrib.txt
@@ -20,4 +20,6 @@
 # sorted.
 ##########################################################################
 dXO3142iRNcbpIKO2qxc1o3lNX8+oOCoyG5si+Sb2Ck
+FG0GLuuu5ntPQBJEp8JMrdZaAyzQ3qASGZxKgQIn2CA
+Ply5itbfmwcKAhWTKCx0ujKk+8UivRDQzE64+EKSH5c
 QvzD7VskxHgLvOy3GdB9zvcqWIH9uM347jNLQS8QfFs

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 our @EXPORT_OK = qw(sockatmark);
 
@@ -291,7 +291,7 @@ sub send {
         # this is non-portable for "connected" UDP sockets
         $peer = $_[3];
     }
-    elsif (!defined getpeername($sock)) {
+    elsif (!defined getpeername($sock) && !$!{EOPNOTSUPP}) {
         # we're not connected, so we require a peer from somewhere
         $peer = $sock->peername;
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->

In `IO::Socket send()`, if there is no third (TO/peer) argument, we currently run 
`getpeername()` unconditionally. On some systems (notably GNU/Hurd), this
function is only a stub for Unix sockets. This PR changes this so a peer is no
longer required for `send()` to Unix sockets.

This fixes GH #24195
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
