### PR TITLE
Rename 'is_dist' to 'isdst' in locale.c documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -890,6 +890,7 @@ Tim Jenness <tjenness@cpan.org> <timj@jach.hawaii.edu>
 Tim Jenness <tjenness@cpan.org> Tim Jenness <t.jenness@jach.hawaii.edu>
 Timothe Litt <litt@acm.org> <litt@acm.org>
 Timothe Litt <litt@acm.org> tlhackque <tlhackque@yahoo.com>
+Toby Inkster <mail@tobyinkster.co.uk> Toby Inkster <github@toby.ink>
 Todd Rinaldo <toddr@cpan.org> Todd Rinaldo <perlbug-comment@perl.org>
 Todd Rinaldo <toddr@cpan.org> Todd Rinaldo <toddr@cpanel.net>
 Tom Christiansen <tchrist@perl.com> Tom Christiansen <tchrist@jhereg.perl.com>

--- a/locale.c
+++ b/locale.c
@@ -8278,18 +8278,18 @@ aligned, as best we can, with the POSIX Standard, as follows:
 
 =over
 
-=item C<is_dist> is 0
+=item C<isdst> is 0
 
 The function is to assume that daylight savings time is not in effect.  This
 should now always work properly, as perl uses its own implementation in this
 case, avoiding non-conforming libc ones.
 
-=item C<is_dist> is E<gt>0
+=item C<isdst> is E<gt>0
 
 The function is to assume that daylight savings time is in effect, though some
 underlying libc implementations treat this as a hint instead of a mandate.
 
-=item C<is_dist> is E<lt>0
+=item C<isdst> is E<lt>0
 
 The function is to itself try to calculate if daylight savings time is in
 effect.  More recent libc implementations are better at this than earlier


### PR DESCRIPTION
I assume the use of "is_dist" was a typo.

Committer: Add .mailmap entry for Toby Inkster.  This pull request substitutes for https://github.com/Perl/perl5/pull/24104 (code already approved but not committed).

* This set of changes does not require a perldelta entry.
