### PR TITLE
scan_num: Reformat/fix comments

### DIFF
--- a/toke.c
+++ b/toke.c
@@ -12772,14 +12772,26 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
   returns: pointer to new position in buffer
   side-effects: builds ops for the constant in pl_yylval.op
 
-  Read a number in any of the formats that Perl accepts:
+  Read a number in any of the formats that Perl accepts (where \x stands for a
+  hexadecimal character [0-9A-Fa-f]):
 
-  \d(_?\d)*(\.(\d(_?\d)*)?)?[Ee][\+\-]?(\d(_?\d)*)	12 12.34 12.
-  \.\d(_?\d)*[Ee][\+\-]?(\d(_?\d)*)			.34
-  0b[01](_?[01])*                                       binary integers
-  0o?[0-7](_?[0-7])*                                    octal integers
-  0x[0-9A-Fa-f](_?[0-9A-Fa-f])*                         hexadecimal integers
-  0x[0-9A-Fa-f](_?[0-9A-Fa-f])*(?:\.\d*)?p[+-]?[0-9]+   hexadecimal floats
+  0b  [0-1] (_* [0-1] )*       binary integers
+  0o? [0-7] (_* [0-7] )*       octal integers
+      \d    (_* \d    )*       decimal integers
+  0x  \x    (_* \x    )*       hexadecimal integers
+
+  And decimal or hex floats
+                      |-----------|                     |--------------|
+    \d (_* \d )* ( \. ( \d (_* \d )* )? )? ( [Ee] [-+]? ( \d (_* \d )* ) )?
+                   \.   \d (_* \d )        ( [Ee] [-+]? ( \d (_* \d)*  ) )?
+  0x\x (_* \x )* ( \. ( \x (_* \x )* )? )? ( [Pp] [-+]? ( \d (_* \d )* ) )
+       |______|  |______________________|  |_____________________________|
+
+  Hex floats require an exponent; the fractional part is optional.  Decimal
+  floats require either or both the fractional part and the exponent part.
+
+  Any number of underscores may separate any two digits, but multiple
+  sequential underscores are warned about.
 
   Like most scan_ routines, it uses the PL_tokenbuf buffer to hold the
   thing it reads.


### PR DESCRIPTION
These comments that gave complicated regex patterns that show the syntax of the various types of numerical constants recognized by this function had some oversights in them, and were hard to read.


* This set of changes does not require a perldelta entry.
