### PR TITLE
pp_methstart: ensure we release the right SV on method exit

### DIFF
--- a/class.c
+++ b/class.c
@@ -318,11 +318,13 @@ PP(pp_methstart)
              *   See also https://github.com/Perl/perl5/issues/22278
              */
             if(fieldp[fieldix]) {
-              /* TODO: There isn't a convenient SAVE macro for doing both these
-               * steps in one go. Add one. */
-              SAVESPTR(PAD_SVl(padix));
-              SV *sv = PAD_SVl(padix) = SvREFCNT_inc(fieldp[fieldix]);
-              save_freesv(sv);
+                /* TODO: There isn't a convenient SAVE macro for doing
+                 * both these steps in one go. Add one.
+                 */
+                SV ** const padentry = &(PAD_SVl(padix));
+                SAVESPTR(*padentry);
+                *padentry = SvREFCNT_inc(fieldp[fieldix]);
+                save_clearsv(padentry);
             }
         }
     }

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -368,6 +368,13 @@ manager will later use a regex to expand these into links.
 
 XXX
 
+=item *
+
+Refassigning to a class field in a method could result in the SV for
+that field being released when the method exited.  The next access to
+that field could result in a crash or an assertion, or if the freed SV
+had been re-used, random data.  Discussed in [GH #24187]
+
 =back
 
 =head1 Known Problems

--- a/t/class/method.t
+++ b/t/class/method.t
@@ -164,7 +164,7 @@ no warnings 'experimental::class';
 }
 
 { # came up during GH #24187 review
-    local $::TODO = "refaliasing a field in a method crashed";
+    # https://github.com/Perl/perl5/pull/24187#discussion_r2814795858
     fresh_perl_is(<<'CODE', "OK", {}, "clear the right SV");
 use feature 'class', 'refaliasing';
 no warnings 'experimental::class';

--- a/t/class/method.t
+++ b/t/class/method.t
@@ -163,4 +163,29 @@ no warnings 'experimental::class';
         'lexical method with signature counts $self correctly');
 }
 
+{ # came up during GH #24187 review
+    local $::TODO = "refaliasing a field in a method crashed";
+    fresh_perl_is(<<'CODE', "OK", {}, "clear the right SV");
+use feature 'class', 'refaliasing';
+no warnings 'experimental::class';
+no warnings 'experimental::refaliasing';
+
+class TestCase10 {
+    field %x : reader;
+    method magic {
+        # this doesn't modify the field itself, just the
+        # lexical slot in the method's pad
+        \%x = \%ENV;
+        $self;
+    }
+}
+
+my $c = TestCase10->new;
+$c->magic;
+# the reference to $x would crash/assert
+$c->x;
+print "OK\n";
+CODE
+}
+
 done_testing;


### PR DESCRIPTION
Prior to this change, pp_methstart would save_freesv() each method pad
entry SV as it populated the method pad with fields, so the field SV
would be released when the method finished (or if an exception was
thrown.)

But if the field (really just the method pad entry) was refassigned
to, *that* would release the reference on the field SV, and then the
save stack entry from save_freesv() would also release the SV,
typically resulting the SV being freed.

Later references to that field would then typically crash, or throw an
assertion.

To avoid that use save_clearsv(), which releases whatever is in the
given SV** pointer, not the SV * provided.

https://github.com/Perl/perl5/pull/24187#discussion_r2814795858
 
-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
