### PR TITLE
Revert vutil.c changes from ba04a9040af061424b6d6f0b1e888cd3ce4b3d9f

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1309,9 +1309,6 @@ our %Modules = (
         # only necessary with the CPAN release.
         'CUSTOMIZED'   => [
             'lib/version.pm',
-
-            # Customized by ba04a9040af061424b6d6f0b1e888cd3ce4b3d9f
-            'vutil.c',
          ],
 
         'MAP' => {

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -17,4 +17,3 @@ Win32API::File cpan/Win32API-File/File.xs beb870fed4490d2faa547b4a8576b8d64d1d27
 autodie cpan/autodie/t/utime.t f94c3000b5b23db59df64895594050d7151f8333
 podlators pod/perlpodstyle.pod 3430e61d84673b62944ceed6d023bfd5aebe3847
 version cpan/version/lib/version.pm aa9f25fe6f6815139a9fb85d817b4e2802732c03
-version vutil.c d2967934cdd5dfbcc2f7c783712e199d57d69ba1

--- a/vutil.c
+++ b/vutil.c
@@ -1013,7 +1013,7 @@ Perl_vnumify(pTHX_ SV *vs)
     {
         SV * tsv = *av_fetch(av, i, 0);
         digit = SvIV(tsv);
-        sv_catpvf(sv, "%03d", (int)digit);
+        Perl_sv_catpvf(aTHX_ sv, "%03d", (int)digit);
     }
 
     if ( len == 0 ) {
@@ -1071,7 +1071,7 @@ Perl_vnormal(pTHX_ SV *vs)
     for ( i = 1 ; i <= len ; i++ ) {
         SV * tsv = *av_fetch(av, i, 0);
         digit = SvIV(tsv);
-        sv_catpvf(sv, ".%" IVdf, (IV)digit);
+        Perl_sv_catpvf(aTHX_ sv, ".%" IVdf, (IV)digit);
     }
 
     if ( len <= 2 ) { /* short version, must be at least three */


### PR DESCRIPTION
This part of ba04a9040af061424b6d6f0b1e888cd3ce4b3d9f should not have happened, because vutil.c is maintained outside of core, and this particular change isn't appropriate for older perls.

This change facilitates updating version.pm to a newer version.