### PR TITLE
plan9: potentially reduce -Wall noise

### DIFF
--- a/plan9/config.plan9
+++ b/plan9/config.plan9
@@ -277,7 +277,7 @@
  *	This symbol, if defined, indicates that the link routine is
  *	available to create hard links.
  */
-/* #define HAS_LINK	/**/
+/* #define HAS_LINK	/ **/
 
 /* HAS_LOCALECONV:
  *	This symbol, if defined, indicates that the localeconv routine is
@@ -295,7 +295,7 @@
  *	This symbol, if defined, indicates that the lstat routine is
  *	available to do file stats on symbolic links.
  */
-/*#define HAS_LSTAT		/**/
+/*#define HAS_LSTAT		/ **/
 
 /* HAS_MBLEN:
  *	This symbol, if defined, indicates that the mblen routine is available
@@ -415,7 +415,7 @@
  *	This symbol, if defined, indicates that the readlink routine is
  *	available to read the value of a symbolic link.
  */
-/*#define HAS_READLINK		/**/
+/*#define HAS_READLINK		/ **/
 
 /* HAS_RENAME:
  *	This symbol, if defined, indicates that the rename routine is available
@@ -535,7 +535,7 @@
  *	This symbol, if defined, indicates that the strtod routine is
  *	available to provide better numeric string conversion than atof().
  */
-/*#define HAS_STRTOD	/**/
+/*#define HAS_STRTOD	/ **/
 
 /* HAS_STRTOL:
  *	This symbol, if defined, indicates that the strtol routine is available
@@ -553,7 +553,7 @@
  *	This symbol, if defined, indicates that the symlink routine is available
  *	to create symbolic links.
  */
-/*#define HAS_SYMLINK	/**/
+/*#define HAS_SYMLINK	/ **/
 
 /* HAS_SYSCALL:
  *	This symbol, if defined, indicates that the syscall routine is
@@ -1231,7 +1231,7 @@
  *	This symbol, if defined, indicates that the "fast stdio"
  *	is available to manipulate the stdio buffers directly.
  */
-/*#define HAS_FAST_STDIO		/**/
+/*#define HAS_FAST_STDIO		/ **/
 
 /* HAS_FCHDIR:
  *	This symbol, if defined, indicates that the fchdir routine is
@@ -1320,7 +1320,7 @@
  *           FP_NAN        NaN
  *
  */
-#define HAS_FPCLASSIFY		/ **/
+#define HAS_FPCLASSIFY		/**/
 
 /* HAS_FPOS64_T:
  *	This symbol will be defined if the C compiler supports fpos64_t.
@@ -1706,7 +1706,7 @@
  *	REENTRANT_PROTO_T_ABC macros of reentr.h if d_gmtime_r
  *	is defined.
  */
-#define HAS_GMTIME_R	   / **/
+#define HAS_GMTIME_R	   /**/
 #define GMTIME_R_PROTO 0	   /**/
 
 /* HAS_GNULIBC:
@@ -1753,7 +1753,7 @@
  *	This symbol, if defined, indicates that the ilogbl routine is
  *	available.  If scalbnl is also present we can emulate frexpl.
  */
-/*#define HAS_ILOGBL		/**/
+/*#define HAS_ILOGBL		/ **/
 
 /* HAS_INT64_T:
  *     This symbol will defined if the C compiler supports int64_t.
@@ -1824,7 +1824,7 @@
  *	is defined.
  */
 #define HAS_LOCALTIME_R
-#define LOCALTIME_R_NEEDS_TZSET	   / **/
+#define LOCALTIME_R_NEEDS_TZSET	   /**/
 #define LOCALTIME_R_PROTO 0	   /**/
 #ifdef LOCALTIME_R_NEEDS_TZSET
 #define L_R_TZSET tzset(),
@@ -1861,7 +1861,7 @@
  *	It is only defined if the system supports long doubles.
  */
 /*#define  HAS_LDEXPL		/ **/
-#define HAS_LONG_DOUBLE		/ **/
+#define HAS_LONG_DOUBLE		/**/
 #ifdef HAS_LONG_DOUBLE
 #define LONG_DOUBLESIZE 8		/**/
 #define LONG_DOUBLEKIND 0		/**/
@@ -2062,7 +2062,7 @@
  *	This symbol, if defined, indicates that the scalbnl routine is
  *	available.  If ilogbl is also present we can emulate frexpl.
  */
-/*#define HAS_SCALBNL		/**/
+/*#define HAS_SCALBNL		/ **/
 
 /* HAS_SENDMSG:
  *	This symbol, if defined, indicates that the sendmsg routine is
@@ -3673,13 +3673,13 @@
  *	This symbol, if defined, indicates that the copysignl routine is
  *	available.  If aintl is also present we can emulate modfl.
  */
-/*#define HAS_COPYSIGNL		/**/
+/*#define HAS_COPYSIGNL		/ **/
 
 /* USE_CPLUSPLUS:
  *	This symbol, if defined, indicates that a C++ compiler was
  *	used to compiled Perl and will be used to compile extensions.
  */
-/*#define USE_CPLUSPLUS		/**/
+/*#define USE_CPLUSPLUS		/ **/
 
 /* HAS_DBMINIT_PROTO:
  *	This symbol, if defined, indicates that the system provides

--- a/plan9/plan9ish.h
+++ b/plan9/plan9ish.h
@@ -25,14 +25,14 @@
  *	getgrgid() routines are available to get group entries.
  *	The getgrent() has a separate definition, HAS_GETGRENT.
  */
-/*#define HAS_GROUP		/**/
+/*#define HAS_GROUP		/ **/
 
 /* HAS_PASSWD
  *	This symbol, if defined, indicates that the getpwnam() and
  *	getpwuid() routines are available to get password entries.
  *	The getpwent() has a separate definition, HAS_GETPWENT.
  */
-/*#define HAS_PASSWD		/**/
+/*#define HAS_PASSWD		/ **/
 
 #define HAS_KILL
 #define HAS_WAIT
@@ -42,7 +42,7 @@
  *	to remove all versions of a file if unlink() is called.  This is
  *	probably only relevant for VMS.
  */
-/* #define UNLINK_ALL_VERSIONS		/**/
+/* #define UNLINK_ALL_VERSIONS		/ **/
 
 /* PLAN9:
  *	This symbol, if defined, indicates that the program is running under
@@ -124,8 +124,6 @@
 
 /* getenv related stuff */
 #define my_getenv(var) getenv(var)
-/* Plan 9 prefers getenv("home") to getenv("HOME")
-#define HOME home
 
 /* For use by POSIX.xs */
 extern int tcsendbreak(int, int);


### PR DESCRIPTION
Some compilers warn about seeing `/*` in the middle of a comment. Consistently use `/* #define ... / **/` for unset symbols and consistently use `#define ... /**/` for set symbols.

Delete the `HOME` #define entirely because this code has been missing a `*/` comment terminator ever since it was introduced in 1996, so it is all just a single long comment:

    /* Plan 9 prefers getenv("home") to getenv("HOME")
    #define HOME home

     /* For use by POSIX.xs */

(I believe it was intended to modify the behavior of pp_chdir in pp_sys.c, which uses a "HOME" string literal, but it would have only worked on pre-ANSI C compilers anyway. Standard compilers don't expand macros in strings.)

See #10059.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
