### PR TITLE
feature.pm: Add avail start version for module_true

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -533,6 +533,8 @@ failures, but reaching the end of the module when this feature is in effect
 will prevent C<perl> from throwing an exception that the module "did not return
 a true value".
 
+This feature is available from Perl 5.38 onwards.
+
 =head2 The 'multidimensional' feature
 
 This feature enables multidimensional array emulation, a perl 4 (or

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -1065,6 +1065,8 @@ failures, but reaching the end of the module when this feature is in effect
 will prevent C<perl> from throwing an exception that the module "did not return
 a true value".
 
+This feature is available from Perl 5.38 onwards.
+
 =head2 The 'multidimensional' feature
 
 This feature enables multidimensional array emulation, a perl 4 (or


### PR DESCRIPTION
This was the only feature lacking this information

Dan Book looked up the start date


* This set of changes does not require a perldelta entry.
