### PR TITLE
make core XS modules not rely on void XSUB hack

### DIFF
--- a/dist/IO/IO.pm
+++ b/dist/IO/IO.pm
@@ -7,7 +7,7 @@ use Carp;
 use strict;
 use warnings;
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 XSLoader::load 'IO', $VERSION;
 
 sub import {

--- a/dist/IO/IO.xs
+++ b/dist/IO/IO.xs
@@ -146,44 +146,43 @@ io_blocking(pTHX_ InputStream f, int block)
 
 MODULE = IO	PACKAGE = IO::Seekable	PREFIX = f
 
-void
+SV*
 fgetpos(handle)
 	InputStream	handle
     CODE:
 	if (handle) {
 #ifdef PerlIO
-#if PERL_VERSION_LT(5,8,0)
+#  if PERL_VERSION_LT(5,8,0)
 	    Fpos_t pos;
-	    ST(0) = sv_newmortal();
 	    if (PerlIO_getpos(handle, &pos) != 0) {
-		ST(0) = &PL_sv_undef;
+		RETVAL = &PL_sv_undef;
 	    }
 	    else {
-		sv_setpvn(ST(0), (char *)&pos, sizeof(Fpos_t));
+                RETVAL = newSV(0);
+		sv_setpvn(RETVAL, (char *)&pos, sizeof(Fpos_t));
 	    }
-#else
-	    ST(0) = sv_newmortal();
-	    if (PerlIO_getpos(handle, ST(0)) != 0) {
-		ST(0) = &PL_sv_undef;
+#  else
+	    RETVAL = newSV(0);
+	    if (PerlIO_getpos(handle, RETVAL) != 0) {
+		RETVAL = &PL_sv_undef;
 	    }
-#endif
+#  endif
 #else
 	    Fpos_t pos;
 	    if (fgetpos(handle, &pos)) {
-		ST(0) = &PL_sv_undef;
+		RETVAL = &PL_sv_undef;
 	    } else {
-#  if PERL_VERSION_GE(5,11,0)
-		ST(0) = newSVpvn_flags((char*)&pos, sizeof(Fpos_t), SVs_TEMP);
-#  else
-		ST(0) = sv_2mortal(newSVpvn((char*)&pos, sizeof(Fpos_t)));
-#  endif
+		RETVAL = newSVpvn((char*)&pos, sizeof(Fpos_t));
 	    }
 #endif
 	}
 	else {
 	    errno = EINVAL;
-	    ST(0) = &PL_sv_undef;
+	    RETVAL = &PL_sv_undef;
 	}
+
+    OUTPUT: RETVAL
+
 
 SysRet
 fsetpos(handle, pos)
@@ -226,7 +225,7 @@ fsetpos(handle, pos)
 
 MODULE = IO	PACKAGE = IO::File	PREFIX = f
 
-void
+SV*
 new_tmpfile(packname = "IO::File")
     const char * packname
     PREINIT:
@@ -242,14 +241,17 @@ new_tmpfile(packname = "IO::File")
 	if (gv)
 	    (void) hv_delete(GvSTASH(gv), GvNAME(gv), GvNAMELEN(gv), G_DISCARD);
 	if (gv && do_open(gv, "+>&", 3, FALSE, 0, 0, fp)) {
-	    ST(0) = sv_2mortal(newRV_inc((SV*)gv));
-	    sv_bless(ST(0), gv_stashpv(packname, TRUE));
+	    RETVAL = newRV_inc((SV*)gv);
+	    sv_bless(RETVAL, gv_stashpv(packname, TRUE));
 	    SvREFCNT_dec(gv);   /* undo increment in newRV() */
 	}
 	else {
-	    ST(0) = &PL_sv_undef;
+	    RETVAL = &PL_sv_undef;
 	    SvREFCNT_dec(gv);
 	}
+
+    OUTPUT: RETVAL
+
 
 MODULE = IO	PACKAGE = IO::Poll
 

--- a/dist/IO/lib/IO/Dir.pm
+++ b/dist/IO/lib/IO/Dir.pm
@@ -18,7 +18,7 @@ use File::stat;
 use File::Spec;
 
 our @ISA = qw(Tie::Hash Exporter);
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 our @EXPORT_OK = qw(DIR_UNLINK);
 

--- a/dist/IO/lib/IO/File.pm
+++ b/dist/IO/lib/IO/File.pm
@@ -127,7 +127,7 @@ require Exporter;
 
 our @ISA = qw(IO::Handle IO::Seekable Exporter);
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 our @EXPORT = @IO::Seekable::EXPORT;
 

--- a/dist/IO/lib/IO/Handle.pm
+++ b/dist/IO/lib/IO/Handle.pm
@@ -278,7 +278,7 @@ use IO ();	# Load the XS module
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 our @EXPORT_OK = qw(
     autoflush

--- a/dist/IO/lib/IO/Pipe.pm
+++ b/dist/IO/lib/IO/Pipe.pm
@@ -13,7 +13,7 @@ use strict;
 use Carp;
 use Symbol;
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 sub new {
     my $type = shift;

--- a/dist/IO/lib/IO/Seekable.pm
+++ b/dist/IO/lib/IO/Seekable.pm
@@ -106,7 +106,7 @@ require Exporter;
 our @EXPORT = qw(SEEK_SET SEEK_CUR SEEK_END);
 our @ISA = qw(Exporter);
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 sub seek {
     @_ == 3 or croak 'usage: $io->seek(POS, WHENCE)';

--- a/dist/IO/lib/IO/Select.pm
+++ b/dist/IO/lib/IO/Select.pm
@@ -10,7 +10,7 @@ use     strict;
 use warnings::register;
 require Exporter;
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 our @ISA = qw(Exporter); # This is only so we can do version checking
 

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -23,7 +23,7 @@ require IO::Socket::UNIX if ($^O ne 'epoc' && $^O ne 'symbian');
 
 our @ISA = qw(IO::Handle);
 
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 our @EXPORT_OK = qw(sockatmark);
 

--- a/dist/IO/lib/IO/Socket/INET.pm
+++ b/dist/IO/lib/IO/Socket/INET.pm
@@ -14,7 +14,7 @@ use Exporter;
 use Errno;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 my $EINVAL = exists(&Errno::EINVAL) ? Errno::EINVAL() : 1;
 

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -11,7 +11,7 @@ use IO::Socket;
 use Carp;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.55";
+our $VERSION = "1.56";
 
 IO::Socket::UNIX->register_domain( AF_UNIX );
 

--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -7849,7 +7849,7 @@ CODE:
 OUTPUT:
     RETVAL
 
-void
+SV*
 last_op_in_netorder()
 ALIAS:
     is_storing = ST_STORE
@@ -7864,7 +7864,8 @@ CODE:
     } else {
         result = cBOOL(last_op_in_netorder(aTHX));
     }
-    ST(0) = boolSV(result);
+    RETVAL = boolSV(result);
+OUTPUT: RETVAL
 
 
 IV

--- a/dist/Storable/lib/Storable.pm
+++ b/dist/Storable/lib/Storable.pm
@@ -30,7 +30,7 @@ our @EXPORT_OK = qw(
 our ($canonical, $forgive_me);
 
 BEGIN {
-    our $VERSION = '3.39';
+    our $VERSION = '3.40';
 }
 
 our $recursion_limit;

--- a/dist/threads-shared/lib/threads/shared.pm
+++ b/dist/threads-shared/lib/threads/shared.pm
@@ -8,7 +8,7 @@ use Config;
 
 use Scalar::Util qw(reftype refaddr blessed);
 
-our $VERSION = '1.72'; # Please update the pod, too.
+our $VERSION = '1.73'; # Please update the pod, too.
 my $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -196,7 +196,7 @@ threads::shared - Perl extension for sharing data structures between threads
 
 =head1 VERSION
 
-This document describes threads::shared version 1.72
+This document describes threads::shared version 1.73
 
 =head1 SYNOPSIS
 

--- a/dist/threads-shared/shared.xs
+++ b/dist/threads-shared/shared.xs
@@ -1430,7 +1430,7 @@ UNSHIFT(SV *obj, ...)
         LEAVE_LOCK;
 
 
-void
+SV*
 POP(SV *obj)
     CODE:
         dTHXc;
@@ -1440,14 +1440,14 @@ POP(SV *obj)
         SHARED_CONTEXT;
         ssv = av_pop((AV*)sobj);
         CALLER_CONTEXT;
-        ST(0) = sv_newmortal();
-        Perl_sharedsv_associate(aTHX_ ST(0), ssv);
+        RETVAL = newSV(0);
+        Perl_sharedsv_associate(aTHX_ RETVAL, ssv);
         SvREFCNT_dec(ssv);
         LEAVE_LOCK;
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+SV*
 SHIFT(SV *obj)
     CODE:
         dTHXc;
@@ -1457,11 +1457,11 @@ SHIFT(SV *obj)
         SHARED_CONTEXT;
         ssv = av_shift((AV*)sobj);
         CALLER_CONTEXT;
-        ST(0) = sv_newmortal();
-        Perl_sharedsv_associate(aTHX_ ST(0), ssv);
+        RETVAL = newSV(0);
+        Perl_sharedsv_associate(aTHX_ RETVAL, ssv);
         SvREFCNT_dec(ssv);
         LEAVE_LOCK;
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
 void
@@ -1505,7 +1505,7 @@ STORESIZE(SV *obj,IV count)
         SHARED_RELEASE;
 
 
-void
+SV*
 EXISTS(SV *obj, SV *index)
     CODE:
         dTHXc;
@@ -1526,11 +1526,11 @@ EXISTS(SV *obj, SV *index)
             exists = hv_exists((HV*) sobj, key, len);
         }
         SHARED_RELEASE;
-        ST(0) = (exists) ? &PL_sv_yes : &PL_sv_no;
-        /* XSRETURN(1); - implied */
+        RETVAL = (exists) ? &PL_sv_yes : &PL_sv_no;
 
+    OUTPUT: RETVAL
 
-void
+SV*
 FIRSTKEY(SV *obj)
     CODE:
         dTHXc;
@@ -1546,16 +1546,16 @@ FIRSTKEY(SV *obj)
             I32 utf8 = HeKUTF8(entry);
             key = hv_iterkey(entry,&len);
             CALLER_CONTEXT;
-            ST(0) = newSVpvn_flags(key, len, SVs_TEMP | (utf8 ? SVf_UTF8 : 0));
+            RETVAL = newSVpvn_flags(key, len, (utf8 ? SVf_UTF8 : 0));
         } else {
             CALLER_CONTEXT;
-            ST(0) = &PL_sv_undef;
+            RETVAL = &PL_sv_undef;
         }
         LEAVE_LOCK;
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+SV*
 NEXTKEY(SV *obj, SV *oldkey)
     CODE:
         dTHXc;
@@ -1573,20 +1573,20 @@ NEXTKEY(SV *obj, SV *oldkey)
             I32 utf8 = HeKUTF8(entry);
             key = hv_iterkey(entry,&len);
             CALLER_CONTEXT;
-            ST(0) = newSVpvn_flags(key, len, SVs_TEMP | (utf8 ? SVf_UTF8 : 0));
+            RETVAL = newSVpvn_flags(key, len, (utf8 ? SVf_UTF8 : 0));
         } else {
             CALLER_CONTEXT;
-            ST(0) = &PL_sv_undef;
+            RETVAL = &PL_sv_undef;
         }
         LEAVE_LOCK;
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
 MODULE = threads::shared        PACKAGE = threads::shared
 
 PROTOTYPES: ENABLE
 
-void
+UV
 _id(SV *myref)
     PROTOTYPE: \[$@%]
     PREINIT:
@@ -1600,11 +1600,11 @@ _id(SV *myref)
         ssv = Perl_sharedsv_find(aTHX_ myref);
         if (! ssv)
             XSRETURN_UNDEF;
-        ST(0) = sv_2mortal(newSVuv(PTR2UV(ssv)));
-        /* XSRETURN(1); - implied */
+        RETVAL = PTR2UV(ssv);
+    OUTPUT: RETVAL
 
 
-void
+IV
 _refcnt(SV *myref)
     PROTOTYPE: \[$@%]
     PREINIT:
@@ -1621,11 +1621,11 @@ _refcnt(SV *myref)
             }
             XSRETURN_UNDEF;
         }
