### PR TITLE
threads.xs: avoid unreachable code

### DIFF
--- a/dist/threads/threads.xs
+++ b/dist/threads/threads.xs
@@ -1550,8 +1550,8 @@ ithread_kill(...)
         }
 
         /* Return the thread to allow for method chaining: */
-        /* ST(0) still holds the object SV */
-        XSRETURN(1);
+        /* cheap PUSHs(ST(0)) -  ST(0) still holds the object SV */
+        SP++;
 
 
 void


### PR DESCRIPTION
A recent change of mine added an unconditional 'XSRETURN(1)' at the end of a PPCODE block, meaning that the code which the XS parser adds after the block is never reached. This made Coverity sad.

So return the value in a different way.

This should make no functional difference.

* This set of changes does not require a perldelta entry.
