### PR TITLE
grok_uint_by_base: Avoid to-be-discarded work

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1461,18 +1461,18 @@ ATdp	|bool	|grok_atoUV	|NN const char *pv			\
 Adip	|UV	|grok_bin	|NN const char *start			\
 				|NN STRLEN *len_p			\
 				|NN I32 *flags				\
-				|NULLOK NV *result
+				|NULLOK NV *approximation
 Cp	|UV	|grok_bin_hex	|NN const char * const start		\
 				|NN STRLEN *len_p			\
 				|NN I32 *flags				\
-				|NULLOK NV *result			\
+				|NULLOK NV *approximation		\
 				|uint_fast8_t base			\
 				|const U32 lookup_bit			\
 				|const char prefix
 Adip	|UV	|grok_hex	|NN const char *start			\
 				|NN STRLEN *len_p			\
 				|NN I32 *flags				\
-				|NULLOK NV *result
+				|NULLOK NV *approximation
 Adp	|int	|grok_infnan	|SPTR const char **sp			\
 				|EPTRge const char *send
 Adp	|int	|grok_number	|NN const char *pv			\
@@ -1489,12 +1489,12 @@ ARdp	|bool	|grok_numeric_radix					\
 Adip	|UV	|grok_oct	|NN const char *start			\
 				|NN STRLEN *len_p			\
 				|NN I32 *flags				\
-				|NULLOK NV *result
+				|NULLOK NV *approximation
 Cdp	|UV	|grok_uint_by_base					\
 				|NN const char * const start		\
 				|NN STRLEN *len_p			\
 				|NN I32 *flags				\
-				|NULLOK NV *result			\
+				|NULLOK NV *approximation		\
 				|uint_fast8_t base			\
 				|const U32 lookup_bit			\
 				|uint_fast8_t offset

--- a/inline.h
+++ b/inline.h
@@ -3799,16 +3799,16 @@ number is binary in C<grok_bin>, octal in C<grok_oct>, and hexadecimal in
 C<grok_hex>.
 
 On entry C<start> and C<*len_p> give the string to scan, C<*flags> gives
-conversion flags, and C<result> should be C<NULL> or a pointer to an NV.  The
-scan stops at the end of the string, or at just before the first invalid
+conversion flags, and C<approximation> should be C<NULL> or a pointer to an NV.
+The scan stops at the end of the string, or at just before the first invalid
 character.  Unless C<PERL_SCAN_SILENT_ILLDIGIT> is set in C<*flags>,
 encountering an invalid character (except NUL) will also trigger a warning.  On
 return C<*len_p> is set to the length of the scanned string, and C<*flags>
 gives output flags.
 
-If the value is S<E<lt>= C<UV_MAX>>, it is returned as a UV, the output flags are
-clear, and nothing is written to C<*result>.  If the value is S<E<gt>
-C<UV_MAX>>:
+If the value is S<E<lt>= C<UV_MAX>>, it is returned as a UV, the output flags
+are clear, and nothing is written to C<*approximation>.  If the value is
+S<E<gt> C<UV_MAX>>:
 
 =over
 
@@ -3822,8 +3822,8 @@ C<PERL_SCAN_GREATER_THAN_UV_MAX> is set in C<*flags>.
 
 =item *
 
-If C<result> is not null, an approximation of the correct value is written
-into C<*result> (which is an NV).
+If C<approximation> is not null, an approximation of the correct value is
+written into C<*approximation> (which is an NV).
 
 =back
 
@@ -3858,30 +3858,33 @@ numbers that are still valid on this platform.
  */
 
 PERL_STATIC_INLINE UV
-Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags,
+              NV *approximation)
 {
     PERL_ARGS_ASSERT_GROK_BIN;
 
-    return grok_bin_hex(start, len_p, flags, result, 2,
+    return grok_bin_hex(start, len_p, flags, approximation, 2,
                         CC_mask_(CC_BINDIGIT_), 'b');
 }
 
 PERL_STATIC_INLINE UV
-Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags,
+              NV *approximation)
 {
     PERL_ARGS_ASSERT_GROK_HEX;
 
-    return grok_bin_hex(start, len_p, flags, result, 16,
+    return grok_bin_hex(start, len_p, flags, approximation, 16,
                         CC_mask_(CC_XDIGIT_), 'x');
 }
 
 PERL_STATIC_INLINE UV
-Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags,
+              NV *approximation)
 {
     PERL_ARGS_ASSERT_GROK_OCT;
 
     *flags |= PERL_SCAN_DISALLOW_PREFIX;
-    return grok_uint_by_base(start, len_p, flags, result, 8,
+    return grok_uint_by_base(start, len_p, flags, approximation, 8,
                              CC_mask_(CC_OCTDIGIT_), 0);
 }
 

--- a/numeric.c
+++ b/numeric.c
@@ -255,7 +255,7 @@ UV
 Perl_grok_bin_hex(pTHX_ const char * const start,
                         STRLEN *len_p,
                         I32 *flags,
-                        NV *result,
+                        NV *approximation,
                         uint_fast8_t base,  /* 2 or 16 */
                         const U32 lookup_bit,
                         const char prefix       /* 'b' or 'x' */
@@ -289,7 +289,7 @@ Perl_grok_bin_hex(pTHX_ const char * const start,
         }
     }
 
-    return grok_uint_by_base(start, len_p, flags, result,
+    return grok_uint_by_base(start, len_p, flags, approximation,
                             base, lookup_bit, offset);
 }
 
@@ -303,7 +303,7 @@ UV
 Perl_grok_uint_by_base(pTHX_ const char * const start,
                         STRLEN *len_p,
                         I32 *flags,
-                        NV *result,
+                        NV *approximation,
                         uint_fast8_t base,
                         const U32 lookup_bit,
                         uint_fast8_t offset /* parse starting at start+offset */
@@ -333,12 +333,12 @@ bit in *flags.  The flag is cleared if no illegal character is found,
 otherwise it will remain set on output.
 
 If the resultant integer won't fit in a UV, UV_MAX is returned, and *flags
-will contain the PERL_SCAN_NUMBER_OVERFLOWED bit. If 'result' is not NULL, an
-NV approximation to the full integer will be placed into *result.  And for
-bases 2, 8, 16, it raises a warning unless the caller has set the
-PERL_SCAN_SILENT_OVERFLOW bit in *flags.
+will contain the PERL_SCAN_NUMBER_OVERFLOWED bit. If 'approximation' is not
+NULL, an NV approximation to the full integer will be placed into
+*approximation.  And for bases 2, 8, 16, it raises a warning unless the
+caller has set the PERL_SCAN_SILENT_OVERFLOW bit in *flags.
 
-Note that *result is not changed unless overflow occurs.
+Note that *approximation is not changed unless overflow occurs.
 
 For non-base10 operations, by default, a warning is raised for numbers
 that don't overflow but exceed 32 bits in width.  This is suppressed if
@@ -689,7 +689,7 @@ Other compromises kick in only when the result is within a digit of overflowing.
                 break;
             }
 
-            /* If result is no longer exactly half, set to round up */
+            /* If the result is no longer exactly half, set to round up */
             if (to_round == round_to_even_if_half && *s != '0') {
                 to_round = yes_round_up;
             }
@@ -789,8 +789,8 @@ Other compromises kick in only when the result is within a digit of overflowing.
     *flags |= PERL_SCAN_GREATER_THAN_UV_MAX
            |  PERL_SCAN_SILENT_NON_PORTABLE;
 
-    if (result)
-        *result = accumulated_nv;
+    if (approximation)
+        *approximation = accumulated_nv;
 
     if (input_flags & PERL_SCAN_SILENT_OVERFLOW) {
         *flags |= PERL_SCAN_SILENT_OVERFLOW;

--- a/numeric.c
+++ b/numeric.c
@@ -382,7 +382,8 @@ The main switch() statement could have more case statements for non-hex bases.
 There is a special mode that functions as an alternative to overflowing.  It
 is triggered by the caller setting PERL_SCAN_DISCARD_INSTEAD_OF_OVERFLOW into
 *flags.  Should overflow otherwise occur, subsequent digits are instead simply
-discarded, while rounding the result towards even.
+discarded, while rounding the result towards even.  *approximation is not
+changed if this flag is set.
 
 =cut
 
@@ -656,12 +657,57 @@ Other compromises kick in only when the result is within a digit of overflowing.
 
   overflowed: ;
 
-    /* We are about to overflow. 's' points to the first overflowing digit.
-     * Honor a caller's request to discard the overflowing digits instead. */
+    /* Bah. We are about to overflow.  The caller may want an approximation to
+     * the correct value (by passing a pointer to an NV, 'approximation'); or
+     * may not want to actually overflow, but instead return the highest,
+     * non-overflowing value (rounded, a flag indicates to do this, which
+     * overrides also passing 'approximation').
+     *
+     * 's' points to the first overflowing digit. */
+    UV high_order_batch;
     if (UNLIKELY(input_flags & PERL_SCAN_DISCARD_INSTEAD_OF_OVERFLOW)) {
 
         /* Return that it actually happened */
         *flags |= PERL_SCAN_DISCARD_INSTEAD_OF_OVERFLOW;
+
+        /* Override this */
+        approximation = NULL;
+    }
+    else {
+        /* Here, does want overflow to happen.  Set up return, and do
+         * warnings. */
+        *flags |= PERL_SCAN_GREATER_THAN_UV_MAX
+               |  PERL_SCAN_SILENT_NON_PORTABLE;
+
+        if (input_flags & PERL_SCAN_SILENT_OVERFLOW) {
+            *flags |= PERL_SCAN_SILENT_OVERFLOW;
+        }
+        else if (ckWARN_d(WARN_OVERFLOW)) {
+            const char * base_name;
+
+            switch (base) {
+              default: goto bad_base;
+              case 2:  base_name = "binary";      break;
+              case 8:  base_name = "octal";       break;
+              case 16: base_name = "hexadecimal"; break;
+              case 10: /* Base 10 historically has not raised a warning here */
+                goto overflow_warning_done;
+            }
+
+            warner(packWARN(WARN_OVERFLOW), "Integer overflow in %s number",
+                                            base_name);
+          overflow_warning_done: ;
+        }
+
+        high_order_batch = accumulated;
+        accumulated = UV_MAX;
+        input_flags &= ~PERL_SCAN_SILENT_NON_PORTABLE;
+    }
+
+    /* We always have to keep parsing to find the end of the intended number.
+     * If we don't need to compute an approximation, we don't have to pay much
+     * attention to the values */
+    if (approximation == NULL) {
 
         /* When discarding, we round the undiscarded result to even.  In some
          * cases, whether to round isn't known until the final discarded digit
@@ -708,8 +754,7 @@ Other compromises kick in only when the result is within a digit of overflowing.
         goto finish;
     }
 
-    /* Bah. We are about to overflow.  Instead compute an approximation to the
-     * correct value.
+    /* Here, the caller wants an approximation to the overflowed value.
      *
      * It turns out that there is less precision loss if we start at the low
      * order digits of the string and build up the number from there.  This is
@@ -780,40 +825,13 @@ Other compromises kick in only when the result is within a digit of overflowing.
     }
 
     /* Here have accumulated everything.  Combine the low order bits with the
-     * high order that we have saved in 'accumulated'.  Those must be shifted
-     * left to account for the low order ones */
+     * high order that we have saved in 'high_order_batch'.  Those must be
+     * shifted left to account for the low order ones */
     accumulated_nv += this_batch_accumulated * accumulated_factor;
     accumulated_factor *= this_batch_factor;
-    accumulated_nv += accumulated * accumulated_factor;
+    accumulated_nv += high_order_batch * accumulated_factor;
 
-    *flags |= PERL_SCAN_GREATER_THAN_UV_MAX
-           |  PERL_SCAN_SILENT_NON_PORTABLE;
-
-    if (approximation)
-        *approximation = accumulated_nv;
-
-    if (input_flags & PERL_SCAN_SILENT_OVERFLOW) {
-        *flags |= PERL_SCAN_SILENT_OVERFLOW;
-    }
-    else if (ckWARN_d(WARN_OVERFLOW)) {
-        const char * base_name;
-
-        switch (base) {
-          default: goto bad_base;
-          case 2:  base_name = "binary";      break;
-          case 8:  base_name = "octal";       break;
-          case 16: base_name = "hexadecimal"; break;
-          case 10: /* Base 10 historically has not raised a warning here */
-            goto overflow_warning_done;
-        }
-
-        warner(packWARN(WARN_OVERFLOW), "Integer overflow in %s number",
-                                        base_name);
-      overflow_warning_done: ;
-    }
-
-    accumulated = UV_MAX;
-    input_flags &= ~PERL_SCAN_SILENT_NON_PORTABLE;
+    *approximation = accumulated_nv;
     goto finish;
 }
 

--- a/proto.h
+++ b/proto.h
@@ -1651,7 +1651,7 @@ Perl_grok_atoUV(const char *pv, UV *valptr, const char **endptr)
         assert(pv); assert(valptr)
 
 PERL_CALLCONV UV
-Perl_grok_bin_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *result, uint_fast8_t base, const U32 lookup_bit, const char prefix)
+Perl_grok_bin_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *approximation, uint_fast8_t base, const U32 lookup_bit, const char prefix)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
@@ -1691,7 +1691,7 @@ Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
         assert(sp); assert(*sp); assert(send); assert(*sp <= send)
 
 PERL_CALLCONV UV
-Perl_grok_uint_by_base(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *result, uint_fast8_t base, const U32 lookup_bit, uint_fast8_t offset)
+Perl_grok_uint_by_base(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *approximation, uint_fast8_t base, const U32 lookup_bit, uint_fast8_t offset)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
@@ -13183,7 +13183,7 @@ Perl_get_vtbl(pTHX_ int vtbl_id)
 # define PERL_ARGS_ASSERT_GET_VTBL
 
 PERL_STATIC_INLINE UV
-Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
@@ -13192,7 +13192,7 @@ Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
         assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE UV
-Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)
@@ -13201,7 +13201,7 @@ Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
         assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE UV
-Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
+Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2)


### PR DESCRIPTION
The caller  to this function indicates if they want an approximation to an overflowing value by passing a non-NULL pointer to where to store it.
     
It turns out that this function was calculating that approximation and then discarding it if the pointer is NULL.  This PR avoids that calculation when the pointer is NULL.

This also changes the name of that parameter in all related functions to more accurately reflect what it is.
     
* This set of changes does not require a perldelta entry.
