### PR TITLE
Convert Perl_foo calls to foo() in core dot c files

### DIFF
--- a/av.c
+++ b/av.c
@@ -81,7 +81,7 @@ Perl_av_extend(pTHX_ AV *av, SSize_t key)
          * we call the tied method.
          */
         sv_setiv(arg1, (IV)(key + 1));
-        Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(EXTEND), G_DISCARD, 1,
+        magic_methcall(MUTABLE_SV(av), mg, SV_CONST(EXTEND), G_DISCARD, 1,
                             arg1);
         return;
     }
@@ -787,7 +787,7 @@ Perl_av_push(pTHX_ AV *av, SV *val)
         croak_no_modify();
 
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
-        Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(PUSH), G_DISCARD, 1,
+        magic_methcall(MUTABLE_SV(av), mg, SV_CONST(PUSH), G_DISCARD, 1,
                             val);
         return;
     }
@@ -817,7 +817,7 @@ Perl_av_pop(pTHX_ AV *av)
     if (SvREADONLY(av))
         croak_no_modify();
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
-        retval = Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(POP), 0, 0);
+        retval = magic_methcall(MUTABLE_SV(av), mg, SV_CONST(POP), 0, 0);
         if (retval)
             retval = newSVsv(retval);
         return retval;
@@ -876,7 +876,7 @@ Perl_av_unshift(pTHX_ AV *av, SSize_t num)
         croak_no_modify();
 
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
-        Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(UNSHIFT),
+        magic_methcall(MUTABLE_SV(av), mg, SV_CONST(UNSHIFT),
                             G_DISCARD | G_UNDEF_FILL, num);
         return;
     }
@@ -941,7 +941,7 @@ Perl_av_shift(pTHX_ AV *av)
     if (SvREADONLY(av))
         croak_no_modify();
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
-        retval = Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(SHIFT), 0, 0);
+        retval = magic_methcall(MUTABLE_SV(av), mg, SV_CONST(SHIFT), 0, 0);
         if (retval)
             retval = newSVsv(retval);
         return retval;
@@ -1018,7 +1018,7 @@ Perl_av_fill(pTHX_ AV *av, SSize_t fill)
     if ((mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied))) {
         SV *arg1 = sv_newmortal();
         sv_setiv(arg1, (IV)(fill + 1));
-        Perl_magic_methcall(aTHX_ MUTABLE_SV(av), mg, SV_CONST(STORESIZE), G_DISCARD,
+        magic_methcall(MUTABLE_SV(av), mg, SV_CONST(STORESIZE), G_DISCARD,
                             1, arg1);
         return;
     }

--- a/builtin.c
+++ b/builtin.c
@@ -334,7 +334,7 @@ XS(XS_builtin_export_lexically)
             default:
                 /* overwrites the pointer on the stack; but this is fine, the
                  * caller's value isn't modified */
-                ST(i) = name = sv_2mortal(Perl_newSVpvf(aTHX_ "&%" SVf, SVfARG(name)));
+                ST(i) = name = sv_2mortal(newSVpvf("&%" SVf, SVfARG(name)));
 
                 /* FALLTHROUGH */
             case '&':
@@ -695,8 +695,8 @@ static bool S_parse_version(const char *vstr, const char *vend, UV *vmajor, UV *
 #define import_sym(sym)  S_import_sym(aTHX_ sym)
 static void S_import_sym(pTHX_ SV *sym)
 {
-    SV *ampname = sv_2mortal(Perl_newSVpvf(aTHX_ "&%" SVf, SVfARG(sym)));
-    SV *fqname = sv_2mortal(Perl_newSVpvf(aTHX_ "builtin::%" SVf, SVfARG(sym)));
+    SV *ampname = sv_2mortal(newSVpvf("&%" SVf, SVfARG(sym)));
+    SV *fqname = sv_2mortal(newSVpvf("builtin::%" SVf, SVfARG(sym)));
 
     CV *cv = get_cv(SvPV_nolen(fqname), SvUTF8(fqname) ? SVf_UTF8 : 0);
     if(!cv)

--- a/class.c
+++ b/class.c
@@ -386,7 +386,7 @@ Perl_class_setup_stash(pTHX_ HV *stash)
 
     /* Inject the constructor */
     {
-        SV *newname = Perl_newSVpvf(aTHX_ "%s::new", classname);
+        SV *newname = newSVpvf("%s::new", classname);
         SAVEFREESV(newname);
 
         CV *newcv = newXS_flags(SvPV_nolen(newname), injected_constructor, __FILE__, NULL, nameflags);

--- a/cop.h
+++ b/cop.h
@@ -120,8 +120,8 @@ typedef struct jmpenv JMPENV;
             int i = 0;                                                  \
             JMPENV *p = PL_top_env;                                     \
             while (p) { i++; p = p->je_prev; }				\
-            Perl_deb(aTHX_ "JMPENV_PUSH pre level=%d in %s at %s:%d\n", \
-                         i,  SAFE_FUNCTION__, __FILE__, __LINE__);      \
+            deb("JMPENV_PUSH pre level=%d in %s at %s:%d\n",            \
+                i,  SAFE_FUNCTION__, __FILE__, __LINE__);               \
         });                                                             \
         cur_env.je_prev = PL_top_env;					\
         JE_OLD_STACK_HWM_save(cur_env);                                 \
@@ -142,8 +142,8 @@ typedef struct jmpenv JMPENV;
             int i = 0;                                                  \
             JMPENV *p = PL_top_env;                                     \
             while (p) { i++; p = p->je_prev; }				\
-            Perl_deb(aTHX_ "JMPENV_PUSH level=%d ret=%d in %s at %s:%d\n",    \
-                         i, cur_env.je_ret, SAFE_FUNCTION__,  __FILE__, __LINE__); \
+            deb("JMPENV_PUSH level=%d ret=%d in %s at %s:%d\n",         \
+                i, cur_env.je_ret, SAFE_FUNCTION__,  __FILE__, __LINE__); \
         });                                                             \
         (v) = cur_env.je_ret;						\
     } STMT_END
@@ -153,8 +153,8 @@ typedef struct jmpenv JMPENV;
         DEBUG_l({                                                       \
             int i = -1; JMPENV *p = PL_top_env;				\
             while (p) { i++; p = p->je_prev; }				\
-            Perl_deb(aTHX_ "JMPENV_POP level=%d in %s at %s:%d\n",        \
-                         i, SAFE_FUNCTION__, __FILE__, __LINE__);})        \
+            deb("JMPENV_POP level=%d in %s at %s:%d\n",                 \
+                i, SAFE_FUNCTION__, __FILE__, __LINE__);})              \
         assert(PL_top_env == &cur_env);					\
         PL_delaymagic = cur_env.je_old_delaymagic;			\
         PL_top_env = cur_env.je_prev;					\