-        ST(0) = sv_2mortal(newSViv(SvREFCNT(ssv)));
-        /* XSRETURN(1); - implied */
+        RETVAL = SvREFCNT(ssv);
+    OUTPUT: RETVAL
 
 
-void
+SV*
 share(SV *myref)
     PROTOTYPE: \[$@%]
     CODE:
@@ -1635,8 +1635,8 @@ share(SV *myref)
         if (SvROK(myref))
             myref = SvRV(myref);
         Perl_sharedsv_share(aTHX_ myref);
-        ST(0) = sv_2mortal(newRV_inc(myref));
-        /* XSRETURN(1); - implied */
+        RETVAL = newRV_inc(myref);
+    OUTPUT: RETVAL
 
 
 void
@@ -1792,7 +1792,7 @@ cond_broadcast(SV *myref)
         COND_BROADCAST(&ul->user_cond);
 
 
-void
+SV*
 bless(SV* myref, ...)
     PROTOTYPE: $;$
     PREINIT:
@@ -1822,7 +1822,7 @@ bless(SV* myref, ...)
         }
         SvREFCNT_inc_void(myref);
         (void)sv_bless(myref, stash);
-        ST(0) = sv_2mortal(myref);
+        RETVAL = myref;
         ssv = Perl_sharedsv_find(aTHX_ myref);
         if (ssv) {
             dTHXc;
@@ -1835,7 +1835,8 @@ bless(SV* myref, ...)
             CALLER_CONTEXT;
             LEAVE_LOCK;
         }
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
+
 
 #endif /* USE_ITHREADS */
 

