### PR TITLE
find_lexical_cv: fix following the parent indexes after a gap

### DIFF
--- a/op.c
+++ b/op.c
@@ -15238,6 +15238,7 @@ Perl_find_lexical_cv(pTHX_ PADOFFSET off)
                 if (thisname && PadnameLEN(thisname) == PadnameLEN(name)
                     && PadnamePV(thisname) == PadnamePV(name)) {
                     name = thisname;
+                    off = offset;
                     break;
                 }
             }

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -368,6 +368,12 @@ manager will later use a regex to expand these into links.
 
 XXX
 
+=item *
+
+Resolving a lexical sub for prototype checking during parsing in eval
+could result in finding the wrong sub, resulting in confusing
+errors. [GH #24056][GH #24131]
+
 =back
 
 =head1 Known Problems

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -8,7 +8,7 @@ BEGIN {
     *bar::like = *like;
 }
 
-plan 158;
+plan 160;
 
 # -------------------- our -------------------- #
 
@@ -1053,4 +1053,39 @@ my $result =
 say "result=", ($result//"undef");
 EOS
 
+}
+
+{
+    # test case from GH #24131
+    fresh_perl_is(<<'CODE', "ARRAY", {}, "lexical sub call from eval");
+use v5.40;
+sub foo2 {
+sub { eval "say reftype([]);" or die $@ }
+    };
+foo2->();
+CODE
+
+    # adapted test case from GH #24056
+    # may pass on non-threaded perls
+    fresh_perl_is(<<'CODE', "", {}, "another lexical sub call from eval");
+BEGIN {
+    eval <<~'EOS';
+        package eval_bug;
+        $eval_bug::VERSION='0.001';
+        
+        use v5.40;
+        
+        sub do_eval
+        {
+            eval 'use v5.40; true';
+            die $@ if $@;
+        }
+        EOS
+}
+
+{
+    eval_bug::do_eval;
+    die $@ if $@;
+}
+CODE
 }


### PR DESCRIPTION
Normally padvars inherited from outer scopes have a PARENT_PAD_INDEX()
value that is that names index in the outer scope, found by
CvOUTSIDE().

So imagine these pads, each for an enclosing scope:
```
  [&true] [&reftype] [&foo] [&bar]  # outer most scope
  [&true PPI=1] [&reftype PPI=2]    # A scope
  [&true PPI=1]                     # B scope
```
where PPI is the PARENT_PAD_INDEX() for that entry, so the B scope
inherits "&true" from index 1 in the A scope, and A inherits "&true"
from index 1 and "&reftype" from index 2 in the outermost scope.

This might correspond to code like:
```
  # definitions of true, reftype, foo, bar
  use builtin qw(true reftype);
  my sub foo { ... }
  my sub bar { ... }

  sub A {
    # inherited references to reftype and true
    if (reftype($somevar) eq "HASH" && ...)
       return true;

     my sub B {
       eval "... reftype(...) ...";
       return true;
     }
  }
```
The pad cannot be modified after the sub has finished compilation.

So if we do an eval within the B scope and reference &reftype:
```
  [&true] [&reftype] [&foo] [&bar]  # outer most scope
  [&true PPI=1] [&reftype PPI=2]    # A scope
  [$y] [&true PPI=2]                # B scope
  [&reftype]                        # eval scope
```
we can no longer modify scope B to build the PARENT_PAD_INDEX chain up
to the original imported definition.

Before b0bc598140d4 this could result in an assertion or segmentation
fault, since find_lexical_cv() didn't handle the gap in the chain at
all.

The fix in b0bc598140d4 handled the case where the name was found
after the gap in the defining scope, this allows find_lexical_cv() to
correctly find &foo or &bar starting from the eval scope, but it
didn't correctly adjust the working pad index when that name was
inherited from some parent scope, such as &reftype in A being
inherited from the outer most scope.

So for &reftype, the starting index is 1, find_lexical_cv() sees the
missing index, does an exhaustive search up the CvOUTSIDE() chain and
finds it in the A scope, but didn't adjust the index to the found
entry 2, this meant it started following the chain from the &true
entry, resulting it finding the CV for &true and failing to compile
since the prototype for &true allows no arguments, unlike &reftype.

This change fixes that, so when the name is found after the break in
the PARENT_PAD_INDEX chain, the index starts from the correct pad
entry.

Fixes #24131
Fixes #24056
