### PR TITLE
Fix GH #19790: Reset `op_opt` in `gen_constant_list` failure path to prevent heap-buffer-overflow in `Perl_POPMARK`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1018,6 +1018,7 @@ Milton L. Hankins              <mlh@swl.msd.ray.com>
 Misty De Meo                   <mistydemeo@github.com>
 Mohammad S Anwar               <Mohammad.Anwar@yahoo.com>
 Mohammed El-Afifi              <mohammed_elafifi@yahoo.com>
+Molchan Nikita Olegovich       <v.tkalin.ru@gmail.com>
 Moritz Lenz                    <moritz@casella.verplant.org>
 Moshe Kaminsky                 <kaminsky@math.huji.ac.il>
 Mottaqui Karim                 <taqqui.karim@gmail.com>

--- a/MANIFEST
+++ b/MANIFEST
@@ -6480,6 +6480,7 @@ t/op/sleep.t				See if sleep works
 t/op/smartkve.t				See if smart deref for keys/values/each works
 t/op/smartmatch.t			See if the ~~ operator works
 t/op/sort.t				See if sort works
+t/op/sort_const_range.t			Regression test for GH #19790 (gen_constant_list op_opt)
 t/op/splice.t				See if splice works
 t/op/split.t				See if split works
 t/op/split_unicode.t			Test split /\s/ and Unicode

--- a/op.c
+++ b/op.c
@@ -5281,6 +5281,34 @@ S_gen_constant_list(pTHX_ OP *o)
         break;
     case 3:
         CLEAR_ERRSV();
+        /* CALL_PEEP() above set op_opt=1 on ops in the chain, but since we
+         * failed to generate the constant list they remain live in the op
+         * tree.  Reset op_opt so the main rpeep() pass can process them.
+         *
+         * Without this, a sort whose arg list contains a range with constant
+         * string endpoint (e.g. sort { ... } 0, 0.."r") triggers
+         * gen_constant_list which pre-marks the flip-flop ops as optimised.
+         * The numeric warning for "r" makes CALLRUNOPS die here (case 3),
+         * leaving the ops with op_opt=1.  The main rpeep then stops at the
+         * first such op (OP_RANGE), never reaches case OP_SORT, and
+         * null_wrap->op_next (= PL_sortcop) is left pointing into the sort's
+         * argument list instead of the comparator block.  S_sortcv then
+         * re-executes the argument list on each comparison, exhausting the
+         * MARK stack and causing a heap-buffer-overflow in Perl_POPMARK.
+         *
+         * The loop is bounded: o->op_next was zeroed at line 5215 (before
+         * CALL_PEEP), so the chain curop→…→o terminates at o (op_next=0).
+         * The (p != o) guard provides an explicit upper bound in case a
+         * future CALL_PEEP side-effect alters op_next along the way.
+         *
+         * GH #19790, GH #16865.
+         */
+        {
+            OP *p;
+            for (p = curop; p && p != o; p = p->op_next)
+                p->op_opt = 0;
+            o->op_opt = 0;
+        }
         o->op_next = old_next;
         break;
     default:

