### PR TITLE
perlguts: Add section about DEBUG_U, etc

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -2871,6 +2871,101 @@ there is no op tree)
 and C<Perl_dump_all>, which dumps all the subroutines in the stash and
 the op tree of the main root.
 
+=head1 Tracing the interpreter execution
+
+Throughout the source code you'll see statements like
+
+ DEBUG_L(PerlIO_printf(Perl_debug_log, "%s\n", msg));
+ DEBUG_l(deb("Entering new RUNOPS level: depth=%d\n", depth));
+ DEBUG_r(if (!PL_colorset) reginitcolors());
+ DEBUG_y(sv_dump(sv));
+
+Each statement executes the code within the outermost pair of
+parentheses, but only under certain circumstances:
+
+=over
+
+=item perl must have been compiled with -DDEBUGGING
+
+If not, each such statement compiles to nothing.
+
+=item The C<$^D> variable must have the appropriate bit set.
+
+To execute, C<DEBUG_y> needs the C<y> bit set.  Similarly, there are
+C<L>, C<l>, and C<r> bits.
+
+Each bit is for a different aspect of the interpreter execution.  C<L>
+is for locale handling, C<l> is for context (loop) stack processing,
+C<r> for regular expressions, and C<y> for C<tr///>.
+
+All possibe bits and their meanings are listed in L<perlrun/-Dletters>,
+or in the F<perl.h> source under, like, C<DEBUG_L_FLAG>.
+
+Setting these is most often done from the command line that started this
+execution of the interpreter, using C<-D...> options, but a Perl
+program can change the value of this variable at will.
+
+=back
+
+So, for example, when perl has been compiled with C<-DEBUGGING>, and
+turned on by passing the C<-Dy> option to perl at startup, any time the
+execution encounters a C language source C<DEBUG_y(sv_dump(sv));>
+statement, C<sv_dump> is called.  (See L<perlapi/C<sv_dump>> for what
+that does.)
+
+Lines like these are strategically placed in the C code to help find
+problems when turned on, but occupy no space at all without
+C<-DDEBUGGING>.
+
+There is also a C<v> modifier bit which requests extra verbosity for the
+other set bits.  In statements like
+
+ DEBUG_Lv(PerlIO_printf(Perl_debug_log, "Entering function(%s);", ...))
+
+C<PerlIO_printf> is executed only when perl has been compiled with
+C<-DDEBUGGING> and BOTH the C<L> and C<v> bits are enabled, such as
+with C<-DLv> or C<-DvL...>.  Only a few main bits are affected by C<v>,
+and currently there is only one level of extra verbosity.  C<-DLvvv> and
+C<-LDv> do exeactly the same thing.
+
+The most commonly used form of these is like
+
+ DEBUG_L(PerlIO_printf(Perl_debug_log, "%s", msg));
+
+When enabled as described above, this statement causes the contents of
+the C language character string C<msg> to be displayed to C<stderr>
+whenever the statement is encountered during the execution of a Perl
+program.  After C<Perl_debug_log> must be a format string, and then any
+number of arguments to that format, just as-if this were a C<printf()>.
+
+C<deb()> as the interior does the same thing, but automatically notes the
+Perl source code line that was the ultimate cause of this C statement
+getting executed.  This is an easy way to associate the Perl code with
+its corresponding C translation.  See L<perlapi/C<deb>>.  Its use in our
+source should actually be more widespread than it is.  Patches Welcome!
+
+Most of these statements are essentially permanently placed in the
+source code, to be turned on, perhaps in the far distant future,
+as-needed.  But there is one bit that is reserved for temporary
+placement during development or handling special situations.  You can
+add C<DEBUG_U> (for "Unofficial") statements for whatever you need.  But
+these should be removed after the code is debugged, or be converted to
+use other bits.
+
+You can write more complex conditions to more finely tune if output will
+be generated, using the C<DEBUG_U_TEST> and C<DEBUG_Uv_TEST> macros.
+They return true if and only if a debug statement of the corresponding
+type would display.  There are corresponding macros for each of the
+bits.
+
+=for apidoc_section $debugging
+=for apidoc      Amh|    |DEBUG_U |const char * format|...
+=for apidoc_item    |    |DEBUG_Uv|const char * format|...
+=for apidoc_item mn|bool|DEBUG_U_TEST
+=for apidoc_item mn|bool|DEBUG_Uv_TEST
+
+=for apidoc     Cmnh|U32 |DEBUG_L_FLAG
+
 =head1 How multiple interpreters and concurrency are supported
 
 =head2 Background and MULTIPLICITY

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1100,12 +1100,15 @@ For example
     (-e:1)	add
         =>  NV(1)
 