--- a/dist/threads/lib/threads.pm
+++ b/dist/threads/lib/threads.pm
@@ -5,7 +5,7 @@ use 5.008;
 use strict;
 use warnings;
 
-our $VERSION = '2.44';      # remember to update version in POD!
+our $VERSION = '2.45';      # remember to update version in POD!
 my $XS_VERSION = $VERSION;
 #$VERSION = eval $VERSION;
 
@@ -134,7 +134,7 @@ threads - Perl interpreter-based threads
 
 =head1 VERSION
 
-This document describes threads version 2.44
+This document describes threads version 2.45
 
 =head1 WARNING
 

--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -1081,7 +1081,7 @@ PROTOTYPES: DISABLE
 
 #ifdef USE_ITHREADS
 
-void
+SV*
 ithread_create(...)
     PREINIT:
         char *classname;
@@ -1206,7 +1206,7 @@ ithread_create(...)
             XSRETURN_UNDEF;     /* Mutex already unlocked */
         }
         PERL_SRAND_OVERRIDE_NEXT_PARENT();
-        ST(0) = sv_2mortal(S_ithread_to_SV(aTHX_ Nullsv, thread, classname, FALSE));
+        RETVAL = S_ithread_to_SV(aTHX_ Nullsv, thread, classname, FALSE);
 
         /* Let thread run. */
         /* See S_ithread_run() for more detail. */
@@ -1214,7 +1214,7 @@ ithread_create(...)
         /* warning: releasing mutex 'thread->mutex' that was not held [-Wthread-safety-analysis] */
         MUTEX_UNLOCK(&thread->mutex);
         CLANG_DIAG_RESTORE_STMT;
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
 void
@@ -1283,7 +1283,7 @@ ithread_list(...)
         }
 
 
-void
+SV*
 ithread_self(...)
     PREINIT:
         char *classname;
@@ -1297,19 +1297,19 @@ ithread_self(...)
 
         thread = S_ithread_get(aTHX);
 
-        ST(0) = sv_2mortal(S_ithread_to_SV(aTHX_ Nullsv, thread, classname, TRUE));
-        /* XSRETURN(1); - implied */
+        RETVAL = S_ithread_to_SV(aTHX_ Nullsv, thread, classname, TRUE);
+    OUTPUT: RETVAL
 
 
-void
+UV
 ithread_tid(...)
     PREINIT:
         ithread *thread;
     CODE:
         PERL_UNUSED_VAR(items);
         thread = S_SV_to_ithread(aTHX_ ST(0));
