### PR TITLE
Convert scan_num() to use grok_uint_by_base()

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -12752,15 +12752,37 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             just_zero = FALSE;
             break;
 
-          default: /* so it must be octal */
-            shift = 3;
-            s++;
-            if (isALPHA_FOLD_EQ(*s, 'o')) {
+          default: /* Any other leading zero means it could be octal */
+
+            /* Looking at the next character may resolve this */
+            if (isDIGIT_A(s[1])) {
+
+                /* 01..07 are octal.  We treat even 08 or 09 as an attempt at
+                 * octal, and will raise an error */
+                has_digs = true;
+                just_zero = false;
+            }
+            else switch (toFOLD_A(s[1])) {
+              case 'o':     /* Definitely octal */
                 s++;
                 just_zero = FALSE;
                 new_octal = TRUE;
+                break;
+
+              case '_':
+                /* An underscore needs more look ahead, in part to see if a
+                 * warning should be raised, so treat it as octal for now */
+                break;
+
+              default:
+                /* Anything else including a '.' or 'e' means this was just a
+                 * single zero, not indicating an octal, so is a decimal.  0p4
+                 * also isn't considered an octal. */
+                goto decimal;
             }
 
+            shift = 3;
+            s++;
             break;
         }
 

--- a/toke.c
+++ b/toke.c
@@ -12800,7 +12800,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
             /* if we don't mention it, we're done */
             default:
-                goto out;
+                goto finish_integer;
 
             /* _ are ignored -- but warned about if consecutive */
             case '_':
@@ -12829,7 +12829,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
                 /* make sure they said 0x */
                 if (shift != 4)
-                    goto out;
+                    goto finish_integer;
                 b = (*s++ & 7) + 9;
 
                 /* Prepare to put the digit we have onto the end
@@ -12870,7 +12870,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 /* this could be hexfp, but peek ahead
                  * to avoid matching ".." */
                 if (UNLIKELY(HEXFP_PEEK(s))) {
-                    goto out;
+                    goto finish_integer;
                 }
 
                 break;
@@ -12880,7 +12880,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
       /* if we get here, we had success: make a scalar value from
          the number.
       */
-      out:
+      finish_integer:
 
                 /* final misplaced underbar check */
                 SUFFER_AN_UNDERSCORE_JUST_BEFORE_HERE(s);

--- a/toke.c
+++ b/toke.c
@@ -12704,6 +12704,9 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
     /* We use the first character to decide what type of number this is */
 
     switch (*s) {
+      default:
+        croak("panic: scan_num, *s=%c", *s);
+
       case 'v':
       vstring:
         sv = newSV(5); /* preallocate storage space */
@@ -13261,9 +13264,6 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         }
 
         break;
-
-      default:
-        croak("panic: scan_num, *s=%c", *s);
     }  /* End of switch on first character */
 
     /* make the op for the constant and return */

--- a/toke.c
+++ b/toke.c
@@ -12616,6 +12616,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
     PERL_ARGS_ASSERT_SCAN_NUM;
 
     const char *s = start;	/* current position in buffer */
+    const char *s_end = s + strlen(s);
     char *d;			/* destination in temp buffer */
     char *e;			/* end of temp buffer */
     NV nv;				/* number read, as a double */
@@ -12636,7 +12637,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
 /* Call this when we're not expecting an underscore, but are willing to
  * tolerate one if found, but raising a warning about it.  It absorbs any
- * adjacent underscores up to PL_bufend, advancing 's' to point to the byte
+ * adjacent underscores up to s_end, advancing 's' to point to the byte
  * after the final underscore */
 #define SUFFER_AN_UNDERSCORE_HERE(s)                        \
         STMT_START {                                        \
@@ -12646,7 +12647,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 /* Absorb any adjacent underscores */       \
                 do {                                        \
                     (s)++;                                  \
-                } while ((s) < PL_bufend && *(s) == '_');   \
+                } while ((s) < s_end && *(s) == '_');   \
             }                                               \
         } STMT_END
 
@@ -12707,7 +12708,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         sv = newSV(5); /* preallocate storage space */
         ENTER_with_name("scan_vstring");
         SAVEFREESV(sv);
-        s = scan_vstring(s, PL_bufend, sv);
+        s = scan_vstring(s, s_end, sv);
         SvREFCNT_inc_simple_void_NN(sv);
         LEAVE_with_name("scan_vstring");
     }

--- a/toke.c
+++ b/toke.c
@@ -12735,21 +12735,24 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         static const char* const bases[5] =
           { "", "binary", "", "octal", "hexadecimal" };
 
-        /* check for hex */
-        if (isALPHA_FOLD_EQ(s[1], 'x')) {
+        switch (toFOLD_A(s[1])) {
+          case 'x':
             shift = 4;
             s += 2;
             just_zero = FALSE;
-        } else if (isALPHA_FOLD_EQ(s[1], 'b')) {
+            break;
+
+          case 'b':
             shift = 1;
             s += 2;
             just_zero = FALSE;
-        }
-        /* check for a decimal in disguise */
-        else if (s[1] == '.' || isALPHA_FOLD_EQ(s[1], 'e'))
+            break;
+
+          case 'e': /* check for a decimal in disguise */
+          case '.':
             goto decimal;
-        /* so it must be octal */
-        else {
+
+          default: /* so it must be octal */
             shift = 3;
             s++;
             if (isALPHA_FOLD_EQ(*s, 'o')) {
@@ -12757,6 +12760,8 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 just_zero = FALSE;
                 new_octal = TRUE;
             }
+
+            break;
         }
 
         SUFFER_AN_UNDERSCORE_HERE(s);

--- a/toke.c
+++ b/toke.c
@@ -12679,7 +12679,6 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
      * using long doubles), in which case we have to resort to NV,
      * which will probably mean horrible loss of precision due to
      * multiple fp operations. */
-    bool hexfp = FALSE;
     int significant_bits = 0;
 #if NVSIZE == 8 && defined(HAS_QUAD) && defined(Uquad_t)
 #  define HEXFP_UQUAD
@@ -12888,7 +12887,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
                 if (UNLIKELY(HEXFP_PEEK(s))) {
                     /* Do sloppy (on the underbars) but quick detection
-                     * (and value construction) for hexfp, the decimal
+                     * (and value construction); the decimal
                      * detection will shortly be more thorough with the
                      * underbar checks. */
                     const char* h = s;
@@ -13038,7 +13037,6 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 #ifdef HEXFP_UQUAD
                             hexfp_exp -= hexfp_frac_bits;
 #endif
-                            hexfp = TRUE;
                             goto decimal;
                         }
                     }
@@ -13093,7 +13091,8 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         char *d = PL_tokenbuf;
         char *e = C_ARRAY_END(PL_tokenbuf) - 6; /* room for various punct */
         bool floatit = FALSE;       /* boolean: int or float? */
-        if (hexfp) {
+
+        if (base != 10) {
             floatit = TRUE;
             *d++ = '0';
             switch (base) {
@@ -13120,7 +13119,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
         /* read next group of digits and _ and copy into d */
         while (   isDIGIT_or_UNDERSCORE(*s)
-               || UNLIKELY(hexfp && isXDIGIT(*s)))
+               || UNLIKELY(base != 10 && isXDIGIT(*s)))
         {
             /* skip underscores, checking for misplaced ones
                if -w is on
@@ -13155,7 +13154,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             /* copy, ignoring underbars, until we run out of digits.
             */
             while (   isDIGIT_or_UNDERSCORE(*s)
-                   || UNLIKELY(hexfp && isXDIGIT(*s)))
+                   || UNLIKELY(base != 10 && isXDIGIT(*s)))
             {
                 /* fixed length buffer check */
                 if (d >= e)
@@ -13178,7 +13177,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
         /* read exponent part, if present */
         if ((isALPHA_FOLD_EQ(*s, 'e')
-              || UNLIKELY(hexfp && isALPHA_FOLD_EQ(*s, 'p')))
+              || UNLIKELY(base != 10 && isALPHA_FOLD_EQ(*s, 'p')))
             && memCHRs("+-0123456789_", s[1]))
         {
             int exp_digits = 0;
@@ -13191,7 +13190,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 /* At least some Mach atof()s don't grok 'E' */
                 *d++ = 'e';
             }
-            else if (UNLIKELY(hexfp && (isALPHA_FOLD_EQ(*s, 'p')))) {
+            else if (UNLIKELY(base != 10 && (isALPHA_FOLD_EQ(*s, 'p')))) {
                 *d++ = 'p';
             }
 
@@ -13261,7 +13260,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         if (floatit) {
             /* terminate the string */
             *d = '\0';
-            if (UNLIKELY(hexfp)) {
+            if (UNLIKELY(base != 10)) {
 #  ifdef NV_MANT_DIG
                 if (significant_bits > NV_MANT_DIG)
                     ck_warner(packWARN(WARN_OVERFLOW),

--- a/toke.c
+++ b/toke.c
@@ -12617,12 +12617,8 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
     const char *s = start;	/* current position in buffer */
     const char *s_end = s + strlen(s);
-    char *d;			/* destination in temp buffer */
-    char *e;			/* end of temp buffer */
     NV nv;				/* number read, as a double */
     SV *sv = NULL;			/* place to put the converted number */
-    bool floatit;			/* boolean: int or float? */
-    static const char* const number_too_long = "Number too long";
     bool warned_about_underscore = 0;
     I32 shift = 0; /* shift per digit for hex/oct/bin, hoisted here for fp */
 
@@ -13058,13 +13054,15 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
       case '7': case '8': case '9':
       case '.':
       decimal:
+       {
+        static const char* const number_too_long = "Number too long";
 
         /* handle decimal numbers.
            we're also sent here when we read a 0 as the first digit
          */
-        d = PL_tokenbuf;
-        e = C_ARRAY_END(PL_tokenbuf) - 6; /* room for various punctuation */
-        floatit = FALSE;
+        char *d = PL_tokenbuf;
+        char *e = C_ARRAY_END(PL_tokenbuf) - 6; /* room for various punct */
+        bool floatit = FALSE;       /* boolean: int or float? */
         if (hexfp) {
             floatit = TRUE;
             *d++ = '0';
@@ -13264,6 +13262,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         }
 
         break;
+     } /* End of floating/decimal case */
     }  /* End of switch on first character */
 
     /* make the op for the constant and return */

--- a/toke.c
+++ b/toke.c
@@ -12690,7 +12690,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
     NV hexfp_nv = 0.0;
 #endif
     int hexfp_exp = 0;
-    bool new_octal = FALSE;     /* octal with "0o" prefix */
+    bool octal_with_0o = false;     /* octal with "0o" prefix */
 
     /* Make sure "int" is wide enough to hold exponent of NV.
        We use "int" (rather than I32 etc.) to be compatible with ldexp() */
@@ -12766,7 +12766,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
               case 'o':     /* Definitely octal */
                 s++;
                 just_zero = FALSE;
-                new_octal = TRUE;
+                octal_with_0o = TRUE;
                 break;
 
               case '_':
@@ -13099,7 +13099,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 s = start + 2;
                 break;
             case 3:
-                if (new_octal) {
+                if (octal_with_0o) {
                     *d++ = 'o';
                     s = start + 2;
                     break;

--- a/toke.c
+++ b/toke.c
@@ -12736,6 +12736,10 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
           { "", "binary", "", "octal", "hexadecimal" };
 
         switch (toFOLD_A(s[1])) {
+          case 'e': /* check for a decimal in disguise */
+          case '.':
+            goto decimal;
+
           case 'x':
             shift = 4;
             s += 2;
@@ -12747,10 +12751,6 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             s += 2;
             just_zero = FALSE;
             break;
-
-          case 'e': /* check for a decimal in disguise */
-          case '.':
-            goto decimal;
 
           default: /* so it must be octal */
             shift = 3;

--- a/toke.c
+++ b/toke.c
@@ -12620,7 +12620,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
     NV nv;				/* number read, as a double */
     SV *sv = NULL;			/* place to put the converted number */
     bool warned_about_underscore = 0;
-    I32 shift = 0; /* shift per digit for hex/oct/bin, hoisted here for fp */
+    uint_fast8_t base = 10; /* Number base 2, 8, 10, 16 */
 
 #define WARN_ABOUT_UNDERSCORE()                         \
         STMT_START {                                    \
@@ -12731,9 +12731,9 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         bool overflowed = FALSE;
         bool just_zero  = TRUE;	/* just plain 0 or binary number? */
         bool has_digs = FALSE;
-        static const NV nvshift[5] = { 1.0, 2.0, 4.0, 8.0, 16.0 };
         static const char* const bases[5] =
           { "", "binary", "", "octal", "hexadecimal" };
+        I32 shift = 0; /* shift per digit for hex/oct/bin */
 
         switch (toFOLD_A(s[1])) {
           case 'e': /* check for a decimal in disguise */
@@ -12742,12 +12742,14 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
           case 'x':
             shift = 4;
+            base = 16;
             s += 2;
             just_zero = FALSE;
             break;
 
           case 'b':
             shift = 1;
+            base = 2;
             s += 2;
             just_zero = FALSE;
             break;
@@ -12782,6 +12784,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             }
 
             shift = 3;
+            base = 8;
             s++;
             break;
         }
@@ -12852,7 +12855,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                         u = x | b;		/* add the digit to the end */
                 }
                 if (overflowed) {
-                    n *= nvshift[shift];
+                    n *= (NV) base;
                     /* If an NV has not enough bits in its
                      * mantissa to represent an UV this summing of
                      * small low-order numbers is a waste of time
@@ -12972,7 +12975,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                                 }
 #else /* HEXFP_NV */
                                 if (accumulate) {
-                                    nv_mult /= nvshift[shift];
+                                    nv_mult /= (NV) base;
                                     if (nv_mult > 0.0)
                                         hexfp_nv += b * nv_mult;
                                     else
@@ -13058,13 +13061,13 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
             if (overflowed) {
                 if (n > 4294967295.0)
-                    output_non_portable(1 << shift);
+                    output_non_portable(base);
                 sv = newSVnv(n);
             }
             else {
 #if UVSIZE > 4
                 if (u > 0xffffffff)
-                    output_non_portable(1 << shift);
+                    output_non_portable(base);
 #endif
                 sv = newSVuv(u);
             }
@@ -13093,12 +13096,12 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         if (hexfp) {
             floatit = TRUE;
             *d++ = '0';
-            switch (shift) {
-            case 4:
+            switch (base) {
+            case 16:
                 *d++ = 'x';
                 s = start + 2;
                 break;
-            case 3:
+            case 8:
                 if (octal_with_0o) {
                     *d++ = 'o';
                     s = start + 2;
@@ -13106,7 +13109,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
                 }
                 s = start + 1;
                 break;
-            case 1:
+            case 2:
                 *d++ = 'b';
                 s = start + 2;
                 break;

--- a/toke.c
+++ b/toke.c
@@ -12703,7 +12703,8 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 
     /* We use the first character to decide what type of number this is */
 
-    if (*s == 'v') {
+    switch (*s) {
+      case 'v':
       vstring:
         sv = newSV(5); /* preallocate storage space */
         ENTER_with_name("scan_vstring");
@@ -12711,9 +12712,10 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         s = scan_vstring(s, s_end, sv);
         SvREFCNT_inc_simple_void_NN(sv);
         LEAVE_with_name("scan_vstring");
-    }
-    else if (*s == '0') {
+        break;
 
+      case '0':
+       {
         /* if it starts with a 0, it could be an octal number, a decimal in
            0.13 disguise, or a hexadecimal number, or a binary number.
          *
@@ -13046,8 +13048,12 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
         else if (PL_hints & HINT_NEW_BINARY)
             sv = new_constant(start, s - start, "binary",
                               sv, NULL, NULL, 0, NULL);
-    }
-    else if (isDIGIT_A(*s) || *s == '.') {
+        break;
+       }
+
+      case '1': case '2': case '3': case '4': case '5': case '6':
+      case '7': case '8': case '9':
+      case '.':
       decimal:
 
         /* handle decimal numbers.
@@ -13253,13 +13259,14 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
             sv = S_new_constant(aTHX_ PL_tokenbuf, d - PL_tokenbuf,
                                 key, keylen, sv, NULL, NULL, 0, NULL);
         }
-    }
-    else {
+
+        break;
+
+      default:
         croak("panic: scan_num, *s=%c", *s);
-    }
+    }  /* End of switch on first character */
 
     /* make the op for the constant and return */
-
     if (sv)
         lvalp->opval = newSVOP(OP_CONST, 0, sv);
     else


### PR DESCRIPTION
The latter routine is enhanced first to handle the need here to accept sequential underscores (with warning).

This removes this duplication from the core.   This PR does not touch the floating point code; I'm leery of touching that this close to the end of the development cycle.

But, until this PR, decimal integers were parsed twice; the first time to cleanse them from underscores that libc routines don't understand.  Now, they are parsed once.

Floating point remains parsed two to three times.

* This set of changes does not require a perldelta entry.
