### PR TITLE
class.c: allow array fields w/ empty initializer

### DIFF
--- a/class.c
+++ b/class.c
@@ -82,13 +82,17 @@ PP(pp_initfield)
                 SV **svp = PL_stack_base + POPMARK + 1;
                 STRLEN count = PL_stack_sp - svp + 1;
 
-                av = newAV_alloc_x(count);
+                if (count != 0) {
+                    av = newAV_alloc_x(count);
 
-                while(svp <= PL_stack_sp) {
-                    av_push_simple(av, newSVsv(*svp));
-                    svp++;
+                    while(svp <= PL_stack_sp) {
+                        av_push_simple(av, newSVsv(*svp));
+                        svp++;
+                    }
+                    rpp_popfree_to(PL_stack_sp - count);
                 }
-                rpp_popfree_to(PL_stack_sp - count);
+                else
+                    av = newAV();
             }
             else
                 av = newAV();

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -375,7 +375,18 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+On debugging perls, instantiating a class with an array field with an empty
+initializer list would abort with an error:
+
+    class Foo {
+        field @bar = ();
+    }
+    Foo->new();
+
+Error message: C<< perl: inline.h:194: Perl_av_new_alloc: Assertion `size > 0'
+failed. >>
+
+This has been fixed. [GH #24246]
 
 =back
 

--- a/t/class/field.t
+++ b/t/class/field.t
@@ -308,4 +308,25 @@ no warnings 'experimental::class';
     is(Testcase14->new->classname, "Testcase14", '__CLASS__ in field initialisers');
 }
 
+{
+    class Testcase15 {
+        field $scalar = undef;
+        method scalar { return $scalar; }
+
+        field @array = ();
+        method array { return @array; }
+
+        field %hash = ();
+        method hash { return %hash; }
+    }
+
+    my $obj = Testcase15->new;
+
+    is($obj->scalar, undef, 'Scalar field can have redundant initialiser');
+
+    ok(eq_array([$obj->array], []), 'Array field can have redundant initialiser');
+
+    ok(eq_hash({$obj->hash}, {}), 'Hash field can have redundant initialiser');
+}
+
 done_testing;


### PR DESCRIPTION
```perl
class Foo {
    field @bar = ();
}
Foo->new;
```

This code (note the empty initializer list on the array field) would
trip an assert() on DEBUGGING perls.

Fixes #24246.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry, but it is included anyway.