-        XST_mUV(0, thread->tid);
-        /* XSRETURN(1); - implied */
+        RETVAL = thread->tid;
+    OUTPUT: RETVAL
 
 
 void
@@ -1503,7 +1503,7 @@ ithread_kill(...)
         char *sig_name;
         IV signal;
         int no_handler = 1;
-    CODE:
+    PPCODE:
         /* Must have safe signals */
         if (PL_signals & PERL_SIGNALS_UNSAFE_FLAG) {
             Perl_croak(aTHX_ "Cannot signal threads without safe signals");
@@ -1549,9 +1549,9 @@ ithread_kill(...)
                              sig_name, thread->tid);
         }
 
-        /* Return the thread to allow for method chaining */
-        ST(0) = ST(0);
-        /* XSRETURN(1); - implied */
+        /* Return the thread to allow for method chaining: */
+        /* ST(0) still holds the object SV */
+        XSRETURN(1);
 
 
 void
@@ -1561,7 +1561,7 @@ ithread_DESTROY(...)
         sv_unmagic(SvRV(ST(0)), PERL_MAGIC_shared_scalar);
 
 
-void
+IV
 ithread_equal(...)
     PREINIT:
         int are_equal = 0;
@@ -1575,15 +1575,15 @@ ithread_equal(...)
             are_equal = (thr1->tid == thr2->tid);
         }
         if (are_equal) {
-            XST_mYES(0);
+            XSRETURN_YES;
         } else {
             /* Return 0 on false for backward compatibility */
-            XST_mIV(0, 0);
+            RETVAL = 0;
         }
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+SV*
 ithread_object(...)
     PREINIT:
         char *classname;
@@ -1619,7 +1619,7 @@ ithread_object(...)
            ->self() */
         thread = S_ithread_get(aTHX);
         if (thread->tid == tid) {
-            ST(0) = sv_2mortal(S_ithread_to_SV(aTHX_ Nullsv, thread, classname, TRUE));
+            RETVAL = S_ithread_to_SV(aTHX_ Nullsv, thread, classname, TRUE);
             have_obj = 1;
 
         } else {
@@ -1636,8 +1636,8 @@ ithread_object(...)
                     state = thread->state;
                     MUTEX_UNLOCK(&thread->mutex);
                     if (! (state & PERL_ITHR_UNCALLABLE)) {
-                        /* Put object on stack */
-                        ST(0) = sv_2mortal(S_ithread_to_SV(aTHX_ Nullsv, thread, classname, TRUE));
+                        RETVAL = S_ithread_to_SV(aTHX_ Nullsv,
+                                                thread, classname, TRUE);
                         have_obj = 1;
                     }
                     break;
@@ -1649,10 +1649,10 @@ ithread_object(...)
         if (! have_obj) {
             XSRETURN_UNDEF;
         }
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+UV
 ithread__handle(...);
     PREINIT:
         ithread *thread;
@@ -1660,14 +1660,14 @@ ithread__handle(...);
         PERL_UNUSED_VAR(items);
         thread = S_SV_to_ithread(aTHX_ ST(0));
 #ifdef WIN32
-        XST_mUV(0, PTR2UV(&thread->handle));
+        RETVAL = PTR2UV(&thread->handle);
 #else
-        XST_mUV(0, PTR2UV(&thread->thr));
+        RETVAL = PTR2UV(&thread->thr);
 #endif
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+IV
 ithread_get_stack_size(...)
     PREINIT:
         IV stack_size;
@@ -1682,11 +1682,11 @@ ithread_get_stack_size(...)
             /* threads->get_stack_size() */
             stack_size = MY_POOL.default_stack_size;
         }
-        XST_mIV(0, stack_size);
-        /* XSRETURN(1); - implied */
+        RETVAL = stack_size;
+    OUTPUT: RETVAL
 
 
-void
+IV
 ithread_set_stack_size(...)
     PREINIT:
         IV old_size;
@@ -1704,11 +1704,11 @@ ithread_set_stack_size(...)
 
         old_size = MY_POOL.default_stack_size;
         MY_POOL.default_stack_size = S_good_stack_size(aTHX_ SvIV(ST(1)));
-        XST_mIV(0, old_size);
-        /* XSRETURN(1); - implied */
+        RETVAL = old_size;
+    OUTPUT: RETVAL
 
 
-void
+SV*
 ithread_is_running(...)
     PREINIT:
         ithread *thread;
@@ -1720,12 +1720,12 @@ ithread_is_running(...)
 
         thread = INT2PTR(ithread *, SvIV(SvRV(ST(0))));
         MUTEX_LOCK(&thread->mutex);
-        ST(0) = (thread->state & PERL_ITHR_FINISHED) ? &PL_sv_no : &PL_sv_yes;
+        RETVAL = (thread->state & PERL_ITHR_FINISHED) ? &PL_sv_no : &PL_sv_yes;
         MUTEX_UNLOCK(&thread->mutex);
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+SV*
 ithread_is_detached(...)
     PREINIT:
         ithread *thread;
@@ -1733,12 +1733,12 @@ ithread_is_detached(...)
         PERL_UNUSED_VAR(items);
         thread = S_SV_to_ithread(aTHX_ ST(0));
         MUTEX_LOCK(&thread->mutex);
