### PR TITLE
goto: impose scalar context on XSUB return val

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -549,6 +549,17 @@ while being output, garbage bytes would be left in that scalar.
 C<close(STDOUT)> when C<STDOUT> has been opened as a pipe will now
 properly wait for the child to exit on Windows.  [GH #4106]
 
+=item *
+
+Calling an XSUB via goto in scalar context, where the XSUB didn't return
+exactly one value, could result in the return of the wrong number of
+items, leading to potential stack corruption. For example:
+
+    sub wrap { goto \&an_xsub_which_returns_no_values }
+    $ret = wrap();
+
+[GH #24212]
+
 =back
 
 =head1 Known Problems

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3486,9 +3486,10 @@ PP(pp_goto)
                  * provide that information.
                  */
                 Copy(PL_op, &fake_goto_op, 1, UNOP);
+                U8 gimme = (cx->blk_gimme & G_WANT);
                 fake_goto_op.op_flags =
                                   (fake_goto_op.op_flags & ~OPf_WANT)
-                                | (cx->blk_gimme & G_WANT);
+                                | gimme;
                 PL_op = (OP*)&fake_goto_op;
 
                 /* XS subs don't have a CXt_SUB, so pop it;
@@ -3502,7 +3503,31 @@ PP(pp_goto)
 
                 /* Push a mark for the start of arglist */
                 PUSHMARK(mark);
+                SSize_t markix = TOPMARK;
                 rpp_invoke_xs(cv);
+
+                /* Enforce some sanity in scalar context. */
+                if (gimme == G_SCALAR) {
+                    SV **svp = PL_stack_base + markix + 1;
+                    if (svp != PL_stack_sp) {
+#ifdef PERL_RC_STACK
+                        if (svp < PL_stack_sp) {
+                            /* move return value to bottom of stack frame
+                             * and free everything else */
+                            SV* retsv = *PL_stack_sp;
+                            *PL_stack_sp = *svp;
+                            *svp = retsv;
+                            rpp_popfree_to_NN(svp);
+                        }
+                        else
+                            rpp_push_IMM(&PL_sv_undef);
+#else
+                        *svp = svp > PL_stack_sp ? &PL_sv_undef : *PL_stack_sp;
+                        PL_stack_sp = svp;
+#endif
+                    }
+                }
+
                 LEAVE;
             }
             else {

--- a/t/op/goto_xs.t
+++ b/t/op/goto_xs.t
@@ -13,14 +13,15 @@ BEGIN {
 # turn warnings into fatal errors
     $SIG{__WARN__} = sub { die "WARNING: @_" } ;
     set_up_inc('../lib');
-    skip_all_if_miniperl("no dynamic loading on miniperl, no Fcntl");
+    skip_all_if_miniperl("no dynamic loading on miniperl, no Fcntl, APItest");
+    skip_all_without_dynamic_extension('XS::APItest') unless $Config{usedl};
     require Fcntl;
 }
 use strict;
 use warnings;
 my $VALID;
 
-plan(tests => 11);
+plan(tests => 22);
 
 # We don't know what symbols are defined in platform X's system headers.
 # We don't even want to guess, because some platform out there will
@@ -109,5 +110,37 @@ sub goto_croak { goto &mycroak }
     }
     is($e, "boo1\nboo2\nboo3\nboo4\n",
        '[perl #35878] croak in XS after goto segfaulted')
+}
+
+# GH #24212
+# goto'ing a void XSUB in scalar context wasn't pushing an undef
+# onto the stack (unlike a direct scalar call to that xsub)
+#
+{
+    require_ok('XS::APItest');
+
+    # xsreturn_empty() is just a convenient XSUB which happens
+    # to return no values.
+    sub wrap_24212 { goto \&XS::APItest::XSUB::xsreturn_empty }
+
+    my @a = (10, (my $ret1 = wrap_24212()), 20);
+    is(scalar(@a), 3, "void XSUB in scalar cxt: num of results");
+    is($a[0], 10,     "void XSUB in scalar cxt: a[0]");
+    is($a[1], undef,  "void XSUB in scalar cxt: a[1]");
+    is($a[2], 20,     "void XSUB in scalar cxt: a[2]");
+    is($ret1, undef,  "void XSUB in scalar cxt: ret1");
+
+    # Similarly test for for an XSUB in scalar context which returns
+    # several values
+
+    # xsreturn(n) returns a list 0..n-1
+    sub wrap_many_24212 { @_ = (7); goto \&XS::APItest::XSUB::xsreturn }
+
+    @a = (10,(my $ret2 = wrap_many_24212()), 20);
+    is(scalar(@a), 3, "list XSUB in scalar cxt: num of results");
+    is($a[0], 10,     "list XSUB in scalar cxt: a[0]");
+    is($a[1], 6,      "list XSUB in scalar cxt: a[1]");
+    is($a[2], 20,     "list XSUB in scalar cxt: a[2]");
+    is($ret2, 6,      "list XSUB in scalar cxt: ret2");
 }
 


### PR DESCRIPTION
    GH #24212
    
    In something like
    
        my $ret = an_xsub();
    
    pp_entersub() itself, since 5.001, imposes scalar context if necessary
    on the return value(s) from the XSUB: by popping all but the top item in
    the return list, or pushing undef if none.
    
    However for this:
    
        sub wrap { goto an_xsub(); }
        my $ret = wrap();
    
    pp_goto() hasn't been doing the same, resulting in stack underflow or
    the wrong number args returned etc. Somehow no one noticed this for 32
    years.
    
    This commit fixes that by more or less copying the XSUB scalar context
    fixup code as-is from pp_entersub() to pp_goto().


* This set of changes requires a perldelta entry, and it is included.
