### PR TITLE
intuit_more(): fix length in calls to is_existing_identifier

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -4853,9 +4853,9 @@ S_intuit_more(pTHX_ char *s, char *e,
                  * elements.   XXX Maybe the latter should require a following
                  * '[' or '->[' */
                 const bool is_known =
-                           is_existing_identifier(tmpbuf, len, tmpbuf[0], UTF)
+                           is_existing_identifier(tmpbuf, len + 1, tmpbuf[0], UTF)
                        || (   tmpbuf[0] == '$'
-                           && is_existing_identifier(tmpbuf, len, '@', UTF));
+                           && is_existing_identifier(tmpbuf, len + 1, '@', UTF));
 
                 /* Under strict, an unknown variable means an error or a
                  * character class */


### PR DESCRIPTION
`len = length(tmpbuf) - 1`, so pass len + 1 to is_existing_identifier() to compensate for the minus 1.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
