### PR TITLE
intuit_more(): use correct variable name for end of buffer

### DIFF
--- a/t/re/pat_rt_report.t
+++ b/t/re/pat_rt_report.t
@@ -20,7 +20,7 @@ use warnings;
 use 5.010;
 use Config;
 
-plan tests => 2514;  # Update this when adding/deleting tests.
+plan tests => 2515;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -1168,6 +1168,14 @@ EOP
 		ok($result == 0);
 	}
 
+    {
+        # GH #24229
+        # utf8.c:72: Perl_force_out_malformed_utf8_message_: Assertion `p < e' failed.
+        use utf8;
+        my $éx = 0;
+        $_ = qr/$_[$éx]/ if 0;
+        ok(1, "GH #24229 - non-ascii variable in brackets doesn't crash S_intuit_more()");
+    }
 } # End of sub run_tests
 
 1;

--- a/toke.c
+++ b/toke.c
@@ -4846,7 +4846,7 @@ S_intuit_more(pTHX_ char *s, char *e,
                 else
                     weight -= 1;
             }
-            else if (isWORDCHAR_lazy_if_safe(tmpbuf + 1, PL_bufend, UTF)) {
+            else if (isWORDCHAR_lazy_if_safe(tmpbuf + 1, tmpbuf + 1 + len, UTF)) {
 
                 /* See if there is a known identifier of the given kind.  For
                  * arrays, this might also be a reference to one of its


### PR DESCRIPTION
Commit 3b85b09deef9 switched to checking `tmpbuf` so we also need to pass the end of `tmpbuf` as the end of the range.

Otherwise we get errors like

    utf8.c:72: Perl_force_out_malformed_utf8_message_: Assertion `p < e' failed.
    
Fixes #24229.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