+All the options are listed in L<perlrun/-Dletters>.
 
 Some of the functionality of the debugging code can be achieved with a
 non-debugging perl by using XS modules:
 
     -Dr => use re 'debug'
     -Dx => use O 'Debug'
+
+More details can be found in L<perlguts/Tracing the interpreter execution>.
 
 =head2 Using a source-level debugger
 

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -2254,7 +2254,9 @@ X<$^D> X<$DEBUGGING>
 The current value of the debugging flags.  May be read or set.  Like its
 L<command-line equivalent|perlrun/B<-D>I<letters>>, you can use numeric
 or symbolic values, e.g. C<$^D = 10> or C<$^D = "st">.  See
-L<perlrun/B<-D>I<number>>.  The contents of this variable also affects the
+L<perlrun/B<-D>I<number>> and L<perlguts/Tracing the interpreter execution>.
+
+The contents of this variable also affects the
 debugger operation.  See L<perldebguts/Debugger Internals>.
 
 Mnemonic: value of B<-D> switch.

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -580,112 +580,17 @@ my @unresolved_visibility_overrides = qw(
     DBVARMG_SIGNAL
     DBVARMG_SINGLE
     DBVARMG_TRACE
-    DEBUG_A
-    DEBUG_A_FLAG
-    DEBUG_A_TEST
-    DEBUG_B
-    DEBUG_B_FLAG
-    DEBUG_B_TEST
-    DEBUG_c
-    DEBUG_C
-    DEBUG_c_FLAG
-    DEBUG_C_FLAG
-    DEBUG_c_TEST
-    DEBUG_C_TEST
-    DEBUG_D
     DEBUG_DB_RECURSE_FLAG
-    DEBUG_D_FLAG
-    DEBUG_D_TEST
-    DEBUG_f
-    DEBUG_f_FLAG
-    DEBUG_f_TEST
-    DEBUG_h_FLAG
-    DEBUG_h_TEST
-    DEBUG_i
-    DEBUG_i_FLAG
-    DEBUG_i_TEST
-    DEBUG_J_FLAG
-    DEBUG_J_TEST
-    DEBUG_l
-    DEBUG_L
-    DEBUG_l_FLAG
-    DEBUG_L_FLAG
-    DEBUG_l_TEST
-    DEBUG_L_TEST
-    DEBUG_Lv
-    DEBUG_Lv_TEST
-    DEBUG_m
-    DEBUG_M
     DEBUG_MASK
-    DEBUG_m_FLAG
-    DEBUG_M_FLAG
-    DEBUG_m_TEST
-    DEBUG_M_TEST
-    DEBUG_o
-    DEBUG_o_FLAG
-    DEBUG_o_TEST
-    DEBUG_p
-    DEBUG_P
     DEBUG_PEEP
-    DEBUG_p_FLAG
-    DEBUG_P_FLAG
     DEBUG_POST_STMTS
     DEBUG_PRE_STMTS
-    DEBUG_p_TEST
-    DEBUG_P_TEST
-    DEBUG_Pv
-    DEBUG_Pv_TEST
-    DEBUG_q
-    DEBUG_q_FLAG
-    DEBUG_q_TEST
-    DEBUG_r
-    DEBUG_R
     DEBUG_RExC_seen
-    DEBUG_r_FLAG
-    DEBUG_R_FLAG
-    DEBUG_r_TEST
-    DEBUG_R_TEST
-    DEBUG_s
-    DEBUG_S
     DEBUG_SBOX32_HASH
     DEBUG_SCOPE
-    DEBUG_s_FLAG
-    DEBUG_S_FLAG
     DEBUG_SHOW_STUDY_FLAG
-    DEBUG_s_TEST
-    DEBUG_S_TEST
     DEBUG_STUDYDATA
-    DEBUG_t
-    DEBUG_T
-    DEBUG_t_FLAG
-    DEBUG_T_FLAG
     DEBUG_TOP_FLAG
-    DEBUG_t_TEST
-    DEBUG_T_TEST
-    DEBUG_u
-    DEBUG_U
-    DEBUG_u_FLAG
-    DEBUG_U_FLAG
-    DEBUG_u_TEST
-    DEBUG_U_TEST
-    DEBUG_Uv
-    DEBUG_Uv_TEST
-    DEBUG_v
-    DEBUG_v_FLAG
-    DEBUG_v_TEST
-    DEBUG_x
-    DEBUG_X
-    DEBUG_x_FLAG
-    DEBUG_X_FLAG
-    DEBUG_x_TEST
-    DEBUG_X_TEST
-    DEBUG_Xv
-    DEBUG_Xv_TEST
-    DEBUG_y
-    DEBUG_y_FLAG
-    DEBUG_y_TEST
-    DEBUG_yv
-    DEBUG_yv_TEST
     DEBUG_ZAPHOD32_HASH
     DEFAULT_PAT_MOD
     DEFERRED_COULD_BE_OFFICIAL_MARKERc
@@ -3426,43 +3331,7 @@ my @unresolved_visibility_overrides = qw(
     CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG_
     CHECK_AND_WARN_PROBLEMATIC_LOCALE_
     CHECK_MALLOC_TOO_LATE_FOR_
-    DEBUG__
-    DEBUG_A_TEST_
-    DEBUG_BOTH_FLAGS_TEST_
-    DEBUG_B_TEST_
-    DEBUG_c_TEST_
-    DEBUG_C_TEST_
-    DEBUG_D_TEST_
-    DEBUG_f_TEST_
-    DEBUG_h_TEST_
-    DEBUG_i_TEST_
-    DEBUG_J_TEST_
     DEBUG_LOCALE_INITIALIZATION_
-    DEBUG_l_TEST_
-    DEBUG_L_TEST_
-    DEBUG_Lv_TEST_
-    DEBUG_m_TEST_
-    DEBUG_M_TEST_
-    DEBUG_o_TEST_
-    DEBUG_p_TEST_
-    DEBUG_P_TEST_
-    DEBUG_Pv_TEST_
-    DEBUG_q_TEST_
-    DEBUG_r_TEST_
-    DEBUG_R_TEST_
-    DEBUG_s_TEST_
-    DEBUG_S_TEST_
-    DEBUG_t_TEST_
-    DEBUG_T_TEST_
-    DEBUG_u_TEST_
-    DEBUG_U_TEST_
-    DEBUG_Uv_TEST_
-    DEBUG_v_TEST_
-    DEBUG_x_TEST_
-    DEBUG_X_TEST_
-    DEBUG_Xv_TEST_
-    DEBUG_y_TEST_
-    DEBUG_yv_TEST_
     DFA_RETURN_FAILURE_
     DFA_RETURN_SUCCESS_
     DFA_TEASE_APART_FF_
@@ -3637,9 +3506,140 @@ my @needed_by_ext = qw(
 # part have a trailing underscore, indicating the intent for this symbol to
 # not be directly usable by XS code
 my @undocumented_always_visible = qw(
+    DEBUG_A
+    DEBUG_A_FLAG
+    DEBUG_A_TEST
+    DEBUG_B
+    DEBUG_B_FLAG
+    DEBUG_B_TEST
+    DEBUG_c
+    DEBUG_C
+    DEBUG_c_FLAG
+    DEBUG_C_FLAG
+    DEBUG_c_TEST
+    DEBUG_C_TEST
+    DEBUG_D
+    DEBUG_D_FLAG
+    DEBUG_D_TEST
+    DEBUG_f
+    DEBUG_f_FLAG
+    DEBUG_f_TEST
+    DEBUG_h_FLAG
+    DEBUG_h_TEST
+    DEBUG_i
+    DEBUG_i_FLAG
+    DEBUG_i_TEST
+    DEBUG_J_FLAG
+    DEBUG_J_TEST
+    DEBUG_l
+    DEBUG_L
+    DEBUG_l_FLAG
+    DEBUG_L_FLAG
+    DEBUG_l_TEST
+    DEBUG_L_TEST
+    DEBUG_Lv
+    DEBUG_Lv_TEST
+    DEBUG_m
+    DEBUG_M
+    DEBUG_m_FLAG
+    DEBUG_M_FLAG
+    DEBUG_m_TEST
+    DEBUG_M_TEST
+    DEBUG_o
+    DEBUG_o_FLAG
+    DEBUG_o_TEST
+    DEBUG_p
+    DEBUG_P
+    DEBUG_p_FLAG
+    DEBUG_P_FLAG
+    DEBUG_p_TEST
+    DEBUG_P_TEST
+    DEBUG_Pv
+    DEBUG_Pv_TEST
+    DEBUG_q
+    DEBUG_q_FLAG
+    DEBUG_q_TEST
+    DEBUG_r
+    DEBUG_R
+    DEBUG_r_FLAG
+    DEBUG_R_FLAG
+    DEBUG_r_TEST
+    DEBUG_R_TEST
+    DEBUG_s
+    DEBUG_S
+    DEBUG_s_FLAG
+    DEBUG_S_FLAG
+    DEBUG_s_TEST
+    DEBUG_S_TEST
+    DEBUG_t
+    DEBUG_T
+    DEBUG_t_FLAG
+    DEBUG_T_FLAG
+    DEBUG_t_TEST
+    DEBUG_T_TEST
+    DEBUG_u
+    DEBUG_U
+    DEBUG_u_FLAG
+    DEBUG_U_FLAG
+    DEBUG_u_TEST
+    DEBUG_U_TEST
+    DEBUG_Uv
+    DEBUG_Uv_TEST
+    DEBUG_v
+    DEBUG_v_FLAG
+    DEBUG_v_TEST
+    DEBUG_x
+    DEBUG_X
+    DEBUG_x_FLAG
+    DEBUG_X_FLAG
+    DEBUG_x_TEST
+    DEBUG_X_TEST
+    DEBUG_Xv
+    DEBUG_Xv_TEST
+    DEBUG_y
+    DEBUG_y_FLAG
+    DEBUG_y_TEST
+    DEBUG_yv
+    DEBUG_yv_TEST
     MAX_UNICODE_UTF8_BYTES
 
     assert_scalar_or_IO_
+    DEBUG__
+    DEBUG_A_TEST_
+    DEBUG_BOTH_FLAGS_TEST_
+    DEBUG_B_TEST_
+    DEBUG_c_TEST_
+    DEBUG_C_TEST_
+    DEBUG_D_TEST_
+    DEBUG_f_TEST_
+    DEBUG_h_TEST_
+    DEBUG_i_TEST_
+    DEBUG_J_TEST_
+    DEBUG_l_TEST_
+    DEBUG_L_TEST_
+    DEBUG_Lv_TEST_
+    DEBUG_m_TEST_
+    DEBUG_M_TEST_
+    DEBUG_o_TEST_
+    DEBUG_p_TEST_
+    DEBUG_P_TEST_
+    DEBUG_Pv_TEST_
+    DEBUG_q_TEST_
+    DEBUG_r_TEST_
+    DEBUG_R_TEST_
+    DEBUG_s_TEST_
+    DEBUG_S_TEST_
+    DEBUG_t_TEST_
+    DEBUG_T_TEST_
+    DEBUG_u_TEST_
+    DEBUG_U_TEST_
+    DEBUG_Uv_TEST_
+    DEBUG_v_TEST_
+    DEBUG_x_TEST_
+    DEBUG_X_TEST_
+    DEBUG_Xv_TEST_
+    DEBUG_y_TEST_
+    DEBUG_yv_TEST_
     EXTEND_NEEDS_GROW_
     EXTEND_SAFE_N_
     MEM_WRAP_NEEDS_RUNTIME_CHECK_


### PR DESCRIPTION
As a result, consider all the similar macros documented, so that they are marked as resolved in embed.pl


* This set of changes does not require a perldelta entry.