--- a/t/op/sort_const_range.t
+++ b/t/op/sort_const_range.t
@@ -1,0 +1,115 @@
+#!./perl
+# Tests for GH #19790 and GH #16865:
+# sort with a block comparator whose arg list contains a range whose
+# right endpoint is a non-numeric string constant (e.g. 0.."r").
+#
+# Root cause: S_gen_constant_list() calls CALL_PEEP() internally, which
+# sets op_opt=1 on the flip-flop ops.  When CALLRUNOPS dies (the "isn't
+# numeric" warning is fatal inside gen_constant_list), the failure path
+# (case 3) used to restore o->op_next without resetting op_opt.  That
+# left the main rpeep() unable to reach case OP_SORT, so null_wrap->op_next
+# (= PL_sortcop) was left pointing into the sort's argument list instead of
+# the comparator block, causing S_sortcv to re-execute the argument list
+# recursively and exhaust the MARK stack.
+#
+# NOTE: these tests must NOT use "no warnings 'numeric'" around the sort
+# expressions.  That pragma works via cop_warnings which gen_constant_list
+# inherits when it copies the current COP.  Suppressing the numeric warning
+# at compile time prevents gen_constant_list from hitting case 3 (the
+# failure path), so the bug is never triggered and the test becomes a
+# false positive on unpatched perls.
+#
+# Refs: GH #19790, GH #16865, GH #16033
+
+use strict;
+use warnings;
+
+require './test.pl';
+
+my $libdir = -d 'lib' ? 'lib' : '../lib';
+
+# stderr=>1 so warnings in subprocess output are captured but don't
+# interfere with the TAP stream; we only care about exit status.
+# -w is passed explicitly so that cop_warnings==pWARN_STD in the subprocess
+# falls back to PL_dowarn & G_WARN_ON, letting gen_constant_list's internal
+# CALLRUNOPS (which forces PL_dowarn |= G_WARN_ON) hit the WARN_NUMERIC
+# warning for "r" and reach case 3 — the code path this test exercises.
+# Without -w the test still works in practice (gen_constant_list forces
+# PL_dowarn itself), but -w makes the dependency explicit and safe.
+my $run_args = { switches => ["-I$libdir", "-w"], stderr => 1 };
+
+# ---------------------------------------------------------------------------
+# 1-8: crash-safety tests via fresh_perl.
+#
+# On unpatched perl the process crashes (MARK stack underflow) so exit != 0.
+# On patched perl the sort runs to completion and exits cleanly.
+#
+# We do NOT use "no warnings" in the snippets: the numeric warning for "r"
+# must reach gen_constant_list's PERL_WARNHOOK_FATAL so that case 3 is
+# triggered, which is exactly the code path the fix addresses.
+# ---------------------------------------------------------------------------
+
+my $out;
+
+# 1-2: GH #16865 minimal reproducer
+$out = fresh_perl('\(sort {0} 0, 0 .. "r")', $run_args);
+is($?,  0, 'GH #16865 minimal: clean exit');
+unlike($out, qr/MARK underflow/, 'GH #16865 minimal: no MARK underflow panic');
+
+# 3: list context (no outer reference)
+$out = fresh_perl('my @x = sort {0} 0, 0 .. "r"', $run_args);
+is($?, 0, 'GH #19790 list-context: clean exit');
+
+# 4: nested sort (the fuzz variant from GH #19790)
+$out = fresh_perl(
+    'my @x = \(sort {0} 0, 0 .. "r", sort {0} 1, 2)',
+    $run_args
+);
+is($?, 0, 'GH #19790 nested sort: clean exit');
+
+# 5: repeated invocations — no state corruption between calls
+$out = fresh_perl(
+    'for (1..5) { \(sort {0} 0, 0 .. "r") }',
+    $run_args
+);
+is($?, 0, 'repeated invocations: clean exit');
+
+# 6: double-nested, both sorts have non-numeric range args
+$out = fresh_perl(
+    '\(sort { \(sort {0} 0, 0 .. "z") } 0, 0 .. "r")',
+    $run_args
+);
+is($?, 0, 'double-nested sort with range args: clean exit');
+
+# 7-8: GH #16033 variant — assertion failure / MARK underflow via flip-flop
+$out = fresh_perl('\(sort {0} 0 .. "r")', $run_args);
+is($?, 0, 'GH #16033 sort {0} 0.."r" only: clean exit');
+
+$out = fresh_perl('sort { $a cmp $b } 0 .. "r"', $run_args);
+is($?, 0, 'sort with cmp comparator and range arg: clean exit');
+
+# ---------------------------------------------------------------------------
+# 9-10: correctness oracle — run in-process (compilation happens here,
+# so no "no warnings 'numeric'" must be active around the sort expression).
+#
+# Key invariant: if PL_sortcop is wrong, S_sortcv executes the argument
+# list instead of the comparator.  The comparator is never called, and
+# $cmp_called stays 0.  Either that, or the process crashes before
+# reaching the ok() call.
+# ---------------------------------------------------------------------------
+
+{
+    # Suppress only the runtime "isn't numeric" warning that pp_flop
+    # emits when it evaluates 0.."r" at run time.  We use a local
+    # override of $SIG{__WARN__} rather than "no warnings 'numeric'"
+    # to avoid touching cop_warnings and accidentally masking the
+    # compile-time warning that drives gen_constant_list into case 3.
+    local $SIG{__WARN__} = sub {};
+
+    my $cmp_called = 0;
+    my @sorted = sort { $cmp_called++; $a <=> $b } 5, 0 .. "r";
+    ok($cmp_called > 0, 'comparator block was actually called (not arg list)');
+    is("@sorted", "0 5",  'sort result is correct');
+}
+
+done_testing();


### PR DESCRIPTION
### **Description:**
This fix addresses the issue reported in **GH #19790** and **GH #16865**, where a heap-buffer-overflow occurs during sorting with a block comparator when the argument list contains a range with a constant string endpoint, e.g., `0 .. "r"`. The bug is triggered because `gen_constant_list` attempts to generate a constant list but fails, leaving operations in the chain marked as optimized (`op_opt=1`), preventing the main `rpeep()` pass from reaching `OP_SORT`.

In **[PR #24157](https://github.com/Perl/perl5/pull/24157)**, an attempt was made to prevent the crash by adding a bounds check in `Perl_POPMARK`, but the root cause was not addressed, and the underflow issue remained. This PR fully resolves the problem by ensuring that `op_opt` is correctly reset for all operations in the chain when case 3 failure occurs, allowing the main `rpeep()` pass to correctly process `OP_SORT` and preventing the heap overflow.

### **Fix:**
- Added a loop to reset `op_opt=0` on all operations in the chain before restoring `o->op_next`, ensuring the main `rpeep()` can process the operations correctly.
- The loop is bounded by the `op_next` chain, which was explicitly zeroed before calling `CALL_PEEP()`, providing a safe upper bound.

### **Reproduction:**
```perl
\( sort { $a <=> $b } 0, 0 .. "r" )
# Crashes with ASAN heap-buffer-overflow in Perl_POPMARK on unpatched builds.
```

### **Evidence:**
Key findings from GDB and ASan analysis:

- `S_gen_constant_list` case 3 hit count: 1 (bad) vs 0 (good)
- `case OP_SORT` in rpeep: 0 (bad) vs 1 (good)
- `PL_sortcop` in the bad case: points into the argument list instead of the comparator block

### **Testing:**
- A new regression test for **GH #19790** has been added to ensure that the bug is fixed.
- The test verifies the correct behavior of sorting operations when the range contains a non-numeric string endpoint, confirming that the crash no longer occurs.

### **References:**
- **GH #19790**
- **GH #16865**
- **GH #16033** (related issue)
- **[PR #24157](https://github.com/Perl/perl5/pull/24157)** (previous attempt to prevent the crash by adding a bounds check in `Perl_POPMARK`)
