### PR TITLE
Perl_check_hash_fields_and_hekify - hekifying NVs is not locale-safe

### DIFF
--- a/op.c
+++ b/op.c
@@ -2806,6 +2806,7 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
             && SvTYPE(sv) < SVt_PVMG
             && SvOK(sv)
             && !SvROK(sv)
+            && !(SvNOK(sv) && IN_LC_RUNTIME(LC_NUMERIC)) /* Decimal separator depends on runtime locale */
             && real)
         {
             SSize_t keylen;

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -368,6 +368,13 @@ added and are used to hekify some C<OP_CONST> hash keys at compile time.
 
 =item *
 
+C<Perl_check_hash_fields_and_hekify>, partly called as a compile-time
+optimization, no longer preemptively converts an NV to a HEK if the
+compile time and run time locales could differ.
+[GH #24252]
+
+=item *
+
 XXX
 
 =back

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4775,6 +4775,7 @@ PP(pp_multideref)
                        || SvTYPE(keysv) >= SVt_PVMG
                        || !SvOK(keysv)
                        || SvROK(keysv)
+                       || SvNOK(keysv)
                        || SvIsCOW_shared_hash(keysv));
 
                 /* this is basically a copy of pp_helem with OPpDEREF skipped */

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -175,7 +175,7 @@ EOF
     }
 
     SKIP: {
-        skip("no locale available where LC_NUMERIC radix isn't '.'", 30) unless $different;
+        skip("no locale available where LC_NUMERIC radix isn't '.'", 32) unless $different;
         note("using the '$different' locale for LC_NUMERIC tests");
         {
             local $ENV{LC_NUMERIC} = $different;
@@ -292,6 +292,7 @@ EOF
 EOF
                 "too late to ignore the locale at write() time");
             }
+
         }
 
         {
@@ -424,6 +425,27 @@ EOF
 EOF
             "C", { stderr => 'devnull' },
             "No compile error on v-strings when setting the locale to non-dot radix at compile time when default environment has non-dot radix");
+        }
+
+        {
+            fresh_perl_is(<<"EOF", 'OK', { eval $switches },
+                use locale;
+                use POSIX;
+                POSIX::setlocale(POSIX::LC_NUMERIC(),"$different");
+                my \%h = ( "$difference" => 1 );
+                print "OK" if exists(\$h{4.2});
+EOF
+                "Solo NV hash keys are not prematurely hekified");
+        }
+        {
+            fresh_perl_is(<<"EOF", 'OK', { eval $switches },
+                use locale;
+                use POSIX;
+                POSIX::setlocale(POSIX::LC_NUMERIC(),"$different");
+                my \%h = ( 4.2 => 1 );
+                print "OK" if exists(\$h{"$difference"});
+EOF
+                "NV hash keys with values are not prematurely hekified");
         }
 
         unless ($comma) {


### PR DESCRIPTION
`Perl_check_hash_fields_and_hekify` used to convert IV, NV, and PV `OP_CONST` SV values into shared HEKs at compile time. However, the decimal  separator character is locale dependent, so it is unsafe to perform a one-off conversion of an NV to a hash key using the compile time locale.

This commit adds a check to ensure that NVs are no longer hekified.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
