### PR TITLE
Remove the now-unused SvSCREAM set of macros

### DIFF
--- a/sv.h
+++ b/sv.h
@@ -1322,10 +1322,6 @@ object type. Exposed to perl code via Internals::SvREADONLY().
 # define SvREADONLY_off(sv)	(SvFLAGS(sv) &= ~SVf_READONLY)
 #endif
 
-#define SvSCREAM(sv) ((SvFLAGS(sv) & (SVp_SCREAM|SVp_POK)) == (SVp_SCREAM|SVp_POK))
-#define SvSCREAM_on(sv)		(SvFLAGS(sv) |= SVp_SCREAM)
-#define SvSCREAM_off(sv)	(SvFLAGS(sv) &= ~SVp_SCREAM)
-
 #ifndef PERL_CORE
 #  define SvCOMPILED(sv)	0
 #  define SvCOMPILED_on(sv)


### PR DESCRIPTION
The `SCREAM` bit hasn't actually been used for anything in a long time. The bit position is reused for a few different purposes, but all those have specific named better access macros.

Across the whole of CPAN, there is now just one distribution which still uses the `SvSCREAM_on()` macro, but none of the others. I will leave this PR as a draft for now, but once that is hopefully updated, we can drop them here.

See also: https://rt.cpan.org/Ticket/Display.html?id=173582