### PR TITLE
Implement `foreach` on lvref lexical without magic

### DIFF
--- a/cop.h
+++ b/cop.h
@@ -1166,7 +1166,7 @@ struct context {
 /* this is only set in conjunction with CXp_FOR_GV */
 #define CXp_FOR_DEF	0x10	/* foreach using $_ */
 /* these 3 are mutually exclusive */
-#define CXp_FOR_LVREF	0x20	/* foreach using \$var */
+#define CXp_FOR_LVREF	0x20	/* foreach using \our $var */
 #define CXp_FOR_GV	0x40	/* foreach using package var */
 #define CXp_FOR_PAD	0x80	/* foreach using lexical var */
 

--- a/inline.h
+++ b/inline.h
@@ -4317,43 +4317,35 @@ Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
         MAGIC *mg = SvMAGIC(itervar);
         assert(mg);
         assert(mg->mg_type == PERL_MAGIC_lvref);
-        if (!mg->mg_obj) {
-            // LV ref around a lexical, mg_len gives its pad index
-            SV **padslot = &PAD_SVl(mg->mg_len);
-            SV *oldsv = *padslot;
-            *padslot = origval;
-            SvREFCNT_dec(oldsv);
+        assert(mg->mg_obj);
+        // LV ref around a package lexical, mg_obj gives its GV
+        GV *gv = (GV *)mg->mg_obj;
+        SV *oldsv = NULL;
+        switch(mg->mg_private & OPpLVREF_TYPE) {
+            case OPpLVREF_SV:
+                oldsv = GvSVn(gv);
+                GvSVn(gv) = origval;
+                break;
+
+            case OPpLVREF_AV:
+                oldsv = (SV *)GvAV(gv);
+                GvAV(gv) = (AV *)origval;
+                break;
+
+            case OPpLVREF_HV:
+                oldsv = (SV *)GvHV(gv);
+                GvHV(gv) = (HV *)origval;
+                break;
+
+            case OPpLVREF_CV:
+                oldsv = (SV *)GvCV(gv);
+                GvCV_set(gv, (CV *)origval);
+                break;
+
+            default:
+                NOT_REACHED;
         }
-        else {
-            // LV ref around a package lexical, mg_obj gives its GV
-            GV *gv = (GV *)mg->mg_obj;
-            SV *oldsv = NULL;
-            switch(mg->mg_private & OPpLVREF_TYPE) {
-                case OPpLVREF_SV:
-                    oldsv = GvSVn(gv);
-                    GvSVn(gv) = origval;
-                    break;
-
-                case OPpLVREF_AV:
-                    oldsv = (SV *)GvAV(gv);
-                    GvAV(gv) = (AV *)origval;
-                    break;
-
-                case OPpLVREF_HV:
-                    oldsv = (SV *)GvHV(gv);
-                    GvHV(gv) = (HV *)origval;
-                    break;
-
-                case OPpLVREF_CV:
-                    oldsv = (SV *)GvCV(gv);
-                    GvCV_set(gv, (CV *)origval);
-                    break;
-
-                default:
-                    NOT_REACHED;
-            }
-            SvREFCNT_dec(oldsv);
-        }
+        SvREFCNT_dec(oldsv);
     }
     if (cx->cx_type & (CXp_FOR_GV|CXp_FOR_LVREF))
         SvREFCNT_dec(cx->blk_loop.itervar_u.svp);

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -2622,51 +2622,6 @@ my %h;
 $_ == 3 ? \$_ : $_ = \3;
 $_ == 3 ? \$_ : \$x = \3;
 \($_ == 3 ? $_ : $x) = \3;
-for \my $topic (\$1, \$2) {
-    die;
-}
-for \state $topic (\$1, \$2) {
-    die;
-}
-for \our $topic (\$1, \$2) {
-    die;
-}
-for \$_ (\$1, \$2) {
-    die;
-}
-for \my @a ([1,2], [3,4]) {
-    die;
-}
-for \state @a ([1,2], [3,4]) {
-    die;
-}
-for \our @a ([1,2], [3,4]) {
-    die;
-}
-for \@_ ([1,2], [3,4]) {
-    die;
-}
-for \my %a ({5,6}, {7,8}) {
-    die;
-}
-for \our %a ({5,6}, {7,8}) {
-    die;
-}
-for \state %a ({5,6}, {7,8}) {
-    die;
-}
-for \%_ ({5,6}, {7,8}) {
-    die;
-}
-{
-    my sub a;
-    for \&a (sub { 9; }, sub { 10; }) {
-        die;
-    }
-}
-for \&a (sub { 9; }, sub { 10; }) {
-    die;
-}
 >>>>
 our $x;
 \$x = \$x;
@@ -2745,6 +2700,55 @@ my %h;
 $_ == 3 ? \$_ : $_ = \3;
 $_ == 3 ? \$_ : \$x = \3;
 ($_ == 3 ? \$_ : \$x) = \3;
+####
+# lvalue reference iteration
+# CONTEXT use feature "state", 'refaliasing', 'lexical_subs'; no warnings 'experimental';
+for \my $topic (\$1, \$2) {
+    die;
+}
+for \state $topic (\$1, \$2) {
+    die;
+}
+for \our $topic (\$1, \$2) {
+    die;
+}
+for \$_ (\$1, \$2) {
+    die;
+}
+for \my @a ([1,2], [3,4]) {
+    die;
+}
+for \state @a ([1,2], [3,4]) {
+    die;
+}
+for \our @a ([1,2], [3,4]) {
+    die;
+}
+for \@_ ([1,2], [3,4]) {
+    die;
+}
+for \my %a ({5,6}, {7,8}) {
+    die;
+}
+for \our %a ({5,6}, {7,8}) {
+    die;
+}
+for \state %a ({5,6}, {7,8}) {
+    die;
+}
+for \%_ ({5,6}, {7,8}) {
+    die;
+}
+{
+    my sub a;
+    for \&a (sub { 9; }, sub { 10; }) {
+        die;
+    }
+}
+for \&a (sub { 9; }, sub { 10; }) {
+    die;
+}
+>>>>
 foreach \my $topic (\$1, \$2) {
     die;
 }

--- a/op.c
+++ b/op.c
@@ -10086,11 +10086,14 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
                      varop->op_type == OP_PADAV ||
                      varop->op_type == OP_PADHV));
 
