### PR TITLE
Convert OP_CONST hash keys in key+val lists to HEKs

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5110,6 +5110,8 @@ S	|void	|bad_type_pv	|I32 n					\
 				|NN const char *t			\
 				|NN const OP *o 			\
 				|NN const OP *kid
+S	|void	|check_alt_hash_fields_hekify				\
+				|NN OP *o
 S	|CV *	|clear_special_blocks					\
 				|NN const char * const fullname 	\
 				|NN GV * const gv			\

--- a/embed.h
+++ b/embed.h
@@ -1254,7 +1254,9 @@
 #   endif
 #   if defined(PERL_IN_CLASS_C) || defined(PERL_IN_GLOBALS_C) || \
        defined(PERL_IN_OP_C)    || defined(PERL_IN_PEEP_C)
+#     define ck_aassign(a)                      Perl_ck_aassign(aTHX_ a)
 #     define ck_anoncode(a)                     Perl_ck_anoncode(aTHX_ a)
+#     define ck_anonhash(a)                     Perl_ck_anonhash(aTHX_ a)
 #     define ck_backtick(a)                     Perl_ck_backtick(aTHX_ a)
 #     define ck_bitop(a)                        Perl_ck_bitop(aTHX_ a)
 #     define ck_classname(a)                    Perl_ck_classname(aTHX_ a)
@@ -1474,6 +1476,7 @@
 #     define assignment_type(a)                 S_assignment_type(aTHX_ a)
 #     define bad_type_gv(a,b,c,d)               S_bad_type_gv(aTHX_ a,b,c,d)
 #     define bad_type_pv(a,b,c,d)               S_bad_type_pv(aTHX_ a,b,c,d)
+#     define check_alt_hash_fields_hekify(a)    S_check_alt_hash_fields_hekify(aTHX_ a)
 #     define clear_special_blocks(a,b,c)        S_clear_special_blocks(aTHX_ a,b,c)
 #     define cop_free(a)                        S_cop_free(aTHX_ a)
 #     define dup_attrlist(a)                    S_dup_attrlist(aTHX_ a)

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -2606,9 +2606,9 @@ my %h;
 (\my %d) = foo();
 \local %_ = \%h;
 (\local %_) = \%h;
-\state %y = {1,2};
-\our %z = {1,2};
-(\our %zz) = {1,2};
+\state %y = {'1',2};
+\our %z = {'1',2};
+(\our %zz) = {'1',2};
 \&a = foo();
 (\&a) = foo();
 \(&a) = foo();
@@ -2684,9 +2684,9 @@ my %h;
 (\my %d) = foo();
 \local %_ = \%h;
 (\local %_) = \%h;
-\state %y = {1, 2};
-\our %z = {1, 2};
-(\our %zz) = {1, 2};
+\state %y = {'1', 2};
+\our %z = {'1', 2};
+(\our %zz) = {'1', 2};
 \&a = foo();
 (\&a) = foo();
 (\&a) = foo();