@@ -165,8 +165,8 @@ typedef struct jmpenv JMPENV;
         DEBUG_l({                                               \
             int i = -1; JMPENV *p = PL_top_env;			\
             while (p) { i++; p = p->je_prev; }			\
-            Perl_deb(aTHX_ "JMPENV_JUMP(%d) level=%d in %s at %s:%d\n",         \
-                         (int)(v), i, SAFE_FUNCTION__, __FILE__, __LINE__);})   \
+            deb("JMPENV_JUMP(%d) level=%d in %s at %s:%d\n",    \
+                (int)(v), i, SAFE_FUNCTION__, __FILE__, __LINE__);}) \
         if (PL_top_env->je_prev) {				\
             assert((v) >= 0 && (v) <= 3);			\
             PerlProc_longjmp(PL_top_env->je_buf, (v));		\
@@ -181,8 +181,7 @@ typedef struct jmpenv JMPENV;
 #define CATCH_SET(v) \
     STMT_START {							\
         DEBUG_l(                                                        \
-            Perl_deb(aTHX_						\
-                "JUMPLEVEL set catch %d => %d (for %p) in %s at %s:%d\n",   \
+            deb("JUMPLEVEL set catch %d => %d (for %p) in %s at %s:%d\n", \
                  PL_top_env->je_mustcatch, (v), (void*)PL_top_env,      \
                  SAFE_FUNCTION__, __FILE__, __LINE__);)			\
         PL_top_env->je_mustcatch = (v);					\
@@ -1035,15 +1034,15 @@ struct block {
 
 #define CX_DEBUG(cx, action)						\
     DEBUG_l(								\
-        Perl_deb(aTHX_ "CX %ld %s %s (scope %ld,%ld) (save %ld,%ld) in %s at %s:%d\n",\
-                    (long)cxstack_ix,					\
-                    action,						\
-                    PL_block_type[CxTYPE(cx)],	                        \
-                    (long)PL_scopestack_ix,				\
-                    (long)(cx->blk_oldscopesp),		                \
-                    (long)PL_savestack_ix,				\
-                    (long)(cx->blk_oldsaveix),                          \
-                    SAFE_FUNCTION__, __FILE__, __LINE__));
+        deb("CX %ld %s %s (scope %ld,%ld) (save %ld,%ld) in %s at %s:%d\n",\
+            (long)cxstack_ix,					        \
+            action,						        \
+            PL_block_type[CxTYPE(cx)],	                                \
+            (long)PL_scopestack_ix,				        \
+            (long)(cx->blk_oldscopesp),		                        \
+            (long)PL_savestack_ix,				        \
+            (long)(cx->blk_oldsaveix),                                  \
+            SAFE_FUNCTION__, __FILE__, __LINE__));
 
 
 

--- a/deb.c
+++ b/deb.c
@@ -49,7 +49,7 @@ Perl_deb_nocontext(const char *pat, ...)
 
 When perl is compiled with C<-DDEBUGGING>, these each print to STDERR the
 information given by the arguments, prefaced by the name of the file containing
-the script causing the call, and the line number within that file.
+the Perl script causing the call, and the line number within that file.
 
 If the C<v> (verbose) debugging option is in effect, the process id is also
 printed.

--- a/doop.c
+++ b/doop.c
@@ -809,7 +809,7 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
         croak("Illegal number of bits in vec");
 
     if (SvUTF8(sv)) {
-        if (Perl_sv_utf8_downgrade_flags(aTHX_ sv, TRUE, 0)) {
+        if (sv_utf8_downgrade_flags(sv, TRUE, 0)) {
             /* PVX may have changed */
             s = (unsigned char *) SvPV_flags(sv, srclen, svpv_flags);
         }
@@ -918,10 +918,10 @@ Perl_do_vecset(pTHX_ SV *sv)
                                          SV_GMAGIC | SV_UNDEF_RETURNS_NULL);
     if (SvUTF8(targ)) {
         /* This is handled by the SvPOK_only below...
-        if (!Perl_sv_utf8_downgrade_flags(aTHX_ targ, TRUE, 0))
+        if (!sv_utf8_downgrade_flags(targ, TRUE, 0))
             SvUTF8_off(targ);
          */
-        (void) Perl_sv_utf8_downgrade_flags(aTHX_ targ, TRUE, 0);
+        (void) sv_utf8_downgrade_flags(targ, TRUE, 0);
     }
 
     (void)SvPOK_only(targ);

--- a/dump.c
+++ b/dump.c
@@ -3276,7 +3276,7 @@ Perl_runops_debug(pTHX)
         ck_warner_d(packWARN(WARN_DEBUGGING), "NULL OP IN RUN");
         return 0;
     }
-    DEBUG_l(Perl_deb(aTHX_ "Entering new RUNOPS level\n"));
+    DEBUG_l(deb("Entering new RUNOPS level\n"));
     do {
 #ifdef PERL_TRACE_OPS
         ++PL_op_exec_cnt[PL_op->op_type];
@@ -3316,7 +3316,7 @@ Perl_runops_debug(pTHX)
 
         PERL_DTRACE_PROBE_OP(PL_op);
     } while ((PL_op = PL_op->op_ppaddr(aTHX)));
-    DEBUG_l(Perl_deb(aTHX_ "leaving RUNOPS level\n"));
+    DEBUG_l(deb("leaving RUNOPS level\n"));
     PERL_ASYNC_CHECK();
 
 #ifdef PERL_USE_HWM
@@ -3627,7 +3627,7 @@ Perl_debop(pTHX_ const OP *o)
     if (CopSTASH_eq(PL_curcop, PL_debstash) && !DEBUG_J_TEST_)
         return 0;
 
-    Perl_deb(aTHX_ "%s", OP_NAME(o));
+    deb("%s", OP_NAME(o));
     switch (o->op_type) {
     case OP_CONST:
     case OP_HINTSEVAL:

--- a/dump.c
+++ b/dump.c
@@ -2360,11 +2360,11 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
 
     /* process general SV flags */
 
-    d = Perl_newSVpvf(aTHX_
-                   "(0x%" UVxf ") at 0x%" UVxf "\n%*s  REFCNT = %" IVdf "\n%*s  FLAGS = (",
-                   PTR2UV(SvANY(sv)), PTR2UV(sv),
-                   (int)(PL_dumpindent*level), "", (IV)SvREFCNT(sv),
-                   (int)(PL_dumpindent*level), "");
+    d = newSVpvf("(0x%" UVxf ") at 0x%" UVxf "\n%*s  REFCNT = %" IVdf "\n%*s"
+                 "  FLAGS = (",
+                 PTR2UV(SvANY(sv)), PTR2UV(sv),
+                 (int)(PL_dumpindent*level), "", (IV)SvREFCNT(sv),
+                 (int)(PL_dumpindent*level), "");
 
     if ((flags & SVs_PADSTALE))
             sv_catpvs(d, "PADSTALE,");

--- a/dump.c
+++ b/dump.c
@@ -900,19 +900,19 @@ Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
         STRLEN namelen;
         gv_fullname3(namesv, gv, NULL);
         namepv = SvPV_const(namesv, namelen);
-        Perl_dump_indent(aTHX_ 0, Perl_debug_log, "\nSUB %s = ",
+        dump_indent(0, Perl_debug_log, "\nSUB %s = ",
                      generic_pv_escape(escsv, namepv, namelen, SvUTF8(namesv)));
     } else {
-        Perl_dump_indent(aTHX_ 0, Perl_debug_log, "\nSUB = ");
+        dump_indent(0, Perl_debug_log, "\nSUB = ");
     }
     if (CvISXSUB(cv))
-        Perl_dump_indent(aTHX_ 0, Perl_debug_log, "(xsub 0x%" UVxf " %d)\n",
-            PTR2UV(CvXSUB(cv)),
-            (int)CvXSUBANY(cv).any_i32);
+        dump_indent(0, Perl_debug_log, "(xsub 0x%" UVxf " %d)\n",
+                    PTR2UV(CvXSUB(cv)),
+                    (int)CvXSUBANY(cv).any_i32);
     else if (CvROOT(cv))
         S_do_op_dump_bar(aTHX_ 0, 0, Perl_debug_log, CvROOT(cv), cv);
     else
-        Perl_dump_indent(aTHX_ 0, Perl_debug_log, "<undef>\n");
+        dump_indent(0, Perl_debug_log, "<undef>\n");
 }
 
 /*
@@ -932,11 +932,11 @@ Perl_dump_form(pTHX_ const GV *gv)
     SV * const sv = sv_newmortal();
 
     gv_fullname3(sv, gv, NULL);
-    Perl_dump_indent(aTHX_ 0, Perl_debug_log, "\nFORMAT %s = ", SvPVX_const(sv));
+    dump_indent(0, Perl_debug_log, "\nFORMAT %s = ", SvPVX_const(sv));
     if (CvROOT(GvFORM(gv)))
         op_dump(CvROOT(GvFORM(gv)));
     else
-        Perl_dump_indent(aTHX_ 0, Perl_debug_log, "<undef>\n");
+        dump_indent(0, Perl_debug_log, "<undef>\n");
 }
 
 void
@@ -1961,16 +1961,16 @@ Perl_gv_dump(pTHX_ GV *gv)
     PerlIO_printf(Perl_debug_log, "{\n");
     gv_fullname3(sv, gv, NULL);
     name = SvPV_const(sv, len);
-    Perl_dump_indent(aTHX_ 1, Perl_debug_log, "GV_NAME = %s",
+    dump_indent(1, Perl_debug_log, "GV_NAME = %s",
                      generic_pv_escape( tmp, name, len, SvUTF8(sv) ));
     if (gv != GvEGV(gv)) {
         gv_efullname3(sv, GvEGV(gv), NULL);
         name = SvPV_const(sv, len);
-        Perl_dump_indent(aTHX_ 1, Perl_debug_log, "-> %s",
+        dump_indent(1, Perl_debug_log, "-> %s",
                      generic_pv_escape( tmp, name, len, SvUTF8(sv) ));
     }
     (void)PerlIO_putc(Perl_debug_log, '\n');
-    Perl_dump_indent(aTHX_ 0, Perl_debug_log, "}\n");
+    dump_indent(0, Perl_debug_log, "}\n");
 }
 
 
@@ -1990,24 +1990,24 @@ Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32
     PERL_ARGS_ASSERT_DO_MAGIC_DUMP;
 
     for (; mg; mg = mg->mg_moremagic) {
-        Perl_dump_indent(aTHX_ level, file,
-                         "  MAGIC = 0x%" UVxf "\n", PTR2UV(mg));
+        dump_indent(level, file, "  MAGIC = 0x%" UVxf "\n", PTR2UV(mg));
         if (mg->mg_virtual) {
             const MGVTBL * const v = mg->mg_virtual;
             if (v >= PL_magic_vtables
                 && v < PL_magic_vtables + magic_vtable_max) {
                 const U32 i = v - PL_magic_vtables;
-                Perl_dump_indent(aTHX_ level, file, "    MG_VIRTUAL = &PL_vtbl_%s\n", PL_magic_vtable_names[i]);
+                dump_indent(level, file, "    MG_VIRTUAL = &PL_vtbl_%s\n",
+                            PL_magic_vtable_names[i]);
             }
             else
-                Perl_dump_indent(aTHX_ level, file, "    MG_VIRTUAL = 0x%"
-                                       UVxf "\n", PTR2UV(v));
+                dump_indent(level, file, "    MG_VIRTUAL = 0x%"
+                            UVxf "\n", PTR2UV(v));
         }
         else
-            Perl_dump_indent(aTHX_ level, file, "    MG_VIRTUAL = 0\n");
+            dump_indent(level, file, "    MG_VIRTUAL = 0\n");
 
         if (mg->mg_private)
-            Perl_dump_indent(aTHX_ level, file, "    MG_PRIVATE = %d\n", mg->mg_private);
+            dump_indent(level, file, "    MG_PRIVATE = %d\n", mg->mg_private);
 
         {
             int n;
@@ -2019,38 +2019,38 @@ Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32
                 }
             }
             if (name)
-                Perl_dump_indent(aTHX_ level, file,
+                dump_indent(level, file,
                                 "    MG_TYPE = PERL_MAGIC_%s\n", name);
             else
-                Perl_dump_indent(aTHX_ level, file,
+                dump_indent(level, file,
                                 "    MG_TYPE = UNKNOWN(\\%o)\n", mg->mg_type);
         }
 
         if (mg->mg_flags) {
-            Perl_dump_indent(aTHX_ level, file, "    MG_FLAGS = 0x%02X\n", mg->mg_flags);
+            dump_indent(level, file, "    MG_FLAGS = 0x%02X\n", mg->mg_flags);
             if (mg->mg_type == PERL_MAGIC_envelem &&
                 mg->mg_flags & MGf_TAINTEDDIR)
-                Perl_dump_indent(aTHX_ level, file, "      TAINTEDDIR\n");
+                dump_indent(level, file, "      TAINTEDDIR\n");
             if (mg->mg_type == PERL_MAGIC_regex_global &&
                 mg->mg_flags & MGf_MINMATCH)
-                Perl_dump_indent(aTHX_ level, file, "      MINMATCH\n");
+                dump_indent(level, file, "      MINMATCH\n");
             if (mg->mg_flags & MGf_REFCOUNTED)
-                Perl_dump_indent(aTHX_ level, file, "      REFCOUNTED\n");
+                dump_indent(level, file, "      REFCOUNTED\n");
             if (mg->mg_flags & MGf_GSKIP)
-                Perl_dump_indent(aTHX_ level, file, "      GSKIP\n");
+                dump_indent(level, file, "      GSKIP\n");
             if (mg->mg_flags & MGf_COPY)
-                Perl_dump_indent(aTHX_ level, file, "      COPY\n");
+                dump_indent(level, file, "      COPY\n");
             if (mg->mg_flags & MGf_DUP)
-                Perl_dump_indent(aTHX_ level, file, "      DUP\n");
+                dump_indent(level, file, "      DUP\n");
             if (mg->mg_flags & MGf_LOCAL)
-                Perl_dump_indent(aTHX_ level, file, "      LOCAL\n");
+                dump_indent(level, file, "      LOCAL\n");
             if (mg->mg_type == PERL_MAGIC_regex_global &&
                 mg->mg_flags & MGf_BYTES)
-                Perl_dump_indent(aTHX_ level, file, "      BYTES\n");
+                dump_indent(level, file, "      BYTES\n");
         }
         if (mg->mg_obj) {
-            Perl_dump_indent(aTHX_ level, file, "    MG_OBJ = 0x%" UVxf "\n",
-                PTR2UV(mg->mg_obj));
+            dump_indent(level, file, "    MG_OBJ = 0x%" UVxf "\n",
+                        PTR2UV(mg->mg_obj));
             if (mg->mg_type == PERL_MAGIC_qr) {
                 REGEXP* const re = (REGEXP *)mg->mg_obj;
                 SV * const dsv = sv_newmortal();
@@ -2060,17 +2060,18 @@ Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32
                     ( PERL_PV_PRETTY_QUOTE | PERL_PV_ESCAPE_RE | PERL_PV_PRETTY_ELLIPSES |
                     (RX_UTF8(re) ? PERL_PV_ESCAPE_UNI : 0))
                 );
-                Perl_dump_indent(aTHX_ level+1, file, "    PAT = %s\n", s);
-                Perl_dump_indent(aTHX_ level+1, file, "    REFCNT = %" IVdf "\n",
+                dump_indent(level+1, file, "    PAT = %s\n", s);
+                dump_indent(level+1, file, "    REFCNT = %" IVdf "\n",
                         (IV)RX_REFCNT(re));
             }
             if (mg->mg_flags & MGf_REFCOUNTED)
                 do_sv_dump(level+2, file, mg->mg_obj, nest+1, maxnest, dumpops, pvlim); /* MG is already +1 */
         }
         if (mg->mg_len)
-            Perl_dump_indent(aTHX_ level, file, "    MG_LEN = %ld\n", (long)mg->mg_len);
+            dump_indent(level, file, "    MG_LEN = %ld\n", (long)mg->mg_len);
         if (mg->mg_ptr) {
-            Perl_dump_indent(aTHX_ level, file, "    MG_PTR = 0x%" UVxf, PTR2UV(mg->mg_ptr));
+            dump_indent(level, file, "    MG_PTR = 0x%" UVxf,
+                        PTR2UV(mg->mg_ptr));
             if (mg->mg_len >= 0) {
                 if (mg->mg_type != PERL_MAGIC_utf8) {
                     SV * const sv = newSVpvs("");
@@ -2098,11 +2099,11 @@ Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32
             if (cache) {
                 IV i;
                 for (i = 0; i < PERL_MAGIC_UTF8_CACHESIZE; i++)
-                    Perl_dump_indent(aTHX_ level, file,
-                                     "      %2" IVdf ": %" UVuf " -> %" UVuf "\n",
-                                     i,
-                                     (UV)cache[i * 2],
-                                     (UV)cache[i * 2 + 1]);
+                    dump_indent(level, file,
+                                "      %2" IVdf ": %" UVuf " -> %" UVuf "\n",
+                                i,
+                                (UV)cache[i * 2],
+                                (UV)cache[i * 2 + 1]);
             }
         }
     }
@@ -2131,7 +2132,7 @@ Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
 
     const char *hvname;
 
-    Perl_dump_indent(aTHX_ level, file, "%s = 0x%" UVxf, name, PTR2UV(sv));
+    dump_indent(level, file, "%s = 0x%" UVxf, name, PTR2UV(sv));
     if (sv && (hvname = HvNAME_get(sv)))
     {
         /* we have to use pv_display and HvNAMELEN_get() so that we display the real package
@@ -2152,7 +2153,7 @@ Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
 {
     PERL_ARGS_ASSERT_DO_GV_DUMP;
 
-    Perl_dump_indent(aTHX_ level, file, "%s = 0x%" UVxf, name, PTR2UV(sv));
+    dump_indent(level, file, "%s = 0x%" UVxf, name, PTR2UV(sv));
     if (sv) {
         SV * const tmpsv = newSVpvs("");
         PerlIO_printf(file, "\t\"%s\"\n",
@@ -2167,7 +2168,7 @@ Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
 {
     PERL_ARGS_ASSERT_DO_GVGV_DUMP;
 
-    Perl_dump_indent(aTHX_ level, file, "%s = 0x%" UVxf, name, PTR2UV(sv));
+    dump_indent(level, file, "%s = 0x%" UVxf, name, PTR2UV(sv));
     if (sv) {
        SV *tmp = newSVpvs_flags("", SVs_TEMP);
         const char *hvname;
@@ -2350,7 +2351,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
     U32 type;
 
     if (!sv) {
-        Perl_dump_indent(aTHX_ level, file, "SV = 0\n");
+        dump_indent(level, file, "SV = 0\n");
         return;
     }
 
@@ -2432,7 +2433,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
     /* dump initial SV details */
 
 #ifdef DEBUG_LEAKING_SCALARS
-    Perl_dump_indent(aTHX_ level, file,
+    dump_indent(level, file,
         "ALLOCATED at %s:%d %s %s (parent 0x%" UVxf "); serial %" UVuf "\n",
         sv->sv_debug_file ? sv->sv_debug_file : "(unknown)",
         sv->sv_debug_line,
@@ -2442,7 +2443,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
         sv->sv_debug_serial
     );
 #endif
-    Perl_dump_indent(aTHX_ level, file, "SV = ");
+    dump_indent(level, file, "SV = ");
 
     /* Dump SV type */
 
@@ -2466,9 +2467,9 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
         || (type == SVt_IV && !SvROK(sv))) {
         if (SvIsUV(sv)
                                      )
-            Perl_dump_indent(aTHX_ level, file, "  UV = %" UVuf, (UV)SvUVX(sv));
+            dump_indent(level, file, "  UV = %" UVuf, (UV)SvUVX(sv));
         else
-            Perl_dump_indent(aTHX_ level, file, "  IV = %" IVdf, (IV)SvIVX(sv));
+            dump_indent(level, file, "  IV = %" IVdf, (IV)SvIVX(sv));
         (void)PerlIO_putc(file, '\n');
     }
 
@@ -2477,13 +2478,13 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                || type == SVt_NV) {
         DECLARATION_FOR_LC_NUMERIC_MANIPULATION;
         STORE_LC_NUMERIC_SET_STANDARD();
-        Perl_dump_indent(aTHX_ level, file, "  NV = %.*" NVgf "\n", NV_DECIMAL_DIG, SvNVX(sv));
+        dump_indent(level, file, "  NV = %.*" NVgf "\n",
+                    NV_DECIMAL_DIG, SvNVX(sv));
         RESTORE_LC_NUMERIC();
     }
 
     if (SvROK(sv)) {
-        Perl_dump_indent(aTHX_ level, file, "  RV = 0x%" UVxf "\n",
-                               PTR2UV(SvRV(sv)));
+        dump_indent(level, file, "  RV = 0x%" UVxf "\n", PTR2UV(SvRV(sv)));
         if (nest < maxnest)
             do_sv_dump(level+1, file, SvRV(sv), nest+1, maxnest, dumpops, pvlim);
     }
@@ -2502,13 +2503,11 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             STRLEN delta;
             if (SvOOK(sv)) {
                 SvOOK_offset(sv, delta);
-                Perl_dump_indent(aTHX_ level, file,"  OFFSET = %" UVuf "\n",
-                                 (UV) delta);
+                dump_indent(level, file,"  OFFSET = %" UVuf "\n", (UV) delta);
             } else {
                 delta = 0;
             }
-            Perl_dump_indent(aTHX_ level, file,"  PV = 0x%" UVxf " ",
-                                   PTR2UV(ptr));
+            dump_indent(level, file,"  PV = 0x%" UVxf " ", PTR2UV(ptr));
             if (SvOOK(sv)) {
                 PerlIO_printf(file, "( %s . ) ",
                               pv_display_for_dump(d, ptr - delta, delta, 0,
@@ -2531,23 +2530,23 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                     PerlIO_printf(file, " [BOOL %s]", ptr == PL_Yes ? "PL_Yes" : "PL_No");
                 PerlIO_printf(file, "\n");
             }
-            Perl_dump_indent(aTHX_ level, file, "  CUR = %" IVdf "\n", (IV)SvCUR(sv));
+            dump_indent(level, file, "  CUR = %" IVdf "\n", (IV)SvCUR(sv));
             if (re && type == SVt_PVLV)
                 /* LV-as-REGEXP usurps len field to store pointer to
                  * regexp struct */
-                Perl_dump_indent(aTHX_ level, file, "  REGEXP = 0x%" UVxf "\n",
-                   PTR2UV(((XPV*)SvANY(sv))->xpv_len_u.xpvlenu_rx));
+                dump_indent(level, file, "  REGEXP = 0x%" UVxf "\n",
+                            PTR2UV(((XPV*)SvANY(sv))->xpv_len_u.xpvlenu_rx));
             else
-                Perl_dump_indent(aTHX_ level, file, "  LEN = %" IVdf "\n",
+                dump_indent(level, file, "  LEN = %" IVdf "\n",
                                        (IV)SvLEN(sv));
 #ifdef PERL_COPY_ON_WRITE
             if (SvIsCOW(sv) && SvLEN(sv))
-                Perl_dump_indent(aTHX_ level, file, "  COW_REFCNT = %d\n",
-                                       CowREFCNT(sv));
+                dump_indent(level, file, "  COW_REFCNT = %d\n",
+                                         CowREFCNT(sv));
 #endif
         }
         else
-            Perl_dump_indent(aTHX_ level, file, "  PV = 0\n");
+            dump_indent(level, file, "  PV = 0\n");
     }
 
     if (type >= SVt_PVMG) {
@@ -2557,8 +2556,8 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             do_hv_dump(level, file, "  STASH", SvSTASH(sv));
 
         if ((type == SVt_PVMG || type == SVt_PVLV) && SvVALID(sv)) {
-            Perl_dump_indent(aTHX_ level, file, "  USEFUL = %" IVdf "\n",
-                                   (IV)BmUSEFUL(sv));
+            dump_indent(level, file, "  USEFUL = %" IVdf "\n",
+                                     (IV)BmUSEFUL(sv));
         }
     }
 
@@ -2566,25 +2565,22 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
 
     switch (type) {
     case SVt_PVAV:
-        Perl_dump_indent(aTHX_ level, file, "  ARRAY = 0x%" UVxf,
-                               PTR2UV(AvARRAY(sv)));
+        dump_indent(level, file, "  ARRAY = 0x%" UVxf, PTR2UV(AvARRAY(sv)));
         if (AvARRAY(sv) != AvALLOC(sv)) {
             PerlIO_printf(file, " (offset=%" IVdf ")\n",
                                 (IV)(AvARRAY(sv) - AvALLOC(sv)));
-            Perl_dump_indent(aTHX_ level, file, "  ALLOC = 0x%" UVxf "\n",
-                                   PTR2UV(AvALLOC(sv)));
+            dump_indent(level, file, "  ALLOC = 0x%" UVxf "\n",
+                                     PTR2UV(AvALLOC(sv)));
         }
         else
             (void)PerlIO_putc(file, '\n');
-        Perl_dump_indent(aTHX_ level, file, "  FILL = %" IVdf "\n",
-                               (IV)AvFILLp(sv));
-        Perl_dump_indent(aTHX_ level, file, "  MAX = %" IVdf "\n",
-                               (IV)AvMAX(sv));
+        dump_indent(level, file, "  FILL = %" IVdf "\n", (IV)AvFILLp(sv));
+        dump_indent(level, file, "  MAX = %" IVdf "\n", (IV)AvMAX(sv));
         SvPVCLEAR(d);
         if (AvREAL(sv))	sv_catpvs(d, ",REAL");
         if (AvREIFY(sv))	sv_catpvs(d, ",REIFY");
-        Perl_dump_indent(aTHX_ level, file, "  FLAGS = (%s)\n",
-                         SvCUR(d) ? SvPVX_const(d) + 1 : "");
+        dump_indent(level, file, "  FLAGS = (%s)\n",
+                                 SvCUR(d) ? SvPVX_const(d) + 1 : "");
         if (nest < maxnest && AvARRAY(MUTABLE_AV(sv))) {
             SSize_t count;
             SV **svp = AvARRAY(MUTABLE_AV(sv));
@@ -2593,8 +2589,8 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                  count++, svp++)
             {
                 SV* const elt = *svp;
-                Perl_dump_indent(aTHX_ level + 1, file, "Elt No. %" IVdf "\n",
-                                       (IV)count);
+                dump_indent(level + 1, file, "Elt No. %" IVdf "\n",
+                                             (IV)count);
                 do_sv_dump(level+1, file, elt, nest+1, maxnest, dumpops, pvlim);
             }
         }
@@ -2603,10 +2599,10 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
         U32 totalkeys;
         if (HvHasAUX(sv)) {
             struct xpvhv_aux *const aux = HvAUX(sv);
-            Perl_dump_indent(aTHX_ level, file, "  AUX_FLAGS = %" UVuf "\n",
-                             (UV)aux->xhv_aux_flags);
+            dump_indent(level, file, "  AUX_FLAGS = %" UVuf "\n",
+                                     (UV)aux->xhv_aux_flags);
         }
-        Perl_dump_indent(aTHX_ level, file, "  ARRAY = 0x%" UVxf, PTR2UV(HvARRAY(sv)));
+        dump_indent(level, file, "  ARRAY = 0x%" UVxf, PTR2UV(HvARRAY(sv)));
         totalkeys = HvTOTALKEYS(MUTABLE_HV(sv));
         if (totalkeys) {
             /* Show distribution of HEs in the ARRAY */
@@ -2660,12 +2656,11 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             theoret = totalkeys;
             theoret += theoret * (theoret-1)/pow2;
             (void)PerlIO_putc(file, '\n');
-            Perl_dump_indent(aTHX_ level, file, "  hash quality = %.1"
-                                   NVff "%%", theoret/sum*100);
+            dump_indent(level, file, "  hash quality = %.1"
+                                     NVff "%%", theoret/sum*100);
         }
         (void)PerlIO_putc(file, '\n');
-        Perl_dump_indent(aTHX_ level, file, "  KEYS = %" IVdf "\n",
-                               (IV)totalkeys);
+        dump_indent(level, file, "  KEYS = %" IVdf "\n", (IV)totalkeys);
         {
             STRLEN count = 0;
             HE **ents = HvARRAY(sv);
@@ -2680,19 +2675,18 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                 } while (++ents <= last);
             }
 
-            Perl_dump_indent(aTHX_ level, file, "  FILL = %" UVuf "\n",
-                             (UV)count);
+            dump_indent(level, file, "  FILL = %" UVuf "\n", (UV)count);
         }
-        Perl_dump_indent(aTHX_ level, file, "  MAX = %" IVdf "\n",
+        dump_indent(level, file, "  MAX = %" IVdf "\n",
                                (IV)HvMAX(sv));
         if (HvHasAUX(sv)) {
-            Perl_dump_indent(aTHX_ level, file, "  RITER = %" IVdf "\n",
-                                   (IV)HvRITER_get(sv));
-            Perl_dump_indent(aTHX_ level, file, "  EITER = 0x%" UVxf "\n",
-                                   PTR2UV(HvEITER_get(sv)));
+            dump_indent(level, file, "  RITER = %" IVdf "\n",
+                                     (IV)HvRITER_get(sv));
+            dump_indent(level, file, "  EITER = 0x%" UVxf "\n",
+                                     PTR2UV(HvEITER_get(sv)));
 #ifdef PERL_HASH_RANDOMIZE_KEYS
-            Perl_dump_indent(aTHX_ level, file, "  RAND = 0x%" UVxf,
-                                   (UV)HvRAND_get(sv));
+            dump_indent(level, file, "  RAND = 0x%" UVxf,
+                                     (UV)HvRAND_get(sv));
             if (HvRAND_get(sv) != HvLASTRAND_get(sv) && HvRITER_get(sv) != -1 ) {
                 PerlIO_printf(file, " (LAST = 0x%" UVxf ")",
                                     (UV)HvLASTRAND_get(sv));
@@ -2704,9 +2698,9 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             const char * const hvname = HvNAME_get(sv);
             if (hvname) {
                 SV* tmpsv = newSVpvs_flags("", SVs_TEMP);
-                Perl_dump_indent(aTHX_ level, file, "  NAME = \"%s\"\n",
-                                       generic_pv_escape( tmpsv, hvname,
-                                           HvNAMELEN(sv), HvNAMEUTF8(sv)));
+                dump_indent(level, file, "  NAME = \"%s\"\n",
+                                         generic_pv_escape( tmpsv, hvname,
+                                         HvNAMELEN(sv), HvNAMEUTF8(sv)));
         }
         }
         if (HvHasAUX(sv)) {
@@ -2714,10 +2708,8 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                 = *Perl_hv_backreferences_p(aTHX_ MUTABLE_HV(sv));
             struct mro_meta * const meta = HvAUX(sv)->xhv_mro_meta;
             if (HvAUX(sv)->xhv_name_count)
-                Perl_dump_indent(aTHX_
-                 level, file, "  NAMECOUNT = %" IVdf "\n",
-                 (IV)HvAUX(sv)->xhv_name_count
-                );
+                dump_indent(level, file, "  NAMECOUNT = %" IVdf "\n",
+                                         (IV)HvAUX(sv)->xhv_name_count);
             if (HvAUX(sv)->xhv_name_u.xhvnameu_name && HvENAME_HEK_NN(sv)) {
                 const I32 count = HvAUX(sv)->xhv_name_count;
                 if (count) {
@@ -2739,62 +2731,61 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                         }
                         ++hekp;
                     }
-                    Perl_dump_indent(aTHX_
-                     level, file, "  ENAME = %s\n", SvPV_nolen(names)+2
+                    dump_indent( level, file, "  ENAME = %s\n",
+                                              SvPV_nolen(names)+2
                     );
                 }
                 else {
                     SV * const tmp = newSVpvs_flags("", SVs_TEMP);
                     const char *const hvename = HvENAME_get(sv);
-                    Perl_dump_indent(aTHX_
-                     level, file, "  ENAME = \"%s\"\n",
-                     generic_pv_escape(tmp, hvename,
-                                       HvENAMELEN_get(sv), HvENAMEUTF8(sv)));
+                    dump_indent(level, file, "  ENAME = \"%s\"\n",
+                                        generic_pv_escape(tmp, hvename,
+                                        HvENAMELEN_get(sv), HvENAMEUTF8(sv)));
                 }
             }
             if (backrefs) {
-                Perl_dump_indent(aTHX_ level, file, "  BACKREFS = 0x%" UVxf "\n",
-                                 PTR2UV(backrefs));
+                dump_indent(level, file, "  BACKREFS = 0x%" UVxf "\n",
+                                         PTR2UV(backrefs));
                 do_sv_dump(level+1, file, MUTABLE_SV(backrefs), nest+1, maxnest,
                            dumpops, pvlim);
             }
             if (meta) {
                 SV* tmpsv = newSVpvs_flags("", SVs_TEMP);
-                Perl_dump_indent(aTHX_ level, file, "  MRO_WHICH = \"%s\" (0x%"
-                                 UVxf ")\n",
-                                 generic_pv_escape( tmpsv, meta->mro_which->name,
-                                meta->mro_which->length,
-                                (meta->mro_which->kflags & HVhek_UTF8)),
+                dump_indent(level, file, "  MRO_WHICH = \"%s\" (0x%"
+                              UVxf ")\n",
+                              generic_pv_escape( tmpsv, meta->mro_which->name,
+                              meta->mro_which->length,
+                              (meta->mro_which->kflags & HVhek_UTF8)),
                                  PTR2UV(meta->mro_which));
-                Perl_dump_indent(aTHX_ level, file, "  CACHE_GEN = 0x%"
-                                 UVxf "\n",
-                                 (UV)meta->cache_gen);
-                Perl_dump_indent(aTHX_ level, file, "  PKG_GEN = 0x%" UVxf "\n",
-                                 (UV)meta->pkg_gen);
+                dump_indent(level, file, "  CACHE_GEN = 0x%"
+                                         UVxf "\n",
+                                         (UV)meta->cache_gen);
+                dump_indent(level, file, "  PKG_GEN = 0x%" UVxf "\n",
+                                         (UV)meta->pkg_gen);
                 if (meta->mro_linear_all) {
-                    Perl_dump_indent(aTHX_ level, file, "  MRO_LINEAR_ALL = 0x%"
-                                 UVxf "\n",
-                                 PTR2UV(meta->mro_linear_all));
+                    dump_indent(level, file, "  MRO_LINEAR_ALL = 0x%"
+                                             UVxf "\n",
+                                             PTR2UV(meta->mro_linear_all));
                 do_sv_dump(level+1, file, MUTABLE_SV(meta->mro_linear_all), nest+1, maxnest,
                            dumpops, pvlim);
                 }
                 if (meta->mro_linear_current) {
-                    Perl_dump_indent(aTHX_ level, file,
-                                 "  MRO_LINEAR_CURRENT = 0x%" UVxf "\n",
-                                 PTR2UV(meta->mro_linear_current));
+                    dump_indent(level, file,
+                                "  MRO_LINEAR_CURRENT = 0x%" UVxf "\n",
+                                PTR2UV(meta->mro_linear_current));
                 do_sv_dump(level+1, file, MUTABLE_SV(meta->mro_linear_current), nest+1, maxnest,
                            dumpops, pvlim);
                 }
                 if (meta->mro_nextmethod) {
-                    Perl_dump_indent(aTHX_ level, file,
-                                 "  MRO_NEXTMETHOD = 0x%" UVxf "\n",
-                                 PTR2UV(meta->mro_nextmethod));
+                    dump_indent(level, file,
+                                "  MRO_NEXTMETHOD = 0x%" UVxf "\n",
+                                PTR2UV(meta->mro_nextmethod));
                 do_sv_dump(level+1, file, MUTABLE_SV(meta->mro_nextmethod), nest+1, maxnest,
                            dumpops, pvlim);
                 }
                 if (meta->isa) {
-                    Perl_dump_indent(aTHX_ level, file, "  ISA = 0x%" UVxf "\n",
-                                 PTR2UV(meta->isa));
+                    dump_indent(level, file, "  ISA = 0x%" UVxf "\n",
+                                             PTR2UV(meta->isa));
                 do_sv_dump(level+1, file, MUTABLE_SV(meta->isa), nest+1, maxnest,
                            dumpops, pvlim);
                 }
@@ -2822,7 +2813,8 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                         keypv = SvPV_const(keysv, len);
                         elt = HeVAL(he);
 
-                        Perl_dump_indent(aTHX_ level+1, file, "Elt %s ", pv_display_for_dump(d, keypv, len, 0, pvlim));
+                        dump_indent(level+1, file, "Elt %s ",
+                                pv_display_for_dump(d, keypv, len, 0, pvlim));
                         if (SvUTF8(keysv))
                             PerlIO_printf(file, "[UTF8 \"%s\"] ", sv_uni_display(d, keysv, 6 * SvCUR(keysv), UNI_DISPLAY_QQ));
                         if (HvEITER_get(hv) == he)
@@ -2849,15 +2841,15 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             SV* tmpsv = newSVpvs_flags("", SVs_TEMP);
             STRLEN len;
             const char *const name =  SvPV_const(sv, len);
-            Perl_dump_indent(aTHX_ level, file, "  AUTOLOAD = \"%s\"\n",
+            dump_indent(level, file, "  AUTOLOAD = \"%s\"\n",
                              generic_pv_escape(tmpsv, name, len, SvUTF8(sv)));
         }
         if (SvPOK(sv)) {
             SV* tmpsv = newSVpvs_flags("", SVs_TEMP);
             const char *const proto = CvPROTO(sv);
-            Perl_dump_indent(aTHX_ level, file, "  PROTOTYPE = \"%s\"\n",
-                             generic_pv_escape(tmpsv, proto, CvPROTOLEN(sv),
-                                SvUTF8(sv)));
+            dump_indent(level, file, "  PROTOTYPE = \"%s\"\n",
+                               generic_pv_escape(tmpsv, proto, CvPROTOLEN(sv),
+                               SvUTF8(sv)));
         }
         /* FALLTHROUGH */
     case SVt_PVFM:
@@ -2865,57 +2857,57 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
         if (!CvISXSUB(sv)) {
             if (CvSTART(sv)) {
                 if (CvSLABBED(sv))
-                    Perl_dump_indent(aTHX_ level, file,
-                                 "  SLAB = 0x%" UVxf "\n",
-                                 PTR2UV(CvSTART(sv)));
+                    dump_indent(level, file, "  SLAB = 0x%" UVxf "\n",
+                                             PTR2UV(CvSTART(sv)));
                 else
-                    Perl_dump_indent(aTHX_ level, file,
-                                 "  START = 0x%" UVxf " ===> %" UVuf "\n",
-                                 PTR2UV(CvSTART(sv)),
-                                 sequence_num(CvSTART(sv)));
+                    dump_indent(level, file,
+                                "  START = 0x%" UVxf " ===> %" UVuf "\n",
+                                PTR2UV(CvSTART(sv)),
+                                sequence_num(CvSTART(sv)));
             }
-            Perl_dump_indent(aTHX_ level, file, "  ROOT = 0x%" UVxf "\n",
-                             PTR2UV(CvROOT(sv)));
+            dump_indent(level, file, "  ROOT = 0x%" UVxf "\n",
+                                     PTR2UV(CvROOT(sv)));
             if (CvROOT(sv) && dumpops) {
                 do_op_dump(level+1, file, CvROOT(sv));
             }
         } else {
             SV * const constant = cv_const_sv((const CV *)sv);
 
-            Perl_dump_indent(aTHX_ level, file, "  XSUB = 0x%" UVxf "\n", PTR2UV(CvXSUB(sv)));
+            dump_indent(level, file, "  XSUB = 0x%" UVxf "\n",
+                                     PTR2UV(CvXSUB(sv)));
 
             if (constant) {
-                Perl_dump_indent(aTHX_ level, file, "  XSUBANY = 0x%" UVxf
-                                 " (CONST SV)\n",
-                                 PTR2UV(CvXSUBANY(sv).any_ptr));
+                dump_indent(level, file, "  XSUBANY = 0x%" UVxf
+                                         " (CONST SV)\n",
+                                         PTR2UV(CvXSUBANY(sv).any_ptr));
                 do_sv_dump(level+1, file, constant, nest+1, maxnest, dumpops,
                            pvlim);
             } else {
-                Perl_dump_indent(aTHX_ level, file, "  XSUBANY = %" IVdf "\n",
-                                 (IV)CvXSUBANY(sv).any_i32);
+                dump_indent(level, file, "  XSUBANY = %" IVdf "\n",
+                                         (IV)CvXSUBANY(sv).any_i32);
             }
         }
         if (CvNAMED(sv))
-            Perl_dump_indent(aTHX_ level, file, "  NAME = \"%s\"\n",
-                                   HEK_KEY(CvNAME_HEK((CV *)sv)));
+            dump_indent(level, file, "  NAME = \"%s\"\n",
+                                        HEK_KEY(CvNAME_HEK((CV *)sv)));
         else do_gvgv_dump(level, file, "  GVGV::GV", CvGV(sv));
-        Perl_dump_indent(aTHX_ level, file, "  FILE = \"%s\"\n", CvFILE(sv));
-        Perl_dump_indent(aTHX_ level, file, "  DEPTH = %"
-                                      IVdf "\n", (IV)CvDEPTH(sv));
-        Perl_dump_indent(aTHX_ level, file, "  FLAGS = 0x%" UVxf "\n",
-                               (UV)CvFLAGS(sv));
-        Perl_dump_indent(aTHX_ level, file, "  OUTSIDE_SEQ = %" UVuf "\n", (UV)CvOUTSIDE_SEQ(sv));
+        dump_indent(level, file, "  FILE = \"%s\"\n", CvFILE(sv));
+        dump_indent(level, file, "  DEPTH = %" IVdf "\n", (IV)CvDEPTH(sv));
+        dump_indent(level, file, "  FLAGS = 0x%" UVxf "\n", (UV)CvFLAGS(sv));
+        dump_indent(level, file, "  OUTSIDE_SEQ = %" UVuf "\n",
+                                 (UV)CvOUTSIDE_SEQ(sv));
         if (!CvISXSUB(sv)) {
-            Perl_dump_indent(aTHX_ level, file, "  PADLIST = 0x%" UVxf "\n", PTR2UV(CvPADLIST(sv)));
+            dump_indent(level, file, "  PADLIST = 0x%" UVxf "\n",
+                                     PTR2UV(CvPADLIST(sv)));
             if (nest < maxnest) {
                 do_dump_pad(level+1, file, CvPADLIST(sv), 0);
             }
         }
         else
-            Perl_dump_indent(aTHX_ level, file, "  HSCXT = 0x%p\n", CvHSCXT(sv));
+            dump_indent(level, file, "  HSCXT = 0x%p\n", CvHSCXT(sv));
         {
             const CV * const outside = CvOUTSIDE(sv);
-            Perl_dump_indent(aTHX_ level, file, "  OUTSIDE = 0x%" UVxf " (%s)\n",
+            dump_indent(level, file, "  OUTSIDE = 0x%" UVxf " (%s)\n",
                         PTR2UV(outside),
                         (!outside ? "null"
                          : CvANON(outside) ? "ANON"
@@ -2937,11 +2929,15 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
     case SVt_PVGV:
     case SVt_PVLV:
         if (type == SVt_PVLV) {
-            Perl_dump_indent(aTHX_ level, file, "  TYPE = %c\n", LvTYPE(sv));
-            Perl_dump_indent(aTHX_ level, file, "  TARGOFF = %" IVdf "\n", (IV)LvTARGOFF(sv));
-            Perl_dump_indent(aTHX_ level, file, "  TARGLEN = %" IVdf "\n", (IV)LvTARGLEN(sv));
-            Perl_dump_indent(aTHX_ level, file, "  TARG = 0x%" UVxf "\n", PTR2UV(LvTARG(sv)));
-            Perl_dump_indent(aTHX_ level, file, "  FLAGS = %" IVdf "\n", (IV)LvFLAGS(sv));
+            dump_indent(level, file, "  TYPE = %c\n", LvTYPE(sv));
+            dump_indent(level, file, "  TARGOFF = %" IVdf "\n",
+                                     (IV)LvTARGOFF(sv));
+            dump_indent(level, file, "  TARGLEN = %" IVdf "\n",
+                                     (IV)LvTARGLEN(sv));
+            dump_indent(level, file, "  TARG = 0x%" UVxf "\n",
+                                     PTR2UV(LvTARG(sv)));
+            dump_indent(level, file, "  FLAGS = %" IVdf "\n",
+                                     (IV)LvFLAGS(sv));
             if (isALPHA_FOLD_NE(LvTYPE(sv), 't'))
                 do_sv_dump(level+1, file, LvTARG(sv), nest+1, maxnest,
                     dumpops, pvlim);
@@ -2951,78 +2947,84 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             break;
         {
             SV* tmpsv = newSVpvs_flags("", SVs_TEMP);
-            Perl_dump_indent(aTHX_ level, file, "  NAME = \"%s\"\n",
-                     generic_pv_escape(tmpsv, GvNAME(sv),
-                                       GvNAMELEN(sv),
-                                       GvNAMEUTF8(sv)));
+            dump_indent(level, file, "  NAME = \"%s\"\n",
+                                     generic_pv_escape(tmpsv, GvNAME(sv),
+                                                       GvNAMELEN(sv),
+                                                       GvNAMEUTF8(sv)));
         }
-        Perl_dump_indent(aTHX_ level, file, "  NAMELEN = %" IVdf "\n", (IV)GvNAMELEN(sv));
+        dump_indent(level, file, "  NAMELEN = %" IVdf "\n", (IV)GvNAMELEN(sv));
         do_hv_dump (level, file, "  GvSTASH", GvSTASH(sv));
-        Perl_dump_indent(aTHX_ level, file, "  FLAGS = 0x%" UVxf "\n", (UV)GvFLAGS(sv));
-        Perl_dump_indent(aTHX_ level, file, "  GP = 0x%" UVxf "\n", PTR2UV(GvGP(sv)));
+        dump_indent(level, file, "  FLAGS = 0x%" UVxf "\n", (UV)GvFLAGS(sv));
+        dump_indent(level, file, "  GP = 0x%" UVxf "\n", PTR2UV(GvGP(sv)));
         if (!GvGP(sv))
             break;
-        Perl_dump_indent(aTHX_ level, file, "    SV = 0x%" UVxf "\n", PTR2UV(GvSV(sv)));
-        Perl_dump_indent(aTHX_ level, file, "    REFCNT = %" IVdf "\n", (IV)GvREFCNT(sv));
-        Perl_dump_indent(aTHX_ level, file, "    IO = 0x%" UVxf "\n", PTR2UV(GvIOp(sv)));
-        Perl_dump_indent(aTHX_ level, file, "    FORM = 0x%" UVxf "  \n", PTR2UV(GvFORM(sv)));
-        Perl_dump_indent(aTHX_ level, file, "    AV = 0x%" UVxf "\n", PTR2UV(GvAV(sv)));
-        Perl_dump_indent(aTHX_ level, file, "    HV = 0x%" UVxf "\n", PTR2UV(GvHV(sv)));
-        Perl_dump_indent(aTHX_ level, file, "    CV = 0x%" UVxf "\n", PTR2UV(GvCV(sv)));
-        Perl_dump_indent(aTHX_ level, file, "    CVGEN = 0x%" UVxf "\n", (UV)GvCVGEN(sv));
-        Perl_dump_indent(aTHX_ level, file, "    GPFLAGS = 0x%" UVxf
-                                            " (%s)\n",
-                               (UV)GvGPFLAGS(sv),
-                               "");
-        Perl_dump_indent(aTHX_ level, file, "    LINE = %" LINE_Tf "\n", (line_t)GvLINE(sv));
-        Perl_dump_indent(aTHX_ level, file, "    FILE = \"%s\"\n", GvFILE(sv));
+        dump_indent(level, file, "    SV = 0x%" UVxf "\n", PTR2UV(GvSV(sv)));
+        dump_indent(level, file, "    REFCNT = %" IVdf "\n",
+                                 (IV)GvREFCNT(sv));
+        dump_indent(level, file, "    IO = 0x%" UVxf "\n", PTR2UV(GvIOp(sv)));
+        dump_indent(level, file, "    FORM = 0x%" UVxf "  \n",
+                                 PTR2UV(GvFORM(sv)));
+        dump_indent(level, file, "    AV = 0x%" UVxf "\n", PTR2UV(GvAV(sv)));
+        dump_indent(level, file, "    HV = 0x%" UVxf "\n", PTR2UV(GvHV(sv)));
+        dump_indent(level, file, "    CV = 0x%" UVxf "\n", PTR2UV(GvCV(sv)));
+        dump_indent(level, file, "    CVGEN = 0x%" UVxf "\n",
+                                 (UV)GvCVGEN(sv));
+        dump_indent(level, file, "    GPFLAGS = 0x%" UVxf " (%s)\n",
+                                 (UV)GvGPFLAGS(sv), "");
+        dump_indent(level, file, "    LINE = %" LINE_Tf "\n",
+                                 (line_t)GvLINE(sv));
+        dump_indent(level, file, "    FILE = \"%s\"\n", GvFILE(sv));
         do_gv_dump (level, file, "    EGV", GvEGV(sv));
         break;
     case SVt_PVIO:
-        Perl_dump_indent(aTHX_ level, file, "  IFP = 0x%" UVxf "\n", PTR2UV(IoIFP(sv)));
-        Perl_dump_indent(aTHX_ level, file, "  OFP = 0x%" UVxf "\n", PTR2UV(IoOFP(sv)));
-        Perl_dump_indent(aTHX_ level, file, "  DIRP = 0x%" UVxf "\n", PTR2UV(IoDIRP(sv)));
-        Perl_dump_indent(aTHX_ level, file, "  LINES = %" IVdf "\n", (IV)IoLINES(sv));
-        Perl_dump_indent(aTHX_ level, file, "  PAGE = %" IVdf "\n", (IV)IoPAGE(sv));
-        Perl_dump_indent(aTHX_ level, file, "  PAGE_LEN = %" IVdf "\n", (IV)IoPAGE_LEN(sv));
-        Perl_dump_indent(aTHX_ level, file, "  LINES_LEFT = %" IVdf "\n", (IV)IoLINES_LEFT(sv));
+        dump_indent(level, file, "  IFP = 0x%" UVxf "\n", PTR2UV(IoIFP(sv)));
+        dump_indent(level, file, "  OFP = 0x%" UVxf "\n", PTR2UV(IoOFP(sv)));
+        dump_indent(level, file, "  DIRP = 0x%" UVxf "\n",
+                                 PTR2UV(IoDIRP(sv)));
+        dump_indent(level, file, "  LINES = %" IVdf "\n", (IV)IoLINES(sv));
+        dump_indent(level, file, "  PAGE = %" IVdf "\n", (IV)IoPAGE(sv));
+        dump_indent(level, file, "  PAGE_LEN = %" IVdf "\n",
+                                 (IV)IoPAGE_LEN(sv));
+        dump_indent(level, file, "  LINES_LEFT = %" IVdf "\n",
+                                 (IV)IoLINES_LEFT(sv));
         if (IoTOP_NAME(sv))
-            Perl_dump_indent(aTHX_ level, file, "  TOP_NAME = \"%s\"\n", IoTOP_NAME(sv));
+            dump_indent(level, file, "  TOP_NAME = \"%s\"\n", IoTOP_NAME(sv));
         if (!IoTOP_GV(sv) || SvTYPE(IoTOP_GV(sv)) == SVt_PVGV)
             do_gv_dump (level, file, "  TOP_GV", IoTOP_GV(sv));
         else {
-            Perl_dump_indent(aTHX_ level, file, "  TOP_GV = 0x%" UVxf "\n",
-                             PTR2UV(IoTOP_GV(sv)));
+            dump_indent(level, file, "  TOP_GV = 0x%" UVxf "\n",
+                                     PTR2UV(IoTOP_GV(sv)));
             do_sv_dump (level+1, file, MUTABLE_SV(IoTOP_GV(sv)), nest+1,
                         maxnest, dumpops, pvlim);
         }
         /* Source filters hide things that are not GVs in these three, so let's
            be careful out there.  */
         if (IoFMT_NAME(sv))
-            Perl_dump_indent(aTHX_ level, file, "  FMT_NAME = \"%s\"\n", IoFMT_NAME(sv));
+            dump_indent(level, file, "  FMT_NAME = \"%s\"\n", IoFMT_NAME(sv));
         if (!IoFMT_GV(sv) || SvTYPE(IoFMT_GV(sv)) == SVt_PVGV)
             do_gv_dump (level, file, "  FMT_GV", IoFMT_GV(sv));
         else {
-            Perl_dump_indent(aTHX_ level, file, "  FMT_GV = 0x%" UVxf "\n",
-                             PTR2UV(IoFMT_GV(sv)));
+            dump_indent(level, file, "  FMT_GV = 0x%" UVxf "\n",
+                                     PTR2UV(IoFMT_GV(sv)));
             do_sv_dump (level+1, file, MUTABLE_SV(IoFMT_GV(sv)), nest+1,
                         maxnest, dumpops, pvlim);
         }
         if (IoBOTTOM_NAME(sv))
-            Perl_dump_indent(aTHX_ level, file, "  BOTTOM_NAME = \"%s\"\n", IoBOTTOM_NAME(sv));
+            dump_indent(level, file, "  BOTTOM_NAME = \"%s\"\n",
+                                     IoBOTTOM_NAME(sv));
         if (!IoBOTTOM_GV(sv) || SvTYPE(IoBOTTOM_GV(sv)) == SVt_PVGV)
             do_gv_dump (level, file, "  BOTTOM_GV", IoBOTTOM_GV(sv));
         else {
-            Perl_dump_indent(aTHX_ level, file, "  BOTTOM_GV = 0x%" UVxf "\n",
-                             PTR2UV(IoBOTTOM_GV(sv)));
+            dump_indent(level, file, "  BOTTOM_GV = 0x%" UVxf "\n",
+                                     PTR2UV(IoBOTTOM_GV(sv)));
             do_sv_dump (level+1, file, MUTABLE_SV(IoBOTTOM_GV(sv)), nest+1,
                         maxnest, dumpops, pvlim);
         }
         if (isPRINT(IoTYPE(sv)))
-            Perl_dump_indent(aTHX_ level, file, "  TYPE = '%c'\n", IoTYPE(sv));
+            dump_indent(level, file, "  TYPE = '%c'\n", IoTYPE(sv));
         else
-            Perl_dump_indent(aTHX_ level, file, "  TYPE = '\\%o'\n", IoTYPE(sv));
-        Perl_dump_indent(aTHX_ level, file, "  FLAGS = 0x%" UVxf "\n", (UV)IoFLAGS(sv));
+            dump_indent(level, file, "  TYPE = '\\%o'\n", IoTYPE(sv));
+        dump_indent(level, file, "  FLAGS = 0x%" UVxf "\n", (UV)IoFLAGS(sv));
         break;
     case SVt_REGEXP:
       dumpregexp:
@@ -3038,28 +3040,31 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
             }                                               \
 } STMT_END
             SV_SET_STRINGIFY_REGEXP_FLAGS(d,r->compflags,regexp_extflags_names);
-            Perl_dump_indent(aTHX_ level, file, "  COMPFLAGS = 0x%" UVxf " (%s)\n",
-                                (UV)(r->compflags), SvPVX_const(d));
+            dump_indent(level, file, "  COMPFLAGS = 0x%" UVxf " (%s)\n",
+                                     (UV)(r->compflags), SvPVX_const(d));
 
             SV_SET_STRINGIFY_REGEXP_FLAGS(d,r->extflags,regexp_extflags_names);
-            Perl_dump_indent(aTHX_ level, file, "  EXTFLAGS = 0x%" UVxf " (%s)\n",
-                                (UV)(r->extflags), SvPVX_const(d));
+            dump_indent(level, file, "  EXTFLAGS = 0x%" UVxf " (%s)\n",
+                                     (UV)(r->extflags), SvPVX_const(d));
 
-            Perl_dump_indent(aTHX_ level, file, "  ENGINE = 0x%" UVxf " (%s)\n",
-                                PTR2UV(r->engine), (r->engine == &PL_core_reg_engine) ? "STANDARD" : "PLUG-IN" );
+            dump_indent(level, file, "  ENGINE = 0x%" UVxf " (%s)\n",
+                                     PTR2UV(r->engine),
+                                     (r->engine == &PL_core_reg_engine)
+                                      ? "STANDARD" : "PLUG-IN" );
             if (r->engine == &PL_core_reg_engine) {
                 SV_SET_STRINGIFY_REGEXP_FLAGS(d,r->intflags,regexp_core_intflags_names);
-                Perl_dump_indent(aTHX_ level, file, "  INTFLAGS = 0x%" UVxf " (%s)\n",
-                                (UV)(r->intflags), SvPVX_const(d));
+                dump_indent(level, file, "  INTFLAGS = 0x%" UVxf " (%s)\n",
+                                         (UV)(r->intflags), SvPVX_const(d));
             } else {
-                Perl_dump_indent(aTHX_ level, file, "  INTFLAGS = 0x%" UVxf "(Plug in)\n",
-                                (UV)(r->intflags));
+                dump_indent(level, file,
+                            "  INTFLAGS = 0x%" UVxf "(Plug in)\n",
+                            (UV)(r->intflags));
             }
 #undef SV_SET_STRINGIFY_REGEXP_FLAGS
-            Perl_dump_indent(aTHX_ level, file, "  NPARENS = %" UVuf "\n",
-                                (UV)(r->nparens));
-            Perl_dump_indent(aTHX_ level, file, "  LOGICAL_NPARENS = %" UVuf "\n",
-                                (UV)(r->logical_nparens));
+            dump_indent(level, file, "  NPARENS = %" UVuf "\n",
+                                     (UV)(r->nparens));
+            dump_indent(level, file, "  LOGICAL_NPARENS = %" UVuf "\n",
+                                      (UV)(r->logical_nparens));
 
 #define SV_SET_STRINGIFY_I32_PAREN_ARRAY(d,count,ary)     \
     STMT_START {                                    \
@@ -3073,59 +3078,60 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
         sv_catpvs(d," }\n");                        \
     } STMT_END
 
-            Perl_dump_indent(aTHX_ level, file, "  LOGICAL_TO_PARNO = 0x%" UVxf "\n",
-                                PTR2UV(r->logical_to_parno));
+            dump_indent(level, file, "  LOGICAL_TO_PARNO = 0x%" UVxf "\n",
+                                     PTR2UV(r->logical_to_parno));
             if (r->logical_to_parno) {
                 SV_SET_STRINGIFY_I32_PAREN_ARRAY(d, r->logical_nparens, r->logical_to_parno);
-                Perl_dump_indent(aTHX_ level, file, "    %" SVf, d);
+                dump_indent(level, file, "    %" SVf, d);
             }
-            Perl_dump_indent(aTHX_ level, file, "  PARNO_TO_LOGICAL = 0x%" UVxf "\n",
-                                PTR2UV(r->parno_to_logical));
+            dump_indent(level, file, "  PARNO_TO_LOGICAL = 0x%" UVxf "\n",
+                                     PTR2UV(r->parno_to_logical));
             if (r->parno_to_logical) {
                 SV_SET_STRINGIFY_I32_PAREN_ARRAY(d, r->nparens, r->parno_to_logical);
-                Perl_dump_indent(aTHX_ level, file, "    %" SVf, d);
+                dump_indent(level, file, "    %" SVf, d);
             }
 
-            Perl_dump_indent(aTHX_ level, file, "  PARNO_TO_LOGICAL_NEXT = 0x%" UVxf "\n",
-                                PTR2UV(r->parno_to_logical_next));
+            dump_indent(level, file,
+                        "  PARNO_TO_LOGICAL_NEXT = 0x%" UVxf "\n",
+                        PTR2UV(r->parno_to_logical_next));
             if (r->parno_to_logical_next) {
                 SV_SET_STRINGIFY_I32_PAREN_ARRAY(d, r->nparens, r->parno_to_logical_next);
-                Perl_dump_indent(aTHX_ level, file, "    %" SVf, d);
+                dump_indent(level, file, "    %" SVf, d);
             }
 #undef SV_SET_STRINGIFY_I32_ARRAY
 
-            Perl_dump_indent(aTHX_ level, file, "  LASTPAREN = %" UVuf "\n",
-                                (UV)(RXp_LASTPAREN(r)));
-            Perl_dump_indent(aTHX_ level, file, "  LASTCLOSEPAREN = %" UVuf "\n",
-                                (UV)(RXp_LASTCLOSEPAREN(r)));
-            Perl_dump_indent(aTHX_ level, file, "  MINLEN = %" IVdf "\n",
-                                (IV)(RXp_MINLEN(r)));
-            Perl_dump_indent(aTHX_ level, file, "  MINLENRET = %" IVdf "\n",
-                                (IV)(RXp_MINLENRET(r)));
-            Perl_dump_indent(aTHX_ level, file, "  GOFS = %" UVuf "\n",
-                                (UV)(RXp_GOFS(r)));
-            Perl_dump_indent(aTHX_ level, file, "  PRE_PREFIX = %" UVuf "\n",
-                                (UV)(RXp_PRE_PREFIX(r)));
-            Perl_dump_indent(aTHX_ level, file, "  SUBLEN = %" IVdf "\n",
-                                (IV)(RXp_SUBLEN(r)));
-            Perl_dump_indent(aTHX_ level, file, "  SUBOFFSET = %" IVdf "\n",
-                                (IV)(RXp_SUBOFFSET(r)));
-            Perl_dump_indent(aTHX_ level, file, "  SUBCOFFSET = %" IVdf "\n",
-                                (IV)(RXp_SUBCOFFSET(r)));
+            dump_indent(level, file, "  LASTPAREN = %" UVuf "\n",
+                                     (UV)(RXp_LASTPAREN(r)));
+            dump_indent(level, file, "  LASTCLOSEPAREN = %" UVuf "\n",
+                                     (UV)(RXp_LASTCLOSEPAREN(r)));
+            dump_indent(level, file, "  MINLEN = %" IVdf "\n",
+                                     (IV)(RXp_MINLEN(r)));
+            dump_indent(level, file, "  MINLENRET = %" IVdf "\n",
+                                     (IV)(RXp_MINLENRET(r)));
+            dump_indent(level, file, "  GOFS = %" UVuf "\n",
+                                     (UV)(RXp_GOFS(r)));
+            dump_indent(level, file, "  PRE_PREFIX = %" UVuf "\n",
+                                     (UV)(RXp_PRE_PREFIX(r)));
+            dump_indent(level, file, "  SUBLEN = %" IVdf "\n",
+                                     (IV)(RXp_SUBLEN(r)));
+            dump_indent(level, file, "  SUBOFFSET = %" IVdf "\n",
+                                     (IV)(RXp_SUBOFFSET(r)));
+            dump_indent(level, file, "  SUBCOFFSET = %" IVdf "\n",
+                                     (IV)(RXp_SUBCOFFSET(r)));
             if (RXp_SUBBEG(r))
-                Perl_dump_indent(aTHX_ level, file, "  SUBBEG = 0x%" UVxf " %s\n",
-                            PTR2UV(RXp_SUBBEG(r)),
+                dump_indent(level, file, "  SUBBEG = 0x%" UVxf " %s\n",
+                                         PTR2UV(RXp_SUBBEG(r)),
                             pv_display(d, RXp_SUBBEG(r), RXp_SUBLEN(r), 50, pvlim));
             else
-                Perl_dump_indent(aTHX_ level, file, "  SUBBEG = 0x0\n");
-            Perl_dump_indent(aTHX_ level, file, "  PAREN_NAMES = 0x%" UVxf "\n",
-                                PTR2UV(RXp_PAREN_NAMES(r)));
-            Perl_dump_indent(aTHX_ level, file, "  SUBSTRS = 0x%" UVxf "\n",
-                                PTR2UV(RXp_SUBSTRS(r)));
-            Perl_dump_indent(aTHX_ level, file, "  PPRIVATE = 0x%" UVxf "\n",
-                                PTR2UV(RXp_PPRIVATE(r)));
-            Perl_dump_indent(aTHX_ level, file, "  OFFS = 0x%" UVxf "\n",
-                                PTR2UV(RXp_OFFSp(r)));
+                dump_indent(level, file, "  SUBBEG = 0x0\n");
+            dump_indent(level, file, "  PAREN_NAMES = 0x%" UVxf "\n",
+                                     PTR2UV(RXp_PAREN_NAMES(r)));
+            dump_indent(level, file, "  SUBSTRS = 0x%" UVxf "\n",
+                                     PTR2UV(RXp_SUBSTRS(r)));
+            dump_indent(level, file, "  PPRIVATE = 0x%" UVxf "\n",
+                                     PTR2UV(RXp_PPRIVATE(r)));
+            dump_indent(level, file, "  OFFS = 0x%" UVxf "\n",
+                                     PTR2UV(RXp_OFFSp(r)));
             if (RXp_OFFSp(r)) {
                 U32 n;
                 sv_setpvs(d,"[ ");
@@ -3137,27 +3143,27 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                         (IV)RXp_OFFSp(r)[n].start, (IV)RXp_OFFSp(r)[n].end,
                         n+1 > r->nparens ? " ]\n" : ", ");
                 }
-                Perl_dump_indent(aTHX_ level, file, "    %" SVf, d);
+                dump_indent(level, file, "    %" SVf, d);
             }
-            Perl_dump_indent(aTHX_ level, file, "  QR_ANONCV = 0x%" UVxf "\n",
-                                PTR2UV(RXp_QR_ANONCV(r)));
+            dump_indent(level, file, "  QR_ANONCV = 0x%" UVxf "\n",
+                                     PTR2UV(RXp_QR_ANONCV(r)));
 #ifdef PERL_ANY_COW
-            Perl_dump_indent(aTHX_ level, file, "  SAVED_COPY = 0x%" UVxf "\n",
-                                PTR2UV(RXp_SAVED_COPY(r)));
+            dump_indent(level, file, "  SAVED_COPY = 0x%" UVxf "\n",
+                                     PTR2UV(RXp_SAVED_COPY(r)));
 #endif
             /* this should go LAST or the output gets really confusing */
-            Perl_dump_indent(aTHX_ level, file, "  MOTHER_RE = 0x%" UVxf "\n",
-                                PTR2UV(RXp_MOTHER_RE(r)));
+            dump_indent(level, file, "  MOTHER_RE = 0x%" UVxf "\n",
+                                     PTR2UV(RXp_MOTHER_RE(r)));
             if (nest < maxnest && RXp_MOTHER_RE(r))
                 do_sv_dump(level+1, file, (SV *)RXp_MOTHER_RE(r), nest+1,
                            maxnest, dumpops, pvlim);
         }
         break;
     case SVt_PVOBJ:
-        Perl_dump_indent(aTHX_ level, file, "  MAXFIELD = %" IVdf "\n",
-                (IV)ObjectMAXFIELD(sv));
-        Perl_dump_indent(aTHX_ level, file, "  FIELDS = 0x%" UVxf "\n",
-                PTR2UV(ObjectFIELDS(sv)));
+        dump_indent(level, file, "  MAXFIELD = %" IVdf "\n",
+                                 (IV)ObjectMAXFIELD(sv));
+        dump_indent(level, file, "  FIELDS = 0x%" UVxf "\n",
+                                 PTR2UV(ObjectFIELDS(sv)));
         if (nest < maxnest && ObjectFIELDS(sv)) {
             SSize_t count;
             SV **svp = ObjectFIELDS(sv);
@@ -3169,8 +3175,8 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                 SV *const field = *svp;
                 PADNAME *pn = pname[count];
 
-                Perl_dump_indent(aTHX_ level + 1, file, "Field No. %" IVdf " (%s)\n",
-                        (IV)count, PadnamePV(pn));
+                dump_indent(level + 1, file, "Field No. %" IVdf " (%s)\n",
+                                             (IV)count, PadnamePV(pn));
 
                 do_sv_dump(level+1, file, field, nest+1, maxnest, dumpops, pvlim);
             }

--- a/embed.fnc
+++ b/embed.fnc
@@ -2101,7 +2101,7 @@ p	|int	|magic_getvec	|NN SV *sv				\
 p	|int	|magic_killbackrefs					\
 				|NN SV *sv				\
 				|NN MAGIC *mg
-Fdop	|SV *	|magic_methcall |NN SV *sv				\
+Fdp	|SV *	|magic_methcall |NN SV *sv				\
 				|NN const MAGIC *mg			\
 				|NN SV *meth				\
 				|U32 flags				\

--- a/embed.h
+++ b/embed.h
@@ -1059,6 +1059,7 @@
 #   define magic_getuvar(a,b)                   Perl_magic_getuvar(aTHX_ a,b)
 #   define magic_getvec(a,b)                    Perl_magic_getvec(aTHX_ a,b)
 #   define magic_killbackrefs(a,b)              Perl_magic_killbackrefs(aTHX_ a,b)
+#   define magic_methcall(a,b,c,d,...)          Perl_magic_methcall(aTHX_ a,b,c,d,__VA_ARGS__)
 #   define magic_nextpack(a,b,c)                Perl_magic_nextpack(aTHX_ a,b,c)
 #   define magic_regdata_cnt(a,b)               Perl_magic_regdata_cnt(aTHX_ a,b)
 #   define magic_regdatum_get(a,b)              Perl_magic_regdatum_get(aTHX_ a,b)

--- a/gv.c
+++ b/gv.c
@@ -896,9 +896,9 @@ S_gv_fetchmeth_internal(pTHX_ HV* stash, SV* meth, const char* name, STRLEN len,
     assert(hvname);
     assert(name || meth);
 
-    DEBUG_o( Perl_deb(aTHX_ "Looking for %smethod %s in package %s\n",
-                      flags & GV_SUPER ? "SUPER " : "",
-                      name ? name : SvPV_nolen(meth), hvname) );
+    DEBUG_o( deb("Looking for %smethod %s in package %s\n",
+                 flags & GV_SUPER ? "SUPER " : "",
+                 name ? name : SvPV_nolen(meth), hvname) );
 
     topgen_cmp = HvMROMETA(stash)->cache_gen + PL_sub_generation;
 
@@ -1222,7 +1222,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
             /* ->SUPER::method should really be looked up in original stash */
             stash = CopSTASH(PL_curcop);
             flags |= GV_SUPER;
-            DEBUG_o( Perl_deb(aTHX_ "Treating %s as %s::%s\n",
+            DEBUG_o( deb("Treating %s as %s::%s\n",
                          origname, HvENAME_get(stash), name) );
         }
         else if ( sep_len >= 7 &&
@@ -2994,9 +2994,8 @@ Perl_gp_free(pTHX_ GV *gv)
       if (hv && SvTYPE(hv) == SVt_PVHV) {
         const HEK *hvname_hek = HvNAME_HEK(hv);
         if (PL_stashcache && hvname_hek) {
-           DEBUG_o(Perl_deb(aTHX_
-                          "gp_free clearing PL_stashcache for '%" HEKf "'\n",
-                           HEKfARG(hvname_hek)));
+           DEBUG_o(deb("gp_free clearing PL_stashcache for '%" HEKf "'\n",
+                       HEKfARG(hvname_hek)));
            (void)hv_deletehek(PL_stashcache, hvname_hek, G_DISCARD);
         }
         if (SvREFCNT(hv) > 1 || SvOBJECT(hv) || UNLIKELY(in_global_destruction)) {
@@ -3164,7 +3163,8 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
       sv_unmagic(MUTABLE_SV(stash), PERL_MAGIC_overload_table);
   }
 
-  DEBUG_o( Perl_deb(aTHX_ "Recalculating overload magic in package %s\n",HvNAME_get(stash)) );
+  DEBUG_o( deb("Recalculating overload magic in package %s\n",
+               HvNAME_get(stash)) );
 
   Zero(&amt,1,AMT);
   amt.was_ok_sub = newgen;
@@ -3214,7 +3214,7 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
         const char * const cp = AMG_id2name(i);
         const STRLEN l = PL_AMG_namelens[i];
 
-        DEBUG_o( Perl_deb(aTHX_ "Checking overloading of \"%s\" in package \"%.256s\"\n",
+        DEBUG_o( deb("Checking overloading of \"%s\" in package \"%.256s\"\n",
                      cp, HvNAME_get(stash)) );
         /* don't fill the cache while looking up!
            Creation of inheritance stubs in intermediate packages may
@@ -3238,8 +3238,8 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
                 GV *ngv = NULL;
                 SV *gvsv = GvSV(gv);
 
-                DEBUG_o( Perl_deb(aTHX_ "Resolving method \"%" SVf256\
-                        "\" for overloaded \"%s\" in package \"%.256s\"\n",
+                DEBUG_o( deb("Resolving method \"%" SVf256 "\" for overloaded"
+                             " \"%s\" in package \"%.256s\"\n",
                              (void*)GvSV(gv), cp, HvNAME(stash)) );
                 if (!gvsv || !SvPOK(gvsv)
                     || !(ngv = gv_fetchmethod_sv_flags(stash, gvsv, 0)))
@@ -3266,7 +3266,8 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
                 }
                 cv = GvCV(gv = ngv);
             }
-            DEBUG_o( Perl_deb(aTHX_ "Overloading \"%s\" in package \"%.256s\" via \"%.256s::%.256s\"\n",
+            DEBUG_o( deb("Overloading \"%s\" in package \"%.256s\" via"
+                         " \"%.256s::%.256s\"\n",
                          cp, HvNAME_get(stash), HvNAME_get(GvSTASH(CvGV(cv))),
                          GvNAME(CvGV(cv))) );
             filled = 1;
@@ -4038,7 +4039,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
                         SVfARG(newSVhek_mortal(HvNAME_HEK(SvSTASH(SvRV(right))))):
                         SVfARG(&PL_sv_no)));
         if (use_default_op) {
-          DEBUG_o( Perl_deb(aTHX_ "%" SVf, SVfARG(msg)) );
+          DEBUG_o( deb("%" SVf, SVfARG(msg)) );
         } else {
           croak("%" SVf, SVfARG(msg));
         }
@@ -4119,19 +4120,21 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
 
 #ifdef DEBUGGING
   if (!notfound) {
-    DEBUG_o(Perl_deb(aTHX_
-                     "Overloaded operator \"%s\"%s%s%s:\n\tmethod%s found%s in package %" SVf "%s\n",
-                     AMG_id2name(off),
-                     method+assignshift==off? "" :
-                     " (initially \"",
-                     method+assignshift==off? "" :
-                     AMG_id2name(method+assignshift),
-                     method+assignshift==off? "" : "\")",
-                     flags & AMGf_unary? "" :
-                     lr==1 ? " for right argument": " for left argument",
-                     flags & AMGf_unary? " for argument" : "",
-                     stash ? SVfARG(newSVhek_mortal(HvNAME_HEK(stash))) : SVfARG(newSVpvs_flags("null", SVs_TEMP)),
-                     fl? ",\n\tassignment variant used": "") );
+    DEBUG_o(deb("Overloaded operator \"%s\"%s%s%s:\n\tmethod%s found%s in"
+                " package %" SVf "%s\n",
+                AMG_id2name(off),
+                method+assignshift==off? "" :
+                " (initially \"",
+                method+assignshift==off? "" :
+                AMG_id2name(method+assignshift),
+                method+assignshift==off? "" : "\")",
+                flags & AMGf_unary? "" :
+                lr==1 ? " for right argument": " for left argument",
+                flags & AMGf_unary? " for argument" : "",
+                (stash) ? SVfARG(newSVhek_mortal(HvNAME_HEK(stash)))
+                        : SVfARG(newSVpvs_flags("null", SVs_TEMP)),
+                (fl) ? ",\n\tassignment variant used"
+                     : "") );
   }
 #endif
     /* Since we use shallow copy during assignment, we need

--- a/gv.c
+++ b/gv.c
@@ -3223,7 +3223,7 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
            then we could have created stubs for "(+0" in A and C too.
            But if B overloads "bool", we may want to use it for
            numifying instead of C's "+0". */
-        gv = Perl_gv_fetchmeth_pvn(aTHX_ stash, cooky, l, -1, 0);
+        gv = gv_fetchmeth_pvn(stash, cooky, l, -1, 0);
         cv = 0;
         if (gv && (cv = GvCV(gv)) && CvHASGV(cv)) {
             const HEK * const gvhek = CvGvNAME_HEK(cv);

--- a/gv.c
+++ b/gv.c
@@ -1558,7 +1558,7 @@ S_require_tie_mod(pTHX_ GV *gv, const char varname, const char * name,
         const char type = varname == '[' ? '$' : '%';
         if ( flags & 1 )
             save_scalar(gv);
-        Perl_load_module(aTHX_ PERL_LOADMOD_NOIMPORT, module, NULL);
+        load_module(PERL_LOADMOD_NOIMPORT, module, NULL);
         assert(sp == PL_stack_sp);
         stash = gv_stashpvn(name, len, 0);
         if (!stash)

--- a/gv.c
+++ b/gv.c
@@ -2013,15 +2013,15 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len,
                          (sv_type == SVt_PVHV && !GvIMPORTED_HV(*gvp)) )
                 {
                     /* diag_listed_as: Variable "%s" is not imported%s */
-                    Perl_ck_warner_d(
-                        aTHX_ packWARN(WARN_MISC),
+                    ck_warner_d(
+                        packWARN(WARN_MISC),
                         "Variable \"%c%" UTF8f "\" is not imported",
                         sv_type == SVt_PVAV ? '@' :
                         sv_type == SVt_PVHV ? '%' : '$',
                         UTF8fARG(is_utf8, len, name));
                     if (GvCVu(*gvp))
-                        Perl_ck_warner_d(
-                            aTHX_ packWARN(WARN_MISC),
+                        ck_warner_d(
+                            packWARN(WARN_MISC),
                             "\t(Did you mean &%" UTF8f " instead?)\n",
                             UTF8fARG(is_utf8, len, name)
                         );

--- a/gv.c
+++ b/gv.c
@@ -4020,7 +4020,7 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
       } else {
         SV *msg;
         if (off==-1) off=method;
-        msg = sv_2mortal(Perl_newSVpvf(aTHX_
+        msg = sv_2mortal(newSVpvf(
                       "Operation \"%s\": no method found,%sargument %s%" SVf "%s%" SVf,
                       AMG_id2name(method + assignshift),
                       (flags & AMGf_unary ? " " : "\n\tleft "),

--- a/gv.c
+++ b/gv.c
@@ -2038,7 +2038,7 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len,
     if (!*stash) {
         if (add && !PL_in_clean_all) {
             GV *gv;
-            qerror(Perl_mess(aTHX_
+            qerror(mess(
                  "Global symbol \"%s%" UTF8f
                  "\" requires explicit package name (did you forget to "
                  "declare \"my %s%" UTF8f "\"?)",

--- a/hv.c
+++ b/hv.c
@@ -2305,8 +2305,8 @@ Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
     if (PL_phase != PERL_PHASE_DESTRUCT && HvHasNAME(hv)) {
         if (PL_stashcache) {
             HEK *hek = HvNAME_HEK(hv);
-            DEBUG_o(Perl_deb(aTHX_ "hv_undef_flags clearing PL_stashcache for '%"
-                             HEKf "'\n", HEKfARG(hek)));
+            DEBUG_o(deb("hv_undef_flags clearing PL_stashcache for '%"
+                        HEKf "'\n", HEKfARG(hek)));
             (void)hv_deletehek(PL_stashcache, hek, G_DISCARD);
         }
         hv_name_set(hv, NULL, 0, 0);
@@ -2346,8 +2346,9 @@ Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
         if (PL_phase != PERL_PHASE_DESTRUCT)
             mro_isa_changed_in(hv);
         if (PL_stashcache) {
-            DEBUG_o(Perl_deb(aTHX_ "hv_undef_flags clearing PL_stashcache for effective name '%"
-                             HEKf "'\n", HEKfARG(HvENAME_HEK_NN(hv))));
+            DEBUG_o(deb(
+                "hv_undef_flags clearing PL_stashcache for effective name '%"
+                HEKf "'\n", HEKfARG(HvENAME_HEK_NN(hv))));
             (void)hv_deletehek(PL_stashcache, HvENAME_HEK_NN(hv), G_DISCARD);
         }
       }
@@ -2360,8 +2361,8 @@ Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
           : cBOOL(name))
       {
         if (name && PL_stashcache) {
-            DEBUG_o(Perl_deb(aTHX_ "hv_undef_flags clearing PL_stashcache for name '%"
-                             HEKf "'\n", HEKfARG(HvNAME_HEK_NN(hv))));
+            DEBUG_o(deb("hv_undef_flags clearing PL_stashcache for name '%"
+                        HEKf "'\n", HEKfARG(HvNAME_HEK_NN(hv))));
             (void)hv_deletehek(PL_stashcache, HvNAME_HEK_NN(hv), G_DISCARD);
         }
         hv_name_set(hv, NULL, 0, flags);

--- a/inline.h
+++ b/inline.h
@@ -4520,8 +4520,8 @@ Perl_push_stackinfo(pTHX_ I32 type, UV flags)
     DEBUG_l({
         int i = 0; PERL_SI *p = PL_curstackinfo;
         while (p) { i++; p = p->si_prev; }
-        Perl_deb(aTHX_ "push STACKINFO %d in %s at %s:%d\n",
-                     i, SAFE_FUNCTION__, __FILE__, __LINE__);
+        deb("push STACKINFO %d in %s at %s:%d\n",
+            i, SAFE_FUNCTION__, __FILE__, __LINE__);
     })
 
     if (!next) {
@@ -4560,8 +4560,8 @@ Perl_pop_stackinfo(pTHX)
     DEBUG_l({
         int i = -1; PERL_SI *p = PL_curstackinfo;
         while (p) { i++; p = p->si_prev; }
-        Perl_deb(aTHX_ "pop  STACKINFO %d in %s at %s:%d\n",
-                     i, SAFE_FUNCTION__, __FILE__, __LINE__);})
+        deb("pop  STACKINFO %d in %s at %s:%d\n",
+            i, SAFE_FUNCTION__, __FILE__, __LINE__);})
     if (!prev) {
         Perl_croak_popstack();
     }

--- a/mg.c
+++ b/mg.c
@@ -2214,9 +2214,9 @@ S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
         sv_2mortal(arg1);
     }
     if (!arg1) {
-        return Perl_magic_methcall(aTHX_ sv, mg, meth, flags, n - 1, val);
+        return magic_methcall(sv, mg, meth, flags, n - 1, val);
     }
-    return Perl_magic_methcall(aTHX_ sv, mg, meth, flags, n, arg1, val);
+    return magic_methcall(sv, mg, meth, flags, n, arg1, val);
 }
 
 static int
@@ -2306,7 +2306,7 @@ Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
 {
     PERL_ARGS_ASSERT_MAGIC_WIPEPACK;
 
-    Perl_magic_methcall(aTHX_ sv, mg, SV_CONST(CLEAR), G_DISCARD, 0);
+    magic_methcall(sv, mg, SV_CONST(CLEAR), G_DISCARD, 0);
     return 0;
 }
 
@@ -2317,8 +2317,8 @@ Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
 
     SV* ret;
 
-    ret = SvOK(key) ? Perl_magic_methcall(aTHX_ sv, mg, SV_CONST(NEXTKEY), 0, 1, key)
-        : Perl_magic_methcall(aTHX_ sv, mg, SV_CONST(FIRSTKEY), 0, 0);
+    ret = SvOK(key) ? magic_methcall(sv, mg, SV_CONST(NEXTKEY), 0, 1, key)
+        : magic_methcall(sv, mg, SV_CONST(FIRSTKEY), 0, 0);
     if (ret)
         sv_setsv(key,ret);
     return 0;
@@ -2354,7 +2354,7 @@ Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
     }
    
     /* there is a SCALAR method that we can call */
-    retval = Perl_magic_methcall(aTHX_ MUTABLE_SV(hv), mg, SV_CONST(SCALAR), 0, 0);
+    retval = magic_methcall(MUTABLE_SV(hv), mg, SV_CONST(SCALAR), 0, 0);
     if (!retval)
         retval = &PL_sv_undef;
     return retval;

--- a/mro_core.c
+++ b/mro_core.c
@@ -42,9 +42,9 @@ Perl_mro_get_private_data(pTHX_ struct mro_meta *const smeta,
 
     SV **data;
 
-    data = (SV **)Perl_hv_common(aTHX_ smeta->mro_linear_all, NULL,
-                                 which->name, which->length, which->kflags,
-                                 HV_FETCH_JUST_SV, NULL, which->hash);
+    data = (SV **)hv_common(smeta->mro_linear_all, NULL,
+                            which->name, which->length, which->kflags,
+                            HV_FETCH_JUST_SV, NULL, which->hash);
     if (!data)
         return NULL;
 
@@ -93,9 +93,10 @@ Perl_mro_set_private_data(pTHX_ struct mro_meta *const smeta,
         smeta->mro_linear_current = data;
     }
 
-    if (!Perl_hv_common(aTHX_ smeta->mro_linear_all, NULL,
-                        which->name, which->length, which->kflags,
-                        HV_FETCH_ISSTORE, data, which->hash)) {
+    if (!hv_common(smeta->mro_linear_all, NULL,
+                   which->name, which->length, which->kflags,
+                   HV_FETCH_ISSTORE, data, which->hash))
+    {
         croak("panic: hv_store() failed in set_mro_private_data() "
                    "for '%.*s' %d", (int) which->length, which->name,
                    which->kflags);
@@ -120,8 +121,8 @@ Perl_mro_get_from_name(pTHX_ SV *name)
 
     SV **data;
 
-    data = (SV **)Perl_hv_common(aTHX_ PL_registered_mros, name, NULL, 0, 0,
-                                 HV_FETCH_JUST_SV, NULL, 0);
+    data = (SV **)hv_common(PL_registered_mros, name, NULL, 0, 0,
+                            HV_FETCH_JUST_SV, NULL, 0);
     if (!data)
         return NULL;
     assert(SvTYPE(*data) == SVt_IV);
@@ -144,9 +145,10 @@ Perl_mro_register(pTHX_ const struct mro_alg *mro) {
     PERL_ARGS_ASSERT_MRO_REGISTER;
 
 
-    if (!Perl_hv_common(aTHX_ PL_registered_mros, NULL,
-                        mro->name, mro->length, mro->kflags,
-                        HV_FETCH_ISSTORE, wrapper, mro->hash)) {
+    if (!hv_common(PL_registered_mros, NULL,
+                   mro->name, mro->length, mro->kflags,
+                   HV_FETCH_ISSTORE, wrapper, mro->hash))
+    {
         SvREFCNT_dec_NN(wrapper);
         croak("panic: hv_store() failed in mro_register() "
                    "for '%.*s' %d", (int) mro->length, mro->name, mro->kflags);
@@ -939,12 +941,11 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
     if(oldstash) {
         /* Add to the big list. */
         struct mro_meta * meta;
-        HE * const entry
-         = (HE *)
-             hv_common(
-              seen_stashes, NULL, (const char *)&oldstash, sizeof(HV *), 0,
-              HV_FETCH_LVALUE|HV_FETCH_EMPTY_HE, NULL, 0
-             );
+        HE * const entry =
+            (HE *) hv_common(
+                  seen_stashes, NULL, (const char *)&oldstash, sizeof(HV *),
+                  0, HV_FETCH_LVALUE|HV_FETCH_EMPTY_HE, NULL, 0
+            );
         if(HeVAL(entry) == &PL_sv_undef || HeVAL(entry) == &PL_sv_yes) {
             oldstash = NULL;
             goto check_stash;
@@ -1040,8 +1041,8 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
         entry
          = (HE *)
              hv_common(
-              seen_stashes, NULL, (const char *)&stash, sizeof(HV *), 0,
-              HV_FETCH_LVALUE|HV_FETCH_EMPTY_HE, NULL, 0
+                  seen_stashes, NULL, (const char *)&stash, sizeof(HV *), 0,
+                  HV_FETCH_LVALUE|HV_FETCH_EMPTY_HE, NULL, 0
              );
         if(HeVAL(entry) == &PL_sv_yes || HeVAL(entry) == &PL_sv_no)
             stash = NULL;

--- a/mro_core.c
+++ b/mro_core.c
@@ -978,8 +978,8 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                 STRLEN len;
                 const char *name = SvPVx_const(*svp, len);
                 if(PL_stashcache) {
-                    DEBUG_o(Perl_deb(aTHX_ "mro_gather_and_rename clearing PL_stashcache for '%" SVf "'\n",
-                                     SVfARG(*svp)));
+                    DEBUG_o(deb("mro_gather_and_rename clearing PL_stashcache"
+                                " for '%" SVf "'\n", SVfARG(*svp)));
                     (void)hv_delete_ent(PL_stashcache, *svp, G_DISCARD, 0);
                 }
                 hv_ename_delete(oldstash, name, len, name_utf8);

--- a/numeric.c
+++ b/numeric.c
@@ -1436,7 +1436,7 @@ Perl_grok_number_flags(pTHX_ const char *pv, STRLEN len, UV *valuep, U32 flags)
   if ((s + 2 < send) && UNLIKELY(memCHRs("inqs#", toFOLD(*s)))) {
       /* Really detect inf/nan. Start at d, not s, since the above
        * code might have already consumed the "1." or "1". */
-      const int infnan = Perl_grok_infnan(aTHX_ &d, send);
+      const int infnan = grok_infnan(&d, send);
 
       if ((infnan & IS_NUMBER_TRAILING) && !(flags & PERL_SCAN_TRAILING)) {
           return 0;

--- a/op.c
+++ b/op.c
@@ -2374,17 +2374,17 @@ Perl_scalarvoid(pTHX_ OP *arg)
                     else if (SvPOK(sv)) {
                         SV * const dsv = newSVpvs("");
                         useless_sv
-                            = Perl_newSVpvf(aTHX_
-                                            "a constant (%s)",
-                                            pv_pretty(dsv, SvPVX_const(sv),
-                                                      SvCUR(sv), 32, NULL, NULL,
-                                                      PERL_PV_PRETTY_DUMP
-                                                      | PERL_PV_ESCAPE_NOCLEAR
-                                                      | PERL_PV_ESCAPE_UNI_DETECT));
+                            = newSVpvf("a constant (%s)",
+                                       pv_pretty(dsv, SvPVX_const(sv),
+                                                 SvCUR(sv), 32, NULL, NULL,
+                                                 PERL_PV_PRETTY_DUMP
+                                               | PERL_PV_ESCAPE_NOCLEAR
+                                               | PERL_PV_ESCAPE_UNI_DETECT));
                         SvREFCNT_dec_NN(dsv);
                     }
                     else if (SvOK(sv)) {
-                        useless_sv = Perl_newSVpvf(aTHX_ "a constant (%" SVf ")", SVfARG(sv));
+                        useless_sv = newSVpvf("a constant (%" SVf ")",
+                                              SVfARG(sv));
                     }
                     else
                         useless = "a constant (undef)";
@@ -11346,10 +11346,10 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
             GV * const db_postponed = gv_fetchpvs("DB::postponed",
                                                   GV_ADDMULTI, SVt_PVHV);
             HV *hv;
-            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%" LINE_Tf "-%" LINE_Tf,
-                                          CopFILE(PL_curcop),
-                                          (line_t)PL_subline,
-                                          CopLINE(PL_curcop));
+            SV * const sv = newSVpvf("%s:%" LINE_Tf "-%" LINE_Tf,
+                                     CopFILE(PL_curcop),
+                                     (line_t)PL_subline,
+                                     CopLINE(PL_curcop));
             if (HvNAME_HEK(PL_curstash)) {
                 sv_sethek(tmpstr, HvNAME_HEK(PL_curstash));
                 sv_catpvs(tmpstr, "::");
@@ -11967,10 +11967,10 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
             GV * const db_postponed = gv_fetchpvs("DB::postponed",
                                                   GV_ADDMULTI, SVt_PVHV);
             HV *hv;
-            SV * const sv = Perl_newSVpvf(aTHX_ "%s:%" LINE_Tf "-%" LINE_Tf,
-                                          CopFILE(PL_curcop),
-                                          (line_t)PL_subline,
-                                          CopLINE(PL_curcop));
+            SV * const sv = newSVpvf("%s:%" LINE_Tf "-%" LINE_Tf,
+                                     CopFILE(PL_curcop),
+                                     (line_t)PL_subline,
+                                     CopLINE(PL_curcop));
             (void)hv_store_ent(GvHV(PL_DBsub), tmpstr, sv, 0);
             hv = GvHVn(db_postponed);
             if (HvTOTALKEYS(hv) > 0 && hv_exists_ent(hv, tmpstr, 0)) {
@@ -13867,10 +13867,9 @@ Perl_ck_fun(pTHX_ OP *o)
                                            GV * const gv = cGVOPx_gv(firstop);
                                            if (gv)
                                                 tmpstr =
-                                                     Perl_newSVpvf(aTHX_
-                                                                   "%s%c...%c",
-                                                                   GvNAME(gv),
-                                                                   a[0], a[1]);
+                                                     newSVpvf("%s%c...%c",
+                                                              GvNAME(gv),
+                                                              a[0], a[1]);
                                       }
                                       else if (op->op_type == OP_PADAV
                                                || op->op_type == OP_PADHV) {
@@ -13879,10 +13878,9 @@ Perl_ck_fun(pTHX_ OP *o)
                                                 PAD_COMPNAME_PV(op->op_targ);
                                            if (padname)
                                                 tmpstr =
-                                                     Perl_newSVpvf(aTHX_
-                                                                   "%s%c...%c",
-                                                                   padname + 1,
-                                                                   a[0], a[1]);
+                                                     newSVpvf("%s%c...%c",
+                                                              padname + 1,
+                                                              a[0], a[1]);
                                       }
                                       if (tmpstr) {
                                            name = SvPV_const(tmpstr, len);
@@ -15656,7 +15654,7 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
                     newSVpv(CopFILE(PL_curcop),0));
         case 'L': /* __LINE__ */
             return newSVOP(OP_CONST, 0,
-                    Perl_newSVpvf(aTHX_ "%" LINE_Tf, CopLINE(PL_curcop)));
+                    newSVpvf("%" LINE_Tf, CopLINE(PL_curcop)));
         case 'P': /* __PACKAGE__ */
             return newSVOP(OP_CONST, 0,
                     (PL_curstash

--- a/op.c
+++ b/op.c
@@ -741,9 +741,8 @@ Perl_no_bareword_allowed(pTHX_ OP *o)
 {
     PERL_ARGS_ASSERT_NO_BAREWORD_ALLOWED;
 
-    qerror(Perl_mess(aTHX_
-                     "Bareword \"%" SVf "\" not allowed while \"strict subs\" in use",
-                     SVfARG(cSVOPo_sv)));
+    qerror(mess("Bareword \"%" SVf "\" not allowed while \"strict subs\" in"
+                " use", SVfARG(cSVOPo_sv)));
     o->op_private &= ~OPpCONST_STRICT; /* prevent warning twice about the same OP */
 }
 
@@ -772,7 +771,8 @@ Perl_no_bareword_filehandle(pTHX_ const char *fhname)
     PERL_ARGS_ASSERT_NO_BAREWORD_FILEHANDLE;
 
     if (!is_standard_filehandle_name(fhname)) {
-        qerror(Perl_mess(aTHX_ "Bareword filehandle \"%s\" not allowed under 'no feature \"bareword_filehandles\"'", fhname));
+        qerror(mess("Bareword filehandle \"%s\" not allowed under 'no"
+                    " feature \"bareword_filehandles\"'", fhname));
     }
 }
 
@@ -16193,9 +16193,8 @@ Perl_ck_each(pTHX_ OP *o)
                     goto bad;
                 /* FALLTHROUGH */
             default:
-                qerror(Perl_mess(aTHX_
-                    "Experimental %s on scalar is now forbidden",
-                     PL_op_desc[orig_type]));
+                qerror(mess("Experimental %s on scalar is now forbidden",
+                            PL_op_desc[orig_type]));
                bad:
                 bad_type_pv(1, "hash or array", o, kid);
                 return o;

--- a/op.c
+++ b/op.c
@@ -3966,16 +3966,15 @@ S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
 #define ATTRSMODULE "attributes"
 #define ATTRSMODULE_PM "attributes.pm"
 
-        Perl_load_module(
-          aTHX_ PERL_LOADMOD_IMPORT_OPS,
-          newSVpvs(ATTRSMODULE),
-          NULL,
-          op_prepend_elem(OP_LIST,
-                          newSVOP(OP_CONST, 0, stashsv),
-                          op_prepend_elem(OP_LIST,
-                                          newSVOP(OP_CONST, 0,
-                                                  newRV(target)),
-                                          dup_attrlist(attrs))));
+        load_module(PERL_LOADMOD_IMPORT_OPS,
+                    newSVpvs(ATTRSMODULE),
+                    NULL,
+                    op_prepend_elem(OP_LIST,
+                                    newSVOP(OP_CONST, 0, stashsv),
+                                    op_prepend_elem(OP_LIST,
+                                                    newSVOP(OP_CONST, 0,
+                                                            newRV(target)),
+                                                    dup_attrlist(attrs))));
     }
 }
 
@@ -4000,8 +3999,7 @@ S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
     if (svp && *svp != &PL_sv_undef)
         NOOP;	/* already in %INC */
     else
-        Perl_load_module(aTHX_ PERL_LOADMOD_NOIMPORT,
-                               newSVpvs(ATTRSMODULE), NULL);
+        load_module(PERL_LOADMOD_NOIMPORT, newSVpvs(ATTRSMODULE), NULL);
 
     /* Need package name for method call. */
     pack = newSVOP(OP_CONST, 0, newSVpvs(ATTRSMODULE));
@@ -4068,12 +4066,13 @@ Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv,
         }
     }
 
-    Perl_load_module(aTHX_ PERL_LOADMOD_IMPORT_OPS,
-                     newSVpvs(ATTRSMODULE),
-                     NULL, op_prepend_elem(OP_LIST,
-                                  newSVOP(OP_CONST, 0, newSVpv(stashpv,0)),
-                                  op_prepend_elem(OP_LIST,
-                                               newSVOP(OP_CONST, 0,
+    load_module(PERL_LOADMOD_IMPORT_OPS,
+                newSVpvs(ATTRSMODULE),
+                NULL,
+                op_prepend_elem(OP_LIST,
+                                newSVOP(OP_CONST, 0, newSVpv(stashpv,0)),
+                                op_prepend_elem(OP_LIST,
+                                                newSVOP(OP_CONST, 0,
                                                        newRV(MUTABLE_SV(cv))),
                                                attrs)));
 }
@@ -13989,8 +13988,8 @@ Perl_ck_glob(pTHX_ OP *o)
 #if !defined(PERL_EXTERNAL_GLOB)
     if (!PL_globhook) {
         ENTER;
-        Perl_load_module(aTHX_ PERL_LOADMOD_NOIMPORT,
-                               newSVpvs("File::Glob"), NULL, NULL, NULL);
+        load_module(PERL_LOADMOD_NOIMPORT, newSVpvs("File::Glob"),
+                    NULL, NULL, NULL);
         LEAVE;
     }
 #endif /* !PERL_EXTERNAL_GLOB */

--- a/op.c
+++ b/op.c
@@ -9227,7 +9227,7 @@ Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
     CopHINTHASH_set(cop, cophh_copy(CopHINTHASH_get(PL_curcop)));
     CopFEATURES_setfrom(cop, PL_curcop);
     if (label) {
-        Perl_cop_store_label(aTHX_ cop, label, strlen(label), utf8);
+        cop_store_label(cop, label, strlen(label), utf8);
 
         PL_hints |= HINT_BLOCK_SCOPE;
         /* It seems that we need to defer freeing this pointer, as other parts

--- a/os390/os390.c
+++ b/os390/os390.c
@@ -22,7 +22,7 @@ zos_copytags_fd(pTHX_ CV *cv)
   int ret = 0;
 
   if (items != 2)
-    Perl_croak(aTHX_ "Usage: ZOS::Filespec::copytags_fd(f1, f2])");
+    croak("Usage: ZOS::Filespec::copytags_fd(f1, f2])");
 
   int from_fd = (int)SvIV(ST(0));
   int to_fd = (int)SvIV(ST(1));

--- a/pad.c
+++ b/pad.c
@@ -1849,7 +1849,7 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
     pad = PadlistARRAY(padlist)[1];
     pname = PadnamelistARRAY(pad_name);
     ppad = AvARRAY(pad);
-    Perl_dump_indent(aTHX_ level, file,
+    dump_indent(level, file,
             "PADNAME = 0x%" UVxf "(0x%" UVxf ") PAD = 0x%" UVxf "(0x%" UVxf ")\n",
             PTR2UV(pad_name), PTR2UV(pname), PTR2UV(pad), PTR2UV(ppad)
     );
@@ -1861,7 +1861,7 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
         }
         if (namesv) {
             if (PadnameOUTER(namesv))
-                Perl_dump_indent(aTHX_ level+1, file,
+                dump_indent(level+1, file,
                     "%2d. 0x%" UVxf "<%lu> FAKE \"%s\" flags=0x%lx index=%lu\n",
                     (int) ix,
                     PTR2UV(ppad[ix]),
@@ -1872,7 +1872,7 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
 
                 );
             else
-                Perl_dump_indent(aTHX_ level+1, file,
+                dump_indent(level+1, file,
                     "%2d. 0x%" UVxf "<%lu> (%lu,%lu) \"%s\"\n",
                     (int) ix,
                     PTR2UV(ppad[ix]),
@@ -1883,7 +1883,7 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
                 );
         }
         else if (full) {
-            Perl_dump_indent(aTHX_ level+1, file,
+            dump_indent(level+1, file,
                 "%2d. 0x%" UVxf "<%lu>\n",
                 (int) ix,
                 PTR2UV(ppad[ix]),

--- a/perl.c
+++ b/perl.c
@@ -2113,9 +2113,9 @@ S_Internals_V(pTHX_ CV *cv)
     EXTEND(SP, entries);
 
     PUSHs(newSVpvn_flags(PL_bincompat_options, strlen(PL_bincompat_options),
-                              SVs_TEMP));
-    PUSHs(Perl_newSVpvn_flags(aTHX_ non_bincompat_options,
-                              sizeof(non_bincompat_options) - 1, SVs_TEMP));
+                         SVs_TEMP));
+    PUSHs(newSVpvn_flags(non_bincompat_options,
+                         sizeof(non_bincompat_options) - 1, SVs_TEMP));
 
 #ifndef PERL_BUILD_DATE
 #  ifdef __DATE__
@@ -2138,8 +2138,10 @@ S_Internals_V(pTHX_ CV *cv)
     for (i = 1; i <= local_patch_count; i++) {
         /* This will be an undef, if PL_localpatches[i] is NULL.  */
         PUSHs(newSVpvn_flags(PL_localpatches[i],
-            PL_localpatches[i] == NULL ? 0 : strlen(PL_localpatches[i]),
-            SVs_TEMP));
+                             (PL_localpatches[i] == NULL)
+                              ? 0
+                              : strlen(PL_localpatches[i]),
+                             SVs_TEMP));
     }
 
     XSRETURN(entries);
@@ -2442,7 +2444,8 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
                 while (++s && *s) {
                     if (isSPACE(*s)) {
                         if (!popt_copy) {
-                            popt_copy = SvPVX(newSVpvn_flags(d, strlen(d), SVs_TEMP));
+                            popt_copy = SvPVX(newSVpvn_flags(d, strlen(d),
+                                                             SVs_TEMP));
                             s = popt_copy + (s - d);
                             d = popt_copy;
                         }

--- a/perl.c
+++ b/perl.c
@@ -361,7 +361,7 @@ perl_construct(pTHXx)
          */
 #if defined(USE_HASH_SEED)
         /* get the hash seed from the environment or from an RNG */
-        Perl_get_hash_seed(aTHX_ PL_hash_seed);
+        get_hash_seed(PL_hash_seed);
 #else
         /* they want a hard coded seed, check that it is long enough */
         assert( strlen(PERL_HASH_SEED) >= PERL_HASH_SEED_BYTES );

--- a/perl.c
+++ b/perl.c
@@ -348,7 +348,7 @@ perl_construct(pTHXx)
     Newxz(PL_stashpad, PL_stashpadmax, HV *);
 #endif
 #ifdef USE_REENTRANT_API
-    Perl_reentrant_init(aTHX);
+    reentrant_init();
 #endif
     if (PL_hash_seed_set == FALSE) {
         /* Initialize the hash seed and state at startup. This must be

--- a/perl.c
+++ b/perl.c
@@ -2362,9 +2362,8 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
                 }
                 else {
                     ++s;
-                    opts_prog = Perl_newSVpvf(aTHX_
-                                              "use Config; Config::config_vars(qw%c%s%c)",
-                                              0, s, 0);
+                    opts_prog = newSVpvf("use Config; Config::config_vars"
+                                         "(qw%c%s%c)", 0, s, 0);
                     s += strlen(s);
                 }
                 Perl_av_create_and_push(aTHX_ &PL_preambleav, opts_prog);
@@ -2509,11 +2508,12 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
             /* if lib/buildcustomize.pl exists, it should not fail. If it does,
                it should be reported immediately as a build failure.  */
             (void)Perl_av_create_and_unshift_one(aTHX_ &PL_preambleav,
-                                                 Perl_newSVpvf(aTHX_
+                                                 newSVpvf(
                 "BEGIN { my $f = q%c%s%" SVf "/buildcustomize.pl%c; "
                         "do {local $!; -f $f }"
                         " and do $f || die $@ || qq '$f: $!' }",
-                                0, (TAINTING_get ? "./" : ""), SVfARG(*inc0), 0));
+                                0, (TAINTING_get ? "./" : ""),
+                                SVfARG(*inc0), 0));
         }
 #  else
         /* SITELIB_EXP is a function call on Win32.  */
@@ -2524,10 +2524,11 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
                                            INCPUSH_CAN_RELOCATE);
             const char *const sitelib = SvPVX(sitelib_sv);
             (void)Perl_av_create_and_unshift_one(aTHX_ &PL_preambleav,
-                                                 Perl_newSVpvf(aTHX_
-                                                               "BEGIN { do {local $!; -f q%c%s/sitecustomize.pl%c} && do q%c%s/sitecustomize.pl%c }",
-                                                               0, sitelib, 0,
-                                                               0, sitelib, 0));
+                                                 newSVpvf(
+                "BEGIN { do {local $!; -f q%c%s/sitecustomize.pl%c} &&"
+                         " do q%c%s/sitecustomize.pl%c }",
+                         0, sitelib, 0,
+                         0, sitelib, 0));
             assert (SvREFCNT(sitelib_sv) == 1);
             SvREFCNT_dec(sitelib_sv);
         }
@@ -3530,7 +3531,7 @@ Perl_require_pv(pTHX_ const char *pv)
     SV* sv;
 
     PUSHSTACKi(PERLSI_REQUIRE);
-    sv = Perl_newSVpvf(aTHX_ "require q%c%s%c", 0, pv, 0);
+    sv = newSVpvf("require q%c%s%c", 0, pv, 0);
     eval_sv(sv_2mortal(sv), G_DISCARD);
     POPSTACK;
 }
@@ -5155,7 +5156,7 @@ S_mayberelocate(pTHX_ const char *const dir, STRLEN len, U32 flags)
                        length. libpath points somewhere into the libdir SV.
                        We need to join the 2 with '/' and drop the result into
                        libdir.  */
-                    tempsv = Perl_newSVpvf(aTHX_ "%s/%s", prefix, libpath);
+                    tempsv = newSVpvf("%s/%s", prefix, libpath);
                     SvREFCNT_dec(libdir);
                     /* And this is the new libdir.  */
                     libdir = tempsv;

--- a/perl.c
+++ b/perl.c
@@ -1526,7 +1526,7 @@ perl_destruct(pTHXx)
     PL_debug = 0;
 
 #ifdef USE_REENTRANT_API
-    Perl_reentrant_free(aTHX);
+    reentrant_free();
 #endif
 
     /* These all point to HVs that are about to be blown away.

--- a/perl.c
+++ b/perl.c
@@ -1458,7 +1458,7 @@ perl_destruct(pTHXx)
                         sv->sv_debug_serial
                     );
 #ifdef DEBUG_LEAKING_SCALARS_FORK_DUMP
-                    Perl_dump_sv_child(aTHX_ sv);
+                    dump_sv_child(sv);
 #endif
                 }
             }

--- a/perl.h
+++ b/perl.h
@@ -5121,9 +5121,9 @@ Gid_t getegid (void);
 
 #define DEBUG_SCOPE(where) \
     DEBUG_l( \
-    Perl_deb(aTHX_ "%s scope %ld (savestack=%ld) at %s:%d\n",	\
-                    where, (long)PL_scopestack_ix, (long)PL_savestack_ix, \
-                    __FILE__, __LINE__));
+    deb("%s scope %ld (savestack=%ld) at %s:%d\n",	                \
+        where, (long)PL_scopestack_ix, (long)PL_savestack_ix,           \
+        __FILE__, __LINE__));
 /*
 =for apidoc_section $directives
 =for apidoc     ATmp|void|assert_|bool expr

--- a/perlio.c
+++ b/perlio.c
@@ -385,7 +385,7 @@ PerlIO_debug(const char *fmt, ...)
         STRLEN len;
         SV * const sv = newSVpvf("%s:%" LINE_Tf " ",
                                  s ? s : "(none)", CopLINE(PL_curcop));
-        Perl_sv_vcatpvf(aTHX_ sv, fmt, &ap);
+        sv_vcatpvf(sv, fmt, &ap);
 
         s = SvPV_const(sv, len);
         PERL_UNUSED_RESULT(PerlLIO_write(PL_perlio_debug_fd, s, len));

--- a/perlio.c
+++ b/perlio.c
@@ -383,8 +383,8 @@ PerlIO_debug(const char *fmt, ...)
 #else
         const char *s = CopFILE(PL_curcop);
         STRLEN len;
-        SV * const sv = Perl_newSVpvf(aTHX_ "%s:%" LINE_Tf " ",
-                                      s ? s : "(none)", CopLINE(PL_curcop));
+        SV * const sv = newSVpvf("%s:%" LINE_Tf " ",
+                                 s ? s : "(none)", CopLINE(PL_curcop));
         Perl_sv_vcatpvf(aTHX_ sv, fmt, &ap);
 
         s = SvPV_const(sv, len);

--- a/perlio.c
+++ b/perlio.c
@@ -744,7 +744,7 @@ PerlIO_find_layer(pTHX_ const char *name, STRLEN len, int load)
             /*
              * The two SVs are magically freed by load_module
              */
-            Perl_load_module(aTHX_ 0, pkgsv, NULL, layer, NULL);
+            load_module(0, pkgsv, NULL, layer, NULL);
             LEAVE;
             return PerlIO_find_layer(aTHX_ name, len, 0);
         }

--- a/pp.c
+++ b/pp.c
@@ -6122,7 +6122,7 @@ PP_wrapped(pp_splice, 0, 1)
     const MAGIC * const mg = SvTIED_mg((const SV *)ary, PERL_MAGIC_tied);
 
     if (mg) {
-        return Perl_tied_method(aTHX_ SV_CONST(SPLICE), mark - 1, MUTABLE_SV(ary), mg,
+        return tied_method(SV_CONST(SPLICE), mark - 1, MUTABLE_SV(ary), mg,
                                     GIMME_V | TIED_METHOD_ARGUMENTS_ON_STACK,
                                     sp - mark);
     }

--- a/pp.c
+++ b/pp.c
@@ -5466,7 +5466,7 @@ PP_wrapped(pp_akeys, 1, 0)
         }
         else {
             for (i = 0;  i <= n;  i++) {
-                SV *const *const elem = Perl_av_fetch(aTHX_ array, i, 0);
+                SV *const *const elem = av_fetch(array, i, 0);
                 PUSHs(elem ? *elem : &PL_sv_undef);
             }
         }

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4594,8 +4594,7 @@ S_require_version(pTHX_ SV *sv)
                     second = SvIV(*av_fetch(lav,1,0));
 
                 second /= second >= 600  ? 100 : 10;
-                hintsv = Perl_newSVpvf(aTHX_ "v%d.%d.0",
-                                       (int)first, (int)second);
+                hintsv = newSVpvf("v%d.%d.0", (int)first, (int)second);
                 upg_version(hintsv, TRUE);
 
                 DIE(aTHX_ "Perl %" SVf " required (did you mean %" SVf "?)"

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3969,7 +3969,7 @@ Perl_find_runcv(pTHX_ U32 *db_seqp)
 {
     PERL_ARGS_ASSERT_FIND_RUNCV;
 
-    return Perl_find_runcv_where(aTHX_ 0, 0, db_seqp);
+    return find_runcv_where(0, 0, db_seqp);
 }
 
 /* If this becomes part of the API, it might need a better name. */

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1616,11 +1616,12 @@ S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
                                         (const U8*)cx_label, cx_label_len) == 0)
                     : (len == cx_label_len && ((cx_label == label)
                                     || memEQ(cx_label, label, len))) )) {
-                DEBUG_l(Perl_deb(aTHX_ "(poptolabel(): skipping label at cx=%ld %s)\n",
-                        (long)i, cx_label));
+                DEBUG_l(deb("(poptolabel(): skipping label at cx=%ld %s)\n",
+                            (long)i, cx_label));
                 continue;
             }
-            DEBUG_l( Perl_deb(aTHX_ "(poptolabel(): found label at cx=%ld %s)\n", (long)i, label));
+            DEBUG_l( deb("(poptolabel(): found label at cx=%ld %s)\n",
+                         (long)i, label));
             return i;
           }
         }
@@ -1728,17 +1729,17 @@ S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
              * code block. Hide this faked entry from the world. */
             if (cx->cx_type & CXp_SUB_RE_FAKE)
                 continue;
-            DEBUG_l( Perl_deb(aTHX_ "(dopoptosub_at(): found sub at cx=%ld)\n", (long)i));
+            DEBUG_l( deb("(dopoptosub_at(): found sub at cx=%ld)\n", (long)i));
             return i;
 
         case CXt_EVAL:
             if (CxTRY(cx))
                 continue;
-            DEBUG_l( Perl_deb(aTHX_ "(dopoptosub_at(): found sub at cx=%ld)\n", (long)i));
+            DEBUG_l( deb("(dopoptosub_at(): found sub at cx=%ld)\n", (long)i));
             return i;
 
         case CXt_FORMAT:
-            DEBUG_l( Perl_deb(aTHX_ "(dopoptosub_at(): found sub at cx=%ld)\n", (long)i));
+            DEBUG_l( deb("(dopoptosub_at(): found sub at cx=%ld)\n", (long)i));
             return i;
         }
     }
@@ -1757,7 +1758,7 @@ S_dopoptoeval(pTHX_ I32 startingblock)
         default:
             continue;
         case CXt_EVAL:
-            DEBUG_l( Perl_deb(aTHX_ "(dopoptoeval(): found eval at cx=%ld)\n", (long)i));
+            DEBUG_l( deb("(dopoptoeval(): found eval at cx=%ld)\n", (long)i));
             return i;
         }
     }
@@ -1792,7 +1793,7 @@ S_dopoptoloop(pTHX_ I32 startingblock)
         case CXt_LOOP_LAZYSV:
         case CXt_LOOP_LIST:
         case CXt_LOOP_ARY:
-            DEBUG_l( Perl_deb(aTHX_ "(dopoptoloop(): found loop at cx=%ld)\n", (long)i));
+            DEBUG_l( deb("(dopoptoloop(): found loop at cx=%ld)\n", (long)i));
             return i;
         }
     }
@@ -1813,7 +1814,8 @@ S_dopoptogivenfor(pTHX_ I32 startingblock)
         default:
             continue;
         case CXt_GIVEN:
-            DEBUG_l( Perl_deb(aTHX_ "(dopoptogivenfor(): found given at cx=%ld)\n", (long)i));
+            DEBUG_l( deb("(dopoptogivenfor(): found given at cx=%ld)\n",
+                         (long)i));
             return i;
         case CXt_LOOP_PLAIN:
             assert(!(cx->cx_type & CXp_FOR_DEF));
@@ -1823,7 +1825,8 @@ S_dopoptogivenfor(pTHX_ I32 startingblock)
         case CXt_LOOP_LIST:
         case CXt_LOOP_ARY:
             if (cx->cx_type & CXp_FOR_DEF) {
-                DEBUG_l( Perl_deb(aTHX_ "(dopoptogivenfor(): found foreach at cx=%ld)\n", (long)i));
+                DEBUG_l( deb("(dopoptogivenfor(): found foreach at cx=%ld)\n",
+                         (long)i));
                 return i;
             }
         }
@@ -1843,7 +1846,7 @@ S_dopoptowhen(pTHX_ I32 startingblock)
         default:
             continue;
         case CXt_WHEN:
-            DEBUG_l( Perl_deb(aTHX_ "(dopoptowhen(): found when at cx=%ld)\n", (long)i));
+            DEBUG_l( deb("(dopoptowhen(): found when at cx=%ld)\n", (long)i));
             return i;
         }
     }
@@ -3752,7 +3755,7 @@ PP(pp_goto)
             for (; enterops[ix]; ix++) {
                 PL_op = enterops[ix];
                 S_check_op_type(aTHX_ PL_op);
-                DEBUG_l( Perl_deb(aTHX_ "pp_goto: Entering %s\n",
+                DEBUG_l( deb("pp_goto: Entering %s\n",
                                          OP_NAME(PL_op)));
                 PL_op->op_ppaddr(aTHX);
             }
@@ -5967,7 +5970,7 @@ S_destroy_matcher(pTHX_ PMOP *matcher)
 /* Do a smart match */
 PP(pp_smartmatch)
 {
-    DEBUG_M(Perl_deb(aTHX_ "Starting smart match resolution\n"));
+    DEBUG_M(deb("Starting smart match resolution\n"));
     return do_smartmatch(NULL, NULL, 0);
 }
 
@@ -6000,20 +6003,20 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
     /* First of all, handle overload magic of the rightmost argument */
     if (SvAMAGIC(e)) {
         SV * tmpsv;
-        DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Object\n"));
-        DEBUG_M(Perl_deb(aTHX_ "        attempting overload\n"));
+        DEBUG_M(deb("    applying rule Any-Object\n"));
+        DEBUG_M(deb("        attempting overload\n"));
 
         tmpsv = amagic_call(d, e, smart_amg, AMGf_noleft);
         if (tmpsv) {
             rpp_replace_2_1_NN(tmpsv);
             return NORMAL;
         }
-        DEBUG_M(Perl_deb(aTHX_ "        failed to run overload method; continuing...\n"));
+        DEBUG_M(deb("        failed to run overload method; continuing...\n"));
     }
 
     /* ~~ undef */
     if (!SvOK(e)) {
-        DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-undef\n"));
+        DEBUG_M(deb("    applying rule Any-undef\n"));
         if (SvOK(d))
             goto ret_no;
         else
@@ -6021,7 +6024,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
     }
 
     if (SvROK(e) && SvOBJECT(SvRV(e)) && (SvTYPE(SvRV(e)) != SVt_REGEXP)) {
-        DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Object\n"));
+        DEBUG_M(deb("    applying rule Any-Object\n"));
         croak("Smart matching a non-overloaded object breaks encapsulation");
     }
     if (SvROK(d) && SvOBJECT(SvRV(d)) && (SvTYPE(SvRV(d)) != SVt_REGEXP))
@@ -6038,12 +6041,12 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             bool andedresults = TRUE;
             HV *hv = (HV*) SvRV(d);
             I32 numkeys = hv_iterinit(hv);
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Hash-CodeRef\n"));
+            DEBUG_M(deb("    applying rule Hash-CodeRef\n"));
             if (numkeys == 0)
                 goto ret_yes;
             push_stackinfo(PERLSI_SMARTMATCH, 1);
             while ( (he = hv_iternext(hv)) ) {
-                DEBUG_M(Perl_deb(aTHX_ "        testing hash key...\n"));
+                DEBUG_M(deb("        testing hash key...\n"));
                 ENTER_with_name("smartmatch_hash_key_test");
                 SAVETMPS;
                 PUSHMARK(PL_stack_sp);
@@ -6066,13 +6069,13 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             bool andedresults = TRUE;
             AV *av = (AV*) SvRV(d);
             const Size_t len = av_count(av);
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Array-CodeRef\n"));
+            DEBUG_M(deb("    applying rule Array-CodeRef\n"));
             if (len == 0)
                 goto ret_yes;
             push_stackinfo(PERLSI_SMARTMATCH, 1);
             for (i = 0; i < len; ++i) {
                 SV * const * const svp = av_fetch(av, i, FALSE);
-                DEBUG_M(Perl_deb(aTHX_ "        testing array element...\n"));
+                DEBUG_M(deb("        testing array element...\n"));
                 ENTER_with_name("smartmatch_array_elem_test");
                 SAVETMPS;
                 PUSHMARK(PL_stack_sp);
@@ -6092,7 +6095,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
         }
         else {
           sm_any_sub:
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-CodeRef\n"));
+            DEBUG_M(deb("    applying rule Any-CodeRef\n"));
             push_stackinfo(PERLSI_SMARTMATCH, 1);
             ENTER_with_name("smartmatch_coderef");
             PUSHMARK(PL_stack_sp);
@@ -6114,7 +6117,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             goto sm_any_hash; /* Treat objects like scalars */
         }
         else if (!SvOK(d)) {
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Hash ($a undef)\n"));
+            DEBUG_M(deb("    applying rule Any-Hash ($a undef)\n"));
             goto ret_no;
         }
         else if (SvROK(d) && SvTYPE(SvRV(d)) == SVt_PVHV) {
@@ -6127,7 +6130,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
                 other_key_count = 0;
             HV *hv = HV_FROM_REF(e);
 
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Hash-Hash\n"));
+            DEBUG_M(deb("    applying rule Hash-Hash\n"));
             /* Tied hashes don't know how many keys they have. */
             tied = cBOOL(SvTIED_mg((SV*)hv, PERL_MAGIC_tied));
             other_tied = cBOOL(SvTIED_mg((const SV *)other_hv, PERL_MAGIC_tied));
@@ -6150,7 +6153,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             while ( (he = hv_iternext(hv)) ) {
                 SV *key = hv_iterkeysv(he);
 
-                DEBUG_M(Perl_deb(aTHX_ "        comparing hash key...\n"));
+                DEBUG_M(deb("        comparing hash key...\n"));
                 ++ this_key_count;
                 
                 if(!hv_exists_ent(other_hv, key, 0)) {
@@ -6178,10 +6181,10 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             Size_t i;
             HV *hv = HV_FROM_REF(e);
 
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Array-Hash\n"));
+            DEBUG_M(deb("    applying rule Array-Hash\n"));
             for (i = 0; i < other_len; ++i) {
                 SV ** const svp = av_fetch(other_av, i, FALSE);
-                DEBUG_M(Perl_deb(aTHX_ "        checking for key existence...\n"));
+                DEBUG_M(deb("        checking for key existence...\n"));
                 if (svp) {	/* ??? When can this not happen? */
                     if (hv_exists_ent(hv, *svp, 0))
                         goto ret_yes;
@@ -6190,7 +6193,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             goto ret_no;
         }
         else if (SvROK(d) && SvTYPE(SvRV(d)) == SVt_REGEXP) {
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Regex-Hash\n"));
+            DEBUG_M(deb("    applying rule Regex-Hash\n"));
           sm_regex_hash:
             {
                 PMOP * const matcher = make_matcher((REGEXP*) SvRV(d));
@@ -6199,7 +6202,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
 
                 (void) hv_iterinit(hv);
                 while ( (he = hv_iternext(hv)) ) {
-                    DEBUG_M(Perl_deb(aTHX_ "        testing key against pattern...\n"));
+                    DEBUG_M(deb("        testing key against pattern...\n"));
                     if (matcher_matches_sv(matcher, hv_iterkeysv(he))) {
                         (void) hv_iterinit(hv);
                         destroy_matcher(matcher);
@@ -6212,7 +6215,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
         }
         else {
           sm_any_hash:
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Hash\n"));
+            DEBUG_M(deb("    applying rule Any-Hash\n"));
             if (hv_exists_ent(HV_FROM_REF(e), d, 0))
                 goto ret_yes;
             else
@@ -6229,11 +6232,11 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             const Size_t other_len = av_count(other_av);
             Size_t i;
 
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Hash-Array\n"));
+            DEBUG_M(deb("    applying rule Hash-Array\n"));
             for (i = 0; i < other_len; ++i) {
                 SV ** const svp = av_fetch(other_av, i, FALSE);
 
-                DEBUG_M(Perl_deb(aTHX_ "        testing for key existence...\n"));
+                DEBUG_M(deb("        testing for key existence...\n"));
                 if (svp) {	/* ??? When can this not happen? */
                     if (hv_exists_ent(HV_FROM_REF(d), *svp, 0))
                         goto ret_yes;
@@ -6243,7 +6246,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
         }
         if (SvROK(d) && SvTYPE(SvRV(d)) == SVt_PVAV) {
             AV *other_av = AV_FROM_REF(d);
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Array-Array\n"));
+            DEBUG_M(deb("    applying rule Array-Array\n"));
             if (av_count(AV_FROM_REF(e)) != av_count(other_av))
                 goto ret_no;
             else {
@@ -6281,9 +6284,9 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
                                 sv_2mortal(newSViv(PTR2IV(*other_elem))),
                                 &PL_sv_undef, 0);
                         rpp_xpush_2(*other_elem, *this_elem);
-                        DEBUG_M(Perl_deb(aTHX_ "        recursively comparing array element...\n"));
+                        DEBUG_M(deb("        recursively comparing array element...\n"));
                         (void) do_smartmatch(seen_this, seen_other, 0);
-                        DEBUG_M(Perl_deb(aTHX_ "        recursion finished\n"));
+                        DEBUG_M(deb("        recursion finished\n"));
                         
                          bool ok = SvTRUEx(PL_stack_sp[0]);
                          rpp_popfree_1_NN();
@@ -6295,7 +6298,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             }
         }
         else if (SvROK(d) && SvTYPE(SvRV(d)) == SVt_REGEXP) {
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Regex-Array\n"));
+            DEBUG_M(deb("    applying rule Regex-Array\n"));
           sm_regex_array:
             {
                 PMOP * const matcher = make_matcher((REGEXP*) SvRV(d));
@@ -6304,7 +6307,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
 
                 for(i = 0; i < this_len; ++i) {
                     SV * const * const svp = av_fetch(AV_FROM_REF(e), i, FALSE);
-                    DEBUG_M(Perl_deb(aTHX_ "        testing element against pattern...\n"));
+                    DEBUG_M(deb("        testing element against pattern...\n"));
                     if (svp && matcher_matches_sv(matcher, *svp)) {
                         destroy_matcher(matcher);
                         goto ret_yes;
@@ -6319,10 +6322,10 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
             const Size_t this_len = av_count(AV_FROM_REF(e));
             Size_t i;
 
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Undef-Array\n"));
+            DEBUG_M(deb("    applying rule Undef-Array\n"));
             for (i = 0; i < this_len; ++i) {
                 SV * const * const svp = av_fetch(AV_FROM_REF(e), i, FALSE);
-                DEBUG_M(Perl_deb(aTHX_ "        testing for undef element...\n"));
+                DEBUG_M(deb("        testing for undef element...\n"));
                 if (!svp || !SvOK(*svp))
                     goto ret_yes;
             }
@@ -6334,7 +6337,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
                 Size_t i;
                 const Size_t this_len = av_count(AV_FROM_REF(e));
 
-                DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Array\n"));
+                DEBUG_M(deb("    applying rule Any-Array\n"));
                 for (i = 0; i < this_len; ++i) {
                     SV * const * const svp = av_fetch(AV_FROM_REF(e), i, FALSE);
                     if (!svp)
@@ -6342,9 +6345,9 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
 
                     rpp_xpush_2(d, *svp);
                     /* infinite recursion isn't supposed to happen here */
-                    DEBUG_M(Perl_deb(aTHX_ "        recursively testing array element...\n"));
+                    DEBUG_M(deb("        recursively testing array element...\n"));
                     (void) do_smartmatch(NULL, NULL, 1);
-                    DEBUG_M(Perl_deb(aTHX_ "        recursion finished\n"));
+                    DEBUG_M(deb("        recursion finished\n"));
                     bool ok = SvTRUEx(PL_stack_sp[0]);
                     rpp_popfree_1_NN();
                     if (ok)
@@ -6358,19 +6361,19 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
     else if (SvROK(e) && SvTYPE(SvRV(e)) == SVt_REGEXP) {
         if (!object_on_left && SvROK(d) && SvTYPE(SvRV(d)) == SVt_PVHV) {
             SV *t = d; d = e; e = t;
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Hash-Regex\n"));
+            DEBUG_M(deb("    applying rule Hash-Regex\n"));
             goto sm_regex_hash;
         }
         else if (!object_on_left && SvROK(d) && SvTYPE(SvRV(d)) == SVt_PVAV) {
             SV *t = d; d = e; e = t;
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Array-Regex\n"));
+            DEBUG_M(deb("    applying rule Array-Regex\n"));
             goto sm_regex_array;
         }
         else {
             PMOP * const matcher = make_matcher((REGEXP*) SvRV(e));
             bool result;
 
-            DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Regex\n"));
+            DEBUG_M(deb("    applying rule Any-Regex\n"));
             result = matcher_matches_sv(matcher, d);
             destroy_matcher(matcher);
             if (result)
@@ -6383,29 +6386,29 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
     /* See if there is overload magic on left */
     else if (object_on_left && SvAMAGIC(d)) {
         SV *tmpsv;
-        DEBUG_M(Perl_deb(aTHX_ "    applying rule Object-Any\n"));
-        DEBUG_M(Perl_deb(aTHX_ "        attempting overload\n"));
+        DEBUG_M(deb("    applying rule Object-Any\n"));
+        DEBUG_M(deb("        attempting overload\n"));
         tmpsv = amagic_call(d, e, smart_amg, AMGf_noright);
         if (tmpsv) {
             rpp_replace_2_1_NN(tmpsv);
             return NORMAL;
         }
 
-        DEBUG_M(Perl_deb(aTHX_ "        failed to run overload method; falling back...\n"));
+        DEBUG_M(deb("        failed to run overload method; falling back...\n"));
         goto sm_any_scalar;
     }
     else if (!SvOK(d)) {
         /* undef ~~ scalar ; we already know that the scalar is SvOK */
-        DEBUG_M(Perl_deb(aTHX_ "    applying rule undef-Any\n"));
+        DEBUG_M(deb("    applying rule undef-Any\n"));
         goto ret_no;
     }
     else
   sm_any_scalar:
     if (SvNIOK(e) || (SvPOK(e) && looks_like_number(e) && SvNIOK(d))) {
         DEBUG_M(if (SvNIOK(e))
-                    Perl_deb(aTHX_ "    applying rule Any-Num\n");
+                    deb("    applying rule Any-Num\n");
                 else
-                    Perl_deb(aTHX_ "    applying rule Num-numish\n");
+                    deb("    applying rule Num-numish\n");
         );
         /* numeric comparison */
         rpp_xpush_2(d, e);
@@ -6422,7 +6425,7 @@ S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
     }
     
     /* As a last resort, use string comparison */
-    DEBUG_M(Perl_deb(aTHX_ "    applying rule Any-Any\n"));
+    DEBUG_M(deb("    applying rule Any-Any\n"));
     rpp_xpush_2(d, e);
     Perl_pp_seq(aTHX);
     {

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -4276,14 +4276,14 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
         PL_compiling.cop_warnings =
             DUP_WARNINGS(oldcurcop->cop_warnings);
         cophh_free(CopHINTHASH_get(&PL_compiling));
-        if (Perl_cop_fetch_label(aTHX_ oldcurcop, NULL, NULL)) {
+        if (cop_fetch_label(oldcurcop, NULL, NULL)) {
             /* The label, if present, is the first entry on the chain. So rather
                than writing a blank label in front of it (which involves an
                allocation), just use the next entry in the chain.  */
             PL_compiling.cop_hints_hash
                 = cophh_copy(oldcurcop->cop_hints_hash->refcounted_he_next);
             /* Check the assumption that this removed the label.  */
-            assert(Perl_cop_fetch_label(aTHX_ &PL_compiling, NULL, NULL) == NULL);
+            assert(cop_fetch_label(&PL_compiling, NULL, NULL) == NULL);
         }
         else
             PL_compiling.cop_hints_hash = cophh_copy(oldcurcop->cop_hints_hash);

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -2097,7 +2097,7 @@ PP(pp_print)
             *MARK = NULL;
             ++PL_stack_sp;
         }
-        return Perl_tied_method(aTHX_ SV_CONST(PRINT), mark - 1, MUTABLE_SV(io),
+        return tied_method(SV_CONST(PRINT), mark - 1, MUTABLE_SV(io),
                                 mg,
                                 (G_SCALAR | TIED_METHOD_ARGUMENTS_ON_STACK
                                  | (PL_op->op_type == OP_SAY
@@ -4089,7 +4089,7 @@ Perl_do_readline(pTHX)
 
             /* tied_method() frees everything currently above the passed
              * mark, and returns any values at mark[1] onwards */
-            Perl_tied_method(aTHX_ SV_CONST(READLINE),
+            tied_method(SV_CONST(READLINE),
                 /* mark => */ PL_stack_sp,
                               MUTABLE_SV(io), mg, gimme, 0);
 

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -1639,8 +1639,7 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
                     if (++bytes >= sizeof(UV)) {	/* promote to string */
                         const char *t;
 
-                        sv = Perl_newSVpvf(aTHX_ "%.*" UVuf,
-                                                 (int)TYPE_DIGITS(UV), auv);
+                        sv = newSVpvf("%.*" UVuf, (int)TYPE_DIGITS(UV), auv);
                         while (s < strend) {
                             ch = SHIFT_BYTE(utf8, s, strend, datumtype);
                             sv = mul128(sv, (U8)(ch & 0x7f));

--- a/pp_sort.c
+++ b/pp_sort.c
@@ -974,7 +974,7 @@ PP(pp_sort)
             }
 
             start = p1 - max;
-            Perl_sortsv_flags(aTHX_ start, max,
+            sortsv_flags(start, max,
                     (is_xsub ? S_sortcv_xsub : hasargs ? S_sortcv_stacked : S_sortcv),
                     sort_flags);
 

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -800,11 +800,11 @@ Perl_tied_method(pTHX_ SV *methname, SV **mark, SV *const sv,
 
 
 #define tied_method0(a,b,c,d)		\
-    Perl_tied_method(aTHX_ a,b,c,d,G_SCALAR,0)
+    tied_method(a,b,c,d,G_SCALAR,0)
 #define tied_method1(a,b,c,d,e)		\
-    Perl_tied_method(aTHX_ a,b,c,d,G_SCALAR,1,e)
+    tied_method(a,b,c,d,G_SCALAR,1,e)
 #define tied_method2(a,b,c,d,e,f)	\
-    Perl_tied_method(aTHX_ a,b,c,d,G_SCALAR,2,e,f)
+    tied_method(a,b,c,d,G_SCALAR,2,e,f)
 
 PP_wrapped(pp_open, 0, 1)
 {
@@ -834,7 +834,7 @@ PP_wrapped(pp_open, 0, 1)
         if (mg) {
             /* Method's args are same as ours ... */
             /* ... except handle is replaced by the object */
-            return Perl_tied_method(aTHX_ SV_CONST(OPEN), mark - 1, MUTABLE_SV(io), mg,
+            return tied_method(SV_CONST(OPEN), mark - 1, MUTABLE_SV(io), mg,
                                     G_SCALAR | TIED_METHOD_ARGUMENTS_ON_STACK,
                                     sp - mark);
         }
@@ -1034,7 +1034,7 @@ PP_wrapped(pp_binmode, MAXARG, 0)
                function, which I don't think that the optimiser will be able to
                figure out. Although, as it's a static function, in theory it
                could.  */
-            return Perl_tied_method(aTHX_ SV_CONST(BINMODE), SP, MUTABLE_SV(io), mg,
+            return tied_method(SV_CONST(BINMODE), SP, MUTABLE_SV(io), mg,
                                     G_SCALAR|TIED_METHOD_MORTALIZE_NOT_NEEDED,
                                     discp ? 1 : 0, discp);
         }
@@ -1600,7 +1600,7 @@ PP_wrapped(pp_getc, MAXARG, 0)
         const MAGIC * const mg = SvTIED_mg((const SV *)io, PERL_MAGIC_tiedscalar);
         if (mg) {
             const U8 gimme = GIMME_V;
-            Perl_tied_method(aTHX_ SV_CONST(GETC), SP, MUTABLE_SV(io), mg, gimme, 0);
+            tied_method(SV_CONST(GETC), SP, MUTABLE_SV(io), mg, gimme, 0);
             if (gimme == G_SCALAR) {
                 SPAGAIN;
                 SvSetMagicSV_nosteal(TARG, TOPs);
@@ -1854,7 +1854,7 @@ PP(pp_prtf)
                 *MARK = NULL;
                 ++PL_stack_sp;
             }
-            return Perl_tied_method(aTHX_ SV_CONST(PRINTF), mark - 1, MUTABLE_SV(io),
+            return tied_method(SV_CONST(PRINTF), mark - 1, MUTABLE_SV(io),
                                     mg,
                                     G_SCALAR | TIED_METHOD_ARGUMENTS_ON_STACK,
                                     PL_stack_sp - mark);
@@ -1944,7 +1944,7 @@ PP_wrapped(pp_sysread, 0, 1)
     {
         const MAGIC *const mg = SvTIED_mg((const SV *)io, PERL_MAGIC_tiedscalar);
         if (mg) {
-            return Perl_tied_method(aTHX_ SV_CONST(READ), mark - 1, MUTABLE_SV(io), mg,
+            return tied_method(SV_CONST(READ), mark - 1, MUTABLE_SV(io), mg,
                                     G_SCALAR | TIED_METHOD_ARGUMENTS_ON_STACK,
                                     sp - mark);
         }
@@ -2202,7 +2202,7 @@ PP_wrapped(pp_syswrite, 0, 1)
                 PUTBACK;
             }
 
-            return Perl_tied_method(aTHX_ SV_CONST(WRITE), mark - 1, MUTABLE_SV(io), mg,
+            return tied_method(SV_CONST(WRITE), mark - 1, MUTABLE_SV(io), mg,
                                     G_SCALAR | TIED_METHOD_ARGUMENTS_ON_STACK,
                                     sp - mark);
         }

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -5058,7 +5058,7 @@ PP_wrapped(pp_gmtime, MAXARG, 0)
        else {
            dTARGET;
            PUSHs(TARG);
-           Perl_sv_setpvf_mg(aTHX_ TARG, "%s %s %2d %02d:%02d:%02d %" IVdf,
+           sv_setpvf_mg(TARG, "%s %s %2d %02d:%02d:%02d %" IVdf,
                                 dayname[tmbuf.tm_wday],
                                 monname[tmbuf.tm_mon],
                                 tmbuf.tm_mday,

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -1729,8 +1729,8 @@ PP(pp_leavewrite)
                 SV *topname;
                 if (!IoFMT_NAME(io))
                     IoFMT_NAME(io) = savepv(GvNAME(gv));
-                topname = sv_2mortal(Perl_newSVpvf(aTHX_ "%" HEKf "_TOP",
-                                        HEKfARG(GvNAME_HEK(gv))));
+                topname = sv_2mortal(newSVpvf("%" HEKf "_TOP",
+                                              HEKfARG(GvNAME_HEK(gv))));
                 topgv = gv_fetchsv(topname, 0, SVt_PVFM);
                 if ((topgv && GvFORM(topgv)) ||
                   !gv_fetchpvs("top", GV_NOTQUAL, SVt_PVFM))

--- a/regcomp.c
+++ b/regcomp.c
@@ -9394,7 +9394,7 @@ S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV* posix_warnings)
                                             fail-safe */
             (void) sv_2mortal(msg);
         }
-        Perl_warner(aTHX_ packWARN(WARN_REGEXP), "%s", SvPVX(msg));
+        warner(packWARN(WARN_REGEXP), "%s", SvPVX(msg));
         SvREFCNT_dec_NN(msg);
     }
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -7706,7 +7706,7 @@ Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
         if (posix_warnings) {                                               \
             if (! RExC_warn_text ) RExC_warn_text =                         \
                                    MUTABLE_AV(newSV_type_mortal(SVt_PVAV)); \
-            av_push_simple(RExC_warn_text, Perl_newSVpvf(aTHX_              \
+            av_push_simple(RExC_warn_text, newSVpvf(\
                                              WARNING_PREFIX                 \
                                              text                           \
                                              REPORT_LOCATION,               \
@@ -9682,7 +9682,7 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
     /* We include the /i status at the beginning of this so that we can
      * know it at runtime */
-    listsv = sv_2mortal(Perl_newSVpvf(aTHX_ "#%d\n", cBOOL(FOLD)));
+    listsv = sv_2mortal(newSVpvf("#%d\n", cBOOL(FOLD)));
     initial_listsv_len = SvCUR(listsv);
     SvTEMP_off(listsv); /* Grr, TEMPs and mortals are conflated.  */
 
@@ -16072,7 +16072,7 @@ S_parse_uniprop_string(pTHX_
         if (UNLIKELY(pu_overrides && SvPOK(pu_overrides))) {
 
             /* See if there is an element in the hints hash for this table */
-            SV * pu_lookup = Perl_newSVpvf(aTHX_ "%d=", table_index);
+            SV * pu_lookup = newSVpvf("%d=", table_index);
             const char * pos = strstr(SvPVX(pu_overrides), SvPVX(pu_lookup));
 
             if (pos) {
@@ -16526,7 +16526,7 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
         char * legal = SvPVX(* hv_fetchs(this_series, "legal", 0));
 
         /* Pre-allocate an SV with enough space */
-        SV * algo_name = sv_2mortal(Perl_newSVpvf(aTHX_ "%s-0000",
+        SV * algo_name = sv_2mortal(newSVpvf("%s-0000",
                                                         SvPVX(prefix)));
         if (high >= 0x10000) {
             sv_catpvs(algo_name, "0");

--- a/regcomp.c
+++ b/regcomp.c
@@ -442,7 +442,7 @@ Perl_pregcomp(pTHX_ SV * const pattern, const U32 flags)
 
     /* Dispatch a request to compile a regexp to correct regexp engine. */
     DEBUG_COMPILE_r({
-        Perl_re_printf( aTHX_  "Using engine %" UVxf "\n",
+        re_printf("Using engine %" UVxf "\n",
                         PTR2UV(eng));
     });
     return CALLREGCOMP_ENG(eng, pattern, flags);
@@ -568,7 +568,7 @@ S_pat_upgrade_to_utf8(pTHX_ RExC_state_t * const pRExC_state,
     bool do_end = 0;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    DEBUG_PARSE_r(Perl_re_printf( aTHX_
+    DEBUG_PARSE_r(re_printf(
         "UTF8 mismatch! Converting to utf8 for resizing and compile\n"));
 
     int nblocks = 0;
@@ -1007,7 +1007,7 @@ S_compile_runtime_code(pTHX_ RExC_state_t * const pRExC_state,
         }
         *p++ = '\0';
         DEBUG_COMPILE_r({
-            Perl_re_printf( aTHX_
+            re_printf(
                 "%sre-parsing pattern for runtime code:%s %s\n",
                 PL_colors[4], PL_colors[5], newpat);
         });
@@ -1554,7 +1554,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
 
     }
 
-    DEBUG_PARSE_r(Perl_re_printf( aTHX_
+    DEBUG_PARSE_r(re_printf(
         "Assembling pattern from %d elements%s\n", pat_count,
             orig_rx_flags & RXf_SPLIT ? " for split" : ""));
 
@@ -1583,7 +1583,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             if (is_bare_re)
                 *is_bare_re = true;
             SvREFCNT_inc(re);
-            DEBUG_PARSE_r(Perl_re_printf( aTHX_
+            DEBUG_PARSE_r(re_printf(
                 "Precompiled pattern%s\n",
                     orig_rx_flags & RXf_SPLIT ? " for split" : ""));
 
@@ -1616,7 +1616,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
 
     DEBUG_COMPILE_r({
             RE_PV_QUOTED_DECL(s, RExC_utf8, RExC_mysv, exp, plen, PL_dump_re_max_len);
-            Perl_re_printf( aTHX_  "%sCompiling REx%s %s\n",
+            re_printf("%sCompiling REx%s %s\n",
                           PL_colors[4], PL_colors[5], s);
         });
 
@@ -1653,7 +1653,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     {
         DEBUG_COMPILE_r({
             RE_PV_QUOTED_DECL(s, RExC_utf8, RExC_mysv, exp, plen, PL_dump_re_max_len);
-            Perl_re_printf( aTHX_  "%sSkipping recompilation of unchanged REx%s %s\n",
+            re_printf("%sSkipping recompilation of unchanged REx%s %s\n",
                           PL_colors[4], PL_colors[5], s);
         });
         LEAVE_with_name("re_op_compile");
@@ -1722,7 +1722,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     set_regex_pv(pRExC_state, Rx);
 
     DEBUG_PARSE_r({
-        Perl_re_printf( aTHX_
+        re_printf(
             "Starting parse and generation\n");
         RExC_lastnum = 0;
         RExC_lastparse = NULL;
@@ -1838,10 +1838,10 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
                                                 + RExC_latest_warn_offset);
             }
             S_pat_upgrade_to_utf8(aTHX_ pRExC_state, &exp, &plen);
-            DEBUG_PARSE_r(Perl_re_printf( aTHX_ "Need to redo parse after upgrade\n"));
+            DEBUG_PARSE_r(re_printf("Need to redo parse after upgrade\n"));
         }
         else {
-            DEBUG_PARSE_r(Perl_re_printf( aTHX_ "Need to redo parse\n"));
+            DEBUG_PARSE_r(re_printf("Need to redo parse\n"));
         }
 
         if (ALL_PARENS_COUNTED) {
@@ -1899,7 +1899,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         RExC_whilem_seen = 15;
 
     DEBUG_PARSE_r({
-        Perl_re_printf( aTHX_
+        re_printf(
             "Required size %zd nodes\n", RExC_size);
         RExC_lastnum = 0;
         RExC_lastparse = NULL;
@@ -1911,14 +1911,14 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         SV * const sv = sv_newmortal(); /* can this use RExC_mysv? */
         RXi_GET_DECL(RExC_rx, ri);
         DEBUG_RExC_seen();
-        Perl_re_printf( aTHX_ "Program before optimization:\n");
+        re_printf("Program before optimization:\n");
 
         (void)dumpuntil(RExC_rx, ri->program, ri->program + 1, NULL, NULL,
                         sv, 0, 0);
     });
 
     DEBUG_OPTIMISE_r(
-        Perl_re_printf( aTHX_  "Starting post parse optimization\n");
+        re_printf("Starting post parse optimization\n");
     );
 
     /* XXXX To minimize changes to RE engine we always allocate
@@ -1958,7 +1958,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         copyRExC_state = *pRExC_state;
     } else {
         U32 seen = RExC_seen;
-        DEBUG_OPTIMISE_r(Perl_re_printf( aTHX_ "Restudying\n"));
+        DEBUG_OPTIMISE_r(re_printf("Restudying\n"));
 
         *pRExC_state = copyRExC_state;
         if (seen & REG_TOP_LEVEL_BRANCHES_SEEN)
@@ -2100,11 +2100,11 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         /* search for "restudy" in this file for a detailed explanation */
         DEBUG_PARSE_r(
             if (!restudied)
-                Perl_re_printf( aTHX_  "first at %td\n", first - scan + 1)
+                re_printf("first at %td\n", first - scan + 1)
         );
 #else
         DEBUG_PARSE_r(
-            Perl_re_printf( aTHX_  "first at %td\n", first - scan + 1)
+            re_printf("first at %td\n", first - scan + 1)
         );
 #endif
 
@@ -2226,7 +2226,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             RExC_rx->intflags &= ~PREGf_SKIP;	/* Used in find_byclass(). */
             DEBUG_COMPILE_r({ SV *sv = sv_newmortal();
                       regprop(RExC_rx, sv, (regnode*)data.start_class, NULL, pRExC_state);
-                      Perl_re_printf( aTHX_
+                      re_printf(
                                     "synthetic stclass \"%s\".\n",
                                     SvPVX_const(sv));});
             data.start_class = NULL;
@@ -2264,7 +2264,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
         SSize_t last_close = 0;
         regnode *last_close_op = NULL;
 
-        DEBUG_PARSE_r(Perl_re_printf( aTHX_  "\nMulti Top Level\n"));
+        DEBUG_PARSE_r(re_printf("\nMulti Top Level\n"));
 
         scan = RExC_rxi->program + 1;
         ssc_init(pRExC_state, &ch_class);
@@ -2310,7 +2310,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             RExC_rx->intflags &= ~PREGf_SKIP;	/* Used in find_byclass(). */
             DEBUG_COMPILE_r({ SV* sv = sv_newmortal();
                       regprop(RExC_rx, sv, (regnode*)data.start_class, NULL, pRExC_state);
-                      Perl_re_printf( aTHX_
+                      re_printf(
                                     "synthetic stclass \"%s\".\n",
                                     SvPVX_const(sv));});
             data.start_class = NULL;
@@ -2328,7 +2328,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     /* Guard against an embedded (?=) or (?<=) with a longer minlen than
        the "real" pattern. */
     DEBUG_OPTIMISE_r({
-        Perl_re_printf( aTHX_ "minlen: %zd RExC_rx->minlen:%zd maxlen:%zd\n",
+        re_printf("minlen: %zd RExC_rx->minlen:%zd maxlen:%zd\n",
                       minlen, RExC_rx->minlen, RExC_maxlen);
     });
     RExC_rx->minlenret = minlen;
@@ -2468,12 +2468,12 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     Newxz(RXp_OFFSp(RExC_rx), RExC_total_parens, regexp_paren_pair);
     /* assume we don't need to swap parens around before we match */
     DEBUG_TEST_r({
-        Perl_re_printf( aTHX_ "study_chunk_recursed_count: %lu\n",
+        re_printf("study_chunk_recursed_count: %lu\n",
             (unsigned long)RExC_study_chunk_recursed_count);
     });
     DEBUG_DUMP_r({
         DEBUG_RExC_seen();
-        Perl_re_printf( aTHX_ "Final program:\n");
+        re_printf("Final program:\n");
         regdump(RExC_rx);
     });
 
@@ -2583,7 +2583,7 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
 
 #define DEBUG_PARSE_MSG(funcname)     DEBUG_PARSE_r({           \
     if (RExC_lastparse!=RExC_parse) {                           \
-        Perl_re_printf( aTHX_  "%s",                            \
+        re_printf("%s",                                         \
             pv_pretty(RExC_mysv1, RExC_parse,                   \
                       RExC_end - RExC_parse, 16,                \
                       "", "",                                   \
@@ -2595,13 +2595,13 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
             )                                                   \
         );                                                      \
     } else                                                      \
-        Perl_re_printf( aTHX_ "%16s","");                       \
+        re_printf("%16s","");                                   \
                                                                 \
     if (RExC_lastnum!=RExC_emit)                                \
-       Perl_re_printf( aTHX_ "|%4zu", RExC_emit);               \
+       re_printf("|%4zu", RExC_emit);                           \
     else                                                        \
-       Perl_re_printf( aTHX_ "|%4s","");                        \
-    Perl_re_printf( aTHX_ "|%*s%-4s",                           \
+       re_printf("|%4s","");                                    \
+    re_printf("|%*s%-4s",                                       \
         (int)((depth*2)), "",                                   \
         (funcname)                                              \
     );                                                          \
@@ -2613,11 +2613,11 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
 
 #define DEBUG_PARSE(funcname)     DEBUG_PARSE_r({           \
     DEBUG_PARSE_MSG((funcname));                            \
-    Perl_re_printf( aTHX_ "%4s","\n");                                  \
+    re_printf("%4s","\n");                                  \
 })
 #define DEBUG_PARSE_FMT(funcname,fmt,args)     DEBUG_PARSE_r({\
     DEBUG_PARSE_MSG((funcname));                            \
-    Perl_re_printf( aTHX_ fmt "\n",args);                               \
+    re_printf(fmt "\n",args);                               \
 })
 
 
@@ -3824,7 +3824,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                  */
                 ret = reg2node(pRExC_state, GOSUB, num, RExC_recurse_count);
                 RExC_recurse_count++;
-                DEBUG_OPTIMISE_MORE_r(Perl_re_printf( aTHX_
+                DEBUG_OPTIMISE_MORE_r(re_printf(
                     "%*s%*s Recurse #%" UVuf " to %" IVdf "\n",
                             22, "|    |", (int)(depth * 2 + 1), "",
                             (UV)ARG1u(REGNODE_p(ret)),
@@ -4229,7 +4229,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                 RExC_nestroot = parno;
             if (RExC_open_parens && !RExC_open_parens[parno])
             {
-                DEBUG_OPTIMISE_MORE_r(Perl_re_printf( aTHX_
+                DEBUG_OPTIMISE_MORE_r(re_printf(
                     "%*s%*s Setting open paren #%" IVdf " to %zu\n",
                     22, "|    |", (int)(depth * 2 + 1), "",
                     (IV)parno, ret));
@@ -4345,7 +4345,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
         case 1: case 2:
             ender = reg1node(pRExC_state, CLOSE, parno);
             if ( RExC_close_parens ) {
-                DEBUG_OPTIMISE_MORE_r(Perl_re_printf( aTHX_
+                DEBUG_OPTIMISE_MORE_r(re_printf(
                         "%*s%*s Setting close paren #%" IVdf " to %zu\n",
                         22, "|    |", (int)(depth * 2 + 1), "",
                         (IV)parno, ender));
@@ -4382,7 +4382,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
             assert(!RExC_end_op); /* there can only be one! */
             RExC_end_op = REGNODE_p(ender);
             if (RExC_close_parens) {
-                DEBUG_OPTIMISE_MORE_r(Perl_re_printf( aTHX_
+                DEBUG_OPTIMISE_MORE_r(re_printf(
                     "%*s%*s Setting close paren #0 (END) to %zu\n",
                     22, "|    |", (int)(depth * 2 + 1), "",
                     ender));
@@ -4395,7 +4395,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
             DEBUG_PARSE_MSG("lsbr");
             regprop(RExC_rx, RExC_mysv1, REGNODE_p(lastbr), NULL, pRExC_state);
             regprop(RExC_rx, RExC_mysv2, REGNODE_p(ender), NULL, pRExC_state);
-            Perl_re_printf( aTHX_  "~ tying lastbr %s (%zd) to ender %s (%zd) offset %zd\n",
+            re_printf("~ tying lastbr %s (%zd) to ender %s (%zd) offset %zd\n",
                           SvPV_nolen_const(RExC_mysv1),
                           lastbr,
                           SvPV_nolen_const(RExC_mysv2),
@@ -4459,7 +4459,7 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                                      NULL, pRExC_state);
                     regprop(RExC_rx, RExC_mysv2, REGNODE_p(ender),
                                      NULL, pRExC_state);
-                    Perl_re_printf( aTHX_  "~ converting ret %s (%" IVdf ") to ender %s (%zd) offset %zd\n",
+                    re_printf("~ converting ret %s (%" IVdf ") to ender %s (%zd) offset %zd\n",
                                   SvPV_nolen_const(RExC_mysv1),
                                   (IV)REG_NODE_NUM(ret_as_regnode),
                                   SvPV_nolen_const(RExC_mysv2),
@@ -13218,7 +13218,7 @@ S_regtail(pTHX_ RExC_state_t * pRExC_state,
         DEBUG_PARSE_r({
             DEBUG_PARSE_MSG((scan == p ? "tail" : ""));
             regprop(RExC_rx, RExC_mysv, REGNODE_p(scan), NULL, pRExC_state);
-            Perl_re_printf( aTHX_  "~ %s (%zu) %s %s\n",
+            re_printf("~ %s (%zu) %s %s\n",
                 SvPV_nolen_const(RExC_mysv), scan,
                     (temp == NULL ? "->" : ""),
                     (temp == NULL ? REGNODE_NAME(OP(REGNODE_p(val))) : "")
@@ -13311,7 +13311,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
         DEBUG_PARSE_r({
             DEBUG_PARSE_MSG((scan == p ? "tsdy" : ""));
             regprop(RExC_rx, RExC_mysv, REGNODE_p(scan), NULL, pRExC_state);
-            Perl_re_printf( aTHX_  "~ %s (%zu) -> %s\n",
+            re_printf("~ %s (%zu) -> %s\n",
                 SvPV_nolen_const(RExC_mysv),
                 scan,
                 REGNODE_NAME(exact));
@@ -13323,7 +13323,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
     DEBUG_PARSE_r({
         DEBUG_PARSE_MSG("");
         regprop(RExC_rx, RExC_mysv, REGNODE_p(val), NULL, pRExC_state);
-        Perl_re_printf( aTHX_
+        re_printf(
                       "~ attach to %s (%zd) offset to %zd\n",
                       SvPV_nolen_const(RExC_mysv),
                       val,
@@ -13424,7 +13424,7 @@ Perl_re_intuit_string(pTHX_ REGEXP * const r)
                       ? prog->check_utf8 : prog->check_substr);
 
                 if (!PL_colorset) reginitcolors();
-                Perl_re_printf( aTHX_
+                re_printf(
                       "%sUsing REx %ssubstr:%s \"%s%.60s%s%s\"\n",
                       PL_colors[4],
                       RX_UTF8(r) ? "utf8 " : "",
@@ -13676,7 +13676,7 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
             SV *dsv= sv_newmortal();
             RE_PV_QUOTED_DECL(s, RX_UTF8(rx),
                 dsv, RX_PRECOMP(rx), RX_PRELEN(rx), PL_dump_re_max_len);
-            Perl_re_printf( aTHX_ "%sFreeing REx:%s %s\n",
+            re_printf("%sFreeing REx:%s %s\n",
                 PL_colors[4], PL_colors[5], s);
         }
     });

--- a/regcomp.c
+++ b/regcomp.c
@@ -15023,7 +15023,7 @@ S_parse_uniprop_string(pTHX_
                     goto append_name_to_msg;
                 }
 
-                Perl_ck_warner_d(aTHX_
+                ck_warner_d(
                     packWARN(WARN_EXPERIMENTAL__UNIPROP_WILDCARDS),
                     "The Unicode property wildcards feature is experimental");
 
@@ -16028,7 +16028,7 @@ S_parse_uniprop_string(pTHX_
     if (table_index > MAX_UNI_KEYWORD_INDEX) {
         Size_t warning_offset = table_index / MAX_UNI_KEYWORD_INDEX;
         table_index %= MAX_UNI_KEYWORD_INDEX;
-        Perl_ck_warner_d(aTHX_ packWARN(WARN_DEPRECATED__UNICODE_PROPERTY_NAME),
+        ck_warner_d(packWARN(WARN_DEPRECATED__UNICODE_PROPERTY_NAME),
                 "Use of '%.*s' in \\p{} or \\P{} is deprecated because: %s",
                 (int) name_len, name,
                 get_deprecated_property_msg(warning_offset));
@@ -16112,7 +16112,8 @@ S_parse_uniprop_string(pTHX_
                                &expanded_prop_definition);
                 prop_definition = expanded_prop_definition;
                 cloned = true;
-                Perl_ck_warner_d(aTHX_ packWARN(WARN_EXPERIMENTAL__PRIVATE_USE), "The private_use feature is experimental");
+                ck_warner_d(packWARN(WARN_EXPERIMENTAL__PRIVATE_USE),
+                            "The private_use feature is experimental");
             }
         }
     }

--- a/regcomp.c
+++ b/regcomp.c
@@ -2584,29 +2584,29 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
 #define DEBUG_PARSE_MSG(funcname)     DEBUG_PARSE_r({           \
     if (RExC_lastparse!=RExC_parse) {                           \
         Perl_re_printf( aTHX_  "%s",                            \
-            Perl_pv_pretty(aTHX_ RExC_mysv1, RExC_parse,        \
-                RExC_end - RExC_parse, 16,                      \
-                "", "",                                         \
-                PERL_PV_ESCAPE_UNI_DETECT |                     \
-                PERL_PV_PRETTY_ELLIPSES   |                     \
-                PERL_PV_PRETTY_LTGT       |                     \
-                PERL_PV_ESCAPE_RE         |                     \
-                PERL_PV_PRETTY_EXACTSIZE                        \
+            pv_pretty(RExC_mysv1, RExC_parse,                   \
+                      RExC_end - RExC_parse, 16,                \
+                      "", "",                                   \
+                      PERL_PV_ESCAPE_UNI_DETECT |               \
+                      PERL_PV_PRETTY_ELLIPSES   |               \
+                      PERL_PV_PRETTY_LTGT       |               \
+                      PERL_PV_ESCAPE_RE         |               \
+                      PERL_PV_PRETTY_EXACTSIZE                  \
             )                                                   \
         );                                                      \
     } else                                                      \
         Perl_re_printf( aTHX_ "%16s","");                       \
                                                                 \
     if (RExC_lastnum!=RExC_emit)                                \
-       Perl_re_printf( aTHX_ "|%4zu", RExC_emit);                \
+       Perl_re_printf( aTHX_ "|%4zu", RExC_emit);               \
     else                                                        \
        Perl_re_printf( aTHX_ "|%4s","");                        \
     Perl_re_printf( aTHX_ "|%*s%-4s",                           \
         (int)((depth*2)), "",                                   \
         (funcname)                                              \
     );                                                          \
-    RExC_lastnum = RExC_emit;                                     \
-    RExC_lastparse = RExC_parse;                                  \
+    RExC_lastnum = RExC_emit;                                   \
+    RExC_lastparse = RExC_parse;                                \
 })
 
 

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -99,7 +99,7 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
             (UV)data->flags
         );
 
-        Perl_debug_show_study_flags(aTHX_ data->flags," [","]");
+        debug_show_study_flags(data->flags," [","]");
 
         Perl_re_printf( aTHX_
             " Whilem_c: %" IVdf " Lcp: %" IVdf " %s",
@@ -127,7 +127,7 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
                     (IV)data->substrs[i].min_offset,
                     (IV)data->substrs[i].max_offset
                 );
-                Perl_debug_show_study_flags(aTHX_ data->substrs[i].flags," [","]");
+                debug_show_study_flags(data->substrs[i].flags," [","]");
             }
         }
 
@@ -155,7 +155,7 @@ Perl_debug_peep(pTHX_ const char *str, const RExC_state_t *pRExC_state,
             str,
             REG_NODE_NUM(scan), SvPV_nolen_const(RExC_mysv),
             Next ? (REG_NODE_NUM(Next)) : 0 );
-        Perl_debug_show_study_flags(aTHX_ flags," [ ","]");
+        debug_show_study_flags(flags," [ ","]");
         Perl_re_printf( aTHX_  "\n");
    });
 }

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -56,7 +56,7 @@ Perl_debug_show_study_flags(pTHX_ U32 flags, const char *open_str,
     if (!flags)
         return;
 
-    Perl_re_printf( aTHX_  "%s", open_str);
+    re_printf("%s", open_str);
     DEBUG_SHOW_STUDY_FLAG(flags, SF_BEFORE_SEOL);
     DEBUG_SHOW_STUDY_FLAG(flags, SF_BEFORE_MEOL);
     DEBUG_SHOW_STUDY_FLAG(flags, SF_IS_INF);
@@ -72,7 +72,7 @@ Perl_debug_show_study_flags(pTHX_ U32 flags, const char *open_str,
     DEBUG_SHOW_STUDY_FLAG(flags, SCF_SEEN_ACCEPT);
     DEBUG_SHOW_STUDY_FLAG(flags, SCF_TRIE_DOING_RESTUDY);
     DEBUG_SHOW_STUDY_FLAG(flags, SCF_IN_DEFINE);
-    Perl_re_printf( aTHX_  "%s", close_str);
+    re_printf("%s", close_str);
 }
 
 void
@@ -99,7 +99,7 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
 
         debug_show_study_flags(data->flags," [","]");
 
-        Perl_re_printf( aTHX_
+        re_printf(
             " Whilem_c: %" IVdf " Lcp: %" IVdf " %s",
             (IV)data->whilem_c,
             (IV)(data->last_closep ? *((data)->last_closep) : -1),
@@ -108,7 +108,7 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
 
         if (data->last_found) {
             int i;
-            Perl_re_printf(aTHX_
+            re_printf(
                 "Last:'%s' %" IVdf ":%" IVdf "/%" IVdf,
                     SvPVX_const(data->last_found),
                     (IV)data->last_end,
@@ -117,7 +117,7 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
             );
 
             for (i = 0; i < 2; i++) {
-                Perl_re_printf(aTHX_
+                re_printf(
                     " %s%s: '%s' @ %" IVdf "/%" IVdf,
                     data->cur_is_floating == i ? "*" : "",
                     i ? "Float" : "Fixed",
@@ -129,7 +129,7 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
             }
         }
 
-        Perl_re_printf( aTHX_ "\n");
+        re_printf("\n");
     });
 }
 
@@ -154,7 +154,7 @@ Perl_debug_peep(pTHX_ const char *str, const RExC_state_t *pRExC_state,
                    REG_NODE_NUM(scan), SvPV_nolen_const(RExC_mysv),
                    Next ? (REG_NODE_NUM(Next)) : 0 );
         debug_show_study_flags(flags," [ ","]");
-        Perl_re_printf( aTHX_  "\n");
+        re_printf("\n");
    });
 }
 
@@ -172,7 +172,7 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
 #ifdef DEBUG_DUMPUNTIL
-    Perl_re_printf( aTHX_  "--- %d : %d - %d - %d\n", indent, node-start,
+    re_printf("--- %d : %d - %d - %d\n", indent, node-start,
         last ? last-start : 0, plast ? plast-start : 0);
 #endif
 
@@ -197,18 +197,18 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
             CLEAR_OPTSTART;
 
         regprop(r, sv, node, NULL, NULL);
-        Perl_re_printf( aTHX_  "%4" IVdf ":%*s%s", (IV)(node - start),
+        re_printf("%4" IVdf ":%*s%s", (IV)(node - start),
                       (int)(2*indent + 1), "", SvPVX_const(sv));
 
         if (op != OPTIMIZED) {
             if (next == NULL)           /* Next ptr. */
-                Perl_re_printf( aTHX_  " (0)");
+                re_printf(" (0)");
             else if (REGNODE_TYPE(op) == BRANCH
                      && REGNODE_TYPE(OP(next)) != BRANCH )
-                Perl_re_printf( aTHX_  " (FAIL)");
+                re_printf(" (FAIL)");
             else
-                Perl_re_printf( aTHX_  " (%" IVdf ")", (IV)(next - start));
-            Perl_re_printf( aTHX_ "\n");
+                re_printf(" (%" IVdf ")", (IV)(next - start));
+            re_printf("\n");
         }
 
       after_print:
@@ -259,7 +259,7 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
                 );
                 if (trie->jump) {
                     U16 dist = trie->jump[word_idx+1];
-                    Perl_re_printf( aTHX_  "(%" UVuf ")\n",
+                    re_printf("(%" UVuf ")\n",
                                (UV)((dist ? this_trie + dist : next) - start));
                     if (dist) {
                         if (!nextbranch)
@@ -269,7 +269,7 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
                     if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
                         nextbranch = regnext((regnode *)nextbranch);
                 } else {
-                    Perl_re_printf( aTHX_  "\n");
+                    re_printf("\n");
                 }
             }
             if (last && next > last)
@@ -301,7 +301,7 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
     }
     CLEAR_OPTSTART;
 #ifdef DEBUG_DUMPUNTIL
-    Perl_re_printf( aTHX_  "--- %d\n", (int)indent);
+    re_printf("--- %d\n", (int)indent);
 #endif
     return node;
 }
@@ -325,15 +325,15 @@ S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
     for (bit = 0; bit < REG_INTFLAGS_NAME_SIZE; bit++) {
         if (flags & (1 << bit)) {
             if (!set++ && lead)
-                Perl_re_printf( aTHX_  "%s", lead);
-            Perl_re_printf( aTHX_  "%s ", PL_reg_intflags_name[bit]);
+                re_printf("%s", lead);
+            re_printf("%s ", PL_reg_intflags_name[bit]);
         }
     }
     if (lead)  {
         if (set)
-            Perl_re_printf( aTHX_  "\n");
+            re_printf("\n");
         else
-            Perl_re_printf( aTHX_  "%s[none-set]\n", lead);
+            re_printf("%s[none-set]\n", lead);
     }
 }
 
@@ -354,37 +354,37 @@ S_regdump_extflags(pTHX_ const char *lead, const U32 flags)
                 continue;
             }
             if (!set++ && lead)
-                Perl_re_printf( aTHX_  "%s", lead);
-            Perl_re_printf( aTHX_  "%s ", PL_reg_extflags_name[bit]);
+                re_printf("%s", lead);
+            re_printf("%s ", PL_reg_extflags_name[bit]);
         }
     }
     if ((cs = get_regex_charset(flags)) != REGEX_DEPENDS_CHARSET) {
             if (!set++ && lead) {
-                Perl_re_printf( aTHX_  "%s", lead);
+                re_printf("%s", lead);
             }
             switch (cs) {
                 case REGEX_UNICODE_CHARSET:
-                    Perl_re_printf( aTHX_  "UNICODE");
+                    re_printf("UNICODE");
                     break;
                 case REGEX_LOCALE_CHARSET:
-                    Perl_re_printf( aTHX_  "LOCALE");
+                    re_printf("LOCALE");
                     break;
                 case REGEX_ASCII_RESTRICTED_CHARSET:
-                    Perl_re_printf( aTHX_  "ASCII-RESTRICTED");
+                    re_printf("ASCII-RESTRICTED");
                     break;
                 case REGEX_ASCII_MORE_RESTRICTED_CHARSET:
-                    Perl_re_printf( aTHX_  "ASCII-MORE_RESTRICTED");
+                    re_printf("ASCII-MORE_RESTRICTED");
                     break;
                 default:
-                    Perl_re_printf( aTHX_  "UNKNOWN CHARACTER SET");
+                    re_printf("UNKNOWN CHARACTER SET");
                     break;
             }
     }
     if (lead)  {
         if (set)
-            Perl_re_printf( aTHX_  "\n");
+            re_printf("\n");
         else
-            Perl_re_printf( aTHX_  "%s[none-set]\n", lead);
+            re_printf("%s[none-set]\n", lead);
     }
 }
 #endif
@@ -412,7 +412,7 @@ Perl_regdump(pTHX_ const regexp *r)
                             SvPVX_const(r->substrs->data[i].substr),
                             RE_SV_DUMPLEN(r->substrs->data[i].substr),
                             PL_dump_re_max_len);
-            Perl_re_printf( aTHX_
+            re_printf(
                           "%s %s%s at %" IVdf "..%" UVuf " ",
                           i ? "floating" : "anchored",
                           s,
@@ -425,7 +425,7 @@ Perl_regdump(pTHX_ const regexp *r)
                             SvPVX_const(r->substrs->data[i].utf8_substr),
                             RE_SV_DUMPLEN(r->substrs->data[i].utf8_substr),
                             30);
-            Perl_re_printf( aTHX_
+            re_printf(
                           "%s utf8 %s%s at %" IVdf "..%" UVuf " ",
                           i ? "floating" : "anchored",
                           s,
@@ -436,42 +436,42 @@ Perl_regdump(pTHX_ const regexp *r)
     }
 
     if (r->check_substr || r->check_utf8)
-        Perl_re_printf( aTHX_
+        re_printf(
                       (const char *)
                       (   r->check_substr == r->substrs->data[1].substr
                        && r->check_utf8   == r->substrs->data[1].utf8_substr
                        ? "(checking floating" : "(checking anchored"));
     if (r->intflags & PREGf_NOSCAN)
-        Perl_re_printf( aTHX_  " noscan");
+        re_printf(" noscan");
     if (r->extflags & RXf_CHECK_ALL)
-        Perl_re_printf( aTHX_  " isall");
+        re_printf(" isall");
     if (r->check_substr || r->check_utf8)
-        Perl_re_printf( aTHX_  ") ");
+        re_printf(") ");
 
     if (ri->regstclass) {
         regprop(r, sv, ri->regstclass, NULL, NULL);
-        Perl_re_printf( aTHX_  "stclass %s ", SvPVX_const(sv));
+        re_printf("stclass %s ", SvPVX_const(sv));
     }
     if (r->intflags & PREGf_ANCH) {
-        Perl_re_printf( aTHX_  "anchored");
+        re_printf("anchored");
         if (r->intflags & PREGf_ANCH_MBOL)
-            Perl_re_printf( aTHX_  "(MBOL)");
+            re_printf("(MBOL)");
         if (r->intflags & PREGf_ANCH_SBOL)
-            Perl_re_printf( aTHX_  "(SBOL)");
+            re_printf("(SBOL)");
         if (r->intflags & PREGf_ANCH_GPOS)
-            Perl_re_printf( aTHX_  "(GPOS)");
-        Perl_re_printf( aTHX_ " ");
+            re_printf("(GPOS)");
+        re_printf(" ");
     }
     if (r->intflags & PREGf_GPOS_SEEN)
-        Perl_re_printf( aTHX_  "GPOS:%" UVuf " ", (UV)r->gofs);
+        re_printf("GPOS:%" UVuf " ", (UV)r->gofs);
     if (r->intflags & PREGf_SKIP)
-        Perl_re_printf( aTHX_  "plus ");
+        re_printf("plus ");
     if (r->intflags & PREGf_IMPLICIT)
-        Perl_re_printf( aTHX_  "implicit ");
-    Perl_re_printf( aTHX_  "minlen %" IVdf " ", (IV)r->minlen);
+        re_printf("implicit ");
+    re_printf("minlen %" IVdf " ", (IV)r->minlen);
     if (r->extflags & RXf_EVAL_SEEN)
-        Perl_re_printf( aTHX_  "with eval ");
-    Perl_re_printf( aTHX_  "\n");
+        re_printf("with eval ");
+    re_printf("\n");
     DEBUG_FLAGS_r({
         regdump_extflags("r->extflags: ", r->extflags);
         regdump_intflags("r->intflags: ", r->intflags);

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -85,12 +85,10 @@ Perl_debug_studydata(pTHX_ const char *where, scan_data_t *data,
 
     DEBUG_OPTIMISE_MORE_r({
         if (!data) {
-            Perl_re_indentf(aTHX_  "%s: NO DATA",
-                depth,
-                where);
+            re_indentf("%s: NO DATA", depth, where);
             return;
         }
-        Perl_re_indentf(aTHX_  "%s: M/S/D: %" IVdf "/%" IVdf "/%" IVdf " Pos:%" IVdf "/%" IVdf " Flags: 0x%" UVXf,
+        re_indentf("%s: M/S/D: %" IVdf "/%" IVdf "/%" IVdf " Pos:%" IVdf "/%" IVdf " Flags: 0x%" UVXf,
             depth,
             where,
             min, stopmin, delta,
@@ -150,11 +148,11 @@ Perl_debug_peep(pTHX_ const char *str, const RExC_state_t *pRExC_state,
             return;
         Next = regnext(scan);
         regprop(RExC_rx, RExC_mysv, scan, NULL, pRExC_state);
-        Perl_re_indentf( aTHX_   "%s>%3d: %s (%d)",
-            depth,
-            str,
-            REG_NODE_NUM(scan), SvPV_nolen_const(RExC_mysv),
-            Next ? (REG_NODE_NUM(Next)) : 0 );
+        re_indentf("%s>%3d: %s (%d)",
+                   depth,
+                   str,
+                   REG_NODE_NUM(scan), SvPV_nolen_const(RExC_mysv),
+                   Next ? (REG_NODE_NUM(Next)) : 0 );
         debug_show_study_flags(flags," [ ","]");
         Perl_re_printf( aTHX_  "\n");
    });
@@ -245,19 +243,19 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
             for (word_idx= 0; word_idx < (I32)trie->wordcount; word_idx++) {
                 SV ** const elem_ptr = av_fetch_simple(trie_words, word_idx, 0);
 
-                Perl_re_indentf( aTHX_  "%s ",
-                    indent+3,
-                    elem_ptr
-                    ? pv_pretty(sv, SvPV_nolen_const(*elem_ptr),
-                                SvCUR(*elem_ptr), PL_dump_re_max_len,
-                                PL_colors[0], PL_colors[1],
-                                (SvUTF8(*elem_ptr)
-                                 ? PERL_PV_ESCAPE_UNI
-                                 : 0)
-                                | PERL_PV_PRETTY_ELLIPSES
-                                | PERL_PV_PRETTY_LTGT
-                            )
-                    : "???"
+                re_indentf("%s ",
+                           indent+3,
+                           elem_ptr
+                           ? pv_pretty(sv, SvPV_nolen_const(*elem_ptr),
+                                       SvCUR(*elem_ptr), PL_dump_re_max_len,
+                                       PL_colors[0], PL_colors[1],
+                                       (SvUTF8(*elem_ptr)
+                                        ? PERL_PV_ESCAPE_UNI
+                                        : 0)
+                                       | PERL_PV_PRETTY_ELLIPSES
+                                       | PERL_PV_PRETTY_LTGT
+                                      )
+                           : "???"
                 );
                 if (trie->jump) {
                     U16 dist = trie->jump[word_idx+1];

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -709,8 +709,13 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
             else {
                 const char *s = reginfo->strbeg + ln;
                 sv_catpvf(sv, ": ");
-                Perl_pv_pretty( aTHX_ sv, s, RXp_OFFS_END(prog,n) - RXp_OFFS_START(prog,n), 32, 0, 0,
-                    PERL_PV_ESCAPE_UNI_DETECT|PERL_PV_PRETTY_NOCLEAR|PERL_PV_PRETTY_ELLIPSES|PERL_PV_PRETTY_QUOTE );
+                pv_pretty(sv, s,
+                          RXp_OFFS_END(prog,n) - RXp_OFFS_START(prog,n),
+                          32, 0, 0,
+                          PERL_PV_ESCAPE_UNI_DETECT
+                         |PERL_PV_PRETTY_NOCLEAR
+                         |PERL_PV_PRETTY_ELLIPSES
+                         |PERL_PV_PRETTY_QUOTE );
             }
         }
     } else if (k == GOSUB) {

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -1475,7 +1475,7 @@ Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level,
     STRLEN count = 0;
 
     if (invlist_is_iterating(invlist)) {
-        Perl_dump_indent(aTHX_ level, file,
+        dump_indent(level, file,
              "%sCan't dump inversion list because is in middle of iterating\n",
              indent);
         return;
@@ -1484,17 +1484,17 @@ Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level,
     invlist_iterinit(invlist);
     while (invlist_iternext(invlist, &start, &end)) {
         if (end == UV_MAX) {
-            Perl_dump_indent(aTHX_ level, file,
+            dump_indent(level, file,
                                        "%s[%" UVuf "] 0x%04" UVXf " .. INFTY\n",
                                    indent, (UV)count, start);
         }
         else if (end != start) {
-            Perl_dump_indent(aTHX_ level, file,
+            dump_indent(level, file,
                                     "%s[%" UVuf "] 0x%04" UVXf " .. 0x%04" UVXf "\n",
                                 indent, (UV)count, start,         end);
         }
         else {
-            Perl_dump_indent(aTHX_ level, file, "%s[%" UVuf "] 0x%04" UVXf "\n",
+            dump_indent(level, file, "%s[%" UVuf "] 0x%04" UVXf "\n",
                                             indent, (UV)count, start);
         }
         count += 2;

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1545,7 +1545,7 @@ Perl_study_chunk(pTHX_
     );
     DEBUG_OPTIMISE_MORE_r(
     {
-        Perl_re_indentf( aTHX_  "study_chunk stopparen = %ld recursed_count = %lu "
+        re_indentf("study_chunk stopparen = %ld recursed_count = %lu "
                                 "depth = %lu recursed_depth = %lu scan = %p last = %p",
             depth, (long)stopparen,
             (unsigned long)RExC_study_chunk_recursed_count,
@@ -1847,7 +1847,7 @@ Perl_study_chunk(pTHX_
 
                         DEBUG_TRIE_COMPILE_r({
                             regprop(RExC_rx, RExC_mysv, tail, NULL, pRExC_state);
-                            Perl_re_indentf( aTHX_  "%s %" UVuf ":%s\n",
+                            re_indentf("%s %" UVuf ":%s\n",
                               depth+1,
                               "Looking for TRIE'able sequences. Tail node is ",
                               (UV) REGNODE_OFFSET(tail),
@@ -1943,7 +1943,7 @@ Perl_study_chunk(pTHX_
 
                             DEBUG_TRIE_COMPILE_r({
                                 regprop(RExC_rx, RExC_mysv, cur, NULL, pRExC_state);
-                                Perl_re_indentf( aTHX_  "- %d:%s (%d)",
+                                re_indentf("- %d:%s (%d)",
                                    depth+1,
                                    REG_NODE_NUM(cur), SvPV_nolen_const( RExC_mysv ), REG_NODE_NUM(cur) );
 
@@ -2052,7 +2052,7 @@ Perl_study_chunk(pTHX_
                         } /* loop over branches */
                         DEBUG_TRIE_COMPILE_r({
                             regprop(RExC_rx, RExC_mysv, cur, NULL, pRExC_state);
-                            Perl_re_indentf( aTHX_  "- %s (%d) <SCAN FINISHED> ",
+                            re_indentf("- %s (%d) <SCAN FINISHED> ",
                               depth+1, SvPV_nolen_const( RExC_mysv ), REG_NODE_NUM(cur));
                             Perl_re_printf( aTHX_  "(First == %d, Last == %d, Cur == %d, tt == %s)\n",
                                REG_NODE_NUM(first), REG_NODE_NUM(prev), REG_NODE_NUM(cur),
@@ -2094,7 +2094,7 @@ Perl_study_chunk(pTHX_
                                      * turn it into a plain NOTHING op. */
                                     DEBUG_TRIE_COMPILE_r({
                                         regprop(RExC_rx, RExC_mysv, cur, NULL, pRExC_state);
-                                        Perl_re_indentf( aTHX_  "- %s (%d) <NOTHING BRANCH SEQUENCE>\n",
+                                        re_indentf("- %s (%d) <NOTHING BRANCH SEQUENCE>\n",
                                           depth+1,
                                           SvPV_nolen_const( RExC_mysv ), REG_NODE_NUM(cur));
 

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1558,16 +1558,16 @@ Perl_study_chunk(pTHX_
             for ( j = 0 ; j < recursed_depth ; j++ ) {
                 for ( i = 0 ; i < (U32)RExC_total_parens ; i++ ) {
                     if (PAREN_TEST(j, i) && (!j || !PAREN_TEST(j - 1, i))) {
-                        Perl_re_printf( aTHX_ " %d",(int)i);
+                        re_printf(" %d",(int)i);
                         break;
                     }
                 }
                 if ( j + 1 < recursed_depth ) {
-                    Perl_re_printf( aTHX_  ",");
+                    re_printf(",");
                 }
             }
         }
-        Perl_re_printf( aTHX_ "\n");
+        re_printf("\n");
     }
     );
     while ( scan && OP(scan) != END && scan < last ){
@@ -1948,15 +1948,15 @@ Perl_study_chunk(pTHX_
                                    REG_NODE_NUM(cur), SvPV_nolen_const( RExC_mysv ), REG_NODE_NUM(cur) );
 
                                 regprop(RExC_rx, RExC_mysv, noper, NULL, pRExC_state);
-                                Perl_re_printf( aTHX_  " -> %d:%s",
+                                re_printf(" -> %d:%s",
                                     REG_NODE_NUM(noper), SvPV_nolen_const(RExC_mysv));
 
                                 if ( noper_next ) {
                                   regprop(RExC_rx, RExC_mysv, noper_next, NULL, pRExC_state);
-                                  Perl_re_printf( aTHX_ "\t=> %d:%s\t",
+                                  re_printf("\t=> %d:%s\t",
                                     REG_NODE_NUM(noper_next), SvPV_nolen_const(RExC_mysv));
                                 }
-                                Perl_re_printf( aTHX_  "(First == %d,Last == %d,Cur == %d,tt == %s,ntt == %s,nntt == %s)\n",
+                                re_printf("(First == %d,Last == %d,Cur == %d,tt == %s,ntt == %s,nntt == %s)\n",
                                    REG_NODE_NUM(first), REG_NODE_NUM(prev), REG_NODE_NUM(cur),
                                    REGNODE_NAME(trietype), REGNODE_NAME(noper_trietype), REGNODE_NAME(noper_next_trietype)
                                 );
@@ -2054,7 +2054,7 @@ Perl_study_chunk(pTHX_
                             regprop(RExC_rx, RExC_mysv, cur, NULL, pRExC_state);
                             re_indentf("- %s (%d) <SCAN FINISHED> ",
                               depth+1, SvPV_nolen_const( RExC_mysv ), REG_NODE_NUM(cur));
-                            Perl_re_printf( aTHX_  "(First == %d, Last == %d, Cur == %d, tt == %s)\n",
+                            re_printf("(First == %d, Last == %d, Cur == %d, tt == %s)\n",
                                REG_NODE_NUM(first), REG_NODE_NUM(prev), REG_NODE_NUM(cur),
                                REGNODE_NAME(trietype)
                             );
@@ -2814,14 +2814,14 @@ Perl_study_chunk(pTHX_
                     /* It is counted once already... */
                     data->pos_min += minnext * (mincount - counted);
 #if 0
-    Perl_re_printf( aTHX_  "counted = %" UVuf " deltanext = %" UVuf
+    re_printf("counted = %" UVuf " deltanext = %" UVuf
                               " OPTIMIZE_INFTY = %" UVuf " minnext = %" UVuf
                               " maxcount = %" UVuf " mincount = %" UVuf
                               " data->pos_delta = %" UVuf "\n",
         (UV)counted, (UV)deltanext, (UV)OPTIMIZE_INFTY, (UV)minnext,
         (UV)maxcount, (UV)mincount, (UV)data->pos_delta);
     if (deltanext != OPTIMIZE_INFTY)
-        Perl_re_printf( aTHX_  "LHS = %" UVuf " RHS = %" UVuf "\n",
+        re_printf("LHS = %" UVuf " RHS = %" UVuf "\n",
             (UV)(-counted * deltanext + (minnext + deltanext) * maxcount
             - minnext * mincount), (UV)(OPTIMIZE_INFTY - data->pos_delta));
 #endif

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -2566,7 +2566,7 @@ Perl_study_chunk(pTHX_
                                                    count */
                 {
                     WARN_HELPER_(RExC_precomp_end, packWARN(WARN_REGEXP),
-                        Perl_ck_warner(aTHX_ packWARN(WARN_REGEXP),
+                        ck_warner(packWARN(WARN_REGEXP),
                             "Quantifier unexpected on zero-length expression "
                             "in regex m/%" UTF8f "/",
                              UTF8fARG(UTF, RExC_precomp_end - RExC_precomp,

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -59,7 +59,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
     U16 word;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    Perl_re_indentf( aTHX_  "Char : %-6s%-6s%-4s ",
+    re_indentf("Char : %-6s%-6s%-4s ",
         depth+1, "Match","Base","Ofs" );
 
     for( state = 0 ; state < trie->uniquecharcount ; state++ ) {
@@ -76,7 +76,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
         }
     }
     Perl_re_printf( aTHX_  "\n");
-    Perl_re_indentf( aTHX_ "State|-----------------------", depth+1);
+    re_indentf("State|-----------------------", depth+1);
 
     for( state = 0 ; state < trie->uniquecharcount ; state++ )
         Perl_re_printf( aTHX_  "%.*s", colwidth, "--------");
@@ -85,7 +85,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
     for( state = 1 ; state < trie->statecount ; state++ ) {
         const U32 base = trie->states[ state ].trans.base;
 
-        Perl_re_indentf( aTHX_  "#%4" UVXf "|", depth+1, (UV)state);
+        re_indentf("#%4" UVXf "|", depth+1, (UV)state);
 
         if ( trie->states[ state ].wordnum ) {
             Perl_re_printf( aTHX_  " W%4X", trie->states[ state ].wordnum );
@@ -126,7 +126,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
         }
         Perl_re_printf( aTHX_  "\n" );
     }
-    Perl_re_indentf( aTHX_  "word_info N:(prev,len)=",
+    re_indentf("word_info N:(prev,len)=",
                                 depth);
     for (word = 1; word <= trie->wordcount; word++) {
         Perl_re_printf( aTHX_  " %d:(%d,%d)",
@@ -154,15 +154,15 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     /* print out the table precompression.  */
-    Perl_re_indentf( aTHX_  "State :Word | Transition Data\n",
+    re_indentf("State :Word | Transition Data\n",
             depth+1 );
-    Perl_re_indentf( aTHX_  "%s",
+    re_indentf("%s",
             depth+1, "------:-----+-----------------\n" );
 
     for( state = 1; state < next_alloc; state++ ) {
         U16 charid;
 
-        Perl_re_indentf( aTHX_  " %4" UVXf " :",
+        re_indentf(" %4" UVXf " :",
             depth+1, (UV)state  );
         if ( ! trie->states[ state ].wordnum ) {
             Perl_re_printf( aTHX_  "%5s| ","");
@@ -219,7 +219,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
        that they are identical.
      */
 
-    Perl_re_indentf( aTHX_  "Char : ", depth+1 );
+    re_indentf("Char : ", depth+1 );
 
     for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
         SV ** const tmp = av_fetch_simple( revcharmap, charid, 0);
@@ -238,7 +238,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
     }
 
     Perl_re_printf( aTHX_ "\n");
-    Perl_re_indentf( aTHX_  "State+-", depth+1 );
+    re_indentf("State+-", depth+1 );
 
     for( charid = 0; charid < trie->uniquecharcount; charid++ ) {
         Perl_re_printf( aTHX_  "%.*s", colwidth,"--------");
@@ -248,7 +248,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
 
     for( state = 1; state < next_alloc; state += trie->uniquecharcount ) {
 
-        Perl_re_indentf( aTHX_  "%4" UVXf " : ",
+        re_indentf("%4" UVXf " : ",
             depth+1,
             (UV)TRIE_NODENUM( state ) );
 
@@ -622,7 +622,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         sv_setiv(re_trie_maxbuff, RE_TRIE_MAXBUF_INIT);
     }
     DEBUG_TRIE_COMPILE_r({
-        Perl_re_indentf( aTHX_
+        re_indentf(
           "make_trie start == %d, first == %d, last == %d, tail == %d depth = %d\n",
           depth+1,
           REG_NODE_NUM(startbranch), REG_NODE_NUM(first),
@@ -846,7 +846,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                  ? ARG1b(lastbranch)
                  : ARG2b(lastbranch); /* BRANCHJ */
     DEBUG_TRIE_COMPILE_r(
-        Perl_re_indentf( aTHX_
+        re_indentf(
                 "TRIE(%s): W:%d C:%d Uq:%d Min:%d Max:%d\n",
                 depth+1,
                 ( widecharmap ? "UTF8" : "NATIVE" ), (int)word_count,
@@ -896,7 +896,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
         STRLEN transcount = 1;
 
-        DEBUG_TRIE_COMPILE_MORE_r( Perl_re_indentf( aTHX_  "Compiling trie using list compiler\n",
+        DEBUG_TRIE_COMPILE_MORE_r( re_indentf("Compiling trie using list compiler\n",
             depth+1));
 
         trie->states = (reg_trie_state *)
@@ -1122,7 +1122,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
            we have to use TRIE_NODENUM() to convert.
 
         */
-        DEBUG_TRIE_COMPILE_MORE_r( Perl_re_indentf( aTHX_  "Compiling trie using table compiler\n",
+        DEBUG_TRIE_COMPILE_MORE_r( re_indentf("Compiling trie using table compiler\n",
             depth+1));
 
         trie->trans = (reg_trie_trans *)
@@ -1327,7 +1327,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             PerlMemShared_realloc( trie->states, laststate
                                    * sizeof(reg_trie_state) );
         DEBUG_TRIE_COMPILE_MORE_r(
-            Perl_re_indentf( aTHX_  "Alloc: %d Orig: %" IVdf " elements, Final:%" IVdf ". Savings of %%%5.2f\n",
+            re_indentf("Alloc: %d Orig: %" IVdf " elements, Final:%" IVdf ". Savings of %%%5.2f\n",
                 depth+1,
                 (int)( ( TRIE_CHARCOUNT(trie) + 1 ) * trie->uniquecharcount
                        + 1 ),
@@ -1339,7 +1339,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         } /* end table compress */
     }
     DEBUG_TRIE_COMPILE_MORE_r(
-            Perl_re_indentf( aTHX_  "Statecount:%" UVxf " Lasttrans:%" UVxf "\n",
+            re_indentf("Statecount:%" UVxf " Lasttrans:%" UVxf "\n",
                 depth+1,
                 (UV)trie->statecount,
                 (UV)trie->lasttrans)
@@ -1415,7 +1415,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                 /* clear the bitmap */
                                 Zero(trie->bitmap, ANYOF_BITMAP_SIZE, char);
                                 DEBUG_OPTIMISE_r(
-                                    Perl_re_indentf( aTHX_  "New Start State = %" UVuf " Class: [",
+                                    re_indentf("New Start State = %" UVuf " Class: [",
                                         depth+1,
                                         (UV)state));
                                 if (first_ofs >= 0) {
@@ -1444,7 +1444,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     char *ch = SvPV( *tmp, len );
                     DEBUG_OPTIMISE_r({
                         SV *sv = sv_newmortal();
-                        Perl_re_indentf( aTHX_  "Prefix State: %" UVuf " Ofs: %" UVuf " Char: '%s'\n",
+                        re_indentf("Prefix State: %" UVuf " Ofs: %" UVuf " Char: '%s'\n",
                             depth+1,
                             (UV)state, (UV)first_ofs,
                             pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), 6,
@@ -1725,7 +1725,7 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
      */
     fail[ 0 ] = fail[ 1 ] = 0;
     DEBUG_TRIE_COMPILE_r({
-        Perl_re_indentf( aTHX_  "Stclass Failtable (%" UVuf " states): 0",
+        re_indentf("Stclass Failtable (%" UVuf " states): 0",
                       depth, (UV)numstates
         );
         for( q_read = 1; q_read < numstates; q_read++ ) {

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -65,7 +65,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
     for( state = 0 ; state < trie->uniquecharcount ; state++ ) {
         SV ** const tmp = av_fetch_simple( revcharmap, state, 0);
         if ( tmp ) {
-            Perl_re_printf( aTHX_  "%*s",
+            re_printf("%*s",
                 colwidth,
                 pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), colwidth,
                             PL_colors[0], PL_colors[1],
@@ -75,12 +75,12 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
             );
         }
     }
-    Perl_re_printf( aTHX_  "\n");
+    re_printf("\n");
     re_indentf("State|-----------------------", depth+1);
 
     for( state = 0 ; state < trie->uniquecharcount ; state++ )
-        Perl_re_printf( aTHX_  "%.*s", colwidth, "--------");
-    Perl_re_printf( aTHX_  "\n");
+        re_printf("%.*s", colwidth, "--------");
+    re_printf("\n");
 
     for( state = 1 ; state < trie->statecount ; state++ ) {
         const U32 base = trie->states[ state ].trans.base;
@@ -88,12 +88,12 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
         re_indentf("#%4" UVXf "|", depth+1, (UV)state);
 
         if ( trie->states[ state ].wordnum ) {
-            Perl_re_printf( aTHX_  " W%4X", trie->states[ state ].wordnum );
+            re_printf(" W%4X", trie->states[ state ].wordnum );
         } else {
-            Perl_re_printf( aTHX_  "%6s", "" );
+            re_printf("%6s", "" );
         }
 
-        Perl_re_printf( aTHX_  " @%4" UVXf " ", (UV)base );
+        re_printf(" @%4" UVXf " ", (UV)base );
 
         if ( base ) {
             U32 ofs = 0;
@@ -104,7 +104,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
                                                                     != state))
                     ofs++;
 
-            Perl_re_printf( aTHX_  "+%2" UVXf "[ ", (UV)ofs);
+            re_printf("+%2" UVXf "[ ", (UV)ofs);
 
             for ( ofs = 0 ; ofs < trie->uniquecharcount ; ofs++ ) {
                 if ( ( base + ofs >= trie->uniquecharcount )
@@ -113,27 +113,27 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
                         && trie->trans[ base + ofs
                                     - trie->uniquecharcount ].check == state )
                 {
-                   Perl_re_printf( aTHX_  "%*" UVXf, colwidth,
+                   re_printf("%*" UVXf, colwidth,
                     (UV)trie->trans[ base + ofs - trie->uniquecharcount ].next
                    );
                 } else {
-                    Perl_re_printf( aTHX_  "%*s", colwidth,"   ." );
+                    re_printf("%*s", colwidth,"   ." );
                 }
             }
 
-            Perl_re_printf( aTHX_  "]");
+            re_printf("]");
 
         }
-        Perl_re_printf( aTHX_  "\n" );
+        re_printf("\n" );
     }
     re_indentf("word_info N:(prev,len)=",
                                 depth);
     for (word = 1; word <= trie->wordcount; word++) {
-        Perl_re_printf( aTHX_  " %d:(%d,%d)",
+        re_printf(" %d:(%d,%d)",
             (int)word, (int)(trie->wordinfo[word].prev),
             (int)(trie->wordinfo[word].len));
     }
-    Perl_re_printf( aTHX_  "\n" );
+    re_printf("\n" );
 }
 /*
   Dumps a fully constructed but uncompressed trie in list form.
@@ -165,9 +165,9 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
         re_indentf(" %4" UVXf " :",
             depth+1, (UV)state  );
         if ( ! trie->states[ state ].wordnum ) {
-            Perl_re_printf( aTHX_  "%5s| ","");
+            re_printf("%5s| ","");
         } else {
-            Perl_re_printf( aTHX_  "W%4x| ",
+            re_printf("W%4x| ",
                 trie->states[ state ].wordnum
             );
         }
@@ -175,7 +175,7 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
             SV ** const tmp = av_fetch_simple( revcharmap,
                                         TRIE_LIST_ITEM(state, charid).forid, 0);
             if ( tmp ) {
-                Perl_re_printf( aTHX_  "%*s:%3X=%4" UVXf " | ",
+                re_printf("%*s:%3X=%4" UVXf " | ",
                     colwidth,
                     pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp),
                               colwidth,
@@ -187,11 +187,11 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
                     (UV)TRIE_LIST_ITEM(state, charid).newstate
                 );
                 if (!(charid % 10))
-                    Perl_re_printf( aTHX_  "\n%*s| ",
+                    re_printf("\n%*s| ",
                         (int)((depth * 2) + 14), "");
             }
         }
-        Perl_re_printf( aTHX_  "\n");
+        re_printf("\n");
     }
 }
 
@@ -226,7 +226,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
         if ( tmp ) {
             STRLEN n;
             const char *s = SvPV_const(*tmp, n);
-            Perl_re_printf( aTHX_  "%*s",
+            re_printf("%*s",
                 colwidth,
                 pv_pretty(sv, s, n, colwidth,
                             PL_colors[0], PL_colors[1],
@@ -237,14 +237,14 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
         }
     }
 
-    Perl_re_printf( aTHX_ "\n");
+    re_printf("\n");
     re_indentf("State+-", depth+1 );
 
     for( charid = 0; charid < trie->uniquecharcount; charid++ ) {
-        Perl_re_printf( aTHX_  "%.*s", colwidth,"--------");
+        re_printf("%.*s", colwidth,"--------");
     }
 
-    Perl_re_printf( aTHX_  "\n" );
+    re_printf("\n" );
 
     for( state = 1; state < next_alloc; state += trie->uniquecharcount ) {
 
@@ -255,15 +255,15 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
         for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
             UV v = (UV)SAFE_TRIE_NODENUM( trie->trans[ state + charid ].next );
             if (v)
-                Perl_re_printf( aTHX_  "%*" UVXf, colwidth, v );
+                re_printf("%*" UVXf, colwidth, v );
             else
-                Perl_re_printf( aTHX_  "%*s", colwidth, "." );
+                re_printf("%*s", colwidth, "." );
         }
         if ( ! trie->states[ TRIE_NODENUM( state ) ].wordnum ) {
-            Perl_re_printf( aTHX_  " (%4" UVXf ")\n",
+            re_printf(" (%4" UVXf ")\n",
                                             (UV)trie->trans[ state ].check );
         } else {
-            Perl_re_printf( aTHX_  " (%4" UVXf ") W%4X\n",
+            re_printf(" (%4" UVXf ") W%4X\n",
                                             (UV)trie->trans[ state ].check,
             trie->states[ TRIE_NODENUM( state ) ].wordnum );
         }
@@ -1017,7 +1017,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
                 /*
                 DEBUG_TRIE_COMPILE_MORE_r(
-                    Perl_re_printf( aTHX_  "tp: %d zp: %d ",tp,zp)
+                    re_printf("tp: %d zp: %d ",tp,zp)
                 );
                 */
 
@@ -1079,7 +1079,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 }
                 /*
                 DEBUG_TRIE_COMPILE_MORE_r(
-                    Perl_re_printf( aTHX_  " base: %d\n",base);
+                    re_printf(" base: %d\n",base);
                 );
                 */
                 trie->states[ state ].trans.base = base;
@@ -1424,13 +1424,13 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
                                     S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, *ch, folder);
                                     DEBUG_OPTIMISE_r(
-                                        Perl_re_printf( aTHX_  "%s", (char*)ch)
+                                        re_printf("%s", (char*)ch)
                                     );
                                 }
                             }
                             /* store the current firstchar in the bitmap */
                             S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, *ch, folder);
-                            DEBUG_OPTIMISE_r(Perl_re_printf( aTHX_ "%s", ch));
+                            DEBUG_OPTIMISE_r(re_printf("%s", ch));
                         }
                         first_ofs = ofs;
                     }
@@ -1466,7 +1466,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 } else {
 #ifdef DEBUGGING
                     if (state > 1)
-                        DEBUG_OPTIMISE_r(Perl_re_printf( aTHX_ "]\n"));
+                        DEBUG_OPTIMISE_r(re_printf("]\n"));
 #endif
                     break;
                 }
@@ -1729,9 +1729,9 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
                       depth, (UV)numstates
         );
         for( q_read = 1; q_read < numstates; q_read++ ) {
-            Perl_re_printf( aTHX_  ", %" UVuf, (UV)fail[q_read]);
+            re_printf(", %" UVuf, (UV)fail[q_read]);
         }
-        Perl_re_printf( aTHX_  "\n");
+        re_printf("\n");
     });
     Safefree(q);
     /*RExC_seen |= REG_TRIEDFA_SEEN;*/

--- a/regexec.c
+++ b/regexec.c
@@ -113,7 +113,7 @@ static const char non_utf8_target_but_utf8_required[]
 #endif
 
 #define NON_UTF8_TARGET_BUT_UTF8_REQUIRED(target) STMT_START {           \
-    DEBUG_EXECUTE_r(Perl_re_printf( aTHX_  "%s",                         \
+    DEBUG_EXECUTE_r(re_printf("%s",                         \
                                     non_utf8_target_but_utf8_required)); \
     goto target;                                                         \
 } STMT_END
@@ -960,7 +960,7 @@ Perl_re_intuit_start(pTHX_
 
     PERL_UNUSED_ARG(flags);
     PERL_UNUSED_ARG(data);
-    DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+    DEBUG_EXECUTE_r(re_printf(
                 "Intuit: trying to determine minimum start position...\n"));
 
     /* for now, assume that all substr offsets are positive. If at some point
@@ -991,7 +991,7 @@ Perl_re_intuit_start(pTHX_
      * to quickly reject some cases that can't match, but will reject
      * them later after doing full char arithmetic */
     if (prog->minlen > strend - strpos) {
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
                               "  String too short...\n"));
         goto fail;
     }
@@ -1029,7 +1029,7 @@ Perl_re_intuit_start(pTHX_
             if (!sv)
                 continue;
 
-            Perl_re_printf( aTHX_
+            re_printf(
                 "  substrs[%d]: min = %" IVdf " max = %" IVdf " end shift = %" IVdf
                 " useful = %" IVdf " utf8 = %d [%s]\n",
                 i,
@@ -1069,7 +1069,7 @@ Perl_re_intuit_start(pTHX_
             if (   strpos != strbeg
                 && (prog->intflags & PREGf_ANCH_SBOL))
             {
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                                 "  Not at start...\n"));
                 goto fail;
             }
@@ -1089,7 +1089,7 @@ Perl_re_intuit_start(pTHX_
                 SSize_t slen = SvCUR(check);
                 char *s = HOP3c(strpos, prog->check_offset_min, strend);
 
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                     "  Looking for check substr at fixed offset %" IVdf "...\n",
                     (IV)prog->check_offset_min));
 
@@ -1103,7 +1103,7 @@ Perl_re_intuit_start(pTHX_
                             || strend - s < slen - 1
                             || (strend - s == slen && strend[-1] != '\n')))
                     {
-                        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                        DEBUG_EXECUTE_r(re_printf(
                                             "  String too long...\n"));
                         goto fail_finish;
                     }
@@ -1114,7 +1114,7 @@ Perl_re_intuit_start(pTHX_
                     || *SvPVX_const(check) != *s
                     || (slen > 1 && (memNE(SvPVX_const(check), s, slen)))))
                 {
-                    DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                    DEBUG_EXECUTE_r(re_printf(
                                     "  String not equal...\n"));
                     goto fail_finish;
                 }
@@ -1165,7 +1165,7 @@ Perl_re_intuit_start(pTHX_
         U8* end_point;
 
         DEBUG_OPTIMISE_MORE_r({
-            Perl_re_printf( aTHX_
+            re_printf(
                 "  At restart: rx_origin = %" IVdf " Check offset min: %" IVdf
                 " Start shift: %" IVdf " End shift %" IVdf
                 " Real end Shift: %" IVdf "\n",
@@ -1202,7 +1202,7 @@ Perl_re_intuit_start(pTHX_
             SSize_t targ_len = (char*)end_point - anchor;
 
             if (check_len > targ_len) {
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                   "Target string too short to match required substring...\n"));
                 goto fail_finish;
             }
@@ -1226,7 +1226,7 @@ Perl_re_intuit_start(pTHX_
         check_at = fbm_instr( start_point, end_point,
                       check, multiline ? FBMrf_MULTILINE : 0);
 
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
             "  doing 'check' fbm scan, [%" IVdf "..%" IVdf "] gave %" IVdf "\n",
             (IV)((char*)start_point - strbeg),
             (IV)((char*)end_point   - strbeg),
@@ -1239,7 +1239,7 @@ Perl_re_intuit_start(pTHX_
         DEBUG_EXECUTE_r({
             RE_PV_QUOTED_DECL(quoted, utf8_target, PERL_DEBUG_PAD_ZERO(0),
                 SvPVX_const(check), RE_SV_DUMPLEN(check), 30);
-            Perl_re_printf( aTHX_  "  %s %s substr %s%s%s",
+            re_printf("  %s %s substr %s%s%s",
                               (check_at ? "Found" : "Did not find"),
                 (check == (utf8_target ? prog->anchored_utf8 : prog->anchored_substr)
                     ? "anchored" : "floating"),
@@ -1258,7 +1258,7 @@ Perl_re_intuit_start(pTHX_
         if (check_at - rx_origin > prog->check_offset_max)
             rx_origin = HOP3c(check_at, -prog->check_offset_max, rx_origin);
         /* Finish the diagnostic message */
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
             "%ld (rx_origin now %" IVdf ")...\n",
             (long)(check_at - strbeg),
             (IV)(rx_origin - strbeg)
@@ -1379,7 +1379,7 @@ Perl_re_intuit_start(pTHX_
                 to = strend;
             if (from > to) {
                 s = NULL;
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                     "  skipping 'other' fbm scan: %" IVdf " > %" IVdf "\n",
                     (IV)(from - strbeg),
                     (IV)(to   - strbeg)
@@ -1392,7 +1392,7 @@ Perl_re_intuit_start(pTHX_
                     must,
                     multiline ? FBMrf_MULTILINE : 0
                 );
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                     "  doing 'other' fbm scan, [%" IVdf "..%" IVdf "] gave %" IVdf "\n",
                     (IV)(from - strbeg),
                     (IV)(to   - strbeg),
@@ -1404,7 +1404,7 @@ Perl_re_intuit_start(pTHX_
         DEBUG_EXECUTE_r({
             RE_PV_QUOTED_DECL(quoted, utf8_target, PERL_DEBUG_PAD_ZERO(0),
                 SvPVX_const(must), RE_SV_DUMPLEN(must), 30);
-            Perl_re_printf( aTHX_  "  %s %s substr %s%s",
+            re_printf("  %s %s substr %s%s",
                 s ? "Found" : "Contradicts",
                 other_ix ? "floating" : "anchored",
                 quoted, RE_SV_TAIL(must));
@@ -1415,7 +1415,7 @@ Perl_re_intuit_start(pTHX_
             /* last1 is latest possible substr location. If we didn't
              * find it before there, we never will */
             if (last >= last1) {
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                                         "; giving up...\n"));
                 goto fail_finish;
             }
@@ -1428,7 +1428,7 @@ Perl_re_intuit_start(pTHX_
                 other_ix /* i.e. if other-is-float */
                     ? HOP3c(rx_origin, 1, strend)
                     : HOP4c(last, 1 - other->min_offset, strbeg, strend);
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r(re_printf(
                 "; about to retry %s at offset %ld (rx_origin now %" IVdf ")...\n",
                 (other_ix ? "floating" : "anchored"),
                 (long)(HOP3c(check_at, 1, strend) - strbeg),
@@ -1452,7 +1452,7 @@ Perl_re_intuit_start(pTHX_
                 rx_origin = HOP3c(s, -other->min_offset, strbeg);
                 other_last = HOP3c(s, 1, strend);
             }
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r(re_printf(
                 " at offset %ld (rx_origin now %" IVdf ")...\n",
                   (long)(s - strbeg),
                 (IV)(rx_origin - strbeg)
@@ -1462,7 +1462,7 @@ Perl_re_intuit_start(pTHX_
     }
     else {
         DEBUG_OPTIMISE_MORE_r(
-            Perl_re_printf( aTHX_
+            re_printf(
                 "  Check-only match: offset min:%" IVdf " max:%" IVdf
                 " check_at:%" IVdf " rx_origin:%" IVdf " rx_origin-check_at:%" IVdf
                 " strend:%" IVdf "\n",
@@ -1483,7 +1483,7 @@ Perl_re_intuit_start(pTHX_
     if (ml_anch && rx_origin != strbeg && rx_origin[-1] != '\n') {
         char *s;
 
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
                         "  looking for /^/m anchor"));
 
         /* we have failed the constraint of a \n before rx_origin.
@@ -1503,7 +1503,7 @@ Perl_re_intuit_start(pTHX_
         if (s <= rx_origin ||
             ! ( rx_origin = (char *)memchr(rx_origin, '\n', s - rx_origin)))
         {
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r(re_printf(
                             "  Did not find /%s^%s/m...\n",
                             PL_colors[0], PL_colors[1]));
             goto fail_finish;
@@ -1520,7 +1520,7 @@ Perl_re_intuit_start(pTHX_
             /* Position contradicts check-string; either because
              * check was anchored (and thus has no wiggle room),
              * or check was float and rx_origin is above the float range */
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r(re_printf(
                 "  Found /%s^%s/m, about to restart lookup for check-string with rx_origin %ld...\n",
                 PL_colors[0], PL_colors[1], (long)(rx_origin - strbeg)));
             goto restart;
@@ -1536,7 +1536,7 @@ Perl_re_intuit_start(pTHX_
              * contradict. On the other hand, the float "check" substr
              * didn't contradict, so just retry the anchored "other"
              * substr */
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r(re_printf(
                 "  Found /%s^%s/m, rescanning for anchored from offset %" IVdf " (rx_origin now %" IVdf ")...\n",
                 PL_colors[0], PL_colors[1],
                 (IV)(rx_origin - strbeg + prog->anchored_offset),
@@ -1547,12 +1547,12 @@ Perl_re_intuit_start(pTHX_
 
         /* success: we don't contradict the found floating substring
          * (and there's no anchored substr). */
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
             "  Found /%s^%s/m with rx_origin %ld...\n",
             PL_colors[0], PL_colors[1], (long)(rx_origin - strbeg)));
     }
     else {
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
             "  (multiline anchor test skipped)\n"));
     }
 
@@ -1610,7 +1610,7 @@ Perl_re_intuit_start(pTHX_
         else
             endpos = strend;
 
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
             "  looking for class: start_shift: %" IVdf " check_at: %" IVdf
             " rx_origin: %" IVdf " endpos: %" IVdf "\n",
               (IV)start_shift, (IV)(check_at - strbeg),
@@ -1620,11 +1620,11 @@ Perl_re_intuit_start(pTHX_
                             reginfo);
         if (!s) {
             if (endpos == strend) {
-                DEBUG_EXECUTE_r( Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r( re_printf(
                                 "  Could not match STCLASS...\n") );
                 goto fail;
             }
-            DEBUG_EXECUTE_r( Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r( re_printf(
                                "  This position contradicts STCLASS...\n") );
             if ((prog->intflags & PREGf_ANCH) && !ml_anch
                         && !(prog->intflags & PREGf_IMPLICIT))
@@ -1645,7 +1645,7 @@ Perl_re_intuit_start(pTHX_
                          * an extra anchored search may get done, but in
                          * practice the extra fbm_instr() is likely to
                          * get skipped anyway. */
-                        DEBUG_EXECUTE_r( Perl_re_printf( aTHX_
+                        DEBUG_EXECUTE_r( re_printf(
                             "  about to retry anchored at offset %ld (rx_origin now %" IVdf ")...\n",
                             (long)(other_last - strbeg),
                             (IV)(rx_origin - strbeg)
@@ -1666,7 +1666,7 @@ Perl_re_intuit_start(pTHX_
                      * but since we goto a block of code that's going to
                      * search for the next \n if any, its safe here */
                     rx_origin++;
-                    DEBUG_EXECUTE_r( Perl_re_printf( aTHX_
+                    DEBUG_EXECUTE_r( re_printf(
                               "  about to look for /%s^%s/m starting at rx_origin %ld...\n",
                               PL_colors[0], PL_colors[1],
                               (long)(rx_origin - strbeg)) );
@@ -1690,11 +1690,11 @@ Perl_re_intuit_start(pTHX_
              * It's conservative: it errs on the side of doing 'goto restart',
              * where there is code that does a proper char-based test */
             if (rx_origin + start_shift + end_shift > strend) {
-                DEBUG_EXECUTE_r( Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r( re_printf(
                                        "  Could not match STCLASS...\n") );
                 goto fail;
             }
-            DEBUG_EXECUTE_r( Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r( re_printf(
                 "  about to look for %s substr starting at offset %ld (rx_origin now %" IVdf ")...\n",
                 (prog->substrs->check_ix ? "floating" : "anchored"),
                 (long)(rx_origin + start_shift - strbeg),
@@ -1706,13 +1706,13 @@ Perl_re_intuit_start(pTHX_
         /* Success !!! */
 
         if (rx_origin != s) {
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r(re_printf(
                         "  By STCLASS: moving %ld --> %ld\n",
                                   (long)(rx_origin - strbeg), (long)(s - strbeg))
                    );
         }
         else {
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+            DEBUG_EXECUTE_r(re_printf(
                                   "  Does not contradict STCLASS...\n");
                    );
         }
@@ -1724,7 +1724,7 @@ Perl_re_intuit_start(pTHX_
         /* Fixed substring is found far enough so that the match
            cannot start at strpos. */
 
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_  "  try at offset...\n"));
+        DEBUG_EXECUTE_r(re_printf("  try at offset...\n"));
         ++BmUSEFUL(utf8_target ? prog->check_utf8 : prog->check_substr);	/* hooray/5 */
     }
     else {
@@ -1744,7 +1744,7 @@ Perl_re_intuit_start(pTHX_
             )))
         {
             /* If flags & SOMETHING - do not do it many times on the same match */
-            DEBUG_EXECUTE_r(Perl_re_printf( aTHX_  "  ... Disabling check substring...\n"));
+            DEBUG_EXECUTE_r(re_printf("  ... Disabling check substring...\n"));
             /* XXX Does the destruction order has to change with utf8_target? */
             SvREFCNT_dec(utf8_target ? prog->check_utf8 : prog->check_substr);
             SvREFCNT_dec(utf8_target ? prog->check_substr : prog->check_utf8);
@@ -1758,7 +1758,7 @@ Perl_re_intuit_start(pTHX_
         }
     }
 
-    DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+    DEBUG_EXECUTE_r(re_printf(
             "Intuit: %sSuccessfully guessed:%s match at offset %ld\n",
              PL_colors[4], PL_colors[5], (long)(rx_origin - strbeg)) );
 
@@ -1768,7 +1768,7 @@ Perl_re_intuit_start(pTHX_
     if (prog->check_substr || prog->check_utf8)		/* could be removed already */
         BmUSEFUL(utf8_target ? prog->check_utf8 : prog->check_substr) += 5; /* hooray */
   fail:
-    DEBUG_EXECUTE_r(Perl_re_printf( aTHX_  "%sMatch rejected by optimizer%s\n",
+    DEBUG_EXECUTE_r(re_printf("%sMatch rejected by optimizer%s\n",
                           PL_colors[4], PL_colors[5]));
     return NULL;
 }
@@ -3345,7 +3345,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                     dump_exec_pos( (char *)uc, c, strend,
                                         real_start,
                                         (char *)uc, utf8_target, 0 );
-                                    Perl_re_printf( aTHX_
+                                    re_printf(
                                         " Scanning for legal start char...\n");
                                 }
                             );
@@ -3386,13 +3386,13 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         DEBUG_TRIE_EXECUTE_r({
                             dump_exec_pos( (char *)uc, c, strend,
                                         real_start, s, utf8_target, 0);
-                            Perl_re_printf( aTHX_
+                            re_printf(
                                 "%sAHOC: Chid:0x%-2" UVXf " CP:0x%-4" UVXf " ",
                                  PL_colors[4], (UV)charid, uvc);
                             if (isPRINT_A(uvc))
-                                Perl_re_printf( aTHX_ "'%c' ", (int)uvc );
+                                re_printf("'%c' ", (int)uvc );
                             else
-                                Perl_re_printf( aTHX_ "    " ); /* four spaces to match "'x' " */
+                                re_printf("    " ); /* four spaces to match "'x' " */
                         });
                     }
                     else {
@@ -3411,7 +3411,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             if (failed)
                                 dump_exec_pos((char *)uc, c, strend, real_start,
                                     s,   utf8_target, 0 );
-                            Perl_re_printf( aTHX_
+                            re_printf(
                                 "%s%sSt:0x%-4" UVXf " W:0x%-2" UVXf,
                                 PL_colors[4],
                                 failed ? "AHOC: Fail transition to      " : "",
@@ -3430,7 +3430,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                 failed = false;
                                 state = tmp;
                                 DEBUG_TRIE_EXECUTE_r(
-                                    Perl_re_printf( aTHX_ " - good -> St:%#-6" UVxf "%s\n",
+                                    re_printf(" - good -> St:%#-6" UVxf "%s\n",
                                         (UV)state, PL_colors[5]));
                                 break;
                             }
@@ -3438,14 +3438,14 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                                 failed = true;
                                 state = aho->fail[state];
                                 DEBUG_TRIE_EXECUTE_r(
-                                    Perl_re_printf( aTHX_ " - fail -> St:%#-6" UVxf "%s\n",
+                                    re_printf(" - fail -> St:%#-6" UVxf "%s\n",
                                         (UV)state,PL_colors[5]));
                             }
                         }
                         else {
                             /* we must be accepting here */
                             DEBUG_TRIE_EXECUTE_r(
-                                    Perl_re_printf( aTHX_ " - accepting\n"));
+                                    re_printf(" - accepting\n"));
                             failed = true;
                             break;
                         }
@@ -3469,7 +3469,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                 if (leftmost) {
                     s = (char*)leftmost;
                     DEBUG_TRIE_EXECUTE_r({
-                        Perl_re_printf( aTHX_  "Matches word #%" UVxf
+                        re_printf("Matches word #%" UVxf
                                         " at position %" IVdf ". Trying full"
                                         " pattern...\n",
                             (UV)accepted_word, (IV)(s - real_start)
@@ -3485,13 +3485,13 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         s = HOPc(s,1);
                     }
                     DEBUG_TRIE_EXECUTE_r({
-                        Perl_re_printf( aTHX_
+                        re_printf(
                                        "Pattern failed. Looking for new start"
                                        " point...\n");
                     });
                 } else {
                     DEBUG_TRIE_EXECUTE_r(
-                        Perl_re_printf( aTHX_ "No match.\n"));
+                        re_printf("No match.\n"));
                     break;
                 }
             }
@@ -3544,7 +3544,7 @@ S_reg_set_capture_string(pTHX_ REGEXP * const rx,
     if (flags & REXEC_COPY_STR) {
 #ifdef PERL_ANY_COW
         if (SvCANCOW(sv)) {
-            DEBUG_C(Perl_re_printf( aTHX_
+            DEBUG_C(re_printf(
                               "Copy on write: regexp capture, type %d\n",
                                     (int) SvTYPE(sv)));
             /* Create a new COW SV to share the match string and store
@@ -3752,7 +3752,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
             ? strbeg + MgBYTEPOS(mg, sv, strbeg, strend-strbeg)
             : strbeg; /* pos() not defined; use start of string */
 
-        DEBUG_GPOS_r(Perl_re_printf( aTHX_
+        DEBUG_GPOS_r(re_printf(
             "GPOS ganch set to strbeg[%" IVdf "]\n", (IV)(reginfo->ganch - strbeg)));
 
         /* in the presence of \G, we may need to start looking earlier in
@@ -3771,7 +3771,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
                 if (!startpos ||
                     ((flags & REXEC_FAIL_ON_UNDERFLOW) && startpos < stringarg))
                 {
-                    DEBUG_GPOS_r(Perl_re_printf( aTHX_
+                    DEBUG_GPOS_r(re_printf(
                             "fail: ganch-gofs before earliest possible start\n"));
                     return 0;
                 }
@@ -3790,7 +3790,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 
     minlen = prog->minlen;
     if ((startpos + minlen) > strend || startpos < strbeg) {
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
                         "Regex match can't succeed, so not even tried\n"));
         return 0;
     }
@@ -3825,7 +3825,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
             {
                 /* this should only be possible under \G */
                 assert(prog->intflags & PREGf_GPOS_SEEN);
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                     "matched, but failing for REXEC_FAIL_ON_UNDERFLOW\n"));
                 goto phooey;
             }
@@ -3851,7 +3851,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     multiline = prog->extflags & RXf_PMf_MULTILINE;
 
     if (strend - s < (minlen + ((prog->check_offset_min < 0) ? prog->check_offset_min : 0))) {
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
                               "String too short [regexec_flags]...\n"));
         goto phooey;
     }
@@ -4059,7 +4059,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
             );
         }
         DEBUG_EXECUTE_r(if (!did_match)
-                Perl_re_printf( aTHX_
+                re_printf(
                                   "Did not find anchored character...\n")
                );
     }
@@ -4163,7 +4163,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         DEBUG_EXECUTE_r(if (!did_match) {
             RE_PV_QUOTED_DECL(quoted, utf8_target, PERL_DEBUG_PAD_ZERO(0),
                 SvPVX_const(must), RE_SV_DUMPLEN(must), 30);
-            Perl_re_printf( aTHX_  "Did not find %s substr %s%s...\n",
+            re_printf("Did not find %s substr %s%s...\n",
                               ((must == prog->anchored_substr || must == prog->anchored_utf8)
                                ? "anchored" : "floating"),
                 quoted, RE_SV_TAIL(must));
@@ -4183,7 +4183,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
             {
                 RE_PV_QUOTED_DECL(quoted,utf8_target,PERL_DEBUG_PAD_ZERO(1),
                     s,strend-s,PL_dump_re_max_len);
-                Perl_re_printf( aTHX_
+                re_printf(
                     "Matching stclass %.*s against %s (%d bytes)\n",
                     (int)SvCUR(prop), SvPVX_const(prop),
                      quoted, (int)(strend - s));
@@ -4191,7 +4191,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         });
         if (find_byclass(prog, c, s, strend, reginfo))
             goto got_it;
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_  "Contradicts stclass... [regexec_flags]\n"));
+        DEBUG_EXECUTE_r(re_printf("Contradicts stclass... [regexec_flags]\n"));
     }
     else {
         dontbother = 0;
@@ -4230,14 +4230,14 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
                      * the \n. */
                     char *checkpos= strend - len;
                     DEBUG_OPTIMISE_r(
-                        Perl_re_printf( aTHX_
+                        re_printf(
                             "%sChecking for float_real.%s\n",
                             PL_colors[4], PL_colors[5]));
                     if (checkpos + 1 < strbeg) {
                         /* can't match, even if we remove the trailing \n
                          * string is too short to match */
                         DEBUG_EXECUTE_r(
-                            Perl_re_printf( aTHX_
+                            re_printf(
                                 "%sString shorter than required trailing substring, cannot match.%s\n",
                                 PL_colors[4], PL_colors[5]));
                         goto phooey;
@@ -4249,7 +4249,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
                         /* cant match, string is too short when the "\n" is
                          * included */
                         DEBUG_EXECUTE_r(
-                            Perl_re_printf( aTHX_
+                            re_printf(
                                 "%sString does not contain required trailing substring, cannot match.%s\n",
                                 PL_colors[4], PL_colors[5]));
                         goto phooey;
@@ -4260,7 +4260,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
                             last = checkpos;
                         } else {
                             DEBUG_EXECUTE_r(
-                                Perl_re_printf( aTHX_
+                                re_printf(
                                     "%sString does not contain required trailing substring, cannot match.%s\n",
                                     PL_colors[4], PL_colors[5]));
                             goto phooey;
@@ -4284,7 +4284,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
                  * pretty sure it is not anymore, so I have removed the comment
                  * and replaced it with this one. Yves */
                 DEBUG_EXECUTE_r(
-                    Perl_re_printf( aTHX_
+                    re_printf(
                         "%sString does not contain required substring, cannot match.%s\n",
                         PL_colors[4], PL_colors[5]
                     ));
@@ -4324,7 +4324,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     {
         /* this should only be possible under \G */
         assert(prog->intflags & PREGf_GPOS_SEEN);
-        DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+        DEBUG_EXECUTE_r(re_printf(
             "matched, but failing for REXEC_FAIL_ON_UNDERFLOW\n"));
         goto phooey;
     }
@@ -4347,7 +4347,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     return 1;
 
   phooey:
-    DEBUG_EXECUTE_r(Perl_re_printf( aTHX_  "%sMatch failed%s\n",
+    DEBUG_EXECUTE_r(re_printf("%sMatch failed%s\n",
                           PL_colors[4], PL_colors[5]));
 
     if (swap) {
@@ -4523,12 +4523,12 @@ S_debug_start_match(pTHX_ const REGEXP *prog, const bool utf8_target,
         RE_PV_QUOTED_DECL(s1, utf8_target, PERL_DEBUG_PAD_ZERO(1),
             start, end - start, PL_dump_re_max_len);
 
-        Perl_re_printf( aTHX_
+        re_printf(
             "%s%s REx%s %s against %s\n",
                        PL_colors[4], blurb, PL_colors[5], s0, s1);
 
         if (utf8_target || utf8_pat)
-            Perl_re_printf( aTHX_  "UTF-8 %s%s%s...\n",
+            re_printf("UTF-8 %s%s%s...\n",
                 utf8_pat ? "pattern" : "",
                 utf8_pat && utf8_target ? " and " : "",
                 utf8_target ? "string" : ""
@@ -4593,7 +4593,7 @@ S_dump_exec_pos(pTHX_ const char *locinput,
                     locinput, loc_regeol - locinput, 10, 0, 1);
 
         const STRLEN tlen = len0 + len1 + len2;
-        Perl_re_printf( aTHX_
+        re_printf(
                     "%4" IVdf " <%.*s%.*s%s%.*s>%*s|%4" UVuf "| ",
                     (IV)(locinput - loc_bostr),
                     len0, s0,
@@ -5341,7 +5341,7 @@ S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strb
             matched = false;
 
 #ifdef DEBUGGING
-            Perl_re_printf( aTHX_
+            re_printf(
                            "\nUnhandled GCB pair: GCB_table[%d, %d] = %d\n",
                            before, after, GCB_table[before][after]);
             //assert(0);
@@ -5717,7 +5717,7 @@ S_isLB(pTHX_ LB_enum before,
             matched = false;
 
 #ifdef DEBUGGING
-            Perl_re_printf(aTHX_
+            re_printf(
                            "\nUnhandled LB pair: LB_table[%d, %d] = %d\n",
                            before, after, LB_table[before][after]);
             //assert(0);
@@ -6262,7 +6262,7 @@ S_isWB(pTHX_ WB_enum previous,
             matched = false;
 
 #ifdef DEBUGGING
-            Perl_re_printf(aTHX_
+            re_printf(
                            "\nUnhandled WB pair: WB_table[%d, %d] = %d\n",
                            before, after, WB_table[before][after]);
             //assert(0);
@@ -6479,7 +6479,7 @@ S_backup_one_WB_but_over_Extend_FO(pTHX_ WB_enum * previous,
 #define DEBUG_STATE_pp(pp)                                      \
     DEBUG_STATE_r({                                             \
         DUMP_EXEC_POS(locinput, scan, utf8_target,depth);       \
-        Perl_re_printf( aTHX_                                   \
+        re_printf(\
             "%*s" pp " %s%s%s%s%s\n",                           \
             INDENT_CHARS(depth), "",                            \
             REGNODE_NAME(st->resume_state),                     \
@@ -6738,7 +6738,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
     DEBUG_OPTIMISE_r( DEBUG_EXECUTE_r({
             DUMP_EXEC_POS( locinput, scan, utf8_target, depth );
-            Perl_re_printf( aTHX_ "regmatch start\n" );
+            re_printf("regmatch start\n" );
     }));
 
     REGCP_SET(orig_savestack_ix);
@@ -6757,7 +6757,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                 DUMP_EXEC_POS( locinput, scan, utf8_target, depth );
                 regprop(rex, prop, scan, reginfo, NULL);
-                Perl_re_printf( aTHX_
+                re_printf(
                     "%*s%" IVdf ":%s(%" IVdf ")\n",
                     INDENT_CHARS(depth), "",
                     (IV)(scan - rexi->program),
@@ -7029,14 +7029,14 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     }
                     DEBUG_TRIE_EXECUTE_r(
                         DUMP_EXEC_POS( (char *)uc, scan, utf8_target, depth );
-                        Perl_re_printf( aTHX_
+                        re_printf(
                             "%sTRIE: Chid:0x%-2" UVXf " CP:0x%-4" UVXf " ",
                             PL_colors[4], (UV)charid, uvc);
                         if (isPRINT_A(uvc))
-                            Perl_re_printf( aTHX_ "'%c' ", (int)uvc );
+                            re_printf("'%c' ", (int)uvc );
                         else
-                            Perl_re_printf( aTHX_ "    " ); /* four spaces to match "'x' " */
-                        Perl_re_printf( aTHX_
+                            re_printf("    " ); /* four spaces to match "'x' " */
+                        re_printf(
                                 "St:0x%-4" UVXf " W:0x%-2" UVXf " - %s -> St: 0x%-4" UVXf "%s\n",
                                 (UV)old_state, (UV)wordnum,
                                 state ? "good" : charid ? "fail" : "last",
@@ -8530,7 +8530,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 }
                 nop = nop->op_next;
 
-                DEBUG_STATE_r( Perl_re_printf( aTHX_
+                DEBUG_STATE_r( re_printf(
                     "  re EVAL PL_op = 0x%" UVxf "\n", PTR2UV(nop)) );
 
                 RXp_OFFSp(rex)[0].end = locinput - reginfo->strbeg;
@@ -9149,7 +9149,7 @@ NULL
                         reginfo->poscache_size = size;
                         Newxz(aux->poscache, size, char);
                     }
-                    DEBUG_EXECUTE_r( Perl_re_printf( aTHX_
+                    DEBUG_EXECUTE_r( re_printf(
       "%sWHILEM: Detected a super-linear match, switching on caching%s...\n",
                               PL_colors[4], PL_colors[5])
                     );
@@ -9897,7 +9897,7 @@ NULL
             }
 
             if (locinput < reginfo->till) {
-                DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
+                DEBUG_EXECUTE_r(re_printf(
                                       "%sEND: Match possible, but length = %ld is smaller than requested = %ld, failing!%s\n",
                                       PL_colors[4],
                                       (long)(locinput - startpos),
@@ -10307,7 +10307,7 @@ NULL
         goto reenter_switch;
     }
 
-    DEBUG_EXECUTE_r(Perl_re_printf( aTHX_  "%sMatch successful!%s\n",
+    DEBUG_EXECUTE_r(re_printf("%sMatch successful!%s\n",
                           PL_colors[4], PL_colors[5]));
 
     if (reginfo->info_aux_eval && orig_savestack_ix < PL_savestack_ix) {

--- a/regexec.c
+++ b/regexec.c
@@ -91,8 +91,7 @@ static const char b_utf8_locale_required[] =
 #define CHECK_AND_WARN_NON_UTF8_CTYPE_LOCALE_IN_BOUND                       \
     STMT_START {                                                            \
         if (! IN_UTF8_CTYPE_LOCALE) {                                       \
-          Perl_ck_warner(aTHX_ packWARN(WARN_LOCALE),                       \
-                                                b_utf8_locale_required);    \
+          ck_warner(packWARN(WARN_LOCALE), b_utf8_locale_required);         \
         }                                                                   \
     } STMT_END
 
@@ -102,8 +101,7 @@ static const char sets_utf8_locale_required[] =
 #define CHECK_AND_WARN_NON_UTF8_CTYPE_LOCALE_IN_SETS(n)                     \
     STMT_START {                                                            \
         if (! IN_UTF8_CTYPE_LOCALE && (FLAGS(n) & ANYOFL_UTF8_LOCALE_REQD)){\
-          Perl_ck_warner(aTHX_ packWARN(WARN_LOCALE),                       \
-                                             sets_utf8_locale_required);    \
+          ck_warner(packWARN(WARN_LOCALE), sets_utf8_locale_required);      \
         }                                                                   \
     } STMT_END
 

--- a/regexec.c
+++ b/regexec.c
@@ -12248,7 +12248,7 @@ Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv,
                     && RXp_OFFS_VALID(rx,nums[i]))
                 {
                     ret = newSVpvs("");
-                    Perl_reg_numbered_buff_fetch_flags(aTHX_ r, nums[i], ret, REG_FETCH_ABSOLUTE);
+                    reg_numbered_buff_fetch_flags(r, nums[i], ret, REG_FETCH_ABSOLUTE);
                     if (!retarray)
                         return ret;
                 } else {
@@ -12405,7 +12405,7 @@ Perl_reg_numbered_buff_fetch(pTHX_ REGEXP * const re, const I32 paren,
                              SV * const sv)
 {
     PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH;
-    Perl_reg_numbered_buff_fetch_flags(aTHX_ re, paren, sv, 0);
+    reg_numbered_buff_fetch_flags(re, paren, sv, 0);
 }
 
 #ifndef PERL_IN_XSUB_RE

--- a/regexec.c
+++ b/regexec.c
@@ -11309,7 +11309,7 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
             && OP(n) != ANYOFD
             && ckWARN_d(WARN_NON_UNICODE))
         {
-            Perl_warner(aTHX_ packWARN(WARN_NON_UNICODE),
+            warner(packWARN(WARN_NON_UNICODE),
                 "Matched non-Unicode code point 0x%04" UVXf " against Unicode property; may not be portable", c);
         }
     }

--- a/regexec.c
+++ b/regexec.c
@@ -250,11 +250,11 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
 
     DEBUG_BUFFERS_r(
         if ((int)maxopenparen > (int)parenfloor)
-            Perl_re_exec_indentf( aTHX_
-                "rex = 0x%" UVxf " offs = 0x%" UVxf ": saving capture indices:\n",
-                depth,
-                PTR2UV(rex),
-                PTR2UV(RXp_OFFSp(rex))
+            re_exec_indentf("rex = 0x%" UVxf " offs = 0x%" UVxf ": saving"
+                            " capture indices:\n",
+                            depth,
+                            PTR2UV(rex),
+                            PTR2UV(RXp_OFFSp(rex))
             );
     );
 
@@ -268,14 +268,14 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
     DEBUG_BUFFERS_r({
 	I32 p;
         for (p = parenfloor + 1; p <= (I32)maxopenparen; p++) {
-            Perl_re_exec_indentf(aTHX_
-                "    \\%" UVuf " %" IVdf " (%" IVdf ") .. %" IVdf " (regcppush)\n",
-                depth,
-                (UV)p,
-                (IV)RXp_OFFSp(rex)[p].start,
-                (IV)RXp_OFFSp(rex)[p].start_tmp,
-                (IV)RXp_OFFSp(rex)[p].end
-            );
+            re_exec_indentf("    \\%" UVuf " %" IVdf " (%" IVdf ") .. %" IVdf
+                            " (regcppush)\n",
+                            depth,
+                            (UV)p,
+                            (IV)RXp_OFFSp(rex)[p].start,
+                            (IV)RXp_OFFSp(rex)[p].start_tmp,
+                            (IV)RXp_OFFSp(rex)[p].end
+                         );
         }
     });
 
@@ -287,13 +287,13 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
 
 
     DEBUG_BUFFERS_r({
-        Perl_re_exec_indentf(aTHX_
+        re_exec_indentf(
                 "finished regcppush returning %" IVdf " cur: %" IVdf "\n",
                 depth, retval, PL_savestack_ix);
     });
 
     DEBUG_STATE_r(
-        Perl_re_exec_indentf(aTHX_
+        re_exec_indentf(
             "savestack: regcppush filled in range [%" IVdf "..%" IVdf ")\n",
                 depth, (IV)retval, (IV)PL_savestack_ix
         )
@@ -305,7 +305,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
 /* These are needed since we do not localize EVAL nodes: */
 #define REGCP_SET(cp)                                           \
     DEBUG_STATE_r(                                              \
-        Perl_re_exec_indentf( aTHX_                             \
+        re_exec_indentf(                                        \
             "savestack: snapping ix=%" IVdf "\n",               \
             depth, (IV)PL_savestack_ix                          \
         )                                                       \
@@ -324,7 +324,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
 
 #define REGCP_UNWIND(cp)                                        \
     DEBUG_STATE_r(                                              \
-        Perl_re_exec_indentf( aTHX_                             \
+        re_exec_indentf(                                        \
             "savestack: freeing in range [%"                    \
             IVdf "..%" IVdf ")\n",                              \
             depth, (IV)(cp), (IV)PL_savestack_ix                \
@@ -342,7 +342,7 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
     if (ix > RXp_LASTPAREN(rex))                                            \
         RXp_LASTPAREN(rex) = (ix);                                          \
     RXp_LASTCLOSEPAREN(rex) = (ix);                                         \
-    DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_                             \
+    DEBUG_BUFFERS_r(re_exec_indentf(                                        \
         "CLOSE: rex = 0x%" UVxf " offs = 0x%" UVxf ": \\%" UVuf ": set %" IVdf " .. %" IVdf " max: %" UVuf "\n", \
         depth,                                                              \
         PTR2UV(rex),                                                        \
@@ -364,7 +364,7 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
     PERL_ARGS_ASSERT_UNWIND_PAREN;
     U32 n;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-    DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
+    DEBUG_BUFFERS_r(re_exec_indentf(
         "UNWIND_PAREN: rex = 0x%" UVxf " offs = 0x%" UVxf
         ": invalidate (%" UVuf " .. %" UVuf ") set lcp: %" UVuf "\n",
         depth,
@@ -390,7 +390,7 @@ S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma
     U16 my_ix;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
     for ( my_ix = from_ix; my_ix <= to_ix; my_ix++ ) {
-        DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
+        DEBUG_BUFFERS_r(re_exec_indentf(
                 "CAPTURE_CLEAR %s \\%" IVdf ": "
                 "%" IVdf "(%" IVdf ") .. %" IVdf
                 " => "
@@ -425,9 +425,8 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 
 
     DEBUG_BUFFERS_r({
-        Perl_re_exec_indentf(aTHX_
-                "starting regcppop at %" IVdf "\n",
-                depth, PL_savestack_ix);
+        re_exec_indentf("starting regcppop at %" IVdf "\n",
+                        depth, PL_savestack_ix);
     });
 
     /* Pop REGCP_OTHER_ELEMS before the parentheses loop starts. */
@@ -442,7 +441,7 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
     /* Now restore the parentheses context. */
     DEBUG_BUFFERS_r(
         if (i || RXp_LASTPAREN(rex) + 1 <= rex->nparens)
-            Perl_re_exec_indentf( aTHX_
+            re_exec_indentf(
                 "rex = 0x%" UVxf " offs = 0x%" UVxf ": restoring capture indices to:\n",
                 depth,
                 PTR2UV(rex),
@@ -469,7 +468,7 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 
     DEBUG_BUFFERS_r(
         for (; paren <= *maxopenparen_p; ++paren) {
-            Perl_re_exec_indentf(aTHX_
+            re_exec_indentf(
                 "    \\%" UVuf " %" IVdf "(%" IVdf ") .. %" IVdf " %s (regcppop)\n",
                 depth,
                 (UV)paren,
@@ -494,7 +493,7 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
             RXp_OFFSp(rex)[i].start = -1;
         }
         RXp_OFFSp(rex)[i].end = -1;
-        DEBUG_BUFFERS_r( Perl_re_exec_indentf( aTHX_
+        DEBUG_BUFFERS_r( re_exec_indentf(
             "    \\%" UVuf ": %s   ..-1 undeffing (regcppop)\n",
             depth,
             (UV)i,
@@ -503,13 +502,12 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
     }
 #endif
     DEBUG_BUFFERS_r({
-        Perl_re_exec_indentf(aTHX_
-                "finished regcppop at %" IVdf "\n",
-                depth, PL_savestack_ix);
+        re_exec_indentf("finished regcppop at %" IVdf "\n",
+                        depth, PL_savestack_ix);
     });
 
     DEBUG_STATE_r(
-        Perl_re_exec_indentf(aTHX_
+        re_exec_indentf(
             "savestack: regcppop freed in range [%" IVdf "..%" IVdf ")\n",
                 depth, (IV)(PL_savestack_ix), (IV)orig_ix
         )
@@ -529,7 +527,7 @@ S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
     I32 tmpix = PL_savestack_ix;
 
     DEBUG_STATE_r(
-        Perl_re_exec_indentf( aTHX_
+        re_exec_indentf(
             "savestack: regcp_restore: ix was %" IVdf "\n",
             depth, (IV)PL_savestack_ix);
     );
@@ -537,7 +535,7 @@ S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
     regcppop(rex, maxopenparen_p);
     PL_savestack_ix = tmpix;
     DEBUG_STATE_r(
-        Perl_re_exec_indentf( aTHX_
+        re_exec_indentf(
             "savestack: regcp_restore: reset ix=%" IVdf "\n",
             depth, (IV)PL_savestack_ix);
     );
@@ -3947,7 +3945,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         /* avoid leak if we die, or clean up anyway if match completes */
         SAVEFREEPV(swap);
         Newxz(RXp_OFFSp(prog), (prog->nparens + 1), regexp_paren_pair);
-        DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
+        DEBUG_BUFFERS_r(re_exec_indentf(
             "rex = 0x%" UVxf " saving  offs: orig = 0x%" UVxf " new = 0x%" UVxf "\n",
             0,
             PTR2UV(prog),
@@ -4358,7 +4356,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
          * shortly, restore the old captures by copying 'swap's original
          * data to the new offs buffer
          */
-        DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
+        DEBUG_BUFFERS_r(re_exec_indentf(
             "rex = 0x%" UVxf " rolling back offs: 0x%" UVxf " will be freed; restoring data to =0x%" UVxf "\n",
             0,
             PTR2UV(prog),
@@ -6852,7 +6850,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 && ! ANYOF_BITMAP_TEST(scan, nextbyte))
             {
                 DEBUG_EXECUTE_r(
-                    Perl_re_exec_indentf( aTHX_  "%sTRIE: failed to match trie start class...%s\n",
+                    re_exec_indentf("%sTRIE: failed to match trie start class...%s\n",
                               depth, PL_colors[4], PL_colors[5])
                 );
                 sayNO_SILENT;
@@ -6940,14 +6938,14 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 {
                     if (trie->states[ state ].wordnum) {
                          DEBUG_EXECUTE_r(
-                            Perl_re_exec_indentf( aTHX_  "%sTRIE: matched empty string...%s\n",
+                            re_exec_indentf("%sTRIE: matched empty string...%s\n",
                                           depth, PL_colors[4], PL_colors[5])
                         );
                         if (!trie->jump)
                             break;
                     } else {
                         DEBUG_EXECUTE_r(
-                            Perl_re_exec_indentf( aTHX_  "%sTRIE: failed to match trie start class...%s\n",
+                            re_exec_indentf("%sTRIE: failed to match trie start class...%s\n",
                                           depth, PL_colors[4], PL_colors[5])
                         );
                         sayNO_SILENT;
@@ -7062,7 +7060,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 }
 
                 DEBUG_EXECUTE_r(
-                    Perl_re_exec_indentf( aTHX_  "%sTRIE: got %" IVdf " possible matches%s\n",
+                    re_exec_indentf("%sTRIE: got %" IVdf " possible matches%s\n",
                         depth,
                         PL_colors[4], (IV)ST.accepted, PL_colors[5] );
                 );
@@ -7092,7 +7090,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             }
             if (!--ST.accepted) {
                 DEBUG_EXECUTE_r({
-                    Perl_re_exec_indentf( aTHX_  "%sTRIE failed...%s\n",
+                    re_exec_indentf("%sTRIE failed...%s\n",
                         depth,
                         PL_colors[4],
                         PL_colors[5] );
@@ -7191,7 +7189,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
 
             DEBUG_EXECUTE_r({
-                Perl_re_exec_indentf( aTHX_  "%sTRIE: matched word #%d, continuing%s\n",
+                re_exec_indentf("%sTRIE: matched word #%d, continuing%s\n",
                     depth,
                     PL_colors[4],
                     ST.nextword,
@@ -7216,7 +7214,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                         ? av_fetch(trie_words, ST.nextword - 1, 0) : NULL;
                 SV *sv= tmp ? sv_newmortal() : NULL;
 
-                Perl_re_exec_indentf( aTHX_  "%sTRIE: only one match left, short-circuiting: #%d <%s>%s\n",
+                re_exec_indentf("%sTRIE: only one match left, short-circuiting: #%d <%s>%s\n",
                     depth, PL_colors[4],
                     ST.nextword,
                     tmp ? pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), 0,
@@ -8371,7 +8369,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 DEBUG_r({
                     DECLARE_AND_GET_RE_DEBUG_FLAGS;
                     DEBUG_STACK_r({
-                        Perl_re_exec_indentf( aTHX_
+                        re_exec_indentf(
                             "entering GOSUB, prev_recurse_locinput = %p recurse_locinput[%d]=%p\n",
                             depth, ST.prev_recurse_locinput, arg, rex->recurse_locinput[arg]
                         );
@@ -8729,14 +8727,14 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                                   successful (??{A})B */
             /* note: this is called twice; first after popping B, then A */
             DEBUG_STACK_r({
-                Perl_re_exec_indentf( aTHX_  "EVAL_postponed_A/B cur_eval = %p prev_eval = %p\n",
+                re_exec_indentf("EVAL_postponed_A/B cur_eval = %p prev_eval = %p\n",
                     depth, cur_eval, ST.prev_eval);
             });
 
 #define SET_RECURSE_LOCINPUT(STR,VAL)                                   \
             if ( cur_eval && CUR_EVAL.close_paren ) {                   \
                 DEBUG_STACK_r({                                         \
-                    Perl_re_exec_indentf( aTHX_  STR "                  \
+                    re_exec_indentf(STR "                               \
                         GOSUB%d ce = %p recurse_locinput = %p\n",       \
                         depth,                                          \
                         CUR_EVAL.close_paren - 1,                       \
@@ -8774,7 +8772,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
         case EVAL_postponed_B_fail: /* unsuccessfully ran B in (??{A})B */
             /* note: this is called twice; first after popping B, then A */
             DEBUG_STACK_r({
-                Perl_re_exec_indentf( aTHX_  "EVAL_AB_fail cur_eval = %p prev_eval = %p\n",
+                re_exec_indentf("EVAL_AB_fail cur_eval = %p prev_eval = %p\n",
                     depth, cur_eval, ST.prev_eval);
             });
 
@@ -8805,7 +8803,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             RXp_OFFSp(rex)[n].start_tmp = locinput - reginfo->strbeg;
             if (n > maxopenparen)
                 maxopenparen = n;
-            DEBUG_BUFFERS_r(Perl_re_exec_indentf( aTHX_
+            DEBUG_BUFFERS_r(re_exec_indentf(
                 "OPEN: rex = 0x%" UVxf " offs = 0x%" UVxf ": \\%" UVuf ": set %" IVdf " tmp; maxopenparen = %" UVuf "\n",
                 depth,
                 PTR2UV(rex),
@@ -9066,7 +9064,7 @@ NULL
             ST.cache_offset = 0;
             ST.cache_mask = 0;
 
-            DEBUG_EXECUTE_r( Perl_re_exec_indentf( aTHX_  "WHILEM: matched %ld out of %d..%d\n",
+            DEBUG_EXECUTE_r( re_exec_indentf("WHILEM: matched %ld out of %d..%d\n",
                   depth, (long)n, min, max)
             );
 
@@ -9084,7 +9082,7 @@ NULL
             /* If degenerate A matches "", assume A done. */
 
             if (locinput == cur_curlyx->u.curlyx.lastloc) {
-                DEBUG_EXECUTE_r( Perl_re_exec_indentf( aTHX_  "WHILEM: empty match detected, trying continuation...\n",
+                DEBUG_EXECUTE_r( re_exec_indentf("WHILEM: empty match detected, trying continuation...\n",
                    depth)
                 );
                 goto do_whilem_B_max;
@@ -9168,7 +9166,7 @@ NULL
                     mask    = 1 << (offset % 8);
                     offset /= 8;
                     if (reginfo->info_aux->poscache[offset] & mask) {
-                        DEBUG_EXECUTE_r( Perl_re_exec_indentf( aTHX_  "WHILEM: (cache) already tried at this position...\n",
+                        DEBUG_EXECUTE_r( re_exec_indentf("WHILEM: (cache) already tried at this position...\n",
                             depth)
                         );
                         cur_curlyx->u.curlyx.count--;
@@ -9230,7 +9228,7 @@ NULL
         case WHILEM_A_max_fail: /* just failed to match A in a maximal match */
             REGCP_UNWIND(ST.lastcp);
             regcppop(rex, &maxopenparen); /* Restore some previous $<digit>s? */
-            DEBUG_EXECUTE_r(Perl_re_exec_indentf( aTHX_  "WHILEM: failed, trying continuation...\n",
+            DEBUG_EXECUTE_r(re_exec_indentf("WHILEM: failed, trying continuation...\n",
                 depth)
             );
 
@@ -9251,7 +9249,7 @@ NULL
                 CACHEsayNO;
             }
 
-            DEBUG_EXECUTE_r(Perl_re_exec_indentf( aTHX_  "WHILEM: B min fail: trying longer...\n", depth)
+            DEBUG_EXECUTE_r(re_exec_indentf("WHILEM: B min fail: trying longer...\n", depth)
             );
             /* Try grabbing another A and see if it helps. */
             cur_curlyx->u.curlyx.lastloc = locinput;
@@ -9335,7 +9333,7 @@ NULL
             /* no more branches? */
             if (!scan || (OP(scan) != BRANCH && OP(scan) != BRANCHJ)) {
                 DEBUG_EXECUTE_r({
-                    Perl_re_exec_indentf( aTHX_  "%sBRANCH failed...%s\n",
+                    re_exec_indentf("%sBRANCH failed...%s\n",
                         depth,
                         PL_colors[4],
                         PL_colors[5] );
@@ -9409,7 +9407,7 @@ NULL
                     ST.count = ST.minmod ? ARG1i(ST.me) : ARG2i(ST.me);
             }
             DEBUG_EXECUTE_r(
-                Perl_re_exec_indentf( aTHX_  "CURLYM now matched %" IVdf " times, len = %" IVdf "...\n",
+                re_exec_indentf("CURLYM now matched %" IVdf " times, len = %" IVdf "...\n",
                           depth, (IV) ST.count, (IV)ST.alen)
             );
 
@@ -9462,7 +9460,7 @@ NULL
             }
 
             DEBUG_EXECUTE_r(
-                Perl_re_exec_indentf( aTHX_  "CURLYM trying tail with matches = %" IVdf "...\n",
+                re_exec_indentf("CURLYM trying tail with matches = %" IVdf "...\n",
                     depth, (IV)ST.count)
             );
             if (! NEXTCHR_IS_EOS && ST.Binfo.count >= 0) {
@@ -9473,7 +9471,7 @@ NULL
                     || ! S_test_EXACTISH_ST(locinput, ST.Binfo))
                 {
                     DEBUG_OPTIMISE_r(
-                        Perl_re_exec_indentf( aTHX_
+                        re_exec_indentf(
                             "CURLYM Fast bail next target = 0x%X anded == 0x%X"
                                                                 " mask = 0x%X\n",
                             depth,
@@ -9886,7 +9884,7 @@ NULL
                 st->u.eval.prev_eval = cur_eval;
                 cur_eval = CUR_EVAL.prev_eval;
                 DEBUG_EXECUTE_r(
-                    Perl_re_exec_indentf( aTHX_  "END: EVAL trying tail ... (cur_eval = %p)\n",
+                    re_exec_indentf("END: EVAL trying tail ... (cur_eval = %p)\n",
                                       depth, cur_eval););
                 if ( nochange_depth )
                     nochange_depth--;
@@ -9916,7 +9914,7 @@ NULL
             if (match_end && locinput != match_end)
             {
                 DEBUG_EXECUTE_r(
-                Perl_re_exec_indentf( aTHX_
+                re_exec_indentf(
                     "%sLOOKBEHIND_END: subpattern failed...%s\n",
                     depth, PL_colors[4], PL_colors[5]));
                 sayNO;            /* Variable length match didn't line up */
@@ -9926,7 +9924,7 @@ NULL
         case SUCCEED: /* successful SUSPEND/CURLYM and
                                             *lookahead* IFMATCH/UNLESSM*/
             DEBUG_EXECUTE_r(
-            Perl_re_exec_indentf( aTHX_
+            re_exec_indentf(
                 "%sSUCCEED: subpattern success...%s\n",
                 depth, PL_colors[4], PL_colors[5]));
             sayYES;			/* Success! */
@@ -10109,7 +10107,7 @@ NULL
                 sv_commit = ST.mark_name;
 
                 DEBUG_EXECUTE_r({
-                        Perl_re_exec_indentf( aTHX_  "%sMARKPOINT: next fail: setting cutpoint to mark:%" SVf "...%s\n",
+                        re_exec_indentf("%sMARKPOINT: next fail: setting cutpoint to mark:%" SVf "...%s\n",
                             depth,
                             PL_colors[4], SVfARG(sv_commit), PL_colors[5]);
                 });
@@ -10224,7 +10222,7 @@ NULL
                         slab = slab->prev;
                         cur = SLAB_LAST(slab);
                     }
-                    Perl_re_exec_indentf( aTHX_ "%4s #%-3d %-10s %s\n",
+                    re_exec_indentf("%4s #%-3d %-10s %s\n",
                         depth,
                         i ? "    " : "push",
                         depth - i, REGNODE_NAME(cur->resume_state),
@@ -10333,7 +10331,7 @@ NULL
 
   no:
     DEBUG_EXECUTE_r(
-        Perl_re_exec_indentf( aTHX_  "%sfailed...%s\n",
+        re_exec_indentf("%sfailed...%s\n",
             depth,
             PL_colors[4], PL_colors[5])
         );
@@ -11085,7 +11083,7 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
         DEBUG_EXECUTE_r({
             SV * const prop = sv_newmortal();
             regprop(prog, prop, p, reginfo, NULL);
-            Perl_re_exec_indentf( aTHX_
+            re_exec_indentf(
                         "%s can match %" IVdf " times out of %" IVdf "...\n",
                         depth, SvPVX_const(prop),(IV)c,(IV)max);
         });

--- a/scope.c
+++ b/scope.c
@@ -1182,8 +1182,8 @@ Perl_leave_scope(pTHX_ I32 base)
 
     if (UNLIKELY(base < -1))
         croak("panic: corrupt saved stack index %ld", (long) base);
-    DEBUG_l(Perl_deb(aTHX_ "savestack: releasing items %ld -> %ld\n",
-                        (long)PL_savestack_ix, (long)base));
+    DEBUG_l(deb("savestack: releasing items %ld -> %ld\n",
+                (long)PL_savestack_ix, (long)base));
     while (PL_savestack_ix > base) {
         UV uv;
         U8 type;

--- a/scope.c
+++ b/scope.c
@@ -196,7 +196,7 @@ Perl_savestack_grow(pTHX)
     PERL_ARGS_ASSERT_SAVESTACK_GROW;
 
     const I32 by = PL_savestack_max - PL_savestack_ix;
-    Perl_savestack_grow_cnt(aTHX_ by);
+    savestack_grow_cnt(by);
 }
 
 void

--- a/sv.c
+++ b/sv.c
@@ -4188,7 +4188,7 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
                magic_clearisa do it for us, as it already has the logic for
                dealing with globs vs arrays of globs. */
             assert(mg);
-            Perl_magic_clearisa(aTHX_ NULL, mg);
+            magic_clearisa(NULL, mg);
         }
         else if (stype == SVt_PVIO) {
             DEBUG_o(deb("gv_setref clearing PL_stashcache\n"));

--- a/sv.c
+++ b/sv.c
@@ -7905,7 +7905,7 @@ Perl_sv_free2(pTHX_ SV *const sv, const U32 rc)
     }
     if (ckWARN_d(WARN_INTERNAL)) {
 #ifdef DEBUG_LEAKING_SCALARS_FORK_DUMP
-        Perl_dump_sv_child(aTHX_ sv);
+        dump_sv_child(sv);
 #else
     #ifdef DEBUG_LEAKING_SCALARS
         sv_dump(sv);

--- a/sv.c
+++ b/sv.c
@@ -4079,13 +4079,11 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
                         report_redefined_cv(
                            sv_2mortal(
                              stash
-                               ? Perl_newSVpvf(aTHX_
-                                    "%" HEKf "::%" HEKf,
-                                    HEKfARG(HvNAME_HEK(stash)),
-                                    HEKfARG(GvENAME_HEK(MUTABLE_GV(dsv))))
-                               : Perl_newSVpvf(aTHX_
-                                    "%" HEKf,
-                                    HEKfARG(GvENAME_HEK(MUTABLE_GV(dsv))))
+                               ? newSVpvf("%" HEKf "::%" HEKf,
+                                        HEKfARG(HvNAME_HEK(stash)),
+                                        HEKfARG(GvENAME_HEK(MUTABLE_GV(dsv))))
+                               : newSVpvf("%" HEKf,
+                                        HEKfARG(GvENAME_HEK(MUTABLE_GV(dsv))))
                            ),
                            cv,
                            CvCONST((const CV *)sref) ? &new_const_sv : NULL

--- a/sv.c
+++ b/sv.c
@@ -16821,7 +16821,7 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
      *  PERL_SET_CONTEXT(proto_perl);
      * breaks too many other things
      */
-    Perl_reentrant_init(aTHX);
+    reentrant_init();
 #endif
 
     /* create SV map for pointer relocation */

--- a/sv.c
+++ b/sv.c
@@ -18469,7 +18469,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
         if (sv) {
             const char *name = OP_NAME(obase);
             Perl_sv_insert_flags(aTHX_ sv, 0, 0, STR_WITH_LEN("("), 0);
-            Perl_sv_insert_flags(aTHX_ sv, 0, 0, name, strlen(name), 0);
+            sv_insert_flags(sv, 0, 0, name, strlen(name), 0);
             sv_catpvs_nomg(sv, ")");
         }
         return sv;

--- a/sv.c
+++ b/sv.c
@@ -1275,7 +1275,7 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
             SvOBJECT_on(io);
             /* Clear the stashcache because a new IO could overrule a package
                name */
-            DEBUG_o(Perl_deb(aTHX_ "sv_upgrade clearing PL_stashcache\n"));
+            DEBUG_o(deb("sv_upgrade clearing PL_stashcache\n"));
             hv_clear(PL_stashcache);
 
             SvSTASH_set(io, HvREFCNT_inc(GvHV(iogv)));
@@ -3982,8 +3982,7 @@ S_glob_assign_glob(pTHX_ SV *const dsv, SV *const ssv, const int dtype)
     }
     else if(mro_changes) mro_method_changed_in(GvSTASH(dsv));
     if (GvIO(dsv) && dtype == SVt_PVGV) {
-        DEBUG_o(Perl_deb(aTHX_
-                        "glob_assign_glob clearing PL_stashcache\n"));
+        DEBUG_o(deb("glob_assign_glob clearing PL_stashcache\n"));
         /* It's a cache. It will rebuild itself quite happily.
            It's a lot of effort to work out exactly which key (or keys)
            might be invalidated by the creation of the this file handle.
@@ -4192,7 +4191,7 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
             Perl_magic_clearisa(aTHX_ NULL, mg);
         }
         else if (stype == SVt_PVIO) {
-            DEBUG_o(Perl_deb(aTHX_ "gv_setref clearing PL_stashcache\n"));
+            DEBUG_o(deb("gv_setref clearing PL_stashcache\n"));
             /* It's a cache. It will rebuild itself quite happily.
                It's a lot of effort to work out exactly which key (or keys)
                might be invalidated by the creation of the this file handle.
@@ -7376,10 +7375,8 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
                     && (hek = HvNAME_HEK((HV*)sv)))
                 {
                     if (PL_stashcache) {
-                        DEBUG_o(Perl_deb(aTHX_
-                            "sv_clear clearing PL_stashcache for '%" HEKf
-                            "'\n",
-                             HEKfARG(hek)));
+                        DEBUG_o(deb("sv_clear clearing PL_stashcache for '%"
+                                    HEKf "'\n", HEKfARG(hek)));
                         (void)hv_deletehek(PL_stashcache,
                                            hek, G_DISCARD);
                     }
@@ -7714,7 +7711,7 @@ S_curse(pTHX_ SV * const sv, const bool check_refcnt)
 
             assert (HvHasAUX(stash));
 
-            DEBUG_o( Perl_deb(aTHX_ "Looking for DESTROY method for %s\n",
+            DEBUG_o( deb("Looking for DESTROY method for %s\n",
                          HvNAME(stash)) );
 
             /* don't make this an initialization above the assert, since it needs
@@ -7722,7 +7719,7 @@ S_curse(pTHX_ SV * const sv, const bool check_refcnt)
             meta = HvMROMETA(stash);
             if (meta->destroy_gen && meta->destroy_gen == PL_sub_generation) {
                 destructor = meta->destroy;
-                DEBUG_o( Perl_deb(aTHX_ "Using cached DESTROY method %p for %s\n",
+                DEBUG_o( deb("Using cached DESTROY method %p for %s\n",
                              (void *)destructor, HvNAME(stash)) );
             }
             else {
@@ -7746,11 +7743,11 @@ S_curse(pTHX_ SV * const sv, const bool check_refcnt)
                     meta->destroy_gen = PL_sub_generation;
                     meta->destroy = destructor;
 
-                    DEBUG_o( Perl_deb(aTHX_ "Set cached DESTROY method %p for %s\n",
-                                      (void *)destructor, HvNAME(stash)) );
+                    DEBUG_o( deb("Set cached DESTROY method %p for %s\n",
+                                 (void *)destructor, HvNAME(stash)) );
                 }
                 else {
-                    DEBUG_o( Perl_deb(aTHX_ "Not caching AUTOLOAD for DESTROY method for %s\n",
+                    DEBUG_o( deb("Not caching AUTOLOAD for DESTROY method for %s\n",
                                       HvNAME(stash)) );
                 }
             }

--- a/sv.c
+++ b/sv.c
@@ -15550,7 +15550,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
     case SVt_IV:
         SET_SVANY_FOR_BODYLESS_IV(dsv);
         if(SvROK(ssv)) {
-            Perl_rvpv_dup(aTHX_ dsv, ssv, param);
+            rvpv_dup(dsv, ssv, param);
         } else {
             SvIV_set(dsv, SvIVX(ssv));
         }
@@ -15631,7 +15631,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
                 && !isGV_with_GP(dsv)
                 && !isREGEXP(dsv)
                 && !(sv_type == SVt_PVIO && !(IoFLAGS(dsv) & IOf_FAKE_DIRP)))
-                Perl_rvpv_dup(aTHX_ dsv, ssv, param);
+                rvpv_dup(dsv, ssv, param);
 
             /* The Copy above means that all the source (unduplicated) pointers
                are now in the destination.  We can check the flags and the

--- a/sv.c
+++ b/sv.c
@@ -6691,7 +6691,7 @@ Perl_sv_rvunweaken(pTHX_ SV *const sv)
     SvWEAKREF_off(sv);
     SvROK_on(sv);
     SvREFCNT_inc_NN(tsv);
-    Perl_sv_del_backref(aTHX_ tsv, sv);
+    sv_del_backref(tsv, sv);
     return sv;
 }
 

--- a/sv.c
+++ b/sv.c
@@ -8005,22 +8005,21 @@ Perl_sv_len_utf8_nomg(pTHX_ SV * const sv)
                        The longer value is stored in the first pair.  */
                     STRLEN *cache = (STRLEN *) mg->mg_ptr;
 
-                    ulen = cache[0] + Perl_utf8_length(aTHX_ s + cache[1],
-                                                       s + len);
+                    ulen = cache[0] + utf8_length(s + cache[1], s + len);
                 }
 
                 if (PL_utf8cache < 0) {
-                    const STRLEN real = Perl_utf8_length(aTHX_ s, s + len);
+                    const STRLEN real = utf8_length(s, s + len);
                     assert_uft8_cache_coherent("sv_len_utf8", ulen, real, sv);
                 }
             }
             else {
-                ulen = Perl_utf8_length(aTHX_ s, s + len);
+                ulen = utf8_length(s, s + len);
                 utf8_mg_len_cache_update(sv, &mg, ulen);
             }
             return ulen;
     }
-    return SvUTF8(sv) ? Perl_utf8_length(aTHX_ s, s + len) : len;
+    return SvUTF8(sv) ? utf8_length(s, s + len) : len;
 }
 
 /* Walk forwards to find the byte corresponding to the passed in UTF-8

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -502,7 +502,7 @@ Perl_newSV_type(pTHX_ const svtype type)
             SvOBJECT_on(io);
             /* Clear the stashcache because a new IO could overrule a package
                name */
-            DEBUG_o(Perl_deb(aTHX_ "sv_upgrade clearing PL_stashcache\n"));
+            DEBUG_o(deb("sv_upgrade clearing PL_stashcache\n"));
             hv_clear(PL_stashcache);
 
             SvSTASH_set(io, MUTABLE_HV(SvREFCNT_inc(GvHV(iogv))));

--- a/toke.c
+++ b/toke.c
@@ -2858,7 +2858,7 @@ Perl_load_charnames(pTHX_ SV * char_name, const char * context,
         }
 
         if (i == 0) {
-            Perl_load_module(aTHX_
+            load_module(
                 0,
                 newSVpvs("_charnames"),
 

--- a/toke.c
+++ b/toke.c
@@ -14368,7 +14368,7 @@ S_parse_recdescent(pTHX_ int gramtype, I32 fakeeof)
     SAVEI8(PL_lex_fakeeof);
     PL_lex_fakeeof = (U8)fakeeof;
     if(yyparse(gramtype) && !PL_parser->error_count)
-        qerror(Perl_mess(aTHX_ "Parse error"));
+        qerror(mess("Parse error"));
 }
 
 #define parse_recdescent_for_op(g,p) S_parse_recdescent_for_op(aTHX_ g,p)
@@ -14395,7 +14395,7 @@ S_parse_expr(pTHX_ I32 fakeeof, U32 flags)
     exprop = parse_recdescent_for_op(GRAMEXPR, fakeeof);
     if (!exprop && !(flags & PARSE_OPTIONAL)) {
         if (!PL_parser->error_count)
-            qerror(Perl_mess(aTHX_ "Parse error"));
+            qerror(mess("Parse error"));
         exprop = newOP(OP_NULL, 0);
     }
     return exprop;
@@ -14685,7 +14685,7 @@ Perl_parse_label(pTHX_ U32 flags)
             if (flags & PARSE_OPTIONAL) {
                 return NULL;
             } else {
-                qerror(Perl_mess(aTHX_ "Parse error"));
+                qerror(mess("Parse error"));
                 return newSVpvs("x");
             }
         }
@@ -14771,7 +14771,7 @@ Perl_parse_stmtseq(pTHX_ U32 flags)
     stmtseqop = parse_recdescent_for_op(GRAMSTMTSEQ, LEX_FAKEEOF_CLOSING);
     c = lex_peek_unichar(0);
     if (c != -1 && c != /*{*/'}')
-        qerror(Perl_mess(aTHX_ "Parse error"));
+        qerror(mess("Parse error"));
     return stmtseqop;
 }
 

--- a/toke.c
+++ b/toke.c
@@ -581,7 +581,7 @@ S_tokereport(pTHX_ I32 rv, const YYSTYPE* lvalp)
             }
         }
         if (name)
-            Perl_sv_catpv(aTHX_ report, name);
+            sv_catpv(report, name);
         else if (isGRAPH(rv))
         {
             sv_catpvf(report, "'%c'", (char)rv);

--- a/toke.c
+++ b/toke.c
@@ -11616,7 +11616,7 @@ S_scan_pat(pTHX_ char *start, I32 type)
     }
 
     if (x_mod_count > 1 && FEATURE_ENHANCED_XX_IS_ENABLED) {
-        Perl_ck_warner_d(aTHX_ packWARN(WARN_EXPERIMENTAL__ENHANCED_XX), 
+        ck_warner_d(packWARN(WARN_EXPERIMENTAL__ENHANCED_XX), 
                          "enhanced_xx is experimental");
     }
 
@@ -11679,7 +11679,7 @@ S_scan_subst(pTHX_ char *start)
     }
 
     if (x_mod_count > 1 && FEATURE_ENHANCED_XX_IS_ENABLED) {
-        Perl_ck_warner_d(aTHX_ packWARN(WARN_EXPERIMENTAL__ENHANCED_XX),
+        ck_warner_d(packWARN(WARN_EXPERIMENTAL__ENHANCED_XX),
                          "enhanced_xx is experimental");
     }
 

--- a/toke.c
+++ b/toke.c
@@ -7574,7 +7574,7 @@ yyl_croak_unrecognised(pTHX_ char *s)
         while (d > SvPVX(PL_linestr) && d[-1] && d[-1] != '\n')
             --d;
     }
-    len = UTF ? Perl_utf8_length(aTHX_ (U8 *) d, (U8 *) s) : (STRLEN) (s - d);
+    len = UTF ? utf8_length((U8 *) d, (U8 *) s) : (STRLEN) (s - d);
     if (len > UNRECOGNIZED_PRECEDE_COUNT) {
         d = UTF ? (char *) utf8_hop_back((U8 *) s, -UNRECOGNIZED_PRECEDE_COUNT, (U8 *)d) : s - UNRECOGNIZED_PRECEDE_COUNT;
     }

--- a/toke.c
+++ b/toke.c
@@ -8474,7 +8474,7 @@ yyl_word_or_keyword(pTHX_ char *s, STRLEN len, I32 key, I32 orig_keyword, struct
 
     case KEY___LINE__:
         FUN0OP(newSVOP(OP_CONST, OPpCONST_TOKEN_LINE<<8,
-                Perl_newSVpvf(aTHX_ "%" LINE_Tf, CopLINE(PL_curcop))));
+                newSVpvf("%" LINE_Tf, CopLINE(PL_curcop))));
 
     case KEY___PACKAGE__:
         FUN0OP(newSVOP(OP_CONST, OPpCONST_TOKEN_PACKAGE<<8,

--- a/universal.c
+++ b/universal.c
@@ -879,9 +879,9 @@ XS(XS_PerlIO_get_layers)
                   }
                   else {
                        if (namok && argok)
-                            PUSHs(sv_2mortal(Perl_newSVpvf(aTHX_ "%" SVf "(%" SVf ")",
-                                                 SVfARG(*namsvp),
-                                                 SVfARG(*argsvp))));
+                            PUSHs(sv_2mortal(newSVpvf("%" SVf "(%" SVf ")",
+                                                      SVfARG(*namsvp),
+                                                      SVfARG(*argsvp))));
                        else if (namok)
                             PUSHs(sv_2mortal(SvREFCNT_inc_simple_NN(*namsvp)));
                        else

--- a/utf8.c
+++ b/utf8.c
@@ -4878,8 +4878,7 @@ Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
     const char * const ptr =
         isREGEXP(ssv) ? RX_WRAPPED((REGEXP*)ssv) : SvPVX_const(ssv);
 
-    return Perl_pv_uni_display(aTHX_ dsv, (const U8*)ptr,
-                                SvCUR(ssv), pvlim, flags);
+    return pv_uni_display(dsv, (const U8*)ptr, SvCUR(ssv), pvlim, flags);
 }
 
 /*

--- a/utf8.c
+++ b/utf8.c
@@ -2278,7 +2278,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                  * function */
 
                 assert(0);
-                message = Perl_form(aTHX_ "%s: (empty string)", malformed_text);
+                message = form("%s: (empty string)", malformed_text);
                 break;
 
               case UTF8_GOT_CONTINUATION_BIT_POS_:
@@ -2329,7 +2329,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                  * The other error types either can't generate an overlong, or
                  * else the 'input_uv' is valid */
                 if (orig_problems & (UTF8_GOT_TOO_SHORT|UTF8_GOT_OVERFLOW)) {
-                    message = Perl_form(aTHX_
+                    message = form(
                             "%s: %s (any UTF-8 sequence that starts with"
                             " \"%s\" is overlong which can and should be"
                             " represented with a different, shorter sequence)",
@@ -2354,7 +2354,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                                             )
                                             ? "0x"
                                             : "U+";
-                    message = Perl_form(aTHX_
+                    message = form(
                                 "%s: %s (overlong; instead use %s to represent"
                                 " %s%0*" UVXf ")",
                                 malformed_text,
@@ -2404,13 +2404,13 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                 /* This is the only error that can occur with a surrogate when
                  * the 'input_uv' isn't valid */
                 if (orig_problems & UTF8_GOT_TOO_SHORT) {
-                    message = Perl_form(aTHX_
+                    message = form(
                                    "UTF-16 surrogate (any UTF-8 sequence that"
                                    " starts with \"%s\" is for a surrogate)",
                                    byte_dump_string_(s0, curlen, 0));
                 }
                 else {
-                    message = Perl_form(aTHX_ surrogate_cp_format, input_uv);
+                    message = form(surrogate_cp_format, input_uv);
                 }
 
                 break;
@@ -2495,7 +2495,7 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                  * have this situation. */
 
                 if (overflows) {
-                    message = Perl_form(aTHX_ "%s: %s (overflows)",
+                    message = form("%s: %s (overflows)",
                                               malformed_text,
                                               byte_dump_string_(s0, curlen, 0));
                 }
@@ -2504,14 +2504,14 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                              && ! UNICODE_IS_SUPER(input_uv)))
                 {
                     if (is_extended) {
-                        message = Perl_form(aTHX_
+                        message = form(
                                         "Any UTF-8 sequence that starts with"
                                         " \"%s\" is a Perl extension, and so"
                                         " is not portable",
                                         byte_dump_string_(s0, curlen, 0));
                     }
                     else {
-                        message = Perl_form(aTHX_
+                        message = form(
                                         "Any UTF-8 sequence that starts with"
                                         " \"%s\" is for a non-Unicode code"
                                         " point, may not be portable",
@@ -2519,10 +2519,10 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
                     }
                 }
                 else if (is_extended) {
-                    message = Perl_form(aTHX_ PL_extended_cp_format, input_uv);
+                    message = form(PL_extended_cp_format, input_uv);
                 }
                 else {
-                    message = Perl_form(aTHX_ super_cp_format, input_uv);
+                    message = form(super_cp_format, input_uv);
                 }
 
                 /* This message only needs to output once.  Ww can potentially

--- a/util.c
+++ b/util.c
@@ -3837,8 +3837,7 @@ Perl_report_evil_fh(pTHX_ const GV *gv)
                     have_name ? " " : "",
                     SVfARG(have_name ? name : &PL_sv_no));
         if (io && IoDIRP(io) && !(IoFLAGS(io) & IOf_FAKE_DIRP))
-                Perl_warner(
-                            aTHX_ packWARN(warn_type),
+                warner(packWARN(warn_type),
                         "\t(Are you trying to call %s%s on dirhandle%s%" SVf "?)\n",
                         func, pars, have_name ? " " : "",
                         SVfARG(have_name ? name : &PL_sv_no)

--- a/util.c
+++ b/util.c
@@ -5732,7 +5732,7 @@ S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
             }
             SvREFCNT_dec(string);
 
-            Perl_sv_2mortal(aTHX_ xpt);
+            sv_2mortal(xpt);
             croak_sv(xpt);
         }
     }

--- a/util.c
+++ b/util.c
@@ -1610,7 +1610,7 @@ Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
             && grok_atoUV(ws, &wi, NULL)
             && wi <= PERL_INT_MAX
         ) {
-            Perl_dump_c_backtrace(aTHX_ Perl_debug_log, (int)wi, 1);
+            dump_c_backtrace(Perl_debug_log, (int)wi, 1);
         }
     }
 #endif

--- a/util.c
+++ b/util.c
@@ -5717,8 +5717,9 @@ S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
         xssv = upg_version(xssv, 0);
         if ( vcmp(pmsv,xssv) ) {
             SV *string = vstringify(xssv);
-            SV *xpt = Perl_newSVpvf(aTHX_ "%" SVf " object version %" SVf
-                                    " does not match ", SVfARG(module), SVfARG(string));
+            SV *xpt = newSVpvf("%" SVf " object version %" SVf
+                               " does not match ",
+                               SVfARG(module), SVfARG(string));
 
             SvREFCNT_dec(string);
             string = vstringify(pmsv);

--- a/util.c
+++ b/util.c
@@ -1696,7 +1696,7 @@ Perl_write_to_stderr(pTHX_ SV* msv)
     if (PL_stderrgv && SvREFCNT(PL_stderrgv)
         && (io = GvIO(PL_stderrgv))
         && (mg = SvTIED_mg((const SV *)io, PERL_MAGIC_tiedscalar)))
-        Perl_magic_methcall(aTHX_ MUTABLE_SV(io), mg, SV_CONST(PRINT),
+        magic_methcall(MUTABLE_SV(io), mg, SV_CONST(PRINT),
                             G_SCALAR | G_DISCARD | G_WRITING_TO_STDERR, 1, msv);
     else {
         PerlIO * const serr = Perl_error_log;

--- a/util.c
+++ b/util.c
@@ -5711,7 +5711,7 @@ S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
         }
     }
     if (sv) {
-        SV *xssv = Perl_newSVpvn_flags(aTHX_ xs_p, xs_len, SVs_TEMP);
+        SV *xssv = newSVpvn_flags(xs_p, xs_len, SVs_TEMP);
         SV *pmsv = sv_isobject(sv) && sv_derived_from(sv, "version")
             ? sv : sv_2mortal(new_version(sv));
         xssv = upg_version(xssv, 0);

--- a/util.c
+++ b/util.c
@@ -6746,9 +6746,7 @@ Perl_dump_c_backtrace(pTHX_ PerlIO* fp, int depth, int skip)
 {
     PERL_ARGS_ASSERT_DUMP_C_BACKTRACE;
 
-    SV* sv;
-
-    sv = Perl_get_c_backtrace_dump(aTHX_ depth, skip);
+    SV* sv = get_c_backtrace_dump(depth, skip);
     if (sv) {
         sv_2mortal(sv);
         PerlIO_printf(fp, "%s", SvPV_nolen(sv));

--- a/util.c
+++ b/util.c
@@ -5028,7 +5028,7 @@ S_mem_log_common(enum mem_log_type mlt, const UV n,
                         CopFILE(PL_curcop), CopLINE(PL_curcop));
                 PERL_UNUSED_RESULT(PerlLIO_write(fd, buf, len));
 
-                Perl_c_backtrace *bt = Perl_get_c_backtrace(aTHX_ 3, 3);
+                Perl_c_backtrace *bt = get_c_backtrace(3, 3);
                 Perl_c_backtrace_frame *frame;
                 UV i;
                 for (i = 0, frame = bt->frame_info;

--- a/util.c
+++ b/util.c
@@ -5732,7 +5732,7 @@ S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
             SvREFCNT_dec(string);
 
             Perl_sv_2mortal(aTHX_ xpt);
-            Perl_croak_sv(aTHX_ xpt);
+            croak_sv(xpt);
         }
     }
 }
@@ -5759,9 +5759,8 @@ Perl_api_version_assert(size_t interp_size, void *v_my_perl,
     if (interp_size != sizeof(PerlInterpreter)) {
         /* detects various types of configuration mismatches */
         /* diag_listed_as: Mismatch between expected and libperl %s */
-        Perl_croak(aTHX_
-                   "Mismatch between expected and libperl interpreter structure size %zd vs %zd",
-                   interp_size, sizeof(PerlInterpreter));
+        croak("Mismatch between expected and libperl interpreter structure"
+              " size %zd vs %zd", interp_size, sizeof(PerlInterpreter));
     }
     if (
 #ifdef MULTIPLICITY
@@ -5772,14 +5771,12 @@ Perl_api_version_assert(size_t interp_size, void *v_my_perl,
         ) {
         /* detect threads vs non-threads mismatch */
         /* diag_listed_as: Mismatch between expected and libperl %s */
-        Perl_croak(aTHX_
-                   "Mismatch between expected and libperl interpreter pointer");
+        croak("Mismatch between expected and libperl interpreter pointer");
     }
     if (strNE(api_version, PERL_API_VERSION_STRING)) {
         /* diag_listed_as: Mismatch between expected and libperl %s */
-        Perl_croak(aTHX_
-                   "Mismatch between expected and libperl API versions %s vs %s",
-                   api_version, PERL_API_VERSION_STRING);
+        croak("Mismatch between expected and libperl API versions %s vs %s",
+              api_version, PERL_API_VERSION_STRING);
     }
 }
 

--- a/vms/vms.c
+++ b/vms/vms.c
@@ -4828,7 +4828,7 @@ Perl_my_waitpid(pTHX_ Pid_t pid, int *statusp, int flags)
         /* remind folks they are asking for non-standard waitpid behavior */
         _ckvmssts(lib$getjpi(&pidcode,0,0,&mypid,0,0));
         if (ownerpid != mypid)
-          Perl_warner(aTHX_ packWARN(WARN_EXEC),
+          warner(packWARN(WARN_EXEC),
                       "waitpid: process %x is not a child of process %x",
                       pid,mypid);
       }


### PR DESCRIPTION
This PR consists of a series of commits, each of which takes every instance of a given function whose full name is "Perl_foo"  and converts that to plain "foo".  If there was an aTHX parameter in the long name call, that is now omitted in the short name call.  It does that for every dot c file in the base perl core.

And it adjusts white space to compensate, and where I noticed long line wrapping and it was easy to fix that.

This should not actually change the code that gets generated.

The reason to do this is that it reduces noise in our source, and the cognitive load to deal with that.  And it adds flexibility if we decide to change the internal API -- that is more easily done in the case of macros that expand to the actual call.

There are instances where using the function name instead of the macro in required, so aren't changed here.   An example is when the use includes calls to macros that have fancy C preprocessor effects, such as `STR_WITH_LEN` which returns two tokens.

Most of the changed uses appear to be because we did not have C99 variadic macros available at the time the code was written.  I don't know about the others.  Perhaps it was habit, or something I'm missing that someone can correct me on.

There are quite a few calls that didn't have many instances each that I ran out of energy to track down if they were convertible, given the small gain of each.

* This set of changes does not require a perldelta entry.
