### PR TITLE
Add asserts for aTHX, including ability to specify NULLOK

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -75,7 +75,7 @@ use strict;
 use warnings;
 
 my $known_flags_re =
-       qr/[ aA bB C dD eE fF h iI mM nN oO pP rR sS T uU v W xX y ;@\#? ] /xx;
+      qr/[ aA bB C dD eE fF h iI mM nN oO pP rR sS tT uU v W xX y ;@\#? ] /xx;
 
 # Flags that don't apply to this program, like implementation details.
 my $irrelevant_flags_re = qr/[ ab eE iI P rR X? ]/xx;
@@ -706,6 +706,7 @@ sub check_and_add_proto_defn {
     $flags .= "U" if $flags =~ /@/;     # No usage output for @arrays
     $flags .= "n" if $flags =~ /[#v]/;  # No threads, arguments for #ifdef's,
                                         # plain values
+    my $aTHX_NULLOK = $flags =~ /t/;
 
     if ($flags =~ /N/) {
         state %escapes = (
@@ -775,6 +776,7 @@ sub check_and_add_proto_defn {
         $elements{$element}{args} = \@munged_args;
         $elements{$element}{file} = $file;
         $elements{$element}{line_num} = $line_num // 0;
+        $elements{$element}{aTHX_NULLOK} = $aTHX_NULLOK;
 
         # Don't reset expecting documentation.
         $elements{$element}{docs_expected} = $docs_expected
@@ -1998,6 +2000,7 @@ sub docout ($fh, $section_name, $element_name, $docref) {
     # Accumulate the usage section of the entry into this array.  Output below
     # only when non-empty
     my @usage;
+    my @allowed_pTHX_NULL;
     if (defined $docref->{usage}) {
 
         # A complete override of the usage section.  Note that the O flag
@@ -2131,6 +2134,8 @@ sub docout ($fh, $section_name, $element_name, $docref) {
                         $this_has_pTHX = 1;
                         unshift @args, "pTHX";
                         $any_has_pTHX_ = 1 if @args > 1;
+                        push @allowed_pTHX_NULL, $name
+                                                     if $item->{aTHX_NULLOK};
                     }
 
                     $additional_long_form = 0;
@@ -2396,6 +2401,13 @@ sub docout ($fh, $section_name, $element_name, $docref) {
 
                 push @usage, "\n";
             }
+        }
+    }
+
+    if (@allowed_pTHX_NULL) {
+        print $fh "\n";
+        foreach my $name (@allowed_pTHX_NULL) {
+            print $fh " $name accepts a NULL value for the pTHX parameter\n";
         }
     }
 

--- a/deb.c
+++ b/deb.c
@@ -31,7 +31,7 @@ Perl_deb_nocontext(const char *pat, ...)
     PERL_ARGS_ASSERT_DEB_NOCONTEXT;
 
 #ifdef DEBUGGING
-    dTHX;
+    dTHXa(NULL);
     va_list args;
     va_start(args, pat);
     vdeb(pat, &args);
@@ -80,6 +80,7 @@ void
 Perl_vdeb(pTHX_ const char *pat, va_list *args)
 {
     PERL_ARGS_ASSERT_VDEB;
+    GET_aTHX_if_NULL;
 
 #ifdef DEBUGGING
     const char* const file = PL_curcop ? OutCopFILE(PL_curcop) : "<null>";

--- a/embed.fnc
+++ b/embed.fnc
@@ -784,6 +784,19 @@
 :             "#define foo Perl_foo",      rather than
 :             "#define foo(a,b,c) Perl_foo(aTHX_ a,b,c)
 :
+:   't'	 Almost, but not quite, entirely unlike 'T'.  This means there IS an
+:	 implicit interpreter/thread context argument, but this function is
+:	 equipped to handle the case where it is NULL.  That distinguishes this
+:	 kind of function from those that have no flag at all, which are those
+:	 that do have a thread-context parameter, but it needs to be non-NULL.
+:
+:	 The major use case for this type of function would be those that are
+:	 callable both from places where there is no thread context available,
+:	 and from places where there is, and this keeps the caller from having
+:	 to fetch one just to call this function.
+:
+:          suppress assert that aTHX isn't NULL
+:
 :   'u'  The macro's (it has to be a macro) return value or parameters are
 :        unorthodox, and aren't in the list above of recognized weird ones. For
 :        example, they aren't C parameters, or the macro expands to something

--- a/embed.fnc
+++ b/embed.fnc
@@ -1055,12 +1055,12 @@ Adp	|OP *	|ck_entersub_args_proto_or_list 			\
 				|NN GV *namegv				\
 				|NN SV *protosv
 
-CPop	|bool	|ckwarn 	|U32 w
-CPop	|bool	|ckwarn_d	|U32 w
-Adfp	|void	|ck_warner	|U32 err				\
+CPopt	|bool	|ckwarn 	|U32 w
+CPopt	|bool	|ckwarn_d	|U32 w
+Adfpt	|void	|ck_warner	|U32 err				\
 				|NN const char *pat			\
 				|...
-Adfp	|void	|ck_warner_d	|U32 err				\
+Adfpt	|void	|ck_warner_d	|U32 err				\
 				|NN const char *pat			\
 				|...
 
@@ -1116,7 +1116,7 @@ px	|void	|create_eval_scope					\
 				|NN SV **sp				\
 				|U32 flags
 : croak()'s first parm can be NULL.  Otherwise, mod_perl breaks.
-AMdfpr	|void	|croak		|NULLOK const char *pat 		\
+AMdfprt |void	|croak		|NULLOK const char *pat 		\
 				|...
 Tfpr	|void	|croak_caller	|NULLOK const char *pat 		\
 				|...
@@ -1224,7 +1224,7 @@ ETXdp	|char * |delimcpy_no_escape					\
 				|const int delim			\
 				|NN I32 *retlen
 Cp	|void	|despatch_signals
-AMdfpr	|OP *	|die		|NULLOK const char *pat 		\
+AMdfprt |OP *	|die		|NULLOK const char *pat 		\
 				|...
 Adpr	|OP *	|die_sv 	|NN SV *baseex
 : Used in util.c
@@ -1403,7 +1403,7 @@ ATdmp	|bool	|extended_utf8_to_uv					\
 				|EPTRge const U8 * const e		\
 				|NN UV *cp_p				\
 				|NULLOK Size_t *advance_p
-Adfp	|void	|fatal_warner	|U32 err				\
+Adfpt	|void	|fatal_warner	|U32 err				\
 				|NN const char *pat			\
 				|...
 Adp	|void	|fbm_compile	|NN SV *sv				\
@@ -1469,7 +1469,7 @@ Cp	|void	|force_out_malformed_utf8_message_			\
 				|EPTRgt const U8 * const e		\
 				|U32 flags				\
 				|const bool die_here
-Adfp	|char * |form		|NN const char *pat			\
+Adfpt	|char * |form		|NN const char *pat			\
 				|...
 : Only used in perl.c
 p	|void	|free_tied_hv_pool
@@ -2240,7 +2240,7 @@ Cp	|Stack_off_t *|markstack_grow
 EXp	|int	|mbtowc_	|NULLOK const wchar_t *pwc		\
 				|NULLOK const char *s			\
 				|const Size_t len
-Adfp	|SV *	|mess		|NN const char *pat			\
+Adfpt	|SV *	|mess		|NN const char *pat			\
 				|...
 Adp	|SV *	|mess_sv	|NN SV *basemsg 			\
 				|bool consume
@@ -2692,7 +2692,7 @@ Adp	|OP *	|op_sibling_splice					\
 px	|OP *	|op_unscope	|NULLOK OP *o
 ARdpx	|OP *	|op_wrap_finally|NN OP *block				\
 				|NN OP *finally
-p	|void	|output_non_portable					\
+pt	|void	|output_non_portable					\
 				|const U8 shift
 : Used in perly.y
 dp	|void	|package	|NN OP *name				\
@@ -2788,7 +2788,7 @@ p	|void	|peep		|NULLOK OP *o
 ATdo	|PerlInterpreter *|perl_alloc
 ATdo	|void	|perl_construct |NN PerlInterpreter *my_perl
 
-: The reason for the 'u' flag is that this passes "aTHX_ x" to its callee: not
+t: The reason for the 'u' flag is that this passes "aTHX_ x" to its callee: not
 : a legal C parameter
 Admu	|const XOP *|Perl_custom_op_xop 				\
 				|NN const OP *o
@@ -4212,14 +4212,14 @@ CRTip	|unsigned int|variant_byte_number				\
 				|PERL_UINTMAX_T word
 Adp	|int	|vcmp		|NN SV *lhv				\
 				|NN SV *rhv
-Adpr	|void	|vcroak 	|NULLOK const char *pat 		\
+Adprt	|void	|vcroak 	|NULLOK const char *pat 		\
 				|NULLOK va_list *args
 Adp	|void	|vdeb		|NN const char *pat			\
 				|NULLOK va_list *args
-Adp	|void	|vfatal_warner	|U32 err				\
+Adpt	|void	|vfatal_warner	|U32 err				\
 				|NN const char *pat			\
 				|NULLOK va_list *args
-Adp	|char * |vform		|NN const char *pat			\
+Adpt	|char * |vform		|NN const char *pat			\
 				|NULLOK va_list *args
 : Used by Data::Alias
 EXp	|void	|vivify_defelem |NN SV *sv
@@ -4230,7 +4230,7 @@ Adp	|void	|vload_module	|U32 flags				\
 				|NN SV *name				\
 				|NULLOK SV *ver 			\
 				|NULLOK va_list *args
-Adp	|SV *	|vmess		|NN const char *pat			\
+Adpt	|SV *	|vmess		|NN const char *pat			\
 				|NULLOK va_list *args
 ARdp	|SV *	|vnewSVpvf	|NN const char * const pat		\
 				|NULLOK va_list * const args
@@ -4238,18 +4238,18 @@ Adp	|SV *	|vnormal	|NN SV *vs
 Adp	|SV *	|vnumify	|NN SV *vs
 Adp	|SV *	|vstringify	|NN SV *vs
 Adp	|SV *	|vverify	|NN SV *vs
-Adp	|void	|vwarn		|NN const char *pat			\
+Adpt	|void	|vwarn		|NN const char *pat			\
 				|NULLOK va_list *args
-Adp	|void	|vwarner	|U32 err				\
+Adpt	|void	|vwarner	|U32 err				\
 				|NN const char *pat			\
 				|NULLOK va_list *args
 : Used in pp_sys.c
 p	|I32	|wait4pid	|Pid_t pid				\
 				|NN int *statusp			\
 				|int flags
-Adfp	|void	|warn		|NN const char *pat			\
+Adfpt	|void	|warn		|NN const char *pat			\
 				|...
-Adfp	|void	|warner 	|U32 err				\
+Adfpt	|void	|warner 	|U32 err				\
 				|NN const char *pat			\
 				|...
 Adp	|void	|warn_sv	|NN SV *baseex

--- a/embed.h
+++ b/embed.h
@@ -28,6 +28,7 @@
 #   undef CC_MAGICAL_
 #   undef CC_UNDERSCORE_
 #   undef do_aexec
+#   undef GET_aTHX_if_NULL
 #   undef HASATTRIBUTE_UNINITIALIZED
 #   undef is_WORD_BUT_NONCONT_safe
 #   undef isFOO_or_UNDERSCORE_

--- a/perl.h
+++ b/perl.h
@@ -241,10 +241,22 @@ Now a synonym for C<L</dTHXa>>.
 #  define pTHX_10	11
 #  define pTHX_11	12
 #  define pTHX_12	13
+
+/*
+=for apidoc_section $concurrency
+=for apidoc m||GET_aTHX_if_NULL
+
+Sets C<aTHX> to the current context value if C<aTHX> points to NULL on entry.
+Otherwise it has no effect.
+=cut
+*/
+#  define GET_aTHX_if_NULL                                                  \
+      STMT_START { if (UNLIKELY(aTHX == NULL)) aTHX = PERL_GET_THX; } STMT_END
 #  if defined(DEBUGGING) && !defined(PERL_TRACK_MEMPOOL)
 #    define PERL_TRACK_MEMPOOL
 #  endif
 #else
+#  define GET_aTHX_if_NULL
 #  undef PERL_TRACK_MEMPOOL
 #endif
 

--- a/proto.h
+++ b/proto.h
@@ -631,35 +631,29 @@ Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protos
 
 PERL_CALLCONV void
 Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER              \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV void
 Perl_ck_warner_d(pTHX_ U32 err, const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER_D            \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV bool
 Perl_ckwarn(pTHX_ U32 w)
-        Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__pure__;
-#define PERL_ARGS_ASSERT_CKWARN                 \
-        Perl_assert_aTHX
+#define PERL_ARGS_ASSERT_CKWARN
 
 PERL_CALLCONV bool
 Perl_ckwarn_d(pTHX_ U32 w)
-        Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__pure__;
-#define PERL_ARGS_ASSERT_CKWARN_D               \
-        Perl_assert_aTHX
+#define PERL_ARGS_ASSERT_CKWARN_D
 
 PERL_CALLCONV void
 Perl_clear_defarray(pTHX_ AV *av, bool abandon)
@@ -769,11 +763,9 @@ Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak(pTHX_ const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,pTHX_1,pTHX_2);
-#define PERL_ARGS_ASSERT_CROAK                  \
-        Perl_assert_aTHX
+#define PERL_ARGS_ASSERT_CROAK
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_caller(const char *pat, ...)
@@ -1110,11 +1102,9 @@ Perl_despatch_signals(pTHX)
 
 PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die(pTHX_ const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,pTHX_1,pTHX_2);
-#define PERL_ARGS_ASSERT_DIE                    \
-        Perl_assert_aTHX
+#define PERL_ARGS_ASSERT_DIE
 
 PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die_sv(pTHX_ SV *baseex)
@@ -1529,11 +1519,10 @@ Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_
 
 PERL_CALLCONV void
 Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_FATAL_WARNER           \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV void
 Perl_fbm_compile(pTHX_ SV *sv, U32 flags)
@@ -1657,11 +1646,10 @@ Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * cons
 
 PERL_CALLCONV char *
 Perl_form(pTHX_ const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_FORM                   \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV void
 Perl_free_tied_hv_pool(pTHX)
@@ -3649,11 +3637,10 @@ Perl_mbtowc_(pTHX_ const wchar_t *pwc, const char *s, const Size_t len)
 
 PERL_CALLCONV SV *
 Perl_mess(pTHX_ const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_MESS                   \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV SV *
 Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
@@ -4951,10 +4938,8 @@ Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
 
 PERL_CALLCONV void
 Perl_output_non_portable(pTHX_ const U8 shift)
-        Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_OUTPUT_NON_PORTABLE    \
-        Perl_assert_aTHX
+#define PERL_ARGS_ASSERT_OUTPUT_NON_PORTABLE
 
 PERL_CALLCONV void
 Perl_package(pTHX_ OP *name, OP *version)
@@ -8414,10 +8399,8 @@ Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
 
 PERL_CALLCONV_NO_RET void
 Perl_vcroak(pTHX_ const char *pat, va_list *args)
-        Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-#define PERL_ARGS_ASSERT_VCROAK                 \
-        Perl_assert_aTHX
+#define PERL_ARGS_ASSERT_VCROAK
 
 PERL_CALLCONV void
 Perl_vdeb(pTHX_ const char *pat, va_list *args)
@@ -8428,17 +8411,15 @@ Perl_vdeb(pTHX_ const char *pat, va_list *args)
 
 PERL_CALLCONV void
 Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VFATAL_WARNER          \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV char *
 Perl_vform(pTHX_ const char *pat, va_list *args)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VFORM                  \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV void
 Perl_vivify_defelem(pTHX_ SV *sv)
@@ -8465,10 +8446,9 @@ Perl_vload_module(pTHX_ U32 flags, SV *name, SV *ver, va_list *args)
 
 PERL_CALLCONV SV *
 Perl_vmess(pTHX_ const char *pat, va_list *args)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VMESS                  \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV SV *
 Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
@@ -8508,17 +8488,15 @@ Perl_vverify(pTHX_ SV *vs)
 
 PERL_CALLCONV void
 Perl_vwarn(pTHX_ const char *pat, va_list *args)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VWARN                  \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV void
 Perl_vwarner(pTHX_ U32 err, const char *pat, va_list *args)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VWARNER                \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV I32
 Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
@@ -8530,11 +8508,10 @@ Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
 
 PERL_CALLCONV void
 Perl_warn(pTHX_ const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_WARN                   \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV void
 Perl_warn_sv(pTHX_ SV *baseex)
@@ -8545,11 +8522,10 @@ Perl_warn_sv(pTHX_ SV *baseex)
 
 PERL_CALLCONV void
 Perl_warner(pTHX_ U32 err, const char *pat, ...)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_WARNER                 \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV I32
 Perl_was_lvalue_sub(pTHX)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4016,7 +4016,7 @@ sub generate_proto_h {
         my ($flags, $ret_type, $plain_func, $args, $assertions ) =
                         @{$embed}{qw(flags return_type name args assertions)};
         if ($flags =~
-            m/([^ aA bB C dD eE fF h iI mM nN oO pP Rr sS T uU v W xX ; ])/xx)
+           m/([^ aA bB C dD eE fF h iI mM nN oO pP Rr sS tT uU v W xX ; ])/xx)
         {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }
@@ -4032,6 +4032,8 @@ sub generate_proto_h {
                                                     if $flags =~ tr/ACS// > 1;
         die_at_end "$plain_func: S and p flags are mutually exclusive"
                                                     if $flags =~ tr/Sp// > 1;
+        die_at_end "$plain_func: t and T flags are mutually exclusive"
+                                                    if $flags =~ tr/tT// > 1;
         die_at_end "$plain_func:, M flag requires p flag"
                                             if $flags =~ /M/ && $flags !~ /p/;
         die_at_end "$plain_func: X flag requires one of [Iip] flags"
@@ -4182,7 +4184,8 @@ sub generate_proto_h {
         if ($has_context) {
 
             # Pretend there was an aTHX argument in the first position.
-            unshift $args->@*, "PerlInterpreter* aTHX NN";
+            my $NULL_accept = $flags =~ /t/ ? "NULLOK" : "NN";
+            unshift $args->@*, "PerlInterpreter* aTHX $NULL_accept";
 
             $ret .= "pTHX";
             $ret .= "_ " if $args->@* > 1;

--- a/util.c
+++ b/util.c
@@ -1413,8 +1413,8 @@ char *
 Perl_form_nocontext(const char* pat, ...)
 {
     PERL_ARGS_ASSERT_FORM_NOCONTEXT;
+    dTHXa(NULL);
 
-    dTHX;
     char *retval;
     va_list args;
     va_start(args, pat);
@@ -1473,6 +1473,7 @@ char *
 Perl_vform(pTHX_ const char *pat, va_list *args)
 {
     PERL_ARGS_ASSERT_VFORM;
+    GET_aTHX_if_NULL;
 
     SV * const sv = mess_alloc();
     sv_vsetpvfn(sv, pat, strlen(pat), args, NULL, 0, NULL);
@@ -1507,9 +1508,10 @@ SV *
 Perl_mess_nocontext(const char *pat, ...)
 {
     PERL_ARGS_ASSERT_MESS_NOCONTEXT;
+    dTHXa(NULL);
 
-    dTHX;
     SV *retval;
+
     va_list args;
     va_start(args, pat);
     retval = vmess(pat, &args);
@@ -1734,6 +1736,7 @@ SV *
 Perl_vmess(pTHX_ const char *pat, va_list *args)
 {
     PERL_ARGS_ASSERT_VMESS;
+    GET_aTHX_if_NULL;
 
     SV * const sv = mess_alloc();
 
@@ -1890,6 +1893,7 @@ void
 Perl_vcroak(pTHX_ const char* pat, va_list *args)
 {
     PERL_ARGS_ASSERT_VCROAK;
+    GET_aTHX_if_NULL;
 
     SV *ex = with_queued_errors(pat ? vmess(pat, args) : mess_sv(ERRSV, 0));
     invoke_exception_hook(ex, FALSE);
@@ -2053,6 +2057,7 @@ void
 Perl_vwarn(pTHX_ const char* pat, va_list *args)
 {
     PERL_ARGS_ASSERT_VWARN;
+    GET_aTHX_if_NULL;
 
     SV *ex = vmess(pat, args);
     if (!invoke_exception_hook(ex, TRUE))
@@ -2094,8 +2099,8 @@ void
 Perl_warn_nocontext(const char *pat, ...)
 {
     PERL_ARGS_ASSERT_WARN_NOCONTEXT;
+    dTHXa(NULL);
 
-    dTHX;
     va_list args;
     va_start(args, pat);
     vwarn(pat, &args);
@@ -2180,8 +2185,8 @@ void
 Perl_warner_nocontext(U32 err, const char *pat, ...)
 {
     PERL_ARGS_ASSERT_WARNER_NOCONTEXT;
+    dTHXa(NULL);
 
-    dTHX;
     va_list args;
     va_start(args, pat);
     vwarner(err, pat, &args);
@@ -2193,6 +2198,7 @@ void
 Perl_ck_warner_d(pTHX_ U32 err, const char* pat, ...)
 {
     PERL_ARGS_ASSERT_CK_WARNER_D;
+    GET_aTHX_if_NULL;
 
     if (Perl_ckwarn_d(aTHX_ err)) {
         va_list args;
@@ -2206,6 +2212,7 @@ void
 Perl_ck_warner(pTHX_ U32 err, const char* pat, ...)
 {
     PERL_ARGS_ASSERT_CK_WARNER;
+    GET_aTHX_if_NULL;
 
     if (Perl_ckwarn(aTHX_ err)) {
         va_list args;
@@ -2230,6 +2237,8 @@ void
 Perl_vwarner(pTHX_ U32  err, const char* pat, va_list* args)
 {
     PERL_ARGS_ASSERT_VWARNER;
+    GET_aTHX_if_NULL;
+
     if (
         (PL_warnhook == PERL_WARNHOOK_FATAL || ckDEAD(err)) &&
         !(PL_in_eval & EVAL_KEEPERR)
@@ -2256,7 +2265,7 @@ void
 Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
 {
     PERL_ARGS_ASSERT_VFATAL_WARNER;
-
+    GET_aTHX_if_NULL;
     PERL_UNUSED_ARG(err);
 
     SV * const msv = vmess(pat, args);
@@ -2276,6 +2285,7 @@ bool
 Perl_ckwarn(pTHX_ U32 w)
 {
     PERL_ARGS_ASSERT_CKWARN;
+    GET_aTHX_if_NULL;
 
     /* If lexical warnings have not been set, use $^W.  */
     if (isLEXWARN_off)
@@ -2290,6 +2300,7 @@ bool
 Perl_ckwarn_d(pTHX_ U32 w)
 {
     PERL_ARGS_ASSERT_CKWARN_D;
+    GET_aTHX_if_NULL;
 
     /* If lexical warnings have not been set then default classes warn.  */
     if (isLEXWARN_off)


### PR DESCRIPTION
This PR  adds the ability to optionally include the aTHX parameter in embed.fnc entries so that you can say that a function accepts a NULL aTHX.  It adds an assert that aTHX is not NULL for each function that doesn't have that override.  This syntax was chosen so that the aTHX argument can have more attributes attached to it in future commits.

It changes a few low level functions to accept a NULL aTHX.

* This set of changes does not require a perldelta entry.
