### PR TITLE
feature.pm: Sort features alphabetically, not date

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -4,7 +4,7 @@
 # Any changes made here will be lost!
 
 package feature;
-our $VERSION = '2.00';
+our $VERSION = '2.01';
 
 our %feature = (
     fc                              => 'feature_fc',
@@ -313,100 +313,17 @@ disable I<all> features (an unusual request!) use C<no feature ':all'>.
 
 Read L</"FEATURE BUNDLES"> for the feature cheat sheet summary.
 
-=head2 The 'say' feature
+=head2 The 'apostrophe_as_package_separator' feature
 
-C<use feature 'say'> tells the compiler to enable the Raku-inspired
-C<say> function.
+This feature enables use C<'> (apostrophe) as an alternative to using
+C<::> as a separate in package and other global names.
 
-See L<perlfunc/say> for details.
+This is enabled by default, but disabled from the 5.42 feature bundle
+onwards.  In previous versions it was enabled all the time.
 
-This feature is available starting with Perl 5.10.
-
-=head2 The 'state' feature
-
-C<use feature 'state'> tells the compiler to enable C<state>
-variables.
-
-See L<perlsub/"Persistent Private Variables"> for details.
-
-This feature is available starting with Perl 5.10.
-
-=head2 The 'smartmatch' feature
-
-C<use feature 'smartmatch'> tells the compiler to enable the
-smartmatch operator C<~~>.  It is enabled by default, but can be
-turned off to disallow the C<~~> operator.
-
-This feature is disabled by default in the 5.42 feature bundle
-onwards:
-
-  $x ~~ $y; # fine
-  use v5.42;
-  $x ~~ $y; # error
-
-This has no effect on the implicit smartmatches done by C<when>.
-
-See L<perlop/"Smartmatch Operator"> for details.
-
-=head2 The 'switch' feature
-
-C<use feature 'switch'> tells the compiler to enable the Raku
-given/when construct.
-
-See L<perlsyn/"Switch Statements"> for details.
-
-This feature is available starting with Perl 5.10.  It is enabled by
-feature bundles 5.10 through 5.34, and disabled from the 5.36 feature
-bundle onwards.
-
-=head2 The 'unicode_strings' feature
-
-C<use feature 'unicode_strings'> tells the compiler to use Unicode rules
-in all string operations executed within its scope (unless they are also
-within the scope of either C<use locale> or C<use bytes>).  The same applies
-to all regular expressions compiled within the scope, even if executed outside
-it.  It does not change the internal representation of strings, but only how
-they are interpreted.
-
-C<no feature 'unicode_strings'> tells the compiler to use the traditional
-Perl rules wherein the native character set rules is used unless it is
-clear to Perl that Unicode is desired.  This can lead to some surprises
-when the behavior suddenly changes.  (See
-L<perlunicode/The "Unicode Bug"> for details.)  For this reason, if you are
-potentially using Unicode in your program, the
-C<use feature 'unicode_strings'> subpragma is B<strongly> recommended.
-
-This feature is available starting with Perl 5.12; was almost fully
-implemented in Perl 5.14; and extended in Perl 5.16 to cover C<quotemeta>;
-was extended further in Perl 5.26 to cover L<the range
-operator|perlop/Range Operators>; and was extended again in Perl 5.28 to
-cover L<special-cased whitespace splitting|perlfunc/split>.
-
-=head2 The 'unicode_eval' and 'evalbytes' features
-
-Together, these two features are intended to replace the legacy string
-C<eval> function, which behaves problematically in some instances.  They are
-available starting with Perl 5.16, and are enabled by default by a
-S<C<use 5.16>> or higher declaration.
-
-C<unicode_eval> changes the behavior of plain string C<eval> to work more
-consistently, especially in the Unicode world.  Certain (mis)behaviors
-couldn't be changed without breaking some things that had come to rely on
-them, so the feature can be enabled and disabled.  Details are at
-L<perlfunc/Under the "unicode_eval" feature>.
-
-C<evalbytes> is like string C<eval>, but it treats its argument as a byte
-string. Details are at L<perlfunc/evalbytes EXPR>.  Without a
-S<C<use feature 'evalbytes'>> nor a S<C<use v5.16>> (or higher) declaration in
-the current scope, you can still access it by instead writing
-C<CORE::evalbytes>.
-
-=head2 The 'current_sub' feature
-
-This provides the C<__SUB__> token that returns a reference to the current
-subroutine or C<undef> outside of a subroutine.
-
-This feature is available starting with Perl 5.16.
+This only disables C<'> in symbols in your source code, the internal
+conversion from C<'> to C<::>, including for symbolic references, is
+always enabled.
 
 =head2 The 'array_base' feature
 
@@ -418,6 +335,111 @@ This feature is available under this name starting with Perl 5.16.  In
 previous versions, it was simply on all the time, and this pragma knew
 nothing about it.
 
+=head2 The 'bareword_filehandles' feature
+
+This feature enables bareword filehandles for builtin functions
+operations, a generally discouraged practice.  It is enabled by
+default, but can be turned off to disable bareword filehandles, except
+for the exceptions listed below.
+
+The perl built-in filehandles C<STDIN>, C<STDOUT>, C<STDERR>, C<DATA>,
+C<ARGV>, C<ARGVOUT> and the special C<_> are always enabled.
+
+This feature is available under this name from Perl 5.34 onwards.  In
+previous versions it was simply on all the time.  It is disabled from
+the 5.38 feature bundle onwards.
+
+You can use the L<bareword::filehandles> module on CPAN to disable
+bareword filehandles for older versions of perl.
+
+=head2 The 'bitwise' feature
+
+This makes the four standard bitwise operators (C<& | ^ ~>) treat their
+operands consistently as numbers, and introduces four new dotted operators
+(C<&. |. ^. ~.>) that treat their operands consistently as strings.  The
+same applies to the assignment variants (C<&= |= ^= &.= |.= ^.=>).
+
+See L<perlop/Bitwise String Operators> for details.
+
+This feature is available from Perl 5.22 onwards.  Starting in Perl 5.28,
+C<use v5.28> will enable the feature.  Before 5.28, it was still
+experimental and would emit a warning in the "experimental::bitwise"
+category.
+
+=head2 The 'class' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::class";
+
+This feature enables the C<class> block syntax and other associated keywords
+which implement the "new" object system, previously codenamed "Corinna".
+
+This feature is available starting in Perl 5.38.
+
+=head2 The 'current_sub' feature
+
+This provides the C<__SUB__> token that returns a reference to the current
+subroutine or C<undef> outside of a subroutine.
+
+This feature is available starting with Perl 5.16.
+
+=head2 The 'declared_refs' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::declared_refs";
+
+This allows a reference to a variable to be declared with C<my>, C<state>,
+or C<our>, or localized with C<local>.  It is intended mainly for use in
+conjunction with the "refaliasing" feature.  See L<perlref/Declaring a
+Reference to a Variable> for examples.
+
+This feature is available from Perl 5.26 onwards.
+
+=head2 The 'defer' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::defer";
+
+This feature enables the C<defer> block syntax, which allows a block of code
+to be deferred until when the flow of control leaves the block which contained
+it. For more details, see L<perlsyn/defer>.
+
+This feature is available starting in Perl 5.36.
+
+=head2 The 'evalbytes' feature
+
+See L</The 'unicode_eval' and 'evalbytes' features>
+
+=head2 The 'extra_paired_delimiters' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::extra_paired_delimiters";
+
+This feature enables the use of more paired string delimiters than the
+traditional four, S<C<< <  > >>>, S<C<( )>>, S<C<{ }>>, and S<C<[ ]>>.  When
+this feature is on, for example, you can say S<C<qrE<171>patE<187>>>.
+
+As with any usage of non-ASCII delimiters in a UTF-8-encoded source file, you
+will want to ensure the parser will decode the source code from UTF-8 bytes
+with a declaration such as C<use utf8>.
+
+This feature is available starting in Perl 5.36.
+
+For a full list of the available characters, see
+L<perlop/List of Extra Paired Delimiters>.
+
 =head2 The 'fc' feature
 
 C<use feature 'fc'> tells the compiler to enable the C<fc> function,
@@ -426,6 +448,64 @@ which implements Unicode casefolding.
 See L<perlfunc/fc> for details.
 
 This feature is available from Perl 5.16 onwards.
+
+=head2 The 'indirect' feature
+
+This feature allows the use of L<indirect object
+syntax|perlobj/Indirect Object Syntax> for method calls, e.g.  C<new
+Foo 1, 2;>. It is enabled by default, but can be turned off to
+disallow indirect object syntax.
+
+This feature is available under this name from Perl 5.32 onwards. In
+previous versions, it was simply on all the time.  To disallow (or
+warn on) indirect object syntax on older Perls, see the L<indirect>
+CPAN module.  It is disabled from the 5.36 feature bundle onwards.
+
+=head2 The 'isa' feature
+
+This allows the use of the C<isa> infix operator, which tests whether the
+scalar given by the left operand is an object of the class given by the
+right operand. See L<perlop/Class Instance Operator> for more details.
+
+This feature is available from Perl 5.32 onwards.  From Perl 5.32 to 5.34,
+it was classed as experimental, and Perl emitted a warning for its usage,
+except when explicitly disabled:
+
+    no warnings "experimental::isa";
+
+As of Perl 5.36, use of this feature no longer triggers a warning (though the
+C<experimental::isa> warning category still exists for compatibility with
+code that disables it). This feature is now considered stable, and is enabled
+automatically by C<use v5.36> (or higher).
+
+=head2 The 'keyword_all' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::keyword_all";
+
+This feature enables the L<C<all>|perlfunc/all BLOCK LIST> operator keyword.
+This allow testing whether all of the values in a list satisfy a given
+condition, with short-circuiting behaviour as soon as it finds one that does
+not.
+
+This feature is available starting in Perl 5.42.
+
+=head2 The 'keyword_any' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::keyword_any";
+
+This feature enables the L<C<any>|perlfunc/any BLOCK LIST> operator keyword.
+This allow testing whether any of the values in a list satisfy a given
+condition, with short-circuiting behaviour as soon as it finds one.
+
+This feature is available starting in Perl 5.42.
 
 =head2 The 'lexical_subs' feature
 
@@ -444,6 +524,32 @@ the C<experimental::lexical_subs> warning category still exists (for
 compatibility with code that disables it).  In addition, this syntax is
 not only no longer experimental, but it is enabled for all Perl code,
 regardless of what feature declarations are in scope.
+
+=head2 The 'module_true' feature
+
+This feature removes the need to return a true value at the end of a module
+loaded with C<require> or C<use>. Any errors during compilation will cause
+failures, but reaching the end of the module when this feature is in effect
+will prevent C<perl> from throwing an exception that the module "did not return
+a true value".
+
+=head2 The 'multidimensional' feature
+
+This feature enables multidimensional array emulation, a perl 4 (or
+earlier) feature that was used to emulate multidimensional arrays with
+hashes.  This works by converting code like C<< $foo{$x, $y} >> into
+C<< $foo{join($;, $x, $y)} >>.  It is enabled by default, but can be
+turned off to disable multidimensional array emulation.
+
+When this feature is disabled the syntax that is normally replaced
+will report a compilation error.
+
+This feature is available under this name from Perl 5.34 onwards. In
+previous versions, it was simply on all the time.  It is disabled from
+the 5.36 feature bundle onwards.
+
+You can use the L<multidimensional> module on CPAN to disable
+multidimensional array emulation for older versions of Perl.
 
 =head2 The 'postderef' and 'postderef_qq' features
 
@@ -473,6 +579,37 @@ same way as the 'postderef_qq' feature did. As of Perl 5.24, this syntax is
 not only no longer experimental, but it is enabled for all Perl code,
 regardless of what feature declarations are in scope.
 
+=head2 The 'refaliasing' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::refaliasing";
+
+This enables aliasing via assignment to references:
+
+    \$a = \$b; # $a and $b now point to the same scalar
+    \@a = \@b; #                     to the same array
+    \%a = \%b;
+    \&a = \&b;
+    foreach \%hash (@array_of_hash_refs) {
+        ...
+    }
+
+See L<perlref/Assigning to References> for details.
+
+This feature is available from Perl 5.22 onwards.
+
+=head2 The 'say' feature
+
+C<use feature 'say'> tells the compiler to enable the Raku-inspired
+C<say> function.
+
+See L<perlfunc/say> for details.
+
+This feature is available starting with Perl 5.10.
+
 =head2 The 'signatures' feature
 
 This enables syntax for declaring subroutine arguments as lexical variables.
@@ -497,120 +634,42 @@ C<experimental::signatures> warning category still exists (for compatibility
 with code that disables it). This feature is now considered stable, and is
 enabled automatically by C<use v5.36> (or higher).
 
-=head2 The 'refaliasing' feature
+=head2 The 'smartmatch' feature
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+C<use feature 'smartmatch'> tells the compiler to enable the
+smartmatch operator C<~~>.  It is enabled by default, but can be
+turned off to disallow the C<~~> operator.
 
-    no warnings "experimental::refaliasing";
+This feature is disabled by default in the 5.42 feature bundle
+onwards:
 
-This enables aliasing via assignment to references:
+  $x ~~ $y; # fine
+  use v5.42;
+  $x ~~ $y; # error
 
-    \$a = \$b; # $a and $b now point to the same scalar
-    \@a = \@b; #                     to the same array
-    \%a = \%b;
-    \&a = \&b;
-    foreach \%hash (@array_of_hash_refs) {
-        ...
-    }
+This has no effect on the implicit smartmatches done by C<when>.
 
-See L<perlref/Assigning to References> for details.
+See L<perlop/"Smartmatch Operator"> for details.
 
-This feature is available from Perl 5.22 onwards.
+=head2 The 'state' feature
 
-=head2 The 'bitwise' feature
+C<use feature 'state'> tells the compiler to enable C<state>
+variables.
 
-This makes the four standard bitwise operators (C<& | ^ ~>) treat their
-operands consistently as numbers, and introduces four new dotted operators
-(C<&. |. ^. ~.>) that treat their operands consistently as strings.  The
-same applies to the assignment variants (C<&= |= ^= &.= |.= ^.=>).
+See L<perlsub/"Persistent Private Variables"> for details.
 
-See L<perlop/Bitwise String Operators> for details.
+This feature is available starting with Perl 5.10.
 
-This feature is available from Perl 5.22 onwards.  Starting in Perl 5.28,
-C<use v5.28> will enable the feature.  Before 5.28, it was still
-experimental and would emit a warning in the "experimental::bitwise"
-category.
+=head2 The 'switch' feature
 
-=head2 The 'declared_refs' feature
+C<use feature 'switch'> tells the compiler to enable the Raku
+given/when construct.
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+See L<perlsyn/"Switch Statements"> for details.
 
-    no warnings "experimental::declared_refs";
-
-This allows a reference to a variable to be declared with C<my>, C<state>,
-or C<our>, or localized with C<local>.  It is intended mainly for use in
-conjunction with the "refaliasing" feature.  See L<perlref/Declaring a
-Reference to a Variable> for examples.
-
-This feature is available from Perl 5.26 onwards.
-
-=head2 The 'isa' feature
-
-This allows the use of the C<isa> infix operator, which tests whether the
-scalar given by the left operand is an object of the class given by the
-right operand. See L<perlop/Class Instance Operator> for more details.
-
-This feature is available from Perl 5.32 onwards.  From Perl 5.32 to 5.34,
-it was classed as experimental, and Perl emitted a warning for its usage,
-except when explicitly disabled:
-
-    no warnings "experimental::isa";
-
-As of Perl 5.36, use of this feature no longer triggers a warning (though the
-C<experimental::isa> warning category still exists for compatibility with
-code that disables it). This feature is now considered stable, and is enabled
-automatically by C<use v5.36> (or higher).
-
-=head2 The 'indirect' feature
-
-This feature allows the use of L<indirect object
-syntax|perlobj/Indirect Object Syntax> for method calls, e.g.  C<new
-Foo 1, 2;>. It is enabled by default, but can be turned off to
-disallow indirect object syntax.
-
-This feature is available under this name from Perl 5.32 onwards. In
-previous versions, it was simply on all the time.  To disallow (or
-warn on) indirect object syntax on older Perls, see the L<indirect>
-CPAN module.  It is disabled from the 5.36 feature bundle onwards.
-
-=head2 The 'multidimensional' feature
-
-This feature enables multidimensional array emulation, a perl 4 (or
-earlier) feature that was used to emulate multidimensional arrays with
-hashes.  This works by converting code like C<< $foo{$x, $y} >> into
-C<< $foo{join($;, $x, $y)} >>.  It is enabled by default, but can be
-turned off to disable multidimensional array emulation.
-
-When this feature is disabled the syntax that is normally replaced
-will report a compilation error.
-
-This feature is available under this name from Perl 5.34 onwards. In
-previous versions, it was simply on all the time.  It is disabled from
-the 5.36 feature bundle onwards.
-
-You can use the L<multidimensional> module on CPAN to disable
-multidimensional array emulation for older versions of Perl.
-
-=head2 The 'bareword_filehandles' feature
-
-This feature enables bareword filehandles for builtin functions
-operations, a generally discouraged practice.  It is enabled by
-default, but can be turned off to disable bareword filehandles, except
-for the exceptions listed below.
-
-The perl built-in filehandles C<STDIN>, C<STDOUT>, C<STDERR>, C<DATA>,
-C<ARGV>, C<ARGVOUT> and the special C<_> are always enabled.
-
-This feature is available under this name from Perl 5.34 onwards.  In
-previous versions it was simply on all the time.  It is disabled from
-the 5.38 feature bundle onwards.
-
-You can use the L<bareword::filehandles> module on CPAN to disable
-bareword filehandles for older versions of perl.
+This feature is available starting with Perl 5.10.  It is enabled by
+feature bundles 5.10 through 5.34, and disabled from the 5.36 feature
+bundle onwards.
 
 =head2 The 'try' feature
 
@@ -633,102 +692,47 @@ experimental and emits a warning, except when explicitly disabled as above.
 
 For more information, see L<perlsyn/"Try Catch Exception Handling">.
 
-=head2 The 'defer' feature
+=head2 The 'unicode_eval' and 'evalbytes' features
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+Together, these two features are intended to replace the legacy string
+C<eval> function, which behaves problematically in some instances.  They are
+available starting with Perl 5.16, and are enabled by default by a
+S<C<use 5.16>> or higher declaration.
 
-    no warnings "experimental::defer";
+C<unicode_eval> changes the behavior of plain string C<eval> to work more
+consistently, especially in the Unicode world.  Certain (mis)behaviors
+couldn't be changed without breaking some things that had come to rely on
+them, so the feature can be enabled and disabled.  Details are at
+L<perlfunc/Under the "unicode_eval" feature>.
 
-This feature enables the C<defer> block syntax, which allows a block of code
-to be deferred until when the flow of control leaves the block which contained
-it. For more details, see L<perlsyn/defer>.
+C<evalbytes> is like string C<eval>, but it treats its argument as a byte
+string. Details are at L<perlfunc/evalbytes EXPR>.  Without a
+S<C<use feature 'evalbytes'>> nor a S<C<use v5.16>> (or higher) declaration in
+the current scope, you can still access it by instead writing
+C<CORE::evalbytes>.
 
-This feature is available starting in Perl 5.36.
+=head2 The 'unicode_strings' feature
 
-=head2 The 'extra_paired_delimiters' feature
+C<use feature 'unicode_strings'> tells the compiler to use Unicode rules
+in all string operations executed within its scope (unless they are also
+within the scope of either C<use locale> or C<use bytes>).  The same applies
+to all regular expressions compiled within the scope, even if executed outside
+it.  It does not change the internal representation of strings, but only how
+they are interpreted.
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+C<no feature 'unicode_strings'> tells the compiler to use the traditional
+Perl rules wherein the native character set rules is used unless it is
+clear to Perl that Unicode is desired.  This can lead to some surprises
+when the behavior suddenly changes.  (See
+L<perlunicode/The "Unicode Bug"> for details.)  For this reason, if you are
+potentially using Unicode in your program, the
+C<use feature 'unicode_strings'> subpragma is B<strongly> recommended.
 
-    no warnings "experimental::extra_paired_delimiters";
-
-This feature enables the use of more paired string delimiters than the
-traditional four, S<C<< <  > >>>, S<C<( )>>, S<C<{ }>>, and S<C<[ ]>>.  When
-this feature is on, for example, you can say S<C<qrE<171>patE<187>>>.
-
-As with any usage of non-ASCII delimiters in a UTF-8-encoded source file, you
-will want to ensure the parser will decode the source code from UTF-8 bytes
-with a declaration such as C<use utf8>.
-
-This feature is available starting in Perl 5.36.
-
-For a full list of the available characters, see
-L<perlop/List of Extra Paired Delimiters>.
-
-=head2 The 'module_true' feature
-
-This feature removes the need to return a true value at the end of a module
-loaded with C<require> or C<use>. Any errors during compilation will cause
-failures, but reaching the end of the module when this feature is in effect
-will prevent C<perl> from throwing an exception that the module "did not return
-a true value".
-
-=head2 The 'class' feature
-
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::class";
-
-This feature enables the C<class> block syntax and other associated keywords
-which implement the "new" object system, previously codenamed "Corinna".
-
-This feature is available starting in Perl 5.38.
-
-=head2 The 'apostrophe_as_package_separator' feature
-
-This feature enables use C<'> (apostrophe) as an alternative to using
-C<::> as a separate in package and other global names.
-
-This is enabled by default, but disabled from the 5.42 feature bundle
-onwards.  In previous versions it was enabled all the time.
-
-This only disables C<'> in symbols in your source code, the internal
-conversion from C<'> to C<::>, including for symbolic references, is
-always enabled.
-
-=head2 The 'keyword_any' feature
-
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::keyword_any";
-
-This feature enables the L<C<any>|perlfunc/any BLOCK LIST> operator keyword.
-This allow testing whether any of the values in a list satisfy a given
-condition, with short-circuiting behaviour as soon as it finds one.
-
-This feature is available starting in Perl 5.42.
-
-=head2 The 'keyword_all' feature
-
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::keyword_all";
-
-This feature enables the L<C<all>|perlfunc/all BLOCK LIST> operator keyword.
-This allow testing whether all of the values in a list satisfy a given
-condition, with short-circuiting behaviour as soon as it finds one that does
-not.
-
-This feature is available starting in Perl 5.42.
+This feature is available starting with Perl 5.12; was almost fully
+implemented in Perl 5.14; and extended in Perl 5.16 to cover C<quotemeta>;
+was extended further in Perl 5.26 to cover L<the range
+operator|perlop/Range Operators>; and was extended again in Perl 5.28 to
+cover L<special-cased whitespace splitting|perlfunc/split>.
 
 =head1 FEATURE BUNDLES
 

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -621,7 +621,7 @@ read_only_bottom_close_and_rename($h);
 
 __END__
 package feature;
-our $VERSION = '2.00';
+our $VERSION = '2.01';
 
 FEATURES
 
@@ -845,100 +845,17 @@ disable I<all> features (an unusual request!) use C<no feature ':all'>.
 
 Read L</"FEATURE BUNDLES"> for the feature cheat sheet summary.
 
-=head2 The 'say' feature
+=head2 The 'apostrophe_as_package_separator' feature
 
-C<use feature 'say'> tells the compiler to enable the Raku-inspired
-C<say> function.
+This feature enables use C<'> (apostrophe) as an alternative to using
+C<::> as a separate in package and other global names.
 
-See L<perlfunc/say> for details.
+This is enabled by default, but disabled from the 5.42 feature bundle
+onwards.  In previous versions it was enabled all the time.
 
-This feature is available starting with Perl 5.10.
-
-=head2 The 'state' feature
-
-C<use feature 'state'> tells the compiler to enable C<state>
-variables.
-
-See L<perlsub/"Persistent Private Variables"> for details.
-
-This feature is available starting with Perl 5.10.
-
-=head2 The 'smartmatch' feature
-
-C<use feature 'smartmatch'> tells the compiler to enable the
-smartmatch operator C<~~>.  It is enabled by default, but can be
-turned off to disallow the C<~~> operator.
-
-This feature is disabled by default in the 5.42 feature bundle
-onwards:
-
-  $x ~~ $y; # fine
-  use v5.42;
-  $x ~~ $y; # error
-
-This has no effect on the implicit smartmatches done by C<when>.
-
-See L<perlop/"Smartmatch Operator"> for details.
-
-=head2 The 'switch' feature
-
-C<use feature 'switch'> tells the compiler to enable the Raku
-given/when construct.
-
-See L<perlsyn/"Switch Statements"> for details.
-
-This feature is available starting with Perl 5.10.  It is enabled by
-feature bundles 5.10 through 5.34, and disabled from the 5.36 feature
-bundle onwards.
-
-=head2 The 'unicode_strings' feature
-
-C<use feature 'unicode_strings'> tells the compiler to use Unicode rules
-in all string operations executed within its scope (unless they are also
-within the scope of either C<use locale> or C<use bytes>).  The same applies
-to all regular expressions compiled within the scope, even if executed outside
-it.  It does not change the internal representation of strings, but only how
-they are interpreted.
-
-C<no feature 'unicode_strings'> tells the compiler to use the traditional
-Perl rules wherein the native character set rules is used unless it is
-clear to Perl that Unicode is desired.  This can lead to some surprises
-when the behavior suddenly changes.  (See
-L<perlunicode/The "Unicode Bug"> for details.)  For this reason, if you are
-potentially using Unicode in your program, the
-C<use feature 'unicode_strings'> subpragma is B<strongly> recommended.
-
-This feature is available starting with Perl 5.12; was almost fully
-implemented in Perl 5.14; and extended in Perl 5.16 to cover C<quotemeta>;
-was extended further in Perl 5.26 to cover L<the range
-operator|perlop/Range Operators>; and was extended again in Perl 5.28 to
-cover L<special-cased whitespace splitting|perlfunc/split>.
-
-=head2 The 'unicode_eval' and 'evalbytes' features
-
-Together, these two features are intended to replace the legacy string
-C<eval> function, which behaves problematically in some instances.  They are
-available starting with Perl 5.16, and are enabled by default by a
-S<C<use 5.16>> or higher declaration.
-
-C<unicode_eval> changes the behavior of plain string C<eval> to work more
-consistently, especially in the Unicode world.  Certain (mis)behaviors
-couldn't be changed without breaking some things that had come to rely on
-them, so the feature can be enabled and disabled.  Details are at
-L<perlfunc/Under the "unicode_eval" feature>.
-
-C<evalbytes> is like string C<eval>, but it treats its argument as a byte
-string. Details are at L<perlfunc/evalbytes EXPR>.  Without a
-S<C<use feature 'evalbytes'>> nor a S<C<use v5.16>> (or higher) declaration in
-the current scope, you can still access it by instead writing
-C<CORE::evalbytes>.
-
-=head2 The 'current_sub' feature
-
-This provides the C<__SUB__> token that returns a reference to the current
-subroutine or C<undef> outside of a subroutine.
-
-This feature is available starting with Perl 5.16.
+This only disables C<'> in symbols in your source code, the internal
+conversion from C<'> to C<::>, including for symbolic references, is
+always enabled.
 
 =head2 The 'array_base' feature
 
@@ -950,6 +867,111 @@ This feature is available under this name starting with Perl 5.16.  In
 previous versions, it was simply on all the time, and this pragma knew
 nothing about it.
 
+=head2 The 'bareword_filehandles' feature
+
+This feature enables bareword filehandles for builtin functions
+operations, a generally discouraged practice.  It is enabled by
+default, but can be turned off to disable bareword filehandles, except
+for the exceptions listed below.
+
+The perl built-in filehandles C<STDIN>, C<STDOUT>, C<STDERR>, C<DATA>,
+C<ARGV>, C<ARGVOUT> and the special C<_> are always enabled.
+
+This feature is available under this name from Perl 5.34 onwards.  In
+previous versions it was simply on all the time.  It is disabled from
+the 5.38 feature bundle onwards.
+
+You can use the L<bareword::filehandles> module on CPAN to disable
+bareword filehandles for older versions of perl.
+
+=head2 The 'bitwise' feature
+
+This makes the four standard bitwise operators (C<& | ^ ~>) treat their
+operands consistently as numbers, and introduces four new dotted operators
+(C<&. |. ^. ~.>) that treat their operands consistently as strings.  The
+same applies to the assignment variants (C<&= |= ^= &.= |.= ^.=>).
+
+See L<perlop/Bitwise String Operators> for details.
+
+This feature is available from Perl 5.22 onwards.  Starting in Perl 5.28,
+C<use v5.28> will enable the feature.  Before 5.28, it was still
+experimental and would emit a warning in the "experimental::bitwise"
+category.
+
+=head2 The 'class' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::class";
+
+This feature enables the C<class> block syntax and other associated keywords
+which implement the "new" object system, previously codenamed "Corinna".
+
+This feature is available starting in Perl 5.38.
+
+=head2 The 'current_sub' feature
+
+This provides the C<__SUB__> token that returns a reference to the current
+subroutine or C<undef> outside of a subroutine.
+
+This feature is available starting with Perl 5.16.
+
+=head2 The 'declared_refs' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::declared_refs";
+
+This allows a reference to a variable to be declared with C<my>, C<state>,
+or C<our>, or localized with C<local>.  It is intended mainly for use in
+conjunction with the "refaliasing" feature.  See L<perlref/Declaring a
+Reference to a Variable> for examples.
+
+This feature is available from Perl 5.26 onwards.
+
+=head2 The 'defer' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::defer";
+
+This feature enables the C<defer> block syntax, which allows a block of code
+to be deferred until when the flow of control leaves the block which contained
+it. For more details, see L<perlsyn/defer>.
+
+This feature is available starting in Perl 5.36.
+
+=head2 The 'evalbytes' feature
+
+See L</The 'unicode_eval' and 'evalbytes' features>
+
+=head2 The 'extra_paired_delimiters' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::extra_paired_delimiters";
+
+This feature enables the use of more paired string delimiters than the
+traditional four, S<C<< <  > >>>, S<C<( )>>, S<C<{ }>>, and S<C<[ ]>>.  When
+this feature is on, for example, you can say S<C<qrE<171>patE<187>>>.
+
+As with any usage of non-ASCII delimiters in a UTF-8-encoded source file, you
+will want to ensure the parser will decode the source code from UTF-8 bytes
+with a declaration such as C<use utf8>.
+
+This feature is available starting in Perl 5.36.
+
+For a full list of the available characters, see
+L<perlop/List of Extra Paired Delimiters>.
+
 =head2 The 'fc' feature
 
 C<use feature 'fc'> tells the compiler to enable the C<fc> function,
@@ -958,6 +980,64 @@ which implements Unicode casefolding.
 See L<perlfunc/fc> for details.
 
 This feature is available from Perl 5.16 onwards.
+
+=head2 The 'indirect' feature
+
+This feature allows the use of L<indirect object
+syntax|perlobj/Indirect Object Syntax> for method calls, e.g.  C<new
+Foo 1, 2;>. It is enabled by default, but can be turned off to
+disallow indirect object syntax.
+
+This feature is available under this name from Perl 5.32 onwards. In
+previous versions, it was simply on all the time.  To disallow (or
+warn on) indirect object syntax on older Perls, see the L<indirect>
+CPAN module.  It is disabled from the 5.36 feature bundle onwards.
+
+=head2 The 'isa' feature
+
+This allows the use of the C<isa> infix operator, which tests whether the
+scalar given by the left operand is an object of the class given by the
+right operand. See L<perlop/Class Instance Operator> for more details.
+
+This feature is available from Perl 5.32 onwards.  From Perl 5.32 to 5.34,
+it was classed as experimental, and Perl emitted a warning for its usage,
+except when explicitly disabled:
+
+    no warnings "experimental::isa";
+
+As of Perl 5.36, use of this feature no longer triggers a warning (though the
+C<experimental::isa> warning category still exists for compatibility with
+code that disables it). This feature is now considered stable, and is enabled
+automatically by C<use v5.36> (or higher).
+
+=head2 The 'keyword_all' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::keyword_all";
+
+This feature enables the L<C<all>|perlfunc/all BLOCK LIST> operator keyword.
+This allow testing whether all of the values in a list satisfy a given
+condition, with short-circuiting behaviour as soon as it finds one that does
+not.
+
+This feature is available starting in Perl 5.42.
+
+=head2 The 'keyword_any' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::keyword_any";
+
+This feature enables the L<C<any>|perlfunc/any BLOCK LIST> operator keyword.
+This allow testing whether any of the values in a list satisfy a given
+condition, with short-circuiting behaviour as soon as it finds one.
+
+This feature is available starting in Perl 5.42.
 
 =head2 The 'lexical_subs' feature
 
@@ -976,6 +1056,32 @@ the C<experimental::lexical_subs> warning category still exists (for
 compatibility with code that disables it).  In addition, this syntax is
 not only no longer experimental, but it is enabled for all Perl code,
 regardless of what feature declarations are in scope.
+
+=head2 The 'module_true' feature
+
+This feature removes the need to return a true value at the end of a module
+loaded with C<require> or C<use>. Any errors during compilation will cause
+failures, but reaching the end of the module when this feature is in effect
+will prevent C<perl> from throwing an exception that the module "did not return
+a true value".
+
+=head2 The 'multidimensional' feature
+
+This feature enables multidimensional array emulation, a perl 4 (or
+earlier) feature that was used to emulate multidimensional arrays with
+hashes.  This works by converting code like C<< $foo{$x, $y} >> into
+C<< $foo{join($;, $x, $y)} >>.  It is enabled by default, but can be
+turned off to disable multidimensional array emulation.
+
+When this feature is disabled the syntax that is normally replaced
+will report a compilation error.
+
+This feature is available under this name from Perl 5.34 onwards. In
+previous versions, it was simply on all the time.  It is disabled from
+the 5.36 feature bundle onwards.
+
+You can use the L<multidimensional> module on CPAN to disable
+multidimensional array emulation for older versions of Perl.
 
 =head2 The 'postderef' and 'postderef_qq' features
 
@@ -1005,6 +1111,37 @@ same way as the 'postderef_qq' feature did. As of Perl 5.24, this syntax is
 not only no longer experimental, but it is enabled for all Perl code,
 regardless of what feature declarations are in scope.
 
+=head2 The 'refaliasing' feature
+
+B<WARNING>: This feature is still experimental and the implementation may
+change or be removed in future versions of Perl.  For this reason, Perl will
+warn when you use the feature, unless you have explicitly disabled the warning:
+
+    no warnings "experimental::refaliasing";
+
+This enables aliasing via assignment to references:
+
+    \$a = \$b; # $a and $b now point to the same scalar
+    \@a = \@b; #                     to the same array
+    \%a = \%b;
+    \&a = \&b;
+    foreach \%hash (@array_of_hash_refs) {
+        ...
+    }
+
+See L<perlref/Assigning to References> for details.
+
+This feature is available from Perl 5.22 onwards.
+
+=head2 The 'say' feature
+
+C<use feature 'say'> tells the compiler to enable the Raku-inspired
+C<say> function.
+
+See L<perlfunc/say> for details.
+
+This feature is available starting with Perl 5.10.
+
 =head2 The 'signatures' feature
 
 This enables syntax for declaring subroutine arguments as lexical variables.
@@ -1029,120 +1166,42 @@ C<experimental::signatures> warning category still exists (for compatibility
 with code that disables it). This feature is now considered stable, and is
 enabled automatically by C<use v5.36> (or higher).
 
-=head2 The 'refaliasing' feature
+=head2 The 'smartmatch' feature
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+C<use feature 'smartmatch'> tells the compiler to enable the
+smartmatch operator C<~~>.  It is enabled by default, but can be
+turned off to disallow the C<~~> operator.
 
-    no warnings "experimental::refaliasing";
+This feature is disabled by default in the 5.42 feature bundle
+onwards:
 
-This enables aliasing via assignment to references:
+  $x ~~ $y; # fine
+  use v5.42;
+  $x ~~ $y; # error
 
-    \$a = \$b; # $a and $b now point to the same scalar
-    \@a = \@b; #                     to the same array
-    \%a = \%b;
-    \&a = \&b;
-    foreach \%hash (@array_of_hash_refs) {
-        ...
-    }
+This has no effect on the implicit smartmatches done by C<when>.
 
-See L<perlref/Assigning to References> for details.
+See L<perlop/"Smartmatch Operator"> for details.
 
-This feature is available from Perl 5.22 onwards.
+=head2 The 'state' feature
 
-=head2 The 'bitwise' feature
+C<use feature 'state'> tells the compiler to enable C<state>
+variables.
 
-This makes the four standard bitwise operators (C<& | ^ ~>) treat their
-operands consistently as numbers, and introduces four new dotted operators
-(C<&. |. ^. ~.>) that treat their operands consistently as strings.  The
-same applies to the assignment variants (C<&= |= ^= &.= |.= ^.=>).
+See L<perlsub/"Persistent Private Variables"> for details.
 
-See L<perlop/Bitwise String Operators> for details.
+This feature is available starting with Perl 5.10.
 
-This feature is available from Perl 5.22 onwards.  Starting in Perl 5.28,
-C<use v5.28> will enable the feature.  Before 5.28, it was still
-experimental and would emit a warning in the "experimental::bitwise"
-category.
+=head2 The 'switch' feature
 
-=head2 The 'declared_refs' feature
+C<use feature 'switch'> tells the compiler to enable the Raku
+given/when construct.
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+See L<perlsyn/"Switch Statements"> for details.
 
-    no warnings "experimental::declared_refs";
-
-This allows a reference to a variable to be declared with C<my>, C<state>,
-or C<our>, or localized with C<local>.  It is intended mainly for use in
-conjunction with the "refaliasing" feature.  See L<perlref/Declaring a
-Reference to a Variable> for examples.
-
-This feature is available from Perl 5.26 onwards.
-
-=head2 The 'isa' feature
-
-This allows the use of the C<isa> infix operator, which tests whether the
-scalar given by the left operand is an object of the class given by the
-right operand. See L<perlop/Class Instance Operator> for more details.
-
-This feature is available from Perl 5.32 onwards.  From Perl 5.32 to 5.34,
-it was classed as experimental, and Perl emitted a warning for its usage,
-except when explicitly disabled:
-
-    no warnings "experimental::isa";
-
-As of Perl 5.36, use of this feature no longer triggers a warning (though the
-C<experimental::isa> warning category still exists for compatibility with
-code that disables it). This feature is now considered stable, and is enabled
-automatically by C<use v5.36> (or higher).
-
-=head2 The 'indirect' feature
-
-This feature allows the use of L<indirect object
-syntax|perlobj/Indirect Object Syntax> for method calls, e.g.  C<new
-Foo 1, 2;>. It is enabled by default, but can be turned off to
-disallow indirect object syntax.
-
-This feature is available under this name from Perl 5.32 onwards. In
-previous versions, it was simply on all the time.  To disallow (or
-warn on) indirect object syntax on older Perls, see the L<indirect>
-CPAN module.  It is disabled from the 5.36 feature bundle onwards.
-
-=head2 The 'multidimensional' feature
-
-This feature enables multidimensional array emulation, a perl 4 (or
-earlier) feature that was used to emulate multidimensional arrays with
-hashes.  This works by converting code like C<< $foo{$x, $y} >> into
-C<< $foo{join($;, $x, $y)} >>.  It is enabled by default, but can be
-turned off to disable multidimensional array emulation.
-
-When this feature is disabled the syntax that is normally replaced
-will report a compilation error.
-
-This feature is available under this name from Perl 5.34 onwards. In
-previous versions, it was simply on all the time.  It is disabled from
-the 5.36 feature bundle onwards.
-
-You can use the L<multidimensional> module on CPAN to disable
-multidimensional array emulation for older versions of Perl.
-
-=head2 The 'bareword_filehandles' feature
-
-This feature enables bareword filehandles for builtin functions
-operations, a generally discouraged practice.  It is enabled by
-default, but can be turned off to disable bareword filehandles, except
-for the exceptions listed below.
-
-The perl built-in filehandles C<STDIN>, C<STDOUT>, C<STDERR>, C<DATA>,
-C<ARGV>, C<ARGVOUT> and the special C<_> are always enabled.
-
-This feature is available under this name from Perl 5.34 onwards.  In
-previous versions it was simply on all the time.  It is disabled from
-the 5.38 feature bundle onwards.
-
-You can use the L<bareword::filehandles> module on CPAN to disable
-bareword filehandles for older versions of perl.
+This feature is available starting with Perl 5.10.  It is enabled by
+feature bundles 5.10 through 5.34, and disabled from the 5.36 feature
+bundle onwards.
 
 =head2 The 'try' feature
 
@@ -1165,102 +1224,47 @@ experimental and emits a warning, except when explicitly disabled as above.
 
 For more information, see L<perlsyn/"Try Catch Exception Handling">.
 
-=head2 The 'defer' feature
+=head2 The 'unicode_eval' and 'evalbytes' features
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+Together, these two features are intended to replace the legacy string
+C<eval> function, which behaves problematically in some instances.  They are
+available starting with Perl 5.16, and are enabled by default by a
+S<C<use 5.16>> or higher declaration.
 
-    no warnings "experimental::defer";
+C<unicode_eval> changes the behavior of plain string C<eval> to work more
+consistently, especially in the Unicode world.  Certain (mis)behaviors
+couldn't be changed without breaking some things that had come to rely on
+them, so the feature can be enabled and disabled.  Details are at
+L<perlfunc/Under the "unicode_eval" feature>.
 
-This feature enables the C<defer> block syntax, which allows a block of code
-to be deferred until when the flow of control leaves the block which contained
-it. For more details, see L<perlsyn/defer>.
+C<evalbytes> is like string C<eval>, but it treats its argument as a byte
+string. Details are at L<perlfunc/evalbytes EXPR>.  Without a
+S<C<use feature 'evalbytes'>> nor a S<C<use v5.16>> (or higher) declaration in
+the current scope, you can still access it by instead writing
+C<CORE::evalbytes>.
 
-This feature is available starting in Perl 5.36.
+=head2 The 'unicode_strings' feature
 
-=head2 The 'extra_paired_delimiters' feature
+C<use feature 'unicode_strings'> tells the compiler to use Unicode rules
+in all string operations executed within its scope (unless they are also
+within the scope of either C<use locale> or C<use bytes>).  The same applies
+to all regular expressions compiled within the scope, even if executed outside
+it.  It does not change the internal representation of strings, but only how
+they are interpreted.
 
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
+C<no feature 'unicode_strings'> tells the compiler to use the traditional
+Perl rules wherein the native character set rules is used unless it is
+clear to Perl that Unicode is desired.  This can lead to some surprises
+when the behavior suddenly changes.  (See
+L<perlunicode/The "Unicode Bug"> for details.)  For this reason, if you are
+potentially using Unicode in your program, the
+C<use feature 'unicode_strings'> subpragma is B<strongly> recommended.
 
-    no warnings "experimental::extra_paired_delimiters";
-
-This feature enables the use of more paired string delimiters than the
-traditional four, S<C<< <  > >>>, S<C<( )>>, S<C<{ }>>, and S<C<[ ]>>.  When
-this feature is on, for example, you can say S<C<qrE<171>patE<187>>>.
-
-As with any usage of non-ASCII delimiters in a UTF-8-encoded source file, you
-will want to ensure the parser will decode the source code from UTF-8 bytes
-with a declaration such as C<use utf8>.
-
-This feature is available starting in Perl 5.36.
-
-For a full list of the available characters, see
-L<perlop/List of Extra Paired Delimiters>.
-
-=head2 The 'module_true' feature
-
-This feature removes the need to return a true value at the end of a module
-loaded with C<require> or C<use>. Any errors during compilation will cause
-failures, but reaching the end of the module when this feature is in effect
-will prevent C<perl> from throwing an exception that the module "did not return
-a true value".
-
-=head2 The 'class' feature
-
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::class";
-
-This feature enables the C<class> block syntax and other associated keywords
-which implement the "new" object system, previously codenamed "Corinna".
-
-This feature is available starting in Perl 5.38.
-
-=head2 The 'apostrophe_as_package_separator' feature
-
-This feature enables use C<'> (apostrophe) as an alternative to using
-C<::> as a separate in package and other global names.
-
-This is enabled by default, but disabled from the 5.42 feature bundle
-onwards.  In previous versions it was enabled all the time.
-
-This only disables C<'> in symbols in your source code, the internal
-conversion from C<'> to C<::>, including for symbolic references, is
-always enabled.
-
-=head2 The 'keyword_any' feature
-
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::keyword_any";
-
-This feature enables the L<C<any>|perlfunc/any BLOCK LIST> operator keyword.
-This allow testing whether any of the values in a list satisfy a given
-condition, with short-circuiting behaviour as soon as it finds one.
-
-This feature is available starting in Perl 5.42.
-
-=head2 The 'keyword_all' feature
-
-B<WARNING>: This feature is still experimental and the implementation may
-change or be removed in future versions of Perl.  For this reason, Perl will
-warn when you use the feature, unless you have explicitly disabled the warning:
-
-    no warnings "experimental::keyword_all";
-
-This feature enables the L<C<all>|perlfunc/all BLOCK LIST> operator keyword.
-This allow testing whether all of the values in a list satisfy a given
-condition, with short-circuiting behaviour as soon as it finds one that does
-not.
-
-This feature is available starting in Perl 5.42.
+This feature is available starting with Perl 5.12; was almost fully
+implemented in Perl 5.14; and extended in Perl 5.16 to cover C<quotemeta>;
+was extended further in Perl 5.26 to cover L<the range
+operator|perlop/Range Operators>; and was extended again in Perl 5.28 to
+cover L<special-cased whitespace splitting|perlfunc/split>.
 
 =head1 FEATURE BUNDLES
 


### PR DESCRIPTION
It makes no sense to someone not intimately associated with this project to see a list sorted by when the feature was added.

The only sensible sort order is alphabetically.


* This set of changes does not require a perldelta entry.