-        ST(0) = (thread->state & PERL_ITHR_DETACHED) ? &PL_sv_yes : &PL_sv_no;
+        RETVAL = (thread->state & PERL_ITHR_DETACHED) ? &PL_sv_yes : &PL_sv_no;
         MUTEX_UNLOCK(&thread->mutex);
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+SV*
 ithread_is_joinable(...)
     PREINIT:
         ithread *thread;
@@ -1750,24 +1750,24 @@ ithread_is_joinable(...)
 
         thread = INT2PTR(ithread *, SvIV(SvRV(ST(0))));
         MUTEX_LOCK(&thread->mutex);
-        ST(0) = ((thread->state & PERL_ITHR_FINISHED) &&
+        RETVAL = ((thread->state & PERL_ITHR_FINISHED) &&
                  ! (thread->state & PERL_ITHR_UNCALLABLE))
             ? &PL_sv_yes : &PL_sv_no;
         MUTEX_UNLOCK(&thread->mutex);
-        /* XSRETURN(1); - implied */
+    OUTPUT: RETVAL
 
 
-void
+SV*
 ithread_wantarray(...)
     PREINIT:
         ithread *thread;
     CODE:
         PERL_UNUSED_VAR(items);
         thread = S_SV_to_ithread(aTHX_ ST(0));
-        ST(0) = ((thread->gimme & G_WANT) == G_LIST) ? &PL_sv_yes :
-                ((thread->gimme & G_WANT) == G_VOID) ? &PL_sv_undef
-                                      /* G_SCALAR */ : &PL_sv_no;
-        /* XSRETURN(1); - implied */
+        RETVAL = ((thread->gimme & G_WANT) == G_LIST) ? &PL_sv_yes :
+                 ((thread->gimme & G_WANT) == G_VOID) ? &PL_sv_undef
+                                       /* G_SCALAR */ : &PL_sv_no;
+    OUTPUT: RETVAL
 
 
 void
@@ -1781,6 +1781,12 @@ ithread_set_thread_exit_only(...)
         thread = S_SV_to_ithread(aTHX_ ST(0));
         MUTEX_LOCK(&thread->mutex);
         if (SvTRUE(ST(1))) {
+            /* ; <-- this semicolon disables a spurious false positive
+             * from the XS parser when it is looking for
+             *     'ST( [anything except ;] ='
+             * on void subs and thus emitting XSRETURN(1) rather than
+             * XSRETURN_EMPTY.
+             */
             thread->state |= PERL_ITHR_THREAD_EXIT_ONLY;
         } else {
             thread->state &= ~PERL_ITHR_THREAD_EXIT_ONLY;
@@ -1788,7 +1794,7 @@ ithread_set_thread_exit_only(...)
         MUTEX_UNLOCK(&thread->mutex);
 
 
-void
+SV*
 ithread_error(...)
     PREINIT:
         ithread *thread;
@@ -1864,8 +1870,8 @@ ithread_error(...)
             XSRETURN_UNDEF;
         }
 
-        ST(0) = sv_2mortal(err);
-        /* XSRETURN(1); - implied */
+        RETVAL = err;
+    OUTPUT: RETVAL
 
 
 #endif /* USE_ITHREADS */

--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -20,7 +20,7 @@ sub import {
 # walkoptree comes from B.xs
 
 BEGIN {
-    $B::VERSION = '1.91';
+    $B::VERSION = '1.92';
     @B::EXPORT_OK = ();
 
     # Our BOOT code needs $VERSION set, and will append to @EXPORT_OK.

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -144,9 +144,9 @@ get_overlay_object(pTHX_ const OP *o, const char * const name, U32 namelen)
 
 
 static SV *
-make_sv_object(pTHX_ SV *sv)
+make_sv_object_nonmortal(pTHX_ SV *sv)
 {
-    SV *const arg = sv_newmortal();
+    SV *const arg = newSV(0);
     const char *type = 0;
     IV iv;
     dMY_CXT;
@@ -164,6 +164,14 @@ make_sv_object(pTHX_ SV *sv)
     sv_setiv(newSVrv(arg, type), iv);
     return arg;
 }
+
+
+static SV *
+make_sv_object(pTHX_ SV *sv)
+{
+    return sv_2mortal(make_sv_object_nonmortal(aTHX_ sv));
+}
+
 
 static SV *
 make_temp_object(pTHX_ SV *temp)
@@ -723,36 +731,40 @@ svref_2object(sv)
 	    croak("argument is not a reference");
 	PUSHs(make_sv_object(aTHX_ SvRV(sv)));
 
-void
+
+IV
 opnumber(name)
 const char *	name
 CODE:
 {
  int i;
- IV  result = -1;
- ST(0) = sv_newmortal();
+ RETVAL = -1;
  if (strBEGINs(name,"pp_"))
    name += 3;
  for (i = 0; i < PL_maxo; i++)
   {
    if (strEQ(name, PL_op_name[i]))
     {
-     result = i;
+     RETVAL = i;
      break;
     }
   }
- sv_setiv(ST(0),result);
 }
 
-void
+    OUTPUT: RETVAL
+
+
+SV*
 ppname(opnum)
 	int	opnum
     CODE:
-	ST(0) = sv_newmortal();
-	if (opnum >= 0 && opnum < PL_maxo)
-	    Perl_sv_setpvf(aTHX_ ST(0), "pp_%s", PL_op_name[opnum]);
+        RETVAL = (opnum >= 0 && opnum < PL_maxo)
+                ? Perl_newSVpvf(aTHX_ "pp_%s", PL_op_name[opnum])
+                : &PL_sv_undef;
+    OUTPUT: RETVAL
 
-void
+
+SV*
 hash(sv)
 	SV *	sv
     CODE:
@@ -760,7 +772,9 @@ hash(sv)
 	U32 hash = 0;
 	const char *s = SvPVbyte(sv, len);
 	PERL_HASH(hash, s, len);
-	ST(0) = sv_2mortal(Perl_newSVpvf(aTHX_ "0x%" UVxf, (UV)hash));
+	RETVAL = Perl_newSVpvf(aTHX_ "0x%" UVxf, (UV)hash);
+    OUTPUT: RETVAL
+
 
 #define cast_I32(foo) (I32)foo
 IV
@@ -1654,14 +1668,15 @@ IVX(sv)
 	ST(0) = ret;
 	XSRETURN(1);
 
-void
+
+SV*
 packiv(sv)
 	B::IV	sv
     ALIAS:
 	needs64bits = 1
     CODE:
 	if (ix) {
-	    ST(0) = boolSV((I32)SvIVX(sv) != SvIVX(sv));
+	    RETVAL = boolSV((I32)SvIVX(sv) != SvIVX(sv));
 	} else if (sizeof(IV) == 8) {
 	    U32 wp[2];
 	    const IV iv = SvIVX(sv);
@@ -1678,11 +1693,13 @@ packiv(sv)
 	    wp[0] = htonl(((U32)iv) >> (sizeof(UV)*4));
 #endif
 	    wp[1] = htonl(iv & 0xffffffff);
-	    ST(0) = newSVpvn_flags((char *)wp, 8, SVs_TEMP);
+	    RETVAL = newSVpvn((char *)wp, 8);
 	} else {
 	    U32 w = htonl((U32)SvIVX(sv));
-	    ST(0) = newSVpvn_flags((char *)&w, 4, SVs_TEMP);
+	    RETVAL = newSVpvn((char *)&w, 4);
 	}
+    OUTPUT: RETVAL
+
 
 MODULE = B	PACKAGE = B::NV		PREFIX = Sv
 
@@ -1788,7 +1805,8 @@ RV(sv)
             croak( "argument is not SvROK" );
 	PUSHs(make_sv_object(aTHX_ SvRV(sv)));
 
-void
+
+SV*
 PV(sv)
 	B::PV	sv
     ALIAS:
@@ -1844,7 +1862,10 @@ PV(sv)
             /* croak( "argument is not SvPOK" ); */
 	    p = NULL;
         }
-	ST(0) = newSVpvn_flags(p, len, SVs_TEMP | utf8);
+	RETVAL = newSVpvn_flags(p, len, utf8);
+
+    OUTPUT: RETVAL
+
 
 MODULE = B	PACKAGE = B::PVMG
 
@@ -1944,16 +1965,19 @@ BmRARE(sv)
 
 MODULE = B	PACKAGE = B::GV		PREFIX = Gv
 
-void
+
+SV*
 GvNAME(gv)
 	B::GV	gv
     ALIAS:
 	FILE = 1
 	B::HV::NAME = 2
     CODE:
-	ST(0) = sv_2mortal(newSVhek(!ix ? GvNAME_HEK(gv)
-					: (ix == 1 ? GvFILE_HEK(gv)
-						   : HvNAME_HEK((HV *)gv))));
+        RETVAL = newSVhek(!ix   ? GvNAME_HEK(gv)
+                                : (ix == 1 ? GvFILE_HEK(gv)
+                                           : HvNAME_HEK((HV *)gv)));
+    OUTPUT: RETVAL
+
 
 bool
 is_empty(gv)
@@ -2135,18 +2159,21 @@ CvHSCXT(cv)
     OUTPUT:
 	RETVAL
 
-void
+
+SV*
 CvXSUB(cv)
 	B::CV	cv
     ALIAS:
 	XSUBANY = 1
     CODE:
-	ST(0) = ix && CvCONST(cv)
-	    ? make_sv_object(aTHX_ (SV *)CvXSUBANY(cv).any_ptr)
-	    : sv_2mortal(newSViv(CvISXSUB(cv)
+	RETVAL = ix && CvCONST(cv)
+	    ? make_sv_object_nonmortal(aTHX_ (SV *)CvXSUBANY(cv).any_ptr)
+	    : newSViv(CvISXSUB(cv)
 				 ? (ix ? CvXSUBANY(cv).any_iv
 				       : PTR2IV(CvXSUB(cv)))
-				 : 0));
+				 : 0);
+    OUTPUT: RETVAL
+
 
 void
 const_sv(cv)
@@ -2154,11 +2181,12 @@ const_sv(cv)
     PPCODE:
 	PUSHs(make_sv_object(aTHX_ (SV *)cv_const_sv(cv)));
 
-void
+SV*
 GV(cv)
 	B::CV cv
     CODE:
-	ST(0) = make_sv_object(aTHX_ (SV*)CvGV(cv));
+	RETVAL = make_sv_object_nonmortal(aTHX_ (SV*)CvGV(cv));
+    OUTPUT: RETVAL
 
 SV *
 NAME_HEK(cv)

--- a/ext/Opcode/Opcode.pm
+++ b/ext/Opcode/Opcode.pm
@@ -1,4 +1,4 @@
-package Opcode 1.70;
+package Opcode 1.71;
 
 use strict;
 

--- a/ext/Opcode/Opcode.xs
+++ b/ext/Opcode/Opcode.xs
@@ -342,7 +342,8 @@ CODE:
 OUTPUT:
     RETVAL
 
-void
+
+SV*
 invert_opset(opset)
     SV *opset
 CODE:
@@ -350,7 +351,7 @@ CODE:
     char *bitmap;
     STRLEN len = opset_len;
 
-    opset = sv_2mortal(new_opset(aTHX_ opset));	/* verify and clone opset */
+    opset = new_opset(aTHX_ opset);	/* verify and clone opset */
     bitmap = SvPVX(opset);
     while(len-- > 0)
 	bitmap[len] = ~bitmap[len];
@@ -358,7 +359,8 @@ CODE:
     if (PL_maxo & 07)
 	bitmap[opset_len-1] &= ~(char)(0xFF << (PL_maxo & 0x07));
     }
-    ST(0) = opset;
+    RETVAL = opset;
+OUTPUT: RETVAL
 
 
 void
@@ -385,14 +387,14 @@ PPCODE:
     }
 
 