@@ -2773,16 +2773,16 @@ foreach \our @a ([1, 2], [3, 4]) {
 foreach \@_ ([1, 2], [3, 4]) {
     die;
 }
-foreach \my %a ({5, 6}, {7, 8}) {
+foreach \my %a ({'5', 6}, {'7', 8}) {
     die;
 }
-foreach \our %a ({5, 6}, {7, 8}) {
+foreach \our %a ({'5', 6}, {'7', 8}) {
     die;
 }
-foreach \state %a ({5, 6}, {7, 8}) {
+foreach \state %a ({'5', 6}, {'7', 8}) {
     die;
 }
-foreach \%_ ({5, 6}, {7, 8}) {
+foreach \%_ ({'5', 6}, {'7', 8}) {
     die;
 }
 {

--- a/op.c
+++ b/op.c
@@ -14151,6 +14151,98 @@ Perl_ck_sassign(pTHX_ OP *o)
 }
 
 
+/* This function is very similar to Perl_check_hash_fields_and_hekify.
+ * It provides compile time checks on CONST hash key fields and
+ * converts them to HEK-in-SVs.
+ *
+ * The primary difference is that the other function operates on
+ * one (HELEM) or all (HSLICE, KVSLICE) OPs, this function is called
+ * by functions (anonhash, aassign) taking key/value pairs, and only
+ * the keys require examination so values are skipped. If we lose the
+ * ability to tell which OPs are keys and which are values, the function
+ * exits prematurely so as not to inadvertently operate on any values.
+ * (Doing so could erroneously downgrade some UTF8 CONSTs, which could
+ * introduce subtle logic changes to user code.)
+ *
+ * This function also does not check for fields or for barewords.
+ * (finalize_op() should still report any barewords present here.)
+ */
+static void
+S_check_alt_hash_fields_hekify(pTHX_ OP *o)
+{
+    OP *sib = o;
+
+    if (OP_TYPE_IS_OR_WAS(o, OP_LIST)) {
+        sib = cLISTOPo->op_first;
+        assert(OpSIBLING(sib) &&
+               OP_TYPE_IS(sib, OP_PUSHMARK));
+        sib = OpSIBLING(sib);
+    } else if(OP_TYPE_IS_OR_WAS(o, OP_PUSHMARK)) {
+        sib = OpSIBLING(sib);
+    }
+
+    /* Examine the keys, skip the vals */
+    while (sib) {
+        /* Looking at a key */
+        if (OP_TYPE_IS(sib, OP_CONST)) {
+            SV **svp = cSVOPx_svp(sib);
+            SV *sv = *svp;
+
+            /* Make the CONST have a shared SV */
+            if (!SvIsCOW_shared_hash(sv) && SvTYPE(sv) < SVt_PVMG
+                && SvOK(sv) && !SvROK(sv)
+                && !(SvNOK(sv) && IN_LC_RUNTIME(LC_NUMERIC))
+            ) {
+                STRLEN keylen;
+                const char * const key = SvPV_const(sv, keylen);
+                if (UNLIKELY(keylen > I32_MAX)) {
+                    croak("Sorry, hash keys must be smaller than 2**31 bytes");
+                }
+
+                SV *nsv = newSVpvn_share(key, SvUTF8(sv) ? -(I32)keylen : (I32)keylen, 0);
+                SvREFCNT_dec_NN(sv);
+                *svp = nsv;
+            }
+        } else if (!(PL_opargs[sib->op_type] & OA_RETSCALAR))
+            break;
+
+        /* Looking for a corresponding value OP */
+        sib = OpSIBLING(sib);
+        if (!sib) break;
+
+        /* Is this OP guaranteed to only push a single SV? */
+        if (!(PL_opargs[sib->op_type] & OA_RETSCALAR))
+            break;
+
+        sib = OpSIBLING(sib);
+    }
+    return;
+}
+
+OP *
+Perl_ck_aassign(pTHX_ OP *o)
+{
+    OP * const last = cBINOPo->op_last;
+    if (last && OP_TYPE_IS_OR_WAS(last, OP_LIST)) {
+        OP * const sib = cLISTOPx(last)->op_first;
+        if (sib && OP_TYPE_IS(sib, OP_PUSHMARK)) {
+            OP * const lval = OpSIBLING(sib);
+            if (lval && !OpSIBLING(lval) &&
+                (OP_TYPE_IS(lval, OP_PADHV) || OP_TYPE_IS(lval, OP_RV2HV))) {
+                check_alt_hash_fields_hekify(cBINOPo->op_first);
+            }
+        }
+    }
+    return o;
+}
+
+OP *
+Perl_ck_anonhash(pTHX_ OP *o)
+{
+    check_alt_hash_fields_hekify(cLISTOPo->op_first);
+    return ck_fun(o);
+}
+
 OP *
 Perl_ck_match(pTHX_ OP *o)
 {

--- a/opcode.h
+++ b/opcode.h
@@ -1490,7 +1490,7 @@ INIT({
 	Perl_ck_match,		/* trans */
 	Perl_ck_match,		/* transr */
 	Perl_ck_sassign,	/* sassign */
-	Perl_ck_null,		/* aassign */
+	Perl_ck_aassign,	/* aassign */
 	Perl_ck_spair,		/* chop */
 	Perl_ck_null,		/* schop */
 	Perl_ck_spair,		/* chomp */
@@ -1616,7 +1616,7 @@ INIT({
 	Perl_ck_null,		/* list */
 	Perl_ck_null,		/* lslice */
 	Perl_ck_fun,		/* anonlist */
-	Perl_ck_fun,		/* anonhash */
+	Perl_ck_anonhash,	/* anonhash */
 	Perl_ck_fun,		/* emptyavhv */
 	Perl_ck_fun,		/* splice */
 	Perl_ck_fun,		/* push */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -98,6 +98,11 @@ There may well be none in a stable release.
 
 =item *
 
+Populating a hash from a list of key/value pairs, when the keys are constant
+string operands known at compile time, is commonly now faster. [GH #24228]
+
+=item *
+
 XXX
 
 =back
@@ -354,6 +359,12 @@ well.
 [ List each change as an =item entry ]
 
 =over 4
+
+=item *
+
+Dedicated check functions C<Perl_ck_anonhash> and C<Perl_ck_aassign> have been
+added and are used to hekify some C<OP_CONST> hash keys at compile time.
+[GH #24228]
 
 =item *
 

--- a/proto.h
+++ b/proto.h
@@ -8211,12 +8211,30 @@ S_class_cleanup_definition(pTHX_ HV *stash)
 #if defined(PERL_IN_CLASS_C) || defined(PERL_IN_GLOBALS_C) || \
     defined(PERL_IN_OP_C)    || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV OP *
+Perl_ck_aassign(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
+        Perl_attribute_nonnull_(pTHX_1)
+        __attribute__warn_unused_result__
+        __attribute__visibility__("hidden");
+# define PERL_ARGS_ASSERT_CK_AASSIGN            \
+        assert(o)
+
+PERL_CALLCONV OP *
 Perl_ck_anoncode(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ANONCODE           \
+        assert(o)
+
+PERL_CALLCONV OP *
+Perl_ck_anonhash(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
+        Perl_attribute_nonnull_(pTHX_1)
+        __attribute__warn_unused_result__
+        __attribute__visibility__("hidden");
+# define PERL_ARGS_ASSERT_CK_ANONHASH           \
         assert(o)
 
 PERL_CALLCONV OP *
@@ -9701,6 +9719,13 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
         Perl_attribute_nonnull_(pTHX_4);
 # define PERL_ARGS_ASSERT_BAD_TYPE_PV           \
         assert(t); assert(o); assert(kid)
+
+static void
+S_check_alt_hash_fields_hekify(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX_
+        Perl_attribute_nonnull_(pTHX_1);
+# define PERL_ARGS_ASSERT_CHECK_ALT_HASH_FIELDS_HEKIFY \
+        assert(o)
 
 static CV *
 S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv)

--- a/regen/op_private
+++ b/regen/op_private
@@ -251,6 +251,7 @@ use strict;
                             ops_with_check('ck_stringify'),
                             ops_with_check('ck_tell'),
                             ops_with_check('ck_trunc'),
+                            ops_with_check('ck_anonhash'),
                             ;
 
 

--- a/regen/opcodes
+++ b/regen/opcodes
@@ -95,7 +95,7 @@ transr		transliteration (tr///)	ck_match	is"	S
 # Lvalue operators.
 
 sassign		scalar assignment	ck_sassign	s2	S S
-aassign		list assignment		ck_null		t2	L L
+aassign		list assignment		ck_aassign	t2	L L
 
 chop		chop			ck_spair	mts%	L
 schop		scalar chop		ck_null		stu%	S?
@@ -261,7 +261,7 @@ join		join or string		ck_join		fmst@	S L
 list		list			ck_null		m@	L
 lslice		list slice		ck_null		2	H L L
 anonlist	anonymous array ([])	ck_fun		ms@	L
-anonhash	anonymous hash ({})	ck_fun		ms@	L
+anonhash	anonymous hash ({})	ck_anonhash	ms@	L
 emptyavhv	empty anon hash/array	ck_fun		sT0
 
 splice		splice			ck_fun		m@	A S? S? L


### PR DESCRIPTION
Hash operations in perl are faster when operating upon a `keysv` that uses a `HEK` to represent the key. Hash entry comparisons can then be more lightweight as `HEK` pointer comparisons can be used instead of:
* Re-deriving the hash each time the key is used
* Exhaustive comparison of the hash key values and flags

Some `OP_CONST` SVs that are destined for use as hash keys are already converted (_hekified_) during compilation, such as the arguments to `OP_HELEM`, `OP_MULTIDEREF`, or `OP_HSLICE`/`OP_KVSLICE`. `Perl_check_hash_fields_and_hekify`, which operates on sequential SV pointers, does the work in those cases.

This commit _hekifies_ `OP_CONST` SV keys in key+value `SV*` lists, such as in the arguments to `OP_ANONHASH`:

    my $href = { one => 1, two => 2, three => 3, four => 4 };

and `OP_AASSIGN` (note: may not cover all possible LVALUE constructions):

    my %h = ( one => 1, two => 2, three => 3, four => 4 );

`OP_CONST` SVs in the value positions are not _hekified_, as the process involves attempted downgrade of UTF8 strings, which could result in user-visible behaviour changes (such as in the comparison of string contents).

For this reason, this optimization returns early when either key or value OPs have the potential to return more than one value - it becomes impossible to be sure at compile time whether subsequent OPs represent keys or values.

As a contrived example: in the following statement, the compiler cannot be _absolutely_ sure that 'three' will be used as as a key and `3` is its matching value.

    my $h = (one => 1, @two, three => 3, @four);

Changes in this commit are:
* Addition of the `S_check_alt_hash_fields_hekify` function
* Addition of dedicated `ck` functions for `anonhash` and `aassign`
* Updating of _Deparse.t_ tests to match.

Comparing `for (0..100_000_000) { my %h = (one => 1, two => 2, three => 3, four => 4); }`:

*Blead*
```
         20,409.44 msec task-clock                       #    1.000 CPUs utilized
               117      context-switches                 #    5.733 /sec
                 0      cpu-migrations                   #    0.000 /sec
               190      page-faults                      #    9.309 /sec
    93,850,595,514      cycles                           #    4.598 GHz
   354,784,740,965      instructions                     #    3.78  insn per cycle
    73,658,057,571      branches                         #    3.609 G/sec
        51,196,358      branch-misses                    #    0.07% of all branches
```
*Patched*
```
         15,295.49 msec task-clock                       #    1.000 CPUs utilized
                79      context-switches                 #    5.165 /sec
                 1      cpu-migrations                   #    0.065 /sec
               195      page-faults                      #   12.749 /sec
    70,493,543,069      cycles                           #    4.609 GHz
   272,426,451,548      instructions                     #    3.86  insn per cycle
    55,406,135,074      branches                         #    3.622 G/sec
       100,887,629      branch-misses                    #    0.18% of all branches
```

Comparing `for (0..100_000_000) { my $h = {one => 1, two => 2, three => 3, four => 4}; }`

*blead*
```
         21,088.71 msec task-clock                       #    1.000 CPUs utilized
               100      context-switches                 #    4.742 /sec
                 2      cpu-migrations                   #    0.095 /sec
               195      page-faults                      #    9.247 /sec
    97,377,416,887      cycles                           #    4.618 GHz
   376,434,236,222      instructions                     #    3.87  insn per cycle
    81,607,926,506      branches                         #    3.870 G/sec
         1,159,167      branch-misses                    #    0.00% of all branches
```
*patched*
```
         16,150.16 msec task-clock                       #    1.000 CPUs utilized
                79      context-switches                 #    4.892 /sec
                 0      cpu-migrations                   #    0.000 /sec
               193      page-faults                      #   11.950 /sec
    74,465,581,333      cycles                           #    4.611 GHz
   298,176,803,158      instructions                     #    4.00  insn per cycle
    63,656,208,147      branches                         #    3.942 G/sec
        50,869,763      branch-misses                    #    0.08% of all branches
```

Note: This will stack with [GH #24149], which reduced branch-misses.

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry and one is included.