### PR TITLE
Manually set SvIVX when copying PL_linestr via newSVsv

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -10313,7 +10313,20 @@ Perl_yylex(pTHX)
 
         /* m'foo' still needs to be parsed for possible (?{...}) */
         if (SvIVX(PL_linestr) == '\'' && !PL_lex_inpat) {
+            /* Despite effectively having a live value in its IV slot,
+             * PL_linestr does not have the SVf_IOK or SVp_IOK flags set.
+             * The following assertion is here just to flag any changes
+             * during future development cycles. */
+            assert(!SvIOK(PL_linestr));
+
             SV *sv = newSVsv(PL_linestr);
+
+             /* The parser has assumed that the IV value will be copied to
+              * the new SV, but since PL_linestr does not have any IV flags
+              * set, that's not a safe assumption to make.
+              * Manually set it. */
+            SvIV_set(sv, '\'');
+
             sv = tokeq(sv);
             pl_yylval.opval = newSVOP(OP_CONST, 0, sv);
             s = PL_bufend;


### PR DESCRIPTION
`PL_linestr` sometimes uses its IV slot to store a character then used to control parsing flow. However, at least in the one place where `PL_linestr` is copied via `newSVsv()`, neither `SVf_IOK` nor `SVp_IOK` is set to indicate that the IV value must be copied to the fresh SV.

With the addition of `Perl_newSVsv_flags_NN` in this development cycle, individual values will only be copied when copying entire SVs if the source SV's flags indicate that the value of that type is valid. This avoids unnecessary overhead of copying defunct values.

Wholesale copying of `PL_linestr` only appears to occur in the one place, so rather than reverting to always copying SV values not marked as valid, this commit adds an explicit assignment to the new SV's IV slot.

Closes #24242

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