-void
+SV*
 opset(...)
 CODE:
     int i;
     SV *bitspec;
     STRLEN len, on;
 
-    SV * const opset = sv_2mortal(new_opset(aTHX_ Nullsv));
+    SV * const opset = new_opset(aTHX_ Nullsv);
     char * const bitmap = SvPVX(opset);
     for (i = 0; i < items; i++) {
 	const char *opname;
@@ -408,13 +410,14 @@ CODE:
 	}
 	set_opset_bits(aTHX_ bitmap, bitspec, on, opname);
     }
-    ST(0) = opset;
+    RETVAL = opset;
+OUTPUT: RETVAL
 
 
 #define PERMITING  (ix == 0 || ix == 1)
 #define ONLY_THESE (ix == 0 || ix == 2)
 
-void
+SV*
 permit_only(safe, ...)
     SV *safe
 ALIAS:
@@ -451,7 +454,8 @@ CODE:
 	}
 	set_opset_bits(aTHX_ bitmap, bitspec, on, opname);
     }
-    ST(0) = &PL_sv_yes;
+    RETVAL = &PL_sv_yes;
+OUTPUT: RETVAL
 
 
 
@@ -496,7 +500,7 @@ PPCODE:
     }
 
 
-void
+SV*
 define_optag(optagsv, mask)
     SV *optagsv
     SV *mask