-            if(varop->op_type != OP_LVREF || varop->op_private & OPpLVAL_INTRO) {  /* for my \VAR */
+            /* Any of these ops with a non-zero ->op_targ operates on lexicals
+             * providing it is not OPf_STACKED */
+            if((varop->op_targ && !(varop->op_flags & OPf_STACKED)) || varop->op_private & OPpLVAL_INTRO) {  /* for my \VAR */
                 /* Throw away the sv op subtree and turn this into a simple
                  * padoffset + OPpITER_REFALIAS flag */
                 iterpflags = OPpITER_REFALIAS;
-                enteriterpflags = OPpLVAL_INTRO;
+                if(varop->op_private & OPpLVAL_INTRO)
+                    enteriterpflags = OPpLVAL_INTRO;
                 padoff = varop->op_targ;
                 varop->op_targ = 0;
                 op_free(sv);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2627,22 +2627,17 @@ PP(pp_enteriter)
             MAGIC *mg = SvMAGIC(sv);
             assert(mg);
             assert(mg->mg_type == PERL_MAGIC_lvref);
-            if (!mg->mg_obj) {
-                // LV ref around a lexical, mg_len gives its pad index
-                itersave = SvREFCNT_inc_NN(PAD_SV(mg->mg_len));
+            assert(mg->mg_obj);
+            // LV ref around a package lexical, mg_obj gives its GV
+            GV *gv = (GV *)mg->mg_obj;
+            assert(SvTYPE(gv) == SVt_PVGV);
+            switch(mg->mg_private & OPpLVREF_TYPE) {
+                case OPpLVREF_SV: itersave =       GvSVn(gv); break;
+                case OPpLVREF_AV: itersave = (SV *)GvAV(gv);  break;
+                case OPpLVREF_HV: itersave = (SV *)GvHV(gv);  break;
+                case OPpLVREF_CV: itersave = (SV *)GvCV(gv);  break;
             }
-            else {
-                // LV ref around a package lexical, mg_obj gives its GV
-                GV *gv = (GV *)mg->mg_obj;
-                assert(SvTYPE(gv) == SVt_PVGV);
-                switch(mg->mg_private & OPpLVREF_TYPE) {
-                    case OPpLVREF_SV: itersave =       GvSVn(gv); break;
-                    case OPpLVREF_AV: itersave = (SV *)GvAV(gv);  break;
-                    case OPpLVREF_HV: itersave = (SV *)GvHV(gv);  break;
-                    case OPpLVREF_CV: itersave = (SV *)GvCV(gv);  break;
-                }
-                SvREFCNT_inc_void(itersave);
-            }
+            SvREFCNT_inc_void(itersave);
             cxflags = CXp_FOR_LVREF;
         }
         /* we transfer ownership of 1 ref count of itervarp from the stack


### PR DESCRIPTION
Previously, commit 091a08d8047 made a more efficient implemention of `foreach` loops where the iteration variable was declared using `\my $VAR`. A cornercase of that logic was missed, wherein the iteration variable was *previously* declared as a lexical before the foreach loop itself. That resulted in an optree using `OP_SREFGEN` on `OP_LVREF` directly, rather than on a `OP_PADxV`, so a case was missed.
    
By covering this case here as well, we now manage to remove any uses of `PERL_MAGIC_lvref` to implement `foreach` loops on refaliased lexicals. The code to implement those now-dead cases has been removed and replaced with an `assert(mg->mg_obj)`, to cover the still-remaining case of iteration over a refalias to a package variable. Those may be covered in a later commit.

* This set of changes does not require a perldelta entry.