### PR TITLE
APItest.xs: revise to be more acceptable to clang21

### DIFF
--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -3473,7 +3473,7 @@ void
 test_magic_chain()
     PREINIT:
         SV *sv;
-        MAGIC *callmg, *uvarmg;
+        MAGIC *callmg = NULL, *uvarmg = NULL;
     CODE:
         sv = newSV_type_mortal(SVt_NULL);
         if (SvTYPE(sv) >= SVt_PVMG) croak_fail();


### PR DESCRIPTION
Per suggestion by Leon Timmermans in
https://github.com/Perl/perl5/issues/24165#issuecomment-3910347088.

For GH #24165.


-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