@@ -505,19 +509,24 @@ CODE:
     const char *optag = SvPV(optagsv, len);
 
     put_op_bitspec(aTHX_ optag, len, mask); /* croaks */
-    ST(0) = &PL_sv_yes;
+    RETVAL = &PL_sv_yes;
+OUTPUT: RETVAL
 
 
-void
+SV*
 empty_opset()
 CODE:
-    ST(0) = sv_2mortal(new_opset(aTHX_ Nullsv));
+    RETVAL = new_opset(aTHX_ Nullsv);
+OUTPUT: RETVAL
 
-void
+
+SV*
 full_opset()
 CODE:
     dMY_CXT;
-    ST(0) = sv_2mortal(new_opset(aTHX_ opset_all));
+    RETVAL = new_opset(aTHX_ opset_all);
+OUTPUT: RETVAL
+
 
 void
 opmask_add(opset)
@@ -538,16 +547,18 @@ PPCODE:
 	XPUSHs(sv_2mortal(newSViv(PL_maxo)));
     }
 
-void
+
+SV*
 opmask()
 CODE:
-    ST(0) = sv_2mortal(new_opset(aTHX_ Nullsv));
+    RETVAL = new_opset(aTHX_ Nullsv);
     if (PL_op_mask) {
-	char * const bitmap = SvPVX(ST(0));
+	char * const bitmap = SvPVX(RETVAL);
 	int myopcode;
 	for(myopcode=0; myopcode < PL_maxo; ++myopcode) {
 	    if (PL_op_mask[myopcode])
 		bitmap[myopcode >> 3] |= 1 << (myopcode & 0x07);
 	}
     }
+OUTPUT: RETVAL
 

--- a/ext/POSIX/POSIX.xs
+++ b/ext/POSIX/POSIX.xs
@@ -1776,14 +1776,15 @@ my_tzset(pTHX)
 
 MODULE = SigSet		PACKAGE = POSIX::SigSet		PREFIX = sig
 
-void
+SV*
 new(packname = "POSIX::SigSet", ...)
     const char *	packname
     CODE:
 	{
 	    int i;
 	    sigset_t *const s
-		= (sigset_t *) allocate_struct(aTHX_ (ST(0) = sv_newmortal()),
+		= (sigset_t *) allocate_struct(aTHX_
+                                               (RETVAL = newSV(0)),
 					       sizeof(sigset_t),
 					       packname);
 	    sigemptyset(s);
@@ -1792,8 +1793,9 @@ new(packname = "POSIX::SigSet", ...)
 		if (sigaddset(s, sig) < 0)
                     croak("POSIX::Sigset->new: failed to add signal %" IVdf, sig);
             }
-	    XSRETURN(1);
 	}
+    OUTPUT: RETVAL
+
 
 SysRet
 addset(sigset, sig)
@@ -1823,24 +1825,26 @@ sigismember(sigset, sig)
 
 MODULE = Termios	PACKAGE = POSIX::Termios	PREFIX = cf
 
