### PR TITLE
Handle the case where output data overlaps the target scalar in `PerlIOScalar_write`

### DIFF
--- a/perlio.c
+++ b/perlio.c
@@ -1257,6 +1257,21 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
 	PerlIOScalar *s = PerlIOSelf(f, PerlIOScalar);
 	SV *sv = s->var;
 	char *dst;
+
+        /* XXX Could share the code with sv_insert() ?
+           Below is roughly sv_insert(sv, s->posn, count, vbuf, count)
+           but with small differences */
+
+        /* If vbuf points within sv, we need to make a private copy since
+           it might be modified or reallocated in sv manipulations below.
+           This is probably rare in reality, but possible.  */
+        if (SvTYPE(sv) >= SVt_PV && SvPVX_const(sv) && SvLEN(sv) &&
+            UNLIKELY(SvPVX_const(sv) <= (const char *)vbuf &&
+                     (const char *)vbuf < SvPVX_const(sv) + SvLEN(sv))) {
+            vbuf = savepvn(vbuf, count);
+            SAVEFREEPV(vbuf);
+        }
+
 	SvGETMAGIC(sv);
 	if (!SvROK(sv)) sv_force_normal(sv);
 	if (SvOK(sv)) SvPV_force_nomg_nolen(sv);
@@ -1291,7 +1306,9 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
         if ((STRLEN)offset > cur)
             Zero(dst + cur, (STRLEN)offset - cur, char);
         s->posn = offset + count;
-	Move(vbuf, dst + offset, count, char);
+        /* vbuf is now a private copy if overlapped with sv,
+           so Copy should be safe here */
+        Copy(vbuf, dst + offset, count, char);
 	if ((STRLEN) s->posn > cur) {
 	    SvCUR_set(sv, (STRLEN)s->posn);
 	    dst[(STRLEN) s->posn] = 0;

--- a/perlio.c
+++ b/perlio.c
@@ -1268,7 +1268,7 @@ PerlIOScalar_write(pTHX_ PerlIO * f, const void *vbuf, Size_t count)
         if (SvTYPE(sv) >= SVt_PV && SvPVX_const(sv) && SvLEN(sv) &&
             UNLIKELY(SvPVX_const(sv) <= (const char *)vbuf &&
                      (const char *)vbuf < SvPVX_const(sv) + SvLEN(sv))) {
-            vbuf = savepvn(vbuf, count);
+            vbuf = savepvn((const char *)vbuf, count);
             SAVEFREEPV(vbuf);
         }
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -544,6 +544,16 @@ When a scalar variable used as the target of a filehandle is C<undef>'ed
 while being output, garbage bytes would be left in that scalar.
 [GH #24008]
 
+=over 4
+
+=item *
+
+Additionally, there was a case that would expose garbage bytes in the
+target scalar when that scalar is output on it (as in
+C<< open $fh, '>', \$str; print $fh $str; >>).  This is also fixed.
+
+=back
+
 =item *
 
 C<close(STDOUT)> when C<STDOUT> has been opened as a pipe will now

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -549,8 +549,9 @@ while being output, garbage bytes would be left in that scalar.
 =item *
 
 Additionally, there was a case that would expose garbage bytes in the
-target scalar when that scalar is output on it (as in
-C<< open $fh, '>', \$str; print $fh $str; >>).  This is also fixed.
+target scalar or even trigger a segmentation fault when that scalar is
+output on it (as in C<< open $fh, '>', \$str; print $fh $str; >>).
+This is also fixed.  [GH #24199]
 
 =back
 

--- a/t/io/scalar.t
+++ b/t/io/scalar.t
@@ -12,7 +12,7 @@ use strict;
 use Fcntl qw(SEEK_SET SEEK_CUR SEEK_END); # Not 0, 1, 2 everywhere.
 use Errno qw(EACCES);
 
-plan(134);
+plan(135);
 
 my $fh;
 my $var = "aaa\n";
@@ -567,4 +567,11 @@ SKIP:
     print $fh $str;
     is($str, "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
        "write a string to itself");
+}
+
+{ # GH #24199
+    open my $fh, '>', \my $content or die $!;
+    print {$fh} "o";
+    print {$fh} $content for 1..20; # This used to crash with SEGV
+    is(length($content), 2 ** 20, "write a string to itself [GH #24199]");
 }

--- a/t/io/scalar.t
+++ b/t/io/scalar.t
@@ -12,7 +12,7 @@ use strict;
 use Fcntl qw(SEEK_SET SEEK_CUR SEEK_END); # Not 0, 1, 2 everywhere.
 use Errno qw(EACCES);
 
-plan(133);
+plan(134);
 
 my $fh;
 my $var = "aaa\n";
@@ -558,4 +558,13 @@ SKIP:
     substr($str, 3) = '';
     print $fh "d";
     is($str, "yccd", "truncate string while appending");
+}
+
+{
+    open my $fh, '>', \my $str or die $!;
+    # Needs a sufficiently long string to trigger string expansion (sv_grow).
+    print $fh "abcdefghijklmnopqrstuvwxyz";
+    print $fh $str;
+    is($str, "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+       "write a string to itself");
 }


### PR DESCRIPTION
While creating #24162 and #24063, I've found that there was another case that expose garbage (uninitialized) bytes in the target scalar of a filehandle.

If the output data specified by `vbuf` and `count` were on the target scalar itself, `vbuf` may become invalid because the buffer may be relocated in buffer expansion with `SvGROW`, and `PerlIOScalar_write` would copy invalid data pointed by `vbuf`.  Such a situation is probably rare in reality, but could be reproduced with:
```perl
open my $fh, '>', \my $str;
print $fh "abcdefghijlmn";
print $fh $str;		# <-- vbuf will point $str here
```
-------------------------------------------------------------------------------

* This set of changes requires a perldelta entry, and it is included.