### PR TITLE
Deprecate two constructs under qr//xx

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -147,6 +147,27 @@ as an updated module in the L</Modules and Pragmata> section.
 
 =back
 
+=head2 C<m/...[...].../xx> has new restrictions
+
+Using an unescaped C<#> or literal vertical space is now deprecated in a
+regular expression bracketed character class that is compiled with the
+C</xx> modifier.  These still work, but deprecation warnings will be
+generated unless turned off or the constructs are cured as follows.
+
+=over
+
+=item *
+
+Escape a C<#> by preceding it with a backslash, like in
+
+ m/ [ % \# ( ) ] /xx
+
+=item *
+
+Use constructs like C<\n> instead of literal vertical space.
+
+=back
+
 [ List each other deprecation as a =head2 entry ]
 
 =head1 Performance Enhancements

--- a/regcomp.c
+++ b/regcomp.c
@@ -9774,12 +9774,6 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                         do_posix_warnings ? &posix_warnings : NULL,
                         true /* checking only */);
         }
-        else if (  strict && ! skip_white
-                 && (   generic_isCC_(value, CC_VERTSPACE_)
-                     || is_VERTWS_cp_high(value)))
-        {
-            vFAIL("Literal vertical space in [] is illegal except under /x");
-        }
         else if (value == '\\') {
             /* Is a backslash; get the code point of the char after it */
 
@@ -10234,6 +10228,12 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 break;
             }   /* End of switch on char following backslash */
         } /* end of handling backslash escape sequences */
+        else if (  strict && ! skip_white
+                 && (   generic_isCC_(value, CC_VERTSPACE_)
+                     || is_VERTWS_cp_high(value)))
+        {
+            vFAIL("Literal vertical space in [] is illegal except under /x");
+        }
 
         /* Here, we have the current token in 'value' */
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -10228,11 +10228,22 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                 break;
             }   /* End of switch on char following backslash */
         } /* end of handling backslash escape sequences */
-        else if (  strict && ! skip_white
-                 && (   generic_isCC_(value, CC_VERTSPACE_)
-                     || is_VERTWS_cp_high(value)))
+        else if (   generic_isCC_(value, CC_VERTSPACE_)
+                 || is_VERTWS_cp_high(value))
         {
-            vFAIL("Literal vertical space in [] is illegal except under /x");
+            if (strict && ! skip_white) {
+                vFAIL("Literal vertical space in [] is illegal except"
+                      " under /x");
+            }
+            else if (RExC_flags & RXf_PMf_EXTENDED_MORE) {
+                ckWARNdep(RExC_parse, WARN_DEPRECATED,
+                          "Use of literal vertical space in [] is"
+                          " deprecated under /xx");
+            }
+        }
+        else if (value == '#' && RExC_flags & RXf_PMf_EXTENDED_MORE) {
+            ckWARNdep(RExC_parse, WARN_DEPRECATED,
+                      "Use of unescaped '#' in [] is deprecated under /xx");
         }
 
         /* Here, we have the current token in 'value' */

--- a/t/re/reg_mesg.t
+++ b/t/re/reg_mesg.t
@@ -786,6 +786,12 @@ my @deprecated = (
  '/foo(:?{bar)/' => "",
  '/\s*{/'        => "",
  '/a{3,4}{/'     => "",
+ '/a[b#c]/xx'    => "Use of unescaped '#' in [] is deprecated under /xx"
+                  . " {#} m/a[b#{#}c]/",
+ '/a[b\#c]/xx'    => "",
+ '/a[b
+ c]/xx'    => "Use of literal vertical space in [] is deprecated under /xx {#} m/a[b
+{#} c]/",
 );
 
 for my $strict ("", "use re 'strict';") {


### PR DESCRIPTION
This is part of #24209.

When a regular expression pattern is compiled with the /xx modifier, deprecation warnings will now be raised if any bracketed character class within it contains a '#' not immediately preceded by an odd number of backslashes, or if literal vertical space characters are used instead of (the more typical) \n, etc.

* This set of changes requires a perldelta entry, and it is included.