-void
+SV*
 new(packname = "POSIX::Termios", ...)
     const char *	packname
     CODE:
 	{
 #ifdef I_TERMIOS
-	    void *const p = allocate_struct(aTHX_ (ST(0) = sv_newmortal()),
+	    void *const p = allocate_struct(aTHX_
+                                            (RETVAL = newSV(0)),
 					    sizeof(struct termios), packname);
 	    /* The previous implementation stored a pointer to an uninitialised
 	       struct termios. Seems safer to initialise it, particularly as
 	       this implementation exposes the struct to prying from perl-space.
 	    */
 	    memset(p, 0, 1 + sizeof(struct termios));
-	    XSRETURN(1);
 #else
 	    not_here("termios");
 #endif
 	}
+    OUTPUT: RETVAL
+
 
 SysRet
 getattr(termios_ref, fd = 0)
@@ -3448,7 +3452,7 @@ strtoul(str, base = 0)
             }
         }
 
-void
+SV*
 strxfrm(src)
 	SV *		src
     CODE:
@@ -3458,6 +3462,9 @@ strxfrm(src)
 #else
       ST(0) = src;
 #endif
+      /* skip the mortalising normally done for SV* return */
+      XSRETURN(1);
+    OUTPUT: RETVAL
 
 SysRet
 mkfifo(filename, mode)
@@ -3585,10 +3592,8 @@ difftime(time1, time2)
 	Time_t		time1
 	Time_t		time2
 
-#XXX: if $xsubpp::WantOptimize is always the default
-#     sv_setpv(TARG, ...) could be used rather than
-#     ST(0) = sv_2mortal(newSVpv(...))
-void
+
+SV*
 strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
 	SV *		fmt
 	int		sec
@@ -3607,23 +3612,20 @@ strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
 
             SV *sv = sv_strftime_ints(fmt, sec, min, hour, mday, mon, year,
                                       isdst);
-	    if (sv) {
-                sv = sv_2mortal(sv);
-            }
-            else {
+	    if (!sv) {
                 /* strftime() doesn't distinguish between errors and just an
                  * empty return, so even though sv_strftime_ints() has figured
                  * out the difference, return an empty string in all cases to
                  * mimic strftime() behavior */
-                sv = newSV_type_mortal(SVt_PV);
+                sv = newSV_type(SVt_PV);
                 SvPV_set(sv, (char *) "");
                 SvPOK_on(sv);
                 SvLEN_set(sv, 0);   /* Won't attempt to free the string when sv
                                        gets destroyed */
             }
-
-            ST(0) = sv;
+            RETVAL = sv;
 	}
+    OUTPUT: RETVAL
 
 void
 tzset()

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our ($AUTOLOAD, %SIGRT);
 
-our $VERSION = '2.25';
+our $VERSION = '2.26';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.49';
+our $VERSION = '1.50';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -3364,7 +3364,7 @@ END()
     CODE:
         sv_inc(get_sv("XS::APItest::END_called", GV_ADD|GV_ADDMULTI));
 
-void
+SV*
 utf16_to_utf8 (sv, ...)
     SV* sv
         ALIAS:
@@ -3390,10 +3390,14 @@ utf16_to_utf8 (sv, ...)
         SvCUR_set(dest, got);
         SvPVX(dest)[got] = '\0';
         SvPOK_on(dest);
-        ST(0) = dest;
-        XSRETURN(1);
+        /* counteract the second mortalisation the SV* OUTPUT typmap
+         * is about to perform */
+        SvREFCNT_inc(dest);
+        RETVAL = dest;
+    OUTPUT: RETVAL
 
-void
+
+SV*
 utf8_to_utf16 (sv, ...)
     SV* sv
         ALIAS:
@@ -3419,8 +3423,11 @@ utf8_to_utf16 (sv, ...)
         SvCUR_set(dest, got);
         SvPVX(dest)[got] = '\0';
         SvPOK_on(dest);
-        ST(0) = dest;
-        XSRETURN(1);
+        /* counteract the second mortalisation the SV* OUTPUT typmap
+         * is about to perform */
+        SvREFCNT_inc(dest);
+        RETVAL = dest;
+    OUTPUT: RETVAL
 
 void
 my_exit(int exitcode)
@@ -4278,9 +4285,8 @@ multicall_return(block, context)
     SV *block
     I32 context
 PROTOTYPE: &$
-CODE:
+PPCODE:
 {
-    dSP;
     dMULTICALL;
     GV *gv;
     HV *stash;
@@ -4330,9 +4336,8 @@ CODE:
     size = AvFILLp(av) + 1;
     EXTEND(SP, size);
     for (i = 0; i < size; i++)
-        ST(i) = *av_fetch_simple(av, i, FALSE);
+        PUSHs(*av_fetch_simple(av, i, FALSE));
     sv_2mortal((SV*)av);
-    XSRETURN(size);
 }
 
 


### PR DESCRIPTION
This branch modifies XS code under p5p control to remove any reliance on
the 1996-era ParseXS hack that special-cases void XSUBs which assign to
ST(0).

In detail: a historical quirk of XS, which was fixed in 1996, allowed code
to be written along the lines of:

    void
    foo(...)
      CODE:
        ...
        ST(0) = ...;

This is wrong, because the code is declared as returning nothing, but
still puts something on the stack.

ExtUtils::ParseXS has some hacky logic to work around this coding style.
Normally it would emit 'XSRETURN_EMPTY' for a void XSUB, but if it sees
text like 'ST(n) = ' in the body of a void XSUB, it emits 'XSRETURN(1)'
instead.

These commits make the XSUBs avoid replying on this hack.

A general pattern within these commits is that when changing the XSUB's
return type from void to SV*, account has to taken that the typemap for
SV* mortalises the return value. Thus a lot of these commits remove an
explicit sv_2mortal() call or similar.


* This set of changes does not require a perldelta entry.
