### PR TITLE
Clarify versioning in perlpolicy.pod

### DIFF
--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -525,9 +525,9 @@ C<5.10.0>-type strings, some of which need bumping on every release, and
 some of which need to be left unchanged.
 See below in L</"Update INSTALL"> for more details.
 
-For the first RC release leading up to a BLEAD-FINAL release, update the
-description of which releases are now "officially" supported in
-F<pod/perlpolicy.pod>.
+For the first RC release leading up to a BLEAD-FINAL release, update
+F<pod/perlpolicy.pod>: both the version support status table and the
+description of which releases are now "officially" supported.
 
 When doing a BLEAD-POINT or BLEAD-FINAL release, also make sure the
 C<PERL_API_*> constants in F<patchlevel.h> are in sync with the version

--- a/pod/perlpolicy.pod
+++ b/pod/perlpolicy.pod
@@ -114,6 +114,25 @@ and maintain releases of Perl.
 This document codifies the support and maintenance commitments that
 the Perl community should expect from Perl's developers:
 
+=head2 Version Support Status
+
+The following table summarizes the current support status.  It is updated
+with each stable release.
+
+    Version    Released     Support status
+    -------    --------     --------------
+    5.42.x     2025-Jul     Full support (current stable)
+    5.40.x     2024-Jun     Full support (previous stable)
+    5.38.x     2023-Jul     Security fixes only
+    5.36.x     2022-May     End of life
+    5.34.x     2021-May     End of life
+
+Only the latest point release in each series (e.g., 5.42.1, not 5.42.0)
+receives patches.  Development releases (odd-numbered series like 5.43.x)
+are not supported.
+
+=head2 Support Details
+
 =over
 
 =item *

--- a/pod/perlpolicy.pod
+++ b/pod/perlpolicy.pod
@@ -69,6 +69,32 @@ For the specifics on how the members of the core team and steering
 council are elected or rotated, consult L<perlgov>, which spells it all
 out in detail.
 
+=head1 VERSIONING
+
+Perl uses a C<5.X.Y> version numbering scheme.
+
+=over
+
+=item *
+
+Even-numbered X values (e.g., 5.40, 5.42) are B<stable> release series.
+
+=item *
+
+Odd-numbered X values (e.g., 5.41, 5.43) are B<development> release
+series, leading up to the next stable release.  Development releases get
+a new Y increment roughly every month.
+
+=item *
+
+Y increments in stable series (e.g., 5.42.1, 5.42.2) are
+B<maintenance> releases that contain critical bug fixes and security
+patches only.
+
+=back
+
+A new stable release series is typically produced once a year.
+
 =head1 MAINTENANCE AND SUPPORT
 
 Perl 5 is developed by a community, not a corporate entity. Every change


### PR DESCRIPTION
- **Add an explicit explanation of 5.X.Y versioning scheme**
- **Add a support status table**

@perigrin and I have been having a discussion with [HeroDevs](https://www.herodevs.com/) about Perl versioning and End of Life. What arose out of that is that it's maybe not easy for an outsider to 

a) understand Perl's versioning policy
b) understand Perl's support policy

These changes try to address that. I do understand that this possibly gives the release manager one more thing to track, so that's one thing to keep in mind.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
