### PR TITLE
Add missing ARG_ASSERTs; fix .t that wrongly passed

### DIFF
--- a/av.c
+++ b/av.c
@@ -1190,7 +1190,8 @@ Perl_av_exists(pTHX_ AV *av, SSize_t key)
 }
 
 static MAGIC *
-S_get_aux_mg(pTHX_ AV *av) {
+S_get_aux_mg(pTHX_ AV *av)
+{
     MAGIC *mg;
 
     PERL_ARGS_ASSERT_GET_AUX_MG;
@@ -1208,7 +1209,8 @@ S_get_aux_mg(pTHX_ AV *av) {
 }
 
 SV **
-Perl_av_arylen_p(pTHX_ AV *av) {
+Perl_av_arylen_p(pTHX_ AV *av)
+{
     MAGIC *const mg = get_aux_mg(av);
 
     PERL_ARGS_ASSERT_AV_ARYLEN_P;
@@ -1217,7 +1219,8 @@ Perl_av_arylen_p(pTHX_ AV *av) {
 }
 
 IV *
-Perl_av_iter_p(pTHX_ AV *av) {
+Perl_av_iter_p(pTHX_ AV *av)
+{
     MAGIC *const mg = get_aux_mg(av);
 
     PERL_ARGS_ASSERT_AV_ITER_P;
@@ -1236,7 +1239,8 @@ Perl_av_iter_p(pTHX_ AV *av) {
 }
 
 SV *
-Perl_av_nonelem(pTHX_ AV *av, SSize_t ix) {
+Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
+{
     SV * const sv = newSV_type(SVt_NULL);
     PERL_ARGS_ASSERT_AV_NONELEM;
     if (!av_store(av,ix,sv))

--- a/builtin.c
+++ b/builtin.c
@@ -43,6 +43,8 @@ static void S_warn_experimental_builtin(pTHX_ const char *name)
 void
 Perl_prepare_export_lexical(pTHX)
 {
+    PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL;
+
     assert(PL_compcv);
 
     /* We need to have PL_comppad / PL_curpad set correctly for lexical importing */
@@ -64,6 +66,8 @@ static void S_export_lexical(pTHX_ SV *name, SV *sv)
 void
 Perl_finish_export_lexical(pTHX)
 {
+    PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL;
+
     intro_my();
 
     LEAVE;
@@ -710,6 +714,8 @@ static bool S_cv_is_builtin(pTHX_ CV *cv)
 void
 Perl_import_builtin_bundle(pTHX_ U16 ver)
 {
+    PERL_ARGS_ASSERT_IMPORT_BUILTIN_BUNDLE;
+
     SV *ampname = sv_newmortal();
 
     for(int i = 0; builtins[i].name; i++) {
@@ -776,6 +782,8 @@ XS(XS_builtin_import)
 void
 Perl_boot_core_builtin(pTHX)
 {
+    PERL_ARGS_ASSERT_BOOT_CORE_BUILTIN;
+
     I32 i;
     for(i = 0; builtins[i].name; i++) {
         const struct BuiltinFuncDescriptor *builtin = &builtins[i];

--- a/caretx.c
+++ b/caretx.c
@@ -41,7 +41,8 @@
 #endif
 
 void
-Perl_set_caret_X(pTHX) {
+Perl_set_caret_X(pTHX)
+{
     GV* tmpgv = gv_fetchpvs("\030", GV_ADD|GV_NOTQUAL, SVt_PV); /* $^X */
     SV *const caret_x = GvSV(tmpgv);
 #if defined(OS2)

--- a/caretx.c
+++ b/caretx.c
@@ -43,6 +43,8 @@
 void
 Perl_set_caret_X(pTHX)
 {
+    PERL_ARGS_ASSERT_SET_CARET_X;
+
     GV* tmpgv = gv_fetchpvs("\030", GV_ADD|GV_NOTQUAL, SVt_PV); /* $^X */
     SV *const caret_x = GvSV(tmpgv);
 #if defined(OS2)

--- a/class.c
+++ b/class.c
@@ -666,7 +666,8 @@ been defined so a new attempt can be made.
 */
 
 static void
-S_class_cleanup_definition(pTHX_ HV *stash) {
+S_class_cleanup_definition(pTHX_ HV *stash)
+{
     struct xpvhv_aux *aux = HvAUX(stash);
 
     SvREFCNT_dec(aux->xhv_class_superclass);

--- a/class.c
+++ b/class.c
@@ -668,6 +668,8 @@ been defined so a new attempt can be made.
 static void
 S_class_cleanup_definition(pTHX_ HV *stash)
 {
+    PERL_ARGS_ASSERT_CLASS_CLEANUP_DEFINITION;
+
     struct xpvhv_aux *aux = HvAUX(stash);
 
     SvREFCNT_dec(aux->xhv_class_superclass);
@@ -1383,6 +1385,8 @@ Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv)
 OP *
 Perl_ck_classname(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_CLASSNAME;
+
     if(!CvIsMETHOD(PL_compcv))
         croak("Cannot use __CLASS__ outside of a method or field initializer expression");
 

--- a/deb.c
+++ b/deb.c
@@ -103,6 +103,8 @@ Perl_vdeb(pTHX_ const char *pat, va_list *args)
 I32
 Perl_debstackptrs(pTHX)     /* Currently unused in cpan and core */
 {
+    PERL_ARGS_ASSERT_DEBSTACKPTRS;
+
 #ifdef DEBUGGING
     PerlIO_printf(Perl_debug_log,
                   "%8" UVxf " %8" UVxf " %8" IVdf " %8" IVdf " %8" IVdf "\n",
@@ -198,6 +200,8 @@ Dump the current stack
 I32
 Perl_debstack(pTHX)
 {
+    PERL_ARGS_ASSERT_DEBSTACK;
+
 #ifndef SKIP_DEBUGGING
     if (CopSTASH_eq(PL_curcop, PL_debstash) && !DEBUG_J_TEST_)
         return 0;
@@ -247,6 +251,8 @@ static const char * const si_names[] = {
 void
 Perl_deb_stack_all(pTHX)
 {
+    PERL_ARGS_ASSERT_DEB_STACK_ALL;
+
 #ifdef DEBUGGING
     I32 si_ix;
     const PERL_SI *si;

--- a/doio.c
+++ b/doio.c
@@ -63,7 +63,9 @@
 void
 Perl_setfd_cloexec(int fd)
 {
+    PERL_ARGS_ASSERT_SETFD_CLOEXEC;
     assert(fd >= 0);
+
 #if defined(HAS_FCNTL) && defined(F_SETFD) && defined(FD_CLOEXEC)
     (void) fcntl(fd, F_SETFD, FD_CLOEXEC);
 #elif !defined(DEBUGGING)
@@ -74,7 +76,9 @@ Perl_setfd_cloexec(int fd)
 void
 Perl_setfd_inhexec(int fd)
 {
+    PERL_ARGS_ASSERT_SETFD_INHEXEC;
     assert(fd >= 0);
+
 #if defined(HAS_FCNTL) && defined(F_SETFD) && defined(FD_CLOEXEC)
     (void) fcntl(fd, F_SETFD, 0);
 #elif !defined(DEBUGGING)
@@ -85,7 +89,9 @@ Perl_setfd_inhexec(int fd)
 void
 Perl_setfd_cloexec_for_nonsysfd(pTHX_ int fd)
 {
+    PERL_ARGS_ASSERT_SETFD_CLOEXEC_FOR_NONSYSFD;
     assert(fd >= 0);
+
     if(fd > PL_maxsysfd)
         setfd_cloexec(fd);
 }
@@ -93,14 +99,18 @@ Perl_setfd_cloexec_for_nonsysfd(pTHX_ int fd)
 void
 Perl_setfd_inhexec_for_sysfd(pTHX_ int fd)
 {
+    PERL_ARGS_ASSERT_SETFD_INHEXEC_FOR_SYSFD;
     assert(fd >= 0);
+
     if(fd <= PL_maxsysfd)
         setfd_inhexec(fd);
 }
 void
 Perl_setfd_cloexec_or_inhexec_by_sysfdness(pTHX_ int fd)
 {
+    PERL_ARGS_ASSERT_SETFD_CLOEXEC_OR_INHEXEC_BY_SYSFDNESS;
     assert(fd >= 0);
+
     if(fd <= PL_maxsysfd)
         setfd_inhexec(fd);
     else
@@ -189,6 +199,8 @@ enum { CLOEXEC_EXPERIMENT = 0, CLOEXEC_AT_OPEN, CLOEXEC_AFTER_OPEN };
 int
 Perl_PerlLIO_dup_cloexec(pTHX_ int oldfd)
 {
+    PERL_ARGS_ASSERT_PERLLIO_DUP_CLOEXEC;
+
 #if !defined(PERL_IMPLICIT_SYS) && defined(F_DUPFD_CLOEXEC)
     /*
      * struct IPerlLIO doesn't cover fcntl(), and there's no clear way
@@ -207,6 +219,8 @@ Perl_PerlLIO_dup_cloexec(pTHX_ int oldfd)
 int
 Perl_PerlLIO_dup2_cloexec(pTHX_ int oldfd, int newfd)
 {
+    PERL_ARGS_ASSERT_PERLLIO_DUP2_CLOEXEC;
+
 #if !defined(PERL_IMPLICIT_SYS) && defined(HAS_DUP3) && defined(O_CLOEXEC)
     /*
      * struct IPerlLIO doesn't cover dup3(), and there's no clear way
@@ -325,6 +339,8 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
 int
 Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
 {
+    PERL_ARGS_ASSERT_PERLSOCK_SOCKET_CLOEXEC;
+
 #  if defined(SOCK_CLOEXEC)
     DO_ONEOPEN_EXPERIMENTING_CLOEXEC(
         PL_strategy_socket,
@@ -339,6 +355,8 @@ int
 Perl_PerlSock_accept_cloexec(pTHX_ int listenfd, struct sockaddr *addr,
     Sock_size_t *addrlen)
 {
+    PERL_ARGS_ASSERT_PERLSOCK_ACCEPT_CLOEXEC;
+
 #  if !defined(PERL_IMPLICIT_SYS) && \
         defined(HAS_ACCEPT4) && defined(SOCK_CLOEXEC)
     /*
@@ -1292,7 +1310,10 @@ static const MGVTBL argvout_vtbl =
     };
 
 static bool
-S_is_fork_open(const char *name) {
+S_is_fork_open(const char *name)
+{
+    PERL_ARGS_ASSERT_IS_FORK_OPEN;
+
     /* return true if name matches /^\A\s*(\|\s+-|\-\s+|)\s*\z/ */
     while (isSPACE(*name))
         name++;
@@ -1815,6 +1836,8 @@ indicate the cause.
 bool
 Perl_do_close(pTHX_ GV *gv, bool is_explict)
 {
+    PERL_ARGS_ASSERT_DO_CLOSE;
+
     bool retval;
     IO *io;
     MAGIC *mg;
@@ -1986,6 +2009,8 @@ Perl_do_tell(pTHX_ GV *gv)
 bool
 Perl_do_seek(pTHX_ GV *gv, Off_t pos, int whence)
 {
+    PERL_ARGS_ASSERT_DO_SEEK;
+
     IO *const io = GvIO(gv);
     PerlIO *fp;
 
@@ -2022,6 +2047,8 @@ Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
 int
 Perl_mode_from_discipline(pTHX_ const char *s, STRLEN len)
 {
+    PERL_ARGS_ASSERT_MODE_FROM_DISCIPLINE;
+
     int mode = O_BINARY;
     PERL_UNUSED_CONTEXT;
     if (s) {
@@ -2086,6 +2113,8 @@ The C library L<chsize(3)> if available, or a Perl implementation of it.
 I32
 my_chsize(int fd, Off_t length)
 {
+    PERL_ARGS_ASSERT_MY_CHSIZE;
+
 #  ifdef F_FREESP
         /* code courtesy of William Kucharski */
 #  define HAS_CHSIZE
@@ -2212,6 +2241,8 @@ Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
 I32
 Perl_my_stat_flags(pTHX_ const U32 flags)
 {
+    PERL_ARGS_ASSERT_MY_STAT_FLAGS;
+
     IO *io;
     GV* gv;
 
@@ -2287,6 +2318,8 @@ Perl_my_stat_flags(pTHX_ const U32 flags)
 I32
 Perl_my_lstat_flags(pTHX_ const U32 flags)
 {
+    PERL_ARGS_ASSERT_MY_LSTAT_FLAGS;
+
     static const char* const no_prev_lstat = "The stat preceding -l _ wasn't an lstat";
     const char *file;
     STRLEN len;
@@ -2953,6 +2986,8 @@ Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
 static bool
 S_ingroup(pTHX_ Gid_t testgid, bool effective)
 {
+    PERL_ARGS_ASSERT_INGROUP;
+
 # ifndef PERL_IMPLICIT_SYS
     /* PERL_IMPLICIT_SYS like Win32: getegid() etc. require the context. */
     PERL_UNUSED_CONTEXT;

--- a/doio.c
+++ b/doio.c
@@ -1094,7 +1094,8 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
 */
 
 static bool
-S_openindirtemp(pTHX_ GV *gv, SV *orig_name, SV *temp_out_name) {
+S_openindirtemp(pTHX_ GV *gv, SV *orig_name, SV *temp_out_name)
+{
     int fd;
     PerlIO *fp;
     const char *p = SvPV_nolen(orig_name);
@@ -1187,7 +1188,8 @@ S_openindirtemp(pTHX_ GV *gv, SV *orig_name, SV *temp_out_name) {
 #endif
 
 static int
-S_argvout_free(pTHX_ SV *io, MAGIC *mg) {
+S_argvout_free(pTHX_ SV *io, MAGIC *mg)
+{
     PERL_UNUSED_ARG(io);
 
     /* note this can be entered once the file has been
@@ -1251,7 +1253,8 @@ S_argvout_free(pTHX_ SV *io, MAGIC *mg) {
 }
 
 static int
-S_argvout_dup(pTHX_ MAGIC *mg, CLONE_PARAMS *param) {
+S_argvout_dup(pTHX_ MAGIC *mg, CLONE_PARAMS *param)
+{
     PERL_UNUSED_ARG(param);
 
     /* ideally we could just remove the magic from the SV but we don't get the SV here */
@@ -1550,7 +1553,8 @@ Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
  * equivalent rename() succeeds
  */
 static int
-S_my_renameat(int olddfd, const char *oldpath, int newdfd, const char *newpath) {
+S_my_renameat(int olddfd, const char *oldpath, int newdfd, const char *newpath)
+{
     /* this is intended only for use in Perl_do_close() */
     assert(olddfd == newdfd);
     assert(PERL_FILE_IS_ABSOLUTE(oldpath) == PERL_FILE_IS_ABSOLUTE(newpath));
@@ -1568,7 +1572,8 @@ S_my_renameat(int olddfd, const char *oldpath, int newdfd, const char *newpath) 
 #endif
 
 static bool
-S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg) {
+S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg)
+{
     Stat_t statbuf;
 
 #ifdef ARGV_USE_STAT_INO
@@ -1610,7 +1615,8 @@ S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg) {
     S_dir_unchanged(aTHX_ (orig_psv), (mg))
 
 static bool
-S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict) {
+S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict)
+{
     bool retval;
 
     /* ensure args are checked before we start using them */

--- a/dump.c
+++ b/dump.c
@@ -455,6 +455,8 @@ Implements C<SvPEEK>
 char *
 Perl_sv_peek(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SV_PEEK;
+
     SV * const t = sv_newmortal();
     int unref = 0;
     U32 type;
@@ -804,12 +806,16 @@ C<PL_defstash>.
 void
 Perl_dump_all(pTHX)
 {
+    PERL_ARGS_ASSERT_DUMP_ALL;
+
     dump_all_perl(FALSE);
 }
 
 void
 Perl_dump_all_perl(pTHX_ bool justperl)
 {
+    PERL_ARGS_ASSERT_DUMP_ALL_PERL;
+
     PerlIO_setlinebuf(Perl_debug_log);
     if (PL_main_root)
         op_dump(PL_main_root);
@@ -936,6 +942,8 @@ Perl_dump_form(pTHX_ const GV *gv)
 void
 Perl_dump_eval(pTHX)
 {
+    PERL_ARGS_ASSERT_DUMP_EVAL;
+
     op_dump(PL_eval_root);
 }
 
@@ -1250,6 +1258,8 @@ special handling.
 void
 Perl_pmop_dump(pTHX_ PMOP *pm)
 {
+    PERL_ARGS_ASSERT_PMOP_DUMP;
+
     do_pmop_dump(0, Perl_debug_log, pm);
 }
 
@@ -1261,6 +1271,8 @@ Perl_pmop_dump(pTHX_ PMOP *pm)
 static UV
 S_sequence_num(pTHX_ const OP *o)
 {
+    PERL_ARGS_ASSERT_SEQUENCE_NUM;
+
     SV     *op,
           **seq;
     const char *key;
@@ -1935,6 +1947,8 @@ C<STDERR>.
 void
 Perl_gv_dump(pTHX_ GV *gv)
 {
+    PERL_ARGS_ASSERT_GV_DUMP;
+
     STRLEN len;
     const char* name;
     SV *sv, *tmp = newSVpvs_flags("", SVs_TEMP);
@@ -2105,6 +2119,8 @@ Dumps the contents of the MAGIC C<mg> to C<STDERR>.
 void
 Perl_magic_dump(pTHX_ const MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_DUMP;
+
     do_magic_dump(0, Perl_debug_log, mg, 0, 0, FALSE, 0);
 }
 
@@ -3209,6 +3225,8 @@ deep.
 void
 Perl_sv_dump(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SV_DUMP;
+
     if (sv && SvROK(sv))
         sv_dump_depth(sv, 4);
     else
@@ -3218,6 +3236,8 @@ Perl_sv_dump(pTHX_ SV *sv)
 void
 Perl_sv_dump_depth(pTHX_ SV *sv, I32 depth)
 {
+    PERL_ARGS_ASSERT_SV_DUMP_DEPTH;
+
     do_sv_dump(0, Perl_debug_log, sv, 0, depth, 0, 0);
 }
 
@@ -3238,6 +3258,8 @@ Perl_hv_dump(pTHX_ HV *hv)
 int
 Perl_runops_debug(pTHX)
 {
+    PERL_ARGS_ASSERT_RUNOPS_DEBUG;
+
 #ifdef PERL_USE_HWM
     SSize_t orig_stack_hwm = PL_curstackinfo->si_stack_hwm;
 
@@ -3696,6 +3718,8 @@ Returns one of the OPclass enums, such as OPclass_LISTOP.
 OPclass
 Perl_op_class(pTHX_ const OP *o)
 {
+    PERL_ARGS_ASSERT_OP_CLASS;
+
     bool custom = 0;
 
     if (!o)
@@ -3832,6 +3856,8 @@ Perl_op_class(pTHX_ const OP *o)
 static CV*
 S_deb_curcv(pTHX_ I32 ix)
 {
+    PERL_ARGS_ASSERT_DEB_CURCV;
+
     PERL_SI *si = PL_curstackinfo;
     for (; ix >=0; ix--) {
         const PERL_CONTEXT * const cx = &(si->si_cxstack)[ix];
@@ -3897,6 +3923,8 @@ option.
 void
 Perl_debprofdump(pTHX)
 {
+    PERL_ARGS_ASSERT_DEBPROFDUMP;
+
     unsigned i;
     if (!PL_profiledata)
         return;

--- a/embed.fnc
+++ b/embed.fnc
@@ -180,12 +180,10 @@
 :   the same as GCC and Clang's '__attribute__nonnull__' generated for them for
 :   compilers that we know understand it.
 :
-:   Currently, it is optional to include an empty ARGS_ASSERT macro in your
-:   functions.  But a porting test enforces that a non-empty one does get
-:   included.  The call should be at the top of your function so that the
-:   sanity checks have passed before anything tries to use an argument.  When
-:   writing a new function, add the macro even if not required, and you'll
-:   never have to go back and add one later when more checks do get added.
+:   A porting test enforces that an ARGS_ASSERT macro has been included in all
+:   new functions added to this file.  Each call should be at the top of your
+:   function so that the sanity checks have passed before anything tries to use
+:   an argument.
 :
 :   (Much of the perl core was written assuming the ARGS_ASSERT macro needed to
 :   be placed after any declarations because of the C89 Standard.  That is no

--- a/embed.fnc
+++ b/embed.fnc
@@ -1357,7 +1357,7 @@ AOdp	|SV *	|eval_pv	|NN const char *p			\
 				|I32 croak_on_error
 AOdp	|SSize_t|eval_sv	|NN SV *sv				\
 				|I32 flags
-EMTpx	|Size_t |expected_size	|UV size
+ETmpx	|Size_t |expected_size	|UV size
 ATdmp	|bool	|extended_utf8_to_uv					\
 				|SPTR const U8 * const s		\
 				|EPTRge const U8 * const e		\

--- a/embed.h
+++ b/embed.h
@@ -40,6 +40,7 @@
 #   undef SvRVx
 #   undef UNI_DISPLAY_TR_
 #   if !defined(PERL_EXT)
+#     undef expected_size
 #     undef GV_CACHE_ONLY
 #     undef invlist_intersection_
 #     undef invlist_subtract_
@@ -1896,6 +1897,7 @@
 #   define cv_ckproto_len_flags(a,b,c,d,e)      Perl_cv_ckproto_len_flags(aTHX_ a,b,c,d,e)
 #   define delimcpy_no_escape                   Perl_delimcpy_no_escape
 #   define do_uniprop_match                     Perl_do_uniprop_match
+#   define Perl_expected_size                   expected_size
 #   define get_and_check_backslash_N_name(a,b,c,d) Perl_get_and_check_backslash_N_name(aTHX_ a,b,c,d)
 #   define get_deprecated_property_msg          Perl_get_deprecated_property_msg
 #   define get_prop_definition(a)               Perl_get_prop_definition(aTHX_ a)

--- a/generate_uudmap.c
+++ b/generate_uudmap.c
@@ -66,7 +66,8 @@ struct mg_data_t {
 static struct mg_data_t mg_data[256];
 
 static void
-format_mg_data(FILE *out, const void *thing, size_t count) {
+format_mg_data(FILE *out, const void *thing, size_t count)
+{
   const struct mg_data_t *p = (const struct mg_data_t *)thing;
 
   while (1) {
@@ -84,7 +85,8 @@ format_mg_data(FILE *out, const void *thing, size_t count) {
 }
 
 static void
-format_char_block(FILE *out, const void *thing, size_t count) {
+format_char_block(FILE *out, const void *thing, size_t count)
+{
   const char *block = (const char *)thing;
 
   fputs("    ", out);
@@ -139,7 +141,8 @@ typedef unsigned char U8;
 static char PL_uudmap[256];
 static char PL_bitcount[256];
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   size_t i;
   int bits;
   struct mg_data_raw_t *p = mg_data_raw;

--- a/gv.c
+++ b/gv.c
@@ -1747,13 +1747,15 @@ Perl_gv_stashsv(pTHX_ SV *sv, I32 flags)
     return gv_stashsvpvn_cached(sv, NULL, 0, flags);
 }
 GV *
-Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type) {
+Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type)
+{
     PERL_ARGS_ASSERT_GV_FETCHPV;
     return gv_fetchpvn_flags(nambeg, strlen(nambeg), flags, sv_type);
 }
 
 GV *
-Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type) {
+Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
+{
     STRLEN len;
     const char * const nambeg =
        SvPV_flags_const(name, len, flags & GV_NO_SVGMAGIC ? 0 : SV_GMAGIC);
@@ -3661,7 +3663,8 @@ If overloading is inactive on C<ref>, returns C<ref> itself.
 */
 
 SV *
-Perl_amagic_deref_call(pTHX_ SV *ref, int method) {
+Perl_amagic_deref_call(pTHX_ SV *ref, int method)
+{
     SV *tmpsv = NULL;
     HV *stash;
 

--- a/gv.c
+++ b/gv.c
@@ -57,6 +57,8 @@ Make sure there is a slot of type C<type> in the GV C<gv>.
 GV *
 Perl_gv_add_by_type(pTHX_ GV *gv, svtype type)
 {
+    PERL_ARGS_ASSERT_GV_ADD_BY_TYPE;
+
     SV **where;
 
     if (
@@ -851,6 +853,8 @@ Perl_gv_fetchmeth_pv(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
 PERL_STATIC_INLINE GV*
 S_gv_fetchmeth_internal(pTHX_ HV* stash, SV* meth, const char* name, STRLEN len, I32 level, U32 flags)
 {
+    PERL_ARGS_ASSERT_GV_FETCHMETH_INTERNAL;
+
     GV** gvp;
     HE* he;
     AV* linear_av;
@@ -2857,6 +2861,8 @@ Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
 GP*
 Perl_gp_ref(pTHX_ GP *gp)
 {
+    PERL_ARGS_ASSERT_GP_REF;
+
     if (!gp)
         return NULL;
     gp->gp_refcnt++;
@@ -2876,6 +2882,8 @@ Perl_gp_ref(pTHX_ GP *gp)
 void
 Perl_gp_free(pTHX_ GV *gv)
 {
+    PERL_ARGS_ASSERT_GP_FREE;
+
     GP* gp;
     int attempts = 100;
     bool in_global_destruction = PL_phase == PERL_PHASE_DESTRUCT;
@@ -3353,6 +3361,8 @@ Perl_gv_handler(pTHX_ HV *stash, I32 id)
 bool
 Perl_try_amagic_un(pTHX_ int method, int flags)
 {
+    PERL_ARGS_ASSERT_TRY_AMAGIC_UN;
+
     SV* tmpsv;
     SV* const arg = PL_stack_sp[0];
     bool is_rc = rpp_stack_is_rc();
@@ -3557,6 +3567,8 @@ Perl_amagic_applies(pTHX_ SV *sv, int method, int flags)
 bool
 Perl_try_amagic_bin(pTHX_ int method, int flags)
 {
+    PERL_ARGS_ASSERT_TRY_AMAGIC_BIN;
+
     SV* left  = PL_stack_sp[-1];
     SV* right = PL_stack_sp[0];
     bool is_rc = rpp_stack_is_rc();
@@ -3696,6 +3708,8 @@ Perl_amagic_deref_call(pTHX_ SV *ref, int method)
 bool
 Perl_amagic_is_enabled(pTHX_ int method)
 {
+    PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED;
+
       SV *lex_mask = cop_hints_fetch_pvs(PL_curcop, "overloading", 0);
 
       assert(PL_curcop->cop_hints & HINT_NO_AMAGIC);

--- a/hv.c
+++ b/hv.c
@@ -155,6 +155,8 @@ STMT_START {                                                            \
 static HE*
 S_new_he(pTHX)
 {
+    PERL_ARGS_ASSERT_NEW_HE;
+
     HE* he;
     void ** const root = &PL_body_roots[HE_ARENA_ROOT_IX];
 
@@ -204,6 +206,8 @@ S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
 void
 Perl_free_tied_hv_pool(pTHX)
 {
+    PERL_ARGS_ASSERT_FREE_TIED_HV_POOL;
+
     HE *he = PL_hv_fetch_ent_mh;
     while (he) {
         HE * const ohe = he;
@@ -469,6 +473,8 @@ void *
 Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                int flags, int action, SV *val, U32 hash)
 {
+    PERL_ARGS_ASSERT_HV_COMMON;
+
     XPVHV* xhv;
     HE *entry;
     HE **oentry;
@@ -1296,6 +1302,8 @@ static SV *
 S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                    int k_flags, I32 d_flags, U32 hash)
 {
+    PERL_ARGS_ASSERT_HV_DELETE_COMMON;
+
     XPVHV* xhv;
     HE *entry;
     HE **oentry;
@@ -3259,6 +3267,8 @@ C<len> and C<hash> must both be valid for C<str>.
 void
 Perl_unsharepvn(pTHX_ const char *str, I32 len, U32 hash)
 {
+    PERL_ARGS_ASSERT_UNSHAREPVN;
+
     unshare_hek_or_pvn (NULL, str, len, hash);
 }
 
@@ -3266,7 +3276,9 @@ Perl_unsharepvn(pTHX_ const char *str, I32 len, U32 hash)
 void
 Perl_unshare_hek(pTHX_ HEK *hek)
 {
+    PERL_ARGS_ASSERT_UNSHARE_HEK;
     assert(hek);
+
     unshare_hek_or_pvn(hek, NULL, 0, 0);
 }
 
@@ -3277,6 +3289,8 @@ Perl_unshare_hek(pTHX_ HEK *hek)
 static void
 S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash)
 {
+    PERL_ARGS_ASSERT_UNSHARE_HEK_OR_PVN;
+
     HE *entry;
     HE **oentry;
     int k_flags = 0;
@@ -3602,6 +3616,8 @@ C<flags> is currently unused and must be zero.
 HV *
 Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *chain, U32 flags)
 {
+    PERL_ARGS_ASSERT_REFCOUNTED_HE_CHAIN_2HV;
+
     HV *hv;
     U32 placeholders, max;
 
@@ -3977,6 +3993,7 @@ no action occurs in this case.
 
 void
 Perl_refcounted_he_free(pTHX_ struct refcounted_he *he) {
+    PERL_ARGS_ASSERT_REFCOUNTED_HE_FREE;
     PERL_UNUSED_CONTEXT;
 
     while (he) {
@@ -4013,6 +4030,8 @@ to this function: no action occurs and a null pointer is returned.
 struct refcounted_he *
 Perl_refcounted_he_inc(pTHX_ struct refcounted_he *he)
 {
+    PERL_ARGS_ASSERT_REFCOUNTED_HE_INC;
+
     PERL_UNUSED_CONTEXT;
     if (he) {
         HINTS_REFCNT_LOCK;

--- a/hv.c
+++ b/hv.c
@@ -1629,7 +1629,8 @@ S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
 
 #ifdef PERL_USE_UNSHARED_KEYS_IN_LARGE_HASHES
 static bool
-S_large_hash_heuristic(pTHX_ HV *hv, STRLEN size) {
+S_large_hash_heuristic(pTHX_ HV *hv, STRLEN size)
+{
     if (size > 42
         && !SvOBJECT(hv)
         && !(HvHasAUX(hv) && HvENAME_get(hv))) {
@@ -2457,7 +2458,8 @@ Perl_hv_fill(pTHX_ HV *const hv)
 }
 
 static struct xpvhv_aux*
-S_hv_auxinit(pTHX_ HV *hv) {
+S_hv_auxinit(pTHX_ HV *hv)
+{
     struct xpvhv_aux *iter;
 
     PERL_ARGS_ASSERT_HV_AUXINIT;
@@ -2539,7 +2541,8 @@ Implements C<HvRITER> which you should use instead.
 */
 
 I32 *
-Perl_hv_riter_p(pTHX_ HV *hv) {
+Perl_hv_riter_p(pTHX_ HV *hv)
+{
     struct xpvhv_aux *iter;
 
     PERL_ARGS_ASSERT_HV_RITER_P;
@@ -2557,7 +2560,8 @@ Implements C<HvEITER> which you should use instead.
 */
 
 HE **
-Perl_hv_eiter_p(pTHX_ HV *hv) {
+Perl_hv_eiter_p(pTHX_ HV *hv)
+{
     struct xpvhv_aux *iter;
 
     PERL_ARGS_ASSERT_HV_EITER_P;
@@ -2575,7 +2579,8 @@ Implements C<HvRITER_set> which you should use instead.
 */
 
 void
-Perl_hv_riter_set(pTHX_ HV *hv, I32 riter) {
+Perl_hv_riter_set(pTHX_ HV *hv, I32 riter)
+{
     struct xpvhv_aux *iter;
 
     PERL_ARGS_ASSERT_HV_RITER_SET;
@@ -2592,7 +2597,8 @@ Perl_hv_riter_set(pTHX_ HV *hv, I32 riter) {
 }
 
 void
-Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand) {
+Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand)
+{
     struct xpvhv_aux *iter;
 
     PERL_ARGS_ASSERT_HV_RAND_SET;
@@ -2618,7 +2624,8 @@ Implements C<HvEITER_set> which you should use instead.
 */
 
 void
-Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter) {
+Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter)
+{
     struct xpvhv_aux *iter;
 
     PERL_ARGS_ASSERT_HV_EITER_SET;
@@ -2737,7 +2744,8 @@ and bytes checking.
 */
 
 static I32
-hek_eq_pvn_flags(pTHX_ const HEK *hek, const char* pv, const I32 pvlen, const U32 flags) {
+hek_eq_pvn_flags(pTHX_ const HEK *hek, const char* pv, const I32 pvlen, const U32 flags)
+{
     if ( (HEK_UTF8(hek) ? 1 : 0) != (flags & SVf_UTF8 ? 1 : 0) ) {
         if (flags & SVf_UTF8)
             return (bytes_cmp_utf8(
@@ -2894,7 +2902,8 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 }
 
 AV **
-Perl_hv_backreferences_p(pTHX_ HV *hv) {
+Perl_hv_backreferences_p(pTHX_ HV *hv)
+{
     PERL_ARGS_ASSERT_HV_BACKREFERENCES_P;
     /* See also Perl_sv_get_backrefs in sv.c where this logic is unrolled */
     {
@@ -2904,7 +2913,8 @@ Perl_hv_backreferences_p(pTHX_ HV *hv) {
 }
 
 void
-Perl_hv_kill_backrefs(pTHX_ HV *hv) {
+Perl_hv_kill_backrefs(pTHX_ HV *hv)
+{
     AV *av;
 
     PERL_ARGS_ASSERT_HV_KILL_BACKREFS;
@@ -4031,7 +4041,8 @@ or if you additionally don't need to know the length, C<L</CopLABEL>>.
 /* pp_entereval is aware that labels are stored with a key ':' at the top of
    the linked list.  */
 const char *
-Perl_cop_fetch_label(pTHX_ COP *const cop, STRLEN *len, U32 *flags) {
+Perl_cop_fetch_label(pTHX_ COP *const cop, STRLEN *len, U32 *flags)
+{
     struct refcounted_he *const chain = cop->cop_hints_hash;
 
     PERL_ARGS_ASSERT_COP_FETCH_LABEL;

--- a/hv_func.h
+++ b/hv_func.h
@@ -176,7 +176,8 @@
 #endif
 
 PERL_STATIC_INLINE U32
-S_perl_hash_with_seed(const U8 * seed, const U8 *str, STRLEN len) {
+S_perl_hash_with_seed(const U8 * seed, const U8 *str, STRLEN len)
+{
     PVT__PERL_HASH_WORD_TYPE state[PERL_HASH_STATE_WORDS];
     PVT_PERL_HASH_SEED_STATE(seed,(U8*)state);
     return PVT_PERL_HASH_WITH_STATE((U8*)state,str,len);

--- a/inline.h
+++ b/inline.h
@@ -4912,7 +4912,8 @@ Perl_sv_isbool(pTHX_ const SV *sv)
 #ifdef USE_ITHREADS
 
 PERL_STATIC_INLINE AV *
-Perl_cop_file_avn(pTHX_ const COP *cop) {
+Perl_cop_file_avn(pTHX_ const COP *cop)
+{
 
     PERL_ARGS_ASSERT_COP_FILE_AVN;
 

--- a/inline.h
+++ b/inline.h
@@ -394,6 +394,8 @@ S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq)
 PERL_STATIC_INLINE Stack_off_t
 Perl_TOPMARK(pTHX)
 {
+    PERL_ARGS_ASSERT_TOPMARK;
+
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
                                  "MARK top  %p %" IVdf "\n",
                                   PL_markstack_ptr,
@@ -404,6 +406,8 @@ Perl_TOPMARK(pTHX)
 PERL_STATIC_INLINE Stack_off_t
 Perl_POPMARK(pTHX)
 {
+    PERL_ARGS_ASSERT_POPMARK;
+
     DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
                                  "MARK pop  %p %" IVdf "\n",
                                   (PL_markstack_ptr-1),
@@ -745,7 +749,7 @@ reference count of 1, but has not yet been anchored anywhere.
 PERL_STATIC_INLINE void
 Perl_rpp_push_1_norc(pTHX_ SV *sv)
 {
-    PERL_ARGS_ASSERT_RPP_PUSH_1;
+    PERL_ARGS_ASSERT_RPP_PUSH_1_NORC;
 
     *++PL_stack_sp = sv;
 #ifdef PERL_RC_STACK
@@ -881,6 +885,8 @@ Perl_rpp_replace_2_1(pTHX_ SV *sv)
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1_COMMON(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_RPP_REPLACE_2_1_COMMON;
+
 
     assert(sv);
 #ifdef PERL_RC_STACK
@@ -1112,6 +1118,8 @@ the beginning of the PP function for unary or binary ops.
 PERL_STATIC_INLINE bool
 Perl_rpp_try_AMAGIC_1(pTHX_ int method, int flags)
 {
+    PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_1;
+
     return    UNLIKELY((SvFLAGS(*PL_stack_sp) & (SVf_ROK|SVs_GMG)))
            && Perl_try_amagic_un(aTHX_ method, flags);
 }
@@ -1119,6 +1127,8 @@ Perl_rpp_try_AMAGIC_1(pTHX_ int method, int flags)
 PERL_STATIC_INLINE bool
 Perl_rpp_try_AMAGIC_2(pTHX_ int method, int flags)
 {
+    PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_2;
+
     return    UNLIKELY(((SvFLAGS(PL_stack_sp[-1])|SvFLAGS(PL_stack_sp[0]))
                      & (SVf_ROK|SVs_GMG)))
            && Perl_try_amagic_bin(aTHX_ method, flags);
@@ -1139,6 +1149,8 @@ contains zero items.
 PERL_STATIC_INLINE bool
 Perl_rpp_stack_is_rc(pTHX)
 {
+    PERL_ARGS_ASSERT_RPP_STACK_IS_RC;
+
 #ifdef PERL_RC_STACK
     return AvREAL(PL_curstack) && !PL_curstackinfo->si_stack_nonrc_base;
 #else
@@ -1165,6 +1177,8 @@ in lvalue context.
 PERL_STATIC_INLINE bool
 Perl_rpp_is_lone(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_RPP_IS_LONE;
+
 #ifdef PERL_RC_STACK
     /* note that rpp_is_lone() can be used in wrapped pp functions,
      * where technically the stack is no longer ref-counted; but because
@@ -1277,12 +1291,16 @@ Perl_append_utf8_from_native_byte(const U8 byte, U8** dest)
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
 {
+    PERL_ARGS_ASSERT_BYTES_TO_UTF8;
+
     return bytes_to_utf8_free_me(s, lenp, NULL);
 }
 
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
 {
+    PERL_ARGS_ASSERT_BYTES_TO_UTF8_TEMP_PV;
+
     void * free_me = NULL;
     U8 * converted = bytes_to_utf8_free_me(s, lenp, &free_me);
 
@@ -1296,6 +1314,8 @@ Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void ** free_me)
 {
+    PERL_ARGS_ASSERT_UTF8_TO_BYTES_NEW_PV;
+
     /* utf8_to_bytes_() is declared to take a non-const s_ptr because it may
      * change it, but NOT when called with PL_utf8_to_bytes_new_memory, so it
      * is ok to cast away const */
@@ -1306,6 +1326,8 @@ Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void ** free_me)
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
 {
+    PERL_ARGS_ASSERT_UTF8_TO_BYTES_TEMP_PV;
+
     /* utf8_to_bytes_() requires a non-NULL pointer, but doesn't use it when
      * called with PL_utf8_to_bytes_use_temporary */
     void* dummy = NULL;
@@ -1320,6 +1342,8 @@ Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
 {
+    PERL_ARGS_ASSERT_UTF8_TO_BYTES_OVERWRITE;
+
     /* utf8_to_bytes_() requires a non-NULL pointer, but doesn't use it when
      * called with PL_utf8_to_bytes_overwrite */
     void* dummy = NULL;
@@ -1720,10 +1744,11 @@ Perl_is_utf8_invariant_string_loc(const U8* const s, STRLEN len, const U8 ** ep)
 PERL_STATIC_INLINE unsigned
 Perl_lsbit_pos64(U64 word)
 {
+    PERL_ARGS_ASSERT_LSBIT_POS64;
+    ASSUME(word != 0);
+
     /* Find the position (0..63) of the least significant set bit in the input
      * word */
-
-    ASSUME(word != 0);
 
     /* If we can determine that the platform has a usable fast method to get
      * this info, use that */
@@ -1777,10 +1802,11 @@ Perl_lsbit_pos64(U64 word)
 PERL_STATIC_INLINE unsigned     /* Like above for 32 bit word */
 Perl_lsbit_pos32(U32 word)
 {
+    PERL_ARGS_ASSERT_LSBIT_POS32;
+    ASSUME(word != 0);
+
     /* Find the position (0..31) of the least significant set bit in the input
      * word */
-
-    ASSUME(word != 0);
 
 #if defined(PERL_CTZ_32)
 #  define PERL_HAS_FAST_GET_LSB_POS32
@@ -1828,10 +1854,11 @@ Perl_lsbit_pos32(U32 word)
 PERL_STATIC_INLINE unsigned
 Perl_msbit_pos64(U64 word)
 {
+    PERL_ARGS_ASSERT_MSBIT_POS64;
+    ASSUME(word != 0);
+
     /* Find the position (0..63) of the most significant set bit in the input
      * word */
-
-    ASSUME(word != 0);
 
     /* If we can determine that the platform has a usable fast method to get
      * this, use that */
@@ -1888,10 +1915,11 @@ Perl_msbit_pos64(U64 word)
 PERL_STATIC_INLINE unsigned
 Perl_msbit_pos32(U32 word)
 {
+    PERL_ARGS_ASSERT_MSBIT_POS32;
+    ASSUME(word != 0);
+
     /* Find the position (0..31) of the most significant set bit in the input
      * word */
-
-    ASSUME(word != 0);
 
 #if defined(PERL_CLZ_32)
 #  define PERL_HAS_FAST_GET_MSB_POS32
@@ -1945,6 +1973,8 @@ Perl_msbit_pos32(U32 word)
 PERL_STATIC_INLINE unsigned
 Perl_single_1bit_pos64(U64 word)
 {
+    PERL_ARGS_ASSERT_SINGLE_1BIT_POS64;
+
     /* Given a 64-bit word known to contain all zero bits except one 1 bit,
      * find and return the 1's position: 0..63 */
 
@@ -1984,6 +2014,8 @@ Perl_single_1bit_pos64(U64 word)
 PERL_STATIC_INLINE unsigned
 Perl_single_1bit_pos32(U32 word)
 {
+    PERL_ARGS_ASSERT_SINGLE_1BIT_POS32;
+
     /* Given a 32-bit word known to contain all zero bits except one 1 bit,
      * find and return the 1's position: 0..31 */
 
@@ -2015,6 +2047,8 @@ Perl_single_1bit_pos32(U32 word)
 PERL_STATIC_INLINE unsigned int
 Perl_variant_byte_number(PERL_UINTMAX_T word)
 {
+    PERL_ARGS_ASSERT_VARIANT_BYTE_NUMBER;
+
     /* This returns the position in a word (0..7) of the first byte whose
      * uppermost bit is set.  On ASCII boxes, this is equivalent to the first
      * byte whose representation is different in UTF-8 vs not, hence the name
@@ -3428,12 +3462,16 @@ Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
 PERL_STATIC_INLINE U8 *
 Perl_uv_to_utf8(pTHX_ U8 *d, UV uv)
 {
+    PERL_ARGS_ASSERT_UV_TO_UTF8;
+
     return uv_to_utf8_msgs(d, uv, 0, 0);
 }
 
 PERL_STATIC_INLINE U8 *
 Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
 {
+    PERL_ARGS_ASSERT_UV_TO_UTF8_FLAGS;
+
     return uv_to_utf8_msgs(d, uv, flags, 0);
 }
 
@@ -3953,6 +3991,8 @@ Perl_sv_only_taint_gmagic(SV *sv)
 PERL_STATIC_INLINE U8
 Perl_gimme_V(pTHX)
 {
+    PERL_ARGS_ASSERT_GIMME_V;
+
     I32 cxix;
     U8  gimme = (PL_op->op_flags & OPf_WANT);
 
@@ -4370,10 +4410,10 @@ PERL_STATIC_INLINE void
 Perl_cx_popwhen(pTHX_ PERL_CONTEXT *cx)
 {
     PERL_ARGS_ASSERT_CX_POPWHEN;
+    PERL_UNUSED_CONTEXT;
+    PERL_UNUSED_ARG(cx);
     assert(CxTYPE(cx) == CXt_WHEN);
 
-    PERL_UNUSED_ARG(cx);
-    PERL_UNUSED_CONTEXT;
     /* currently NOOP */
 }
 
@@ -5025,7 +5065,9 @@ Use the C<PerlMemShared_free> function.
 PERL_STATIC_INLINE char *
 Perl_savepv(pTHX_ const char *pv)
 {
+    PERL_ARGS_ASSERT_SAVEPV;
     PERL_UNUSED_CONTEXT;
+
     if (!pv)
         return NULL;
     else {
@@ -5041,6 +5083,8 @@ Perl_savepv(pTHX_ const char *pv)
 PERL_STATIC_INLINE char *
 Perl_savepvn(pTHX_ const char *pv, Size_t len)
 {
+    PERL_ARGS_ASSERT_SAVEPVN;
+
     char *newaddr;
     PERL_UNUSED_CONTEXT;
 
@@ -5095,6 +5139,8 @@ Implements L<perlapi/C<PERL_GET_CONTEXT>>, which you should use instead.
 PERL_STATIC_INLINE void *
 Perl_get_context(void)
 {
+    PERL_ARGS_ASSERT_GET_CONTEXT;
+
 #  if defined(USE_ITHREADS)
 #    ifdef OLD_PTHREADS_API
     pthread_addr_t t;
@@ -5117,6 +5163,7 @@ Perl_get_context(void)
 PERL_STATIC_INLINE MGVTBL*
 Perl_get_vtbl(pTHX_ int vtbl_id)
 {
+    PERL_ARGS_ASSERT_GET_VTBL;
     PERL_UNUSED_CONTEXT;
 
     return (vtbl_id < 0 || vtbl_id >= magic_vtable_max)
@@ -5152,6 +5199,8 @@ Description stolen from http://man.openbsd.org/strlcat.3
 PERL_STATIC_INLINE Size_t
 Perl_my_strlcat(char *dst, const char *src, Size_t size)
 {
+    PERL_ARGS_ASSERT_MY_STRLCAT;
+
     Size_t used, length, copy;
 
     used = strlen(dst);
@@ -5186,6 +5235,8 @@ Description stolen from http://man.openbsd.org/strlcpy.3
 PERL_STATIC_INLINE Size_t
 Perl_my_strlcpy(char *dst, const char *src, Size_t size)
 {
+    PERL_ARGS_ASSERT_MY_STRLCPY;
+
     Size_t length, copy;
 
     length = strlen(src);

--- a/invlist_inline.h
+++ b/invlist_inline.h
@@ -29,6 +29,8 @@
 PERL_STATIC_INLINE bool
 S_is_invlist(const SV* const invlist)
 {
+    PERL_ARGS_ASSERT_IS_INVLIST;
+
     return invlist != NULL && SvTYPE(invlist) == SVt_INVLIST;
 }
 
@@ -127,13 +129,17 @@ S_invlist_set_len(pTHX_ SV* const invlist, const UV len, const bool offset)
 }
 
 PERL_STATIC_INLINE SV*
-S_add_cp_to_invlist(pTHX_ SV* invlist, const UV cp) {
+S_add_cp_to_invlist(pTHX_ SV* invlist, const UV cp)
+{
+    PERL_ARGS_ASSERT_ADD_CP_TO_INVLIST;
+
     return add_range_to_invlist_(invlist, cp, cp);
 }
 
 PERL_STATIC_INLINE UV
 S_invlist_highest(SV* const invlist)
 {
+
     /* Returns the highest code point that matches an inversion list.  This API
      * has an ambiguity, as it returns 0 under either the highest is actually
      * 0, or if the list is empty.  If this distinction matters to you, check

--- a/locale.c
+++ b/locale.c
@@ -6189,7 +6189,8 @@ L<I18N::Langinfo>.
 #endif
 
 SV *
-Perl_sv_langinfo(pTHX_ const nl_item  item) {
+Perl_sv_langinfo(pTHX_ const nl_item  item)
+{
     utf8ness_t dummy;   /* Having this tells the layers below that we want the
                            UTF-8 flag in 'sv' to be set properly. */
 

--- a/locale.c
+++ b/locale.c
@@ -1038,6 +1038,8 @@ S_get_category_index_helper(pTHX_ const int category, bool * succeeded,
 void
 Perl_force_locale_unlock(pTHX)
 {
+    PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK;
+
     /* Remove any locale mutex, in preperation for an inglorious termination,
      * typically a  panic */
 
@@ -1061,6 +1063,8 @@ Perl_force_locale_unlock(pTHX)
 static locale_t
 S_use_curlocale_scratch(pTHX)
 {
+    PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH;
+
     /* This function is used to hide from the caller the case where the current
      * locale_t object in POSIX 2008 is the global one, which is illegal in
      * many of the P2008 API calls.  This checks for that and, if necessary
@@ -1182,6 +1186,8 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
                             const bool panic_on_error,
                             const line_t caller_line)
 {
+    PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING;
+
     /* This function parses the value of the input 'string' which is expected
      * to be the representation of an LC_ALL locale, and splits the result into
      * the values for the individual component categories, returning those in
@@ -3208,6 +3214,8 @@ S_calculate_LC_ALL_string(pTHX_ const char ** category_locales_list,
 static const char *
 S_find_locale_from_environment(pTHX_ const locale_category_index index)
 {
+    PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT;
+
     /* NB: This function may actually change the locale on Windows.  It
      * currently is designed to be called only from setting the locale on
      * Windows, and POSIX 2008
@@ -3375,6 +3383,8 @@ S_find_locale_from_environment(pTHX_ const locale_category_index index)
 static const char *
 S_get_LC_ALL_display(pTHX)
 {
+    PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY;
+
     return calculate_LC_ALL_string(NULL, INTERNAL_FORMAT,
                                    WANT_TEMP_PV,
                                    __LINE__);
@@ -4102,6 +4112,8 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
 void
 Perl_warn_problematic_locale()
 {
+    PERL_ARGS_ASSERT_WARN_PROBLEMATIC_LOCALE;
+
     dTHX;
 
     /* Core-only function that outputs the message in PL_warn_locale,
@@ -4224,6 +4236,8 @@ S_new_collate(pTHX_ const char *newcoll, bool force)
 static wchar_t *
 S_Win_byte_string_to_wstring(const UINT code_page, const char * byte_string)
 {
+    PERL_ARGS_ASSERT_WIN_BYTE_STRING_TO_WSTRING;
+
     /* Caller must arrange to free the returned string */
 
     int req_size = MultiByteToWideChar(code_page, 0, byte_string, -1, NULL, 0);
@@ -4251,6 +4265,8 @@ S_Win_byte_string_to_wstring(const UINT code_page, const char * byte_string)
 static char *
 S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t * wstring)
 {
+    PERL_ARGS_ASSERT_WIN_WSTRING_TO_BYTE_STRING;
+
     /* Caller must arrange to free the returned string */
 
     int req_size =
@@ -4312,6 +4328,8 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
 static const char *
 S_win32_setlocale(pTHX_ int category, const char* locale)
 {
+    PERL_ARGS_ASSERT_WIN32_SETLOCALE;
+
     /* This, for Windows, emulates POSIX setlocale() behavior.  There is no
      * difference between the two unless the input locale is "", which normally
      * means on Windows to get the machine default, which is set via the
@@ -4380,6 +4398,8 @@ S_win32_setlocale(pTHX_ int category, const char* locale)
 static const char *
 S_native_querylocale_i(pTHX_ const locale_category_index cat_index)
 {
+    PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I;
+
     /* Determine the current locale and return it in the form the platform's
      * native locale handling understands.  This is different only from our
      * internal form for the LC_ALL category, as platforms differ in how they
@@ -4487,6 +4507,8 @@ time C<Perl_setlocale> is called from the same thread.
 const char *
 Perl_setlocale(const int category, const char * locale)
 {
+    PERL_ARGS_ASSERT_PERL_SETLOCALE;
+
     /* This wraps POSIX::setlocale() */
 
 #ifndef USE_LOCALE
@@ -4608,6 +4630,8 @@ S_my_setlocale_debug_string_i(pTHX_
 
                               const line_t line)
 {
+    PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I;
+
     /* Returns a pointer to a NUL-terminated string in static storage with
      * added text about the info passed in.  This is not thread safe and will
      * be overwritten by the next call, so this should be used just to
@@ -5004,6 +5028,8 @@ S_is_codeset_name_UTF8(const char * name)
 bool
 Perl_get_win32_message_utf8ness(pTHX_ const char * string)
 {
+    PERL_ARGS_ASSERT_GET_WIN32_MESSAGE_UTF8NESS;
+
     /* This is because Windows doesn't have LC_MESSAGES. */
 
 #    ifdef USE_LOCALE_CTYPE
@@ -5035,6 +5061,8 @@ S_set_save_buffer_min_size(pTHX_ Size_t min_len,
                                  char **buf,
                                  Size_t * buf_cursize)
 {
+    PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE;
+
     /* Make sure the buffer pointed to by *buf is at least as large 'min_len';
      * *buf_cursize is the size of 'buf' upon entry; it will be updated to the
      * new size on exit.  'buf_cursize' being NULL is to be used when this is a
@@ -5122,6 +5150,7 @@ S_save_to_buffer(pTHX_ const char * string, char **buf, Size_t *buf_size)
 int
 Perl_mbtowc_(pTHX_ const wchar_t * pwc, const char * s, const Size_t len)
 {
+    PERL_ARGS_ASSERT_MBTOWC_;
 
 #if ! defined(HAS_MBRTOWC) && ! defined(HAS_MBTOWC)
 
@@ -5227,6 +5256,8 @@ be dealt with immediately.
 HV *
 Perl_localeconv(pTHX)
 {
+    PERL_ARGS_ASSERT_PERL_LOCALECONV;
+
     return (HV *) sv_2mortal((SV *) my_localeconv(0));
 }
 
@@ -6191,6 +6222,8 @@ L<I18N::Langinfo>.
 SV *
 Perl_sv_langinfo(pTHX_ const nl_item  item)
 {
+    PERL_ARGS_ASSERT_SV_LANGINFO;
+
     utf8ness_t dummy;   /* Having this tells the layers below that we want the
                            UTF-8 flag in 'sv' to be set properly. */
 
@@ -6203,6 +6236,8 @@ Perl_sv_langinfo(pTHX_ const nl_item  item)
 const char *
 Perl_langinfo(const nl_item item)
 {
+    PERL_ARGS_ASSERT_PERL_LANGINFO;
+
     dTHX;
 
     (void) external_call_langinfo(item, PL_langinfo_sv, NULL);
@@ -8424,6 +8459,8 @@ S_ints_to_tm(pTHX_ struct tm * mytm,
                    int sec, int min, int hour, int mday, int mon, int year,
                    int isdst)
 {
+    PERL_ARGS_ASSERT_INTS_TO_TM;
+
     /* Create a struct tm structure from the input time-related integer
      * variables for 'locale'.  Unlike mini_mktime(), this populates the
      * tm_gmtoff and tm_zone fields of the structure if the platform has those;
@@ -8800,6 +8837,8 @@ S_give_perl_locale_control(pTHX_
 #  endif
                            const line_t caller_line)
 {
+    PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL;
+
     PERL_UNUSED_ARG(caller_line);
 
     /* This is called when the program is in the global locale and are
@@ -8865,6 +8904,8 @@ S_output_check_environment_warning(pTHX_ const char * const language,
                                          const char * const lc_all,
                                          const char * const lang)
 {
+    PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING;
+
     PerlIO_printf(Perl_error_log,
                   "perl: warning: Please check that your locale settings:\n");
 
@@ -8918,6 +8959,8 @@ S_output_check_environment_warning(pTHX_ const char * const language,
 int
 Perl_init_i18nl10n(pTHX_ int printwarn)
 {
+    PERL_ARGS_ASSERT_INIT_I18NL10N;
+
     /* printwarn is:
      *    0 if not to output warning when setup locale is bad
      *    1 if to output warning based on value of PERL_BADLANG
@@ -10746,6 +10789,7 @@ Perl_my_strerror(pTHX_ const int errnum, utf8ness_t * utf8ness)
 bool
 Perl_is_in_locale_category_(pTHX_ const bool compiling, const int category)
 {
+    PERL_ARGS_ASSERT_IS_IN_LOCALE_CATEGORY_;
 
 #ifndef USE_LOCALE
 
@@ -10861,6 +10905,7 @@ handle all cases of single- vs multi-thread, POSIX 2008-supported or not.
 void
 Perl_switch_to_global_locale(pTHX)
 {
+    PERL_ARGS_ASSERT_SWITCH_TO_GLOBAL_LOCALE;
 
 #ifdef USE_LOCALE
 
@@ -10978,6 +11023,7 @@ was in effect for the caller; and FALSE if a per-thread locale was in effect.
 bool
 Perl_sync_locale(pTHX)
 {
+    PERL_ARGS_ASSERT_SYNC_LOCALE;
 
 #ifndef USE_LOCALE
 
@@ -11045,6 +11091,8 @@ Perl_sync_locale(pTHX)
 void
 Perl_switch_locale_context(pTHX)
 {
+    PERL_ARGS_ASSERT_SWITCH_LOCALE_CONTEXT;
+
     /* libc keeps per-thread locale status information in some configurations.
      * So, we can't just switch out aTHX to switch to a new thread.  libc has
      * to follow along.  This routine does that based on per-interpreter
@@ -11104,6 +11152,8 @@ Perl_switch_locale_context(pTHX)
 void
 Perl_thread_locale_init(pTHX)
 {
+    PERL_ARGS_ASSERT_THREAD_LOCALE_INIT;
+
 
 #  ifdef USE_THREAD_SAFE_LOCALE
 #    ifdef USE_POSIX_2008_LOCALE
@@ -11146,6 +11196,8 @@ Perl_thread_locale_init(pTHX)
 void
 Perl_thread_locale_term(pTHX)
 {
+    PERL_ARGS_ASSERT_THREAD_LOCALE_TERM;
+
     /* Called from a thread as it gets ready to terminate.
      *
      * The operations here have to be done from within the calling thread, as

--- a/malloc.c
+++ b/malloc.c
@@ -1222,6 +1222,8 @@ Implements L<perlapi/C<Newx>> which you should use instead.
 Malloc_t
 Perl_malloc(size_t nbytes)
 {
+    PERL_ARGS_ASSERT_MALLOC;
+
         union overhead *p;
         int bucket;
 #if defined(DEBUGGING) || defined(RCHECK)
@@ -1795,6 +1797,8 @@ Implements L<perlapi/C<Safefree>> which you should use instead.
 Free_t
 Perl_mfree(Malloc_t where)
 {
+    PERL_ARGS_ASSERT_MFREE;
+
         MEM_SIZE size;
         union overhead *ovp;
         char *cp = (char*)where;
@@ -1895,6 +1899,8 @@ Implements L<perlapi/C<Renew>> which you should use instead.
 Malloc_t
 Perl_realloc(void *mp, size_t nbytes)
 {
+    PERL_ARGS_ASSERT_REALLOC;
+
         MEM_SIZE onb;
         union overhead *ovp;
         char *res;
@@ -2090,6 +2096,8 @@ Implements L<perlapi/C<Newxz>> which you should use instead.
 Malloc_t
 Perl_calloc(size_t elements, size_t size)
 {
+    PERL_ARGS_ASSERT_CALLOC;
+
     long sz = elements * size;
     Malloc_t p = Perl_malloc(sz);
 
@@ -2161,6 +2169,8 @@ Perl_malloced_size(void *p)
 MEM_SIZE
 Perl_malloc_good_size(size_t wanted)
 {
+    PERL_ARGS_ASSERT_MALLOC_GOOD_SIZE;
+
     return BUCKET_SIZE_REAL(adjust_size_and_find_bucket(&wanted));
 }
 

--- a/mathoms.c
+++ b/mathoms.c
@@ -79,6 +79,8 @@ GCC_DIAG_IGNORE(-Wdeprecated-declarations)
 void
 Perl_load_mathoms()
 {
+    PERL_ARGS_ASSERT_LOAD_MATHOMS;
+
     /* This exists only to make sure the functions in this file get loaded, as
      * it is referred to by a structure element in intrpvar.h */
 }
@@ -89,6 +91,8 @@ Perl_load_mathoms()
 OP *
 Perl_ref(pTHX_ OP *o, I32 type)
 {
+    PERL_ARGS_ASSERT_REF;
+
     return doref(o, type, TRUE);
 }
 

--- a/mg.c
+++ b/mg.c
@@ -4003,7 +4003,8 @@ Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv,
 }
 
 int
-Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg) {
+Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
+{
     PERL_ARGS_ASSERT_MAGIC_SETDEBUGVAR;
 
 #if DBVARMG_SINGLE != 0
@@ -4017,7 +4018,8 @@ Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg) {
 }
 
 int
-Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg) {
+Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
+{
     PERL_ARGS_ASSERT_MAGIC_GETDEBUGVAR;
 
 #if DBVARMG_SINGLE != 0

--- a/mg.c
+++ b/mg.c
@@ -391,6 +391,8 @@ Finds the magic pointer for C<type> matching the SV.  See C<L</sv_magic>>.
 MAGIC*
 Perl_mg_find(const SV *sv, int type)
 {
+    PERL_ARGS_ASSERT_MG_FIND;
+
     return S_mg_findext_flags(sv, type, NULL, 0);
 }
 
@@ -406,6 +408,8 @@ C<L</sv_magicext>>.
 MAGIC*
 Perl_mg_findext(const SV *sv, int type, const MGVTBL *vtbl)
 {
+    PERL_ARGS_ASSERT_MG_FINDEXT;
+
     return S_mg_findext_flags(sv, type, vtbl, 1);
 }
 
@@ -785,6 +789,8 @@ Perl_emulate_cop_io(pTHX_ const COP *const c, SV *const sv)
 int
 Perl_get_extended_os_errno(void)
 {
+    PERL_ARGS_ASSERT_GET_EXTENDED_OS_ERRNO;
+
 
 #if defined(VMS)
 
@@ -864,6 +870,8 @@ string (currently empty) is returned.
 SV *
 Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv)
 {
+    PERL_ARGS_ASSERT_SV_STRING_FROM_ERRNUM;
+
     char const *errstr;
     utf8ness_t utf8ness;
 
@@ -1542,12 +1550,16 @@ PERL_STACK_REALIGN
 Signal_t
 Perl_csighandler(int sig, Siginfo_t *sip, void *uap)
 {
+    PERL_ARGS_ASSERT_CSIGHANDLER;
+
     Perl_csighandler3(sig, sip, uap);
 }
 #else
 Signal_t
 Perl_csighandler(int sig)
 {
+    PERL_ARGS_ASSERT_CSIGHANDLER;
+
     Perl_csighandler3(sig, NULL, NULL);
 }
 #endif
@@ -1555,6 +1567,8 @@ Perl_csighandler(int sig)
 Signal_t
 Perl_csighandler1(int sig)
 {
+    PERL_ARGS_ASSERT_CSIGHANDLER1;
+
     Perl_csighandler3(sig, NULL, NULL);
 }
 
@@ -1569,6 +1583,8 @@ Perl_csighandler1(int sig)
 Signal_t
 Perl_csighandler3(int sig, Siginfo_t *sip PERL_UNUSED_DECL, void *uap PERL_UNUSED_DECL)
 {
+    PERL_ARGS_ASSERT_CSIGHANDLER3;
+
 #ifdef PERL_GET_SIG_CONTEXT
     dTHXa(PERL_GET_SIG_CONTEXT);
 #else
@@ -1686,6 +1702,8 @@ unblock_sigmask(pTHX_ void* newset)
 void
 Perl_despatch_signals(pTHX)
 {
+    PERL_ARGS_ASSERT_DESPATCH_SIGNALS;
+
     int sig;
     PL_sig_pending = 0;
     for (sig = 1; sig < SIG_SIZE; sig++) {
@@ -3625,6 +3643,8 @@ Perl_whichsig_pvn(pTHX_ const char *sig, STRLEN len)
 Signal_t
 Perl_sighandler(int sig, Siginfo_t *sip, void *uap)
 {
+    PERL_ARGS_ASSERT_SIGHANDLER;
+
     Perl_perly_sighandler(sig, sip, uap, 0);
 }
 
@@ -3633,6 +3653,8 @@ Perl_sighandler(int sig, Siginfo_t *sip, void *uap)
 Signal_t
 Perl_sighandler(int sig)
 {
+    PERL_ARGS_ASSERT_SIGHANDLER;
+
     Perl_perly_sighandler(sig, NULL, NULL, 0);
 }
 
@@ -3641,12 +3663,16 @@ Perl_sighandler(int sig)
 Signal_t
 Perl_sighandler1(int sig)
 {
+    PERL_ARGS_ASSERT_SIGHANDLER1;
+
     Perl_perly_sighandler(sig, NULL, NULL, 0);
 }
 
 Signal_t
 Perl_sighandler3(int sig, Siginfo_t *sip PERL_UNUSED_DECL, void *uap PERL_UNUSED_DECL)
 {
+    PERL_ARGS_ASSERT_SIGHANDLER3;
+
     Perl_perly_sighandler(sig, sip, uap, 0);
 }
 
@@ -3663,6 +3689,8 @@ Signal_t
 Perl_perly_sighandler(int sig, Siginfo_t *sip PERL_UNUSED_DECL,
                     void *uap PERL_UNUSED_DECL, bool safe)
 {
+    PERL_ARGS_ASSERT_PERLY_SIGHANDLER;
+
 #ifdef PERL_GET_SIG_CONTEXT
     dTHXa(PERL_GET_SIG_CONTEXT);
 #else
@@ -3838,6 +3866,8 @@ Perl_perly_sighandler(int sig, Siginfo_t *sip PERL_UNUSED_DECL,
 static void
 S_restore_magic(pTHX_ void *p)
 {
+    PERL_ARGS_ASSERT_RESTORE_MAGIC;
+
     MGS* const mgs = SSPTR(PTR2IV(p), MGS*);
     SV* const sv = mgs->mgs_sv;
     bool bumped;
@@ -3895,6 +3925,7 @@ S_restore_magic(pTHX_ void *p)
 static void
 S_unwind_handler_stack(pTHX_ void *p)
 {
+    PERL_ARGS_ASSERT_UNWIND_HANDLER_STACK;
     PERL_UNUSED_ARG(p);
 
     PL_savestack_ix -= 5; /* Unprotect save in progress. */

--- a/mro_core.c
+++ b/mro_core.c
@@ -1428,6 +1428,8 @@ XS(XS_mro_method_changed_in);
 void
 Perl_boot_core_mro(pTHX)
 {
+    PERL_ARGS_ASSERT_BOOT_CORE_MRO;
+
     static const char file[] = __FILE__;
 
     Perl_mro_register(aTHX_ &dfs_alg);

--- a/mro_core.c
+++ b/mro_core.c
@@ -113,7 +113,8 @@ registered.  See L</C<mro_register>>.
 */
 
 const struct mro_alg *
-Perl_mro_get_from_name(pTHX_ SV *name) {
+Perl_mro_get_from_name(pTHX_ SV *name)
+{
     SV **data;
 
     PERL_ARGS_ASSERT_MRO_GET_FROM_NAME;

--- a/numeric.c
+++ b/numeric.c
@@ -146,6 +146,8 @@ Perl_my_strtod(const char * const s, char **e)
 U32
 Perl_cast_ulong(NV f)
 {
+    PERL_ARGS_ASSERT_CAST_ULONG;
+
   if (f < 0.0)
     return f < I32_MIN ? (U32) I32_MIN : (U32)(I32) f;
   if (f < U32_MAX_P1) {
@@ -164,6 +166,8 @@ Perl_cast_ulong(NV f)
 I32
 Perl_cast_i32(NV f)
 {
+    PERL_ARGS_ASSERT_CAST_I32;
+
   if (f < I32_MAX_P1)
     return f < I32_MIN ? I32_MIN : (I32) f;
   if (f < U32_MAX_P1) {
@@ -182,6 +186,8 @@ Perl_cast_i32(NV f)
 IV
 Perl_cast_iv(NV f)
 {
+    PERL_ARGS_ASSERT_CAST_IV;
+
   if (f < IV_MAX_P1)
     return f < IV_MIN ? IV_MIN : (IV) f;
   if (f < UV_MAX_P1) {
@@ -201,6 +207,8 @@ Perl_cast_iv(NV f)
 UV
 Perl_cast_uv(NV f)
 {
+    PERL_ARGS_ASSERT_CAST_UV;
+
   if (f < 0.0)
     return f < IV_MIN ? (UV) IV_MIN : (UV)(IV) f;
   if (f < UV_MAX_P1) {
@@ -2063,6 +2071,8 @@ This is also the logical inverse of Perl_isfinite().
 bool
 Perl_isinfnan(NV nv)
 {
+    PERL_ARGS_ASSERT_ISINFNAN;
+
   PERL_UNUSED_ARG(nv);
 #ifdef Perl_isinf
     if (Perl_isinf(nv))
@@ -2163,6 +2173,8 @@ Users should just always call C<Perl_signbit()>.
 int
 Perl_signbit(NV x)
 {
+    PERL_ARGS_ASSERT_PERL_SIGNBIT;
+
 #  ifdef Perl_fp_class_nzero
     return Perl_fp_class_nzero(x);
     /* Try finding the high byte, and assume it's highest bit

--- a/numeric.c
+++ b/numeric.c
@@ -2130,7 +2130,8 @@ Perl_my_modfl(long double x, long double *ip)
 /* Similarly, with ilogbl and scalbnl we can emulate frexpl. */
 #if ! defined(HAS_FREXPL) && defined(HAS_ILOGBL) && defined(HAS_SCALBNL)
 long double
-Perl_my_frexpl(long double x, int *e) {
+Perl_my_frexpl(long double x, int *e)
+{
     *e = x == 0.0L ? 0 : ilogbl(x) + 1;
     return (scalbnl(x, -*e));
 }
@@ -2160,7 +2161,8 @@ Users should just always call C<Perl_signbit()>.
 */
 #if !defined(HAS_SIGNBIT)
 int
-Perl_signbit(NV x) {
+Perl_signbit(NV x)
+{
 #  ifdef Perl_fp_class_nzero
     return Perl_fp_class_nzero(x);
     /* Try finding the high byte, and assume it's highest bit

--- a/op.c
+++ b/op.c
@@ -213,6 +213,8 @@ Perl_op_prune_chain_head(OP** op_p)
 PERL_STATIC_INLINE U16
 S_size_to_psize(size_t sz)
 {
+    PERL_ARGS_ASSERT_SIZE_TO_PSIZE;
+
     size_t psize = (sz + sizeof(I32 *) - 1) / sizeof(I32 *);
     assert(psize <= U16_MAX);
 
@@ -341,6 +343,8 @@ S_link_freed_op(pTHX_ OPSLAB *slab, OP *o)
 void *
 Perl_Slab_Alloc(pTHX_ size_t sz)
 {
+    PERL_ARGS_ASSERT_SLAB_ALLOC;
+
     OPSLAB *head_slab; /* first slab in the chain */
     OPSLAB *slab2;
     OPSLOT *slot;
@@ -635,6 +639,8 @@ Perl_opslab_force_free(pTHX_ OPSLAB *slab)
 OP *
 Perl_op_refcnt_inc(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_OP_REFCNT_INC;
+
     if(o) {
         OPSLAB *const slab = o->op_slabbed ? OpSLAB(o) : NULL;
         if (slab && slab->opslab_readonly) {
@@ -743,7 +749,10 @@ filehandles.
 */
 
 PERL_STATIC_INLINE bool
-S_is_standard_filehandle_name(const char *fhname) {
+S_is_standard_filehandle_name(const char *fhname)
+{
+    PERL_ARGS_ASSERT_IS_STANDARD_FILEHANDLE_NAME;
+
     return strEQ(fhname, "STDERR")
         || strEQ(fhname, "STDOUT")
         || strEQ(fhname, "STDIN")
@@ -768,6 +777,7 @@ Perl_no_bareword_filehandle(pTHX_ const char *fhname)
 PADOFFSET
 Perl_allocmy(pTHX_ const char *const name, const STRLEN len, const U32 flags)
 {
+
     PADOFFSET off;
     bool is_idfirst, is_default;
     const bool is_our = (PL_parser->in_my == KEY_our);
@@ -907,6 +917,8 @@ example:
 void
 Perl_op_free(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_OP_FREE;
+
     OPCODE type;
     OP *top_op = o;
     OP *next_op = o;
@@ -1530,6 +1542,8 @@ void
 Perl_op_refcnt_lock(pTHX)
   PERL_TSA_ACQUIRE(PL_op_mutex)
 {
+    PERL_ARGS_ASSERT_OP_REFCNT_LOCK;
+
     PERL_UNUSED_CONTEXT;
     OP_REFCNT_LOCK;
 }
@@ -1546,6 +1560,8 @@ void
 Perl_op_refcnt_unlock(pTHX)
   PERL_TSA_RELEASE(PL_op_mutex)
 {
+    PERL_ARGS_ASSERT_OP_REFCNT_UNLOCK;
+
     PERL_UNUSED_CONTEXT;
     OP_REFCNT_UNLOCK;
 }
@@ -1615,6 +1631,8 @@ see C<L</OpMORESIB_set>>, C<L</OpLASTSIB_set>>, C<L</OpMAYBESIB_set>>.
 OP *
 Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP* insert)
 {
+    PERL_ARGS_ASSERT_OP_SIBLING_SPLICE;
+
     OP *first;
     OP *rest;
     OP *last_del = NULL;
@@ -1756,6 +1774,8 @@ S_op_sibling_newUNOP(pTHX_ OP *parent, OP *start, I32 type, I32 flags)
 LOGOP *
 Perl_alloc_LOGOP(pTHX_ I32 type, OP *first, OP* other)
 {
+    PERL_ARGS_ASSERT_ALLOC_LOGOP;
+
     LOGOP *logop;
     OP *kid = first;
     NewOp(1101, logop, 1, LOGOP);
@@ -1863,6 +1883,8 @@ Perl_op_linklist(pTHX_ OP *o)
 static OP *
 S_scalarkids(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_SCALARKIDS;
+
     if (o && o->op_flags & OPf_KIDS) {
         OP *kid;
         for (kid = cLISTOPo->op_first; kid; kid = OpSIBLING(kid))
@@ -1998,6 +2020,8 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
 OP *
 Perl_scalar(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_SCALAR;
+
     OP * top_op = o;
 
     while (1) {
@@ -2548,6 +2572,8 @@ Perl_scalarvoid(pTHX_ OP *arg)
 static OP *
 S_listkids(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_LISTKIDS;
+
     if (o && o->op_flags & OPf_KIDS) {
         OP *kid;
         for (kid = cLISTOPo->op_first; kid; kid = OpSIBLING(kid))
@@ -2562,6 +2588,8 @@ S_listkids(pTHX_ OP *o)
 OP *
 Perl_list(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_LIST;
+
     OP * top_op = o;
 
     while (1) {
@@ -2707,6 +2735,8 @@ Perl_list(pTHX_ OP *o)
 static OP *
 S_voidnonfinal(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_VOIDNONFINAL;
+
     if (o) {
         const OPCODE type = o->op_type;
 
@@ -2742,6 +2772,8 @@ S_voidnonfinal(pTHX_ OP *o)
 static OP *
 S_modkids(pTHX_ OP *o, I32 type)
 {
+    PERL_ARGS_ASSERT_MODKIDS;
+
     if (o && o->op_flags & OPf_KIDS) {
         OP *kid;
         for (kid = cLISTOPo->op_first; kid; kid = OpSIBLING(kid))
@@ -2761,6 +2793,8 @@ S_modkids(pTHX_ OP *o, I32 type)
 void
 Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
 {
+    PERL_ARGS_ASSERT_CHECK_HASH_FIELDS_AND_HEKIFY;
+
     PADNAME *lexname;
     GV **fields;
     bool check_fields;
@@ -3136,6 +3170,8 @@ op_lvalue().  The flags param has these bits:
 OP *
 Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
 {
+    PERL_ARGS_ASSERT_OP_LVALUE_FLAGS;
+
     OP *top_op = o;
 
     if (!o || (PL_parser && PL_parser->error_count))
@@ -3661,6 +3697,8 @@ Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
 static bool
 S_scalar_mod_type(const OP *o, I32 type)
 {
+    PERL_ARGS_ASSERT_SCALAR_MOD_TYPE;
+
     switch (type) {
     case OP_POS:
     case OP_SASSIGN:
@@ -3744,6 +3782,8 @@ S_is_handle_constructor(const OP *o, I32 numargs)
 static OP *
 S_refkids(pTHX_ OP *o, I32 type)
 {
+    PERL_ARGS_ASSERT_REFKIDS;
+
     if (o && o->op_flags & OPf_KIDS) {
         OP *kid;
         for (kid = cLISTOPo->op_first; kid; kid = OpSIBLING(kid))
@@ -4277,7 +4317,9 @@ Perl_my_attrs(pTHX_ OP *o, OP *attrs)
 OP *
 Perl_sawparens(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_SAWPARENS;
     PERL_UNUSED_CONTEXT;
+
     if (o)
         o->op_flags |= OPf_PARENS;
     return o;
@@ -4378,6 +4420,8 @@ Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
 OP *
 Perl_invert(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_INVERT;
+
     if (!o)
         return NULL;
     return newUNOP(OP_NOT, OPf_SPECIAL, scalar(o));
@@ -4427,6 +4471,8 @@ S_is_control_transfer(pTHX_ OP *op)
 OP *
 Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
 {
+    PERL_ARGS_ASSERT_CMPCHAIN_START;
+
     BINOP *bop;
     OP *op;
 
@@ -4558,6 +4604,8 @@ structure.
 OP *
 Perl_op_scope(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_OP_SCOPE;
+
     if (o) {
         if (o->op_flags & OPf_PARENS || PERLDB_NOOPT || TAINTING_get) {
 
@@ -4591,6 +4639,8 @@ Perl_op_scope(pTHX_ OP *o)
 OP *
 Perl_op_unscope(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_OP_UNSCOPE;
+
     if (o && o->op_type == OP_LINESEQ) {
         OP *kid = cLISTOPo->op_first;
         for(; kid; kid = OpSIBLING(kid))
@@ -4614,6 +4664,8 @@ right.  Returns a savestack index for use with C<block_end>.
 int
 Perl_block_start(pTHX_ int full)
 {
+    PERL_ARGS_ASSERT_BLOCK_START;
+
     const int retval = PL_savestack_ix;
 
     PL_compiling.cop_seq = PL_cop_seqmax;
@@ -4645,6 +4697,8 @@ possibly modified.
 OP*
 Perl_block_end(pTHX_ I32 floor, OP *seq)
 {
+    PERL_ARGS_ASSERT_BLOCK_END;
+
     const int needblockscope = PL_hints & HINT_BLOCK_SCOPE;
     OP* retval = voidnonfinal(seq);
     OP *o;
@@ -5227,6 +5281,8 @@ S_fold_constants(pTHX_ OP *const o)
 static void
 S_gen_constant_list(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_GEN_CONSTANT_LIST;
+
     OP *curop, *old_next;
     SV * const oldwarnhook = PL_warnhook;
     SV * const olddiehook  = PL_diehook;
@@ -5545,6 +5601,8 @@ is null, the other is returned unchanged.
 OP *
 Perl_op_append_elem(pTHX_ I32 type, OP *first, OP *last)
 {
+    PERL_ARGS_ASSERT_OP_APPEND_ELEM;
+
     if (!first)
         return last;
 
@@ -5578,6 +5636,8 @@ the other is returned unchanged.
 OP *
 Perl_op_append_list(pTHX_ I32 type, OP *first, OP *last)
 {
+    PERL_ARGS_ASSERT_OP_APPEND_LIST;
+
     if (!first)
         return last;
 
@@ -5616,6 +5676,8 @@ the other is returned unchanged.
 OP *
 Perl_op_prepend_elem(pTHX_ I32 type, OP *first, OP *last)
 {
+    PERL_ARGS_ASSERT_OP_PREPEND_ELEM;
+
     if (!first)
         return last;
 
@@ -5655,6 +5717,8 @@ C<op_convert_list> to make it the right type.
 OP *
 Perl_op_convert_list(pTHX_ I32 type, I32 flags, OP *o)
 {
+    PERL_ARGS_ASSERT_OP_CONVERT_LIST;
+
     if (type < 0) type = -type, flags |= OPf_SPECIAL;
     if (type == OP_RETURN) {
         if (FEATURE_MODULE_TRUE_IS_ENABLED)
@@ -5723,6 +5787,8 @@ empty list expression.
 OP *
 Perl_newNULLLIST(pTHX)
 {
+    PERL_ARGS_ASSERT_NEWNULLLIST;
+
     return newOP(OP_STUB, 0);
 }
 
@@ -5742,6 +5808,8 @@ Perl_newNULLLIST(pTHX)
 static OP *
 S_force_list(pTHX_ OP *o, bool nullit)
 {
+    PERL_ARGS_ASSERT_FORCE_LIST;
+
     if (!o || o->op_type != OP_LIST) {
         OP *rest = NULL;
         if (o) {
@@ -5776,6 +5844,8 @@ context; as
 OP *
 Perl_op_force_list(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_OP_FORCE_LIST;
+
     return force_list(o, TRUE);
 }
 
@@ -5804,6 +5874,8 @@ need to create a temporary plain C<OP_LIST> in a new variable.
 OP *
 Perl_newLISTOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
 {
+    PERL_ARGS_ASSERT_NEWLISTOP;
+
     LISTOP *listop;
     /* Note that allocating an OP_PUSHMARK can die under Safe.pm if
      * pushmark is banned. So do it now while existing ops are in a
@@ -5866,6 +5938,8 @@ L</op_convert_list>.
 OP *
 Perl_newLISTOPn(pTHX_ I32 type, I32 flags, ...)
 {
+    PERL_ARGS_ASSERT_NEWLISTOPN;
+
     va_list args;
     va_start(args, flags);
 
@@ -5894,6 +5968,8 @@ of C<op_private>.
 OP *
 Perl_newOP(pTHX_ I32 type, I32 flags)
 {
+    PERL_ARGS_ASSERT_NEWOP;
+
     OP *o;
 
     if (type == -OP_ENTEREVAL) {
@@ -5937,6 +6013,8 @@ of the constructed op tree.
 OP *
 Perl_newUNOP(pTHX_ I32 type, I32 flags, OP *first)
 {
+    PERL_ARGS_ASSERT_NEWUNOP;
+
     UNOP *unop;
 
     if (type == -OP_ENTEREVAL) {
@@ -5987,6 +6065,8 @@ initialised to C<aux>
 OP *
 Perl_newUNOP_AUX(pTHX_ I32 type, I32 flags, OP *first, UNOP_AUX_item *aux)
 {
+    PERL_ARGS_ASSERT_NEWUNOP_AUX;
+
     UNOP_AUX *unop;
 
     assert((PL_opargs[type] & OA_CLASS_MASK) == OA_UNOP_AUX
@@ -6026,6 +6106,8 @@ Supported optypes: C<OP_METHOD>.
 static OP*
 S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP* dynamic_meth, SV* const_meth)
 {
+    PERL_ARGS_ASSERT_NEWMETHOP_INTERNAL;
+
     METHOP *methop;
 
     assert((PL_opargs[type] & OA_CLASS_MASK) == OA_METHOP
@@ -6103,6 +6185,8 @@ by this function and become part of the constructed op tree.
 OP *
 Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
 {
+    PERL_ARGS_ASSERT_NEWBINOP;
+
     BINOP *binop;
 
     ASSUME((PL_opargs[type] & OA_CLASS_MASK) == OA_BINOP
@@ -6264,6 +6348,8 @@ Perl_invmap_dump(pTHX_ SV* invlist, UV *map)
 static const char *
 S_get_displayable_tr_operand(pTHX_ const U8 * s, STRLEN len, bool is_utf8)
 {
+    PERL_ARGS_ASSERT_GET_DISPLAYABLE_TR_OPERAND;
+
     SV * output = sv_2mortal(newSVpvs(""));
     if (is_utf8) {
         return pv_uni_display(output, s, len, 1000, UNI_DISPLAY_TR_);
@@ -7665,6 +7751,8 @@ and, shifted up eight bits, the eight bits of C<op_private>.
 OP *
 Perl_newPMOP(pTHX_ I32 type, I32 flags)
 {
+    PERL_ARGS_ASSERT_NEWPMOP;
+
     PMOP *pmop;
 
     assert((PL_opargs[type] & OA_CLASS_MASK) == OA_PMOP
@@ -8187,7 +8275,9 @@ Constructs and returns an op to access C<$_>.
 OP *
 Perl_newDEFSVOP(pTHX)
 {
-        return newSVREF(newGVOP(OP_GV, 0, PL_defgv));
+    PERL_ARGS_ASSERT_NEWDEFSVOP;
+
+    return newSVREF(newGVOP(OP_GV, 0, PL_defgv));
 }
 
 #ifdef USE_ITHREADS
@@ -8276,6 +8366,8 @@ have been allocated using C<PerlMemShared_malloc>.
 OP *
 Perl_newPVOP(pTHX_ I32 type, I32 flags, char *pv)
 {
+    PERL_ARGS_ASSERT_NEWPVOP;
+
     const bool utf8 = cBOOL(flags & SVf_UTF8);
     PVOP *pvop;
 
@@ -8730,6 +8822,8 @@ constructed op tree.
 OP *
 Perl_newSLICEOP(pTHX_ I32 flags, OP *subscript, OP *listval)
 {
+    PERL_ARGS_ASSERT_NEWSLICEOP;
+
     return newBINOP(OP_LSLICE, flags,
             list(op_force_list(subscript)),
             list(op_force_list(listval)));
@@ -8748,6 +8842,8 @@ Perl_newSLICEOP(pTHX_ I32 flags, OP *subscript, OP *listval)
 static I32
 S_assignment_type(pTHX_ const OP *o)
 {
+    PERL_ARGS_ASSERT_ASSIGNMENT_TYPE;
+
     unsigned type;
     U8 flags;
     U8 ret;
@@ -8884,6 +8980,8 @@ set as required.
 OP *
 Perl_newASSIGNOP(pTHX_ I32 flags, OP *left, I32 optype, OP *right)
 {
+    PERL_ARGS_ASSERT_NEWASSIGNOP;
+
     OP *o;
     I32 assign_type;
 
@@ -9097,6 +9195,8 @@ is consumed by this function and becomes part of the returned op tree.
 OP *
 Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
 {
+    PERL_ARGS_ASSERT_NEWSTATEOP;
+
     const U32 seq = intro_my();
     const U32 utf8 = flags & SVf_UTF8;
     COP *cop;
@@ -9844,6 +9944,8 @@ OP *
 Perl_newWHILEOP(pTHX_ I32 flags, I32 debuggable, LOOP *loop,
         OP *expr, OP *block, OP *cont, I32 has_my)
 {
+    PERL_ARGS_ASSERT_NEWWHILEOP;
+
     OP *redo;
     OP *next = NULL;
     OP *listop;
@@ -10404,6 +10506,8 @@ Perl_newLOOPEX(pTHX_ I32 type, OP *label)
 static OP *
 S_ref_array_or_hash(pTHX_ OP *cond)
 {
+    PERL_ARGS_ASSERT_REF_ARRAY_OR_HASH;
+
     if (cond
     && (cond->op_type == OP_RV2AV
     ||  cond->op_type == OP_PADAV
@@ -10798,6 +10902,8 @@ L<perlsub/"Constant Functions">.
 SV *
 Perl_cv_const_sv(const CV *const cv)
 {
+    PERL_ARGS_ASSERT_CV_CONST_SV;
+
     SV *sv;
     if (!cv)
         return NULL;
@@ -10811,6 +10917,8 @@ Perl_cv_const_sv(const CV *const cv)
 SV *
 Perl_cv_const_sv_or_av(const CV * const cv)
 {
+    PERL_ARGS_ASSERT_CV_CONST_SV_OR_AV;
+
     if (!cv)
         return NULL;
     if (SvROK(cv)) return SvRV((SV *)cv);
@@ -11403,6 +11511,8 @@ CV *
 Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
                             OP *block, bool o_is_gv)
 {
+    PERL_ARGS_ASSERT_NEWATTRSUB_X;
+
     GV *gv;
     const char *ps;
     STRLEN ps_len = 0; /* init it to avoid false uninit warning from icc */
@@ -12504,6 +12614,8 @@ Constructs, checks, and returns a format op.
 void
 Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block)
 {
+    PERL_ARGS_ASSERT_NEWFORM;
+
     CV *cv;
     GV *gv;
     OP *root;
@@ -12568,6 +12680,8 @@ Constructs, checks, and returns an anonymous list op.
 OP *
 Perl_newANONLIST(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_NEWANONLIST;
+
     return (o) ? op_convert_list(OP_ANONLIST, OPf_SPECIAL, o)
                : newOP(OP_EMPTYAVHV, 0);
 }
@@ -12583,6 +12697,8 @@ Constructs, checks, and returns an anonymous hash op.
 OP *
 Perl_newANONHASH(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_NEWANONHASH;
+
     OP * anon = (o) ? op_convert_list(OP_ANONHASH, OPf_SPECIAL, o)
                     : newOP(OP_EMPTYAVHV, 0);
     if (!o)
@@ -12606,6 +12722,8 @@ For more details, see L<perlintern/C<newATTRSUB_x>>.
 OP *
 Perl_newANONSUB(pTHX_ I32 floor, OP *proto, OP *block)
 {
+    PERL_ARGS_ASSERT_NEWANONSUB;
+
     return newANONATTRSUB(floor, proto, NULL, block);
 }
 
@@ -12625,6 +12743,8 @@ For more details, see L<perlintern/C<newATTRSUB_x>>.
 OP *
 Perl_newANONATTRSUB(pTHX_ I32 floor, OP *proto, OP *attrs, OP *block)
 {
+    PERL_ARGS_ASSERT_NEWANONATTRSUB;
+
     SV * const cv = MUTABLE_SV(newATTRSUB(floor, 0, proto, attrs, block));
 
     bool is_const = CvANONCONST(cv);
@@ -12730,6 +12850,8 @@ Constructs, checks, and returns a glob reference op.
 OP *
 Perl_newGVREF(pTHX_ I32 type, OP *o)
 {
+    PERL_ARGS_ASSERT_NEWGVREF;
+
     switch(type) {
         /* The thing that looks like a GVREF at the start of these operators
          * isn't really */
@@ -12785,6 +12907,8 @@ Constructs, checks, and returns a code reference op.
 OP *
 Perl_newCVREF(pTHX_ I32 flags, OP *o)
 {
+    PERL_ARGS_ASSERT_NEWCVREF;
+
     if (o->op_type == OP_PADANY) {
         OpTYPE_set(o, OP_PADCV);
     }
@@ -14181,6 +14305,8 @@ Perl_ck_sassign(pTHX_ OP *o)
 static void
 S_check_alt_hash_fields_hekify(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CHECK_ALT_HASH_FIELDS_HEKIFY;
+
     OP *sib = o;
 
     if (OP_TYPE_IS_OR_WAS(o, OP_LIST)) {
@@ -14233,6 +14359,8 @@ S_check_alt_hash_fields_hekify(pTHX_ OP *o)
 OP *
 Perl_ck_aassign(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_AASSIGN;
+
     OP * const last = cBINOPo->op_last;
     if (last && OP_TYPE_IS_OR_WAS(last, OP_LIST)) {
         OP * const sib = cLISTOPx(last)->op_first;
@@ -14250,6 +14378,8 @@ Perl_ck_aassign(pTHX_ OP *o)
 OP *
 Perl_ck_anonhash(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_ANONHASH;
+
     check_alt_hash_fields_hekify(cLISTOPo->op_first);
     return ck_fun(o);
 }
@@ -14336,6 +14466,8 @@ Perl_ck_null(pTHX_ OP *o)
 static bool
 S_is_dup_mode(const OP *o)
 {
+    PERL_ARGS_ASSERT_IS_DUP_MODE;
+
     if (o->op_type != OP_CONST) {
         return false;
     }
@@ -15055,6 +15187,8 @@ subroutine.
 CV *
 Perl_find_lexical_cv(pTHX_ PADOFFSET off)
 {
+    PERL_ARGS_ASSERT_FIND_LEXICAL_CV;
+
     const PADNAME *name = PAD_COMPNAME(off);
     CV *compcv = PL_compcv;
     while (PadnameOUTER(name)) {
@@ -16776,6 +16910,8 @@ const_av_xsub(pTHX_ CV* cv)
 char *
 Perl_dup_warnings(pTHX_ char* warnings)
 {
+    PERL_ARGS_ASSERT_DUP_WARNINGS;
+
     if (warnings == NULL || specialWARN(warnings))
         return warnings;
 

--- a/op.c
+++ b/op.c
@@ -211,7 +211,8 @@ Perl_op_prune_chain_head(OP** op_p)
 
 /* rounds up to nearest pointer */
 PERL_STATIC_INLINE U16
-S_size_to_psize(size_t sz) {
+S_size_to_psize(size_t sz)
+{
     size_t psize = (sz + sizeof(I32 *) - 1) / sizeof(I32 *);
     assert(psize <= U16_MAX);
 
@@ -225,7 +226,8 @@ S_size_to_psize(size_t sz) {
 */
 
 PERL_STATIC_INLINE U16
-S_opslab_slot_offset(const OPSLAB *slab, const OPSLOT *slot) {
+S_opslab_slot_offset(const OPSLAB *slab, const OPSLOT *slot)
+{
     PERL_ARGS_ASSERT_OPSLAB_SLOT_OFFSET;
 
     const char *base = (const char *)&slab->opslab_slots;
@@ -294,7 +296,8 @@ S_new_slab(pTHX_ OPSLAB *head, size_t sz)
 
 #define link_freed_op(slab, o) S_link_freed_op(aTHX_ slab, o)
 static void
-S_link_freed_op(pTHX_ OPSLAB *slab, OP *o) {
+S_link_freed_op(pTHX_ OPSLAB *slab, OP *o)
+{
     U16 sz = OpSLOT(o)->opslot_size;
     U16 index = OPSLOT_SIZE_TO_INDEX(sz);
 
@@ -751,7 +754,8 @@ S_is_standard_filehandle_name(const char *fhname) {
 }
 
 void
-Perl_no_bareword_filehandle(pTHX_ const char *fhname) {
+Perl_no_bareword_filehandle(pTHX_ const char *fhname)
+{
     PERL_ARGS_ASSERT_NO_BAREWORD_FILEHANDLE;
 
     if (!is_standard_filehandle_name(fhname)) {
@@ -4979,7 +4983,8 @@ S_op_integerize(pTHX_ OP *o)
    it uses setjmp
  */
 static int
-S_fold_constants_eval(pTHX) {
+S_fold_constants_eval(pTHX)
+{
     int ret = 0;
     dJMPENV;
 
@@ -6019,7 +6024,8 @@ Supported optypes: C<OP_METHOD>.
 */
 
 static OP*
-S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP* dynamic_meth, SV* const_meth) {
+S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP* dynamic_meth, SV* const_meth)
+{
     METHOP *methop;
 
     assert((PL_opargs[type] & OA_CLASS_MASK) == OA_METHOP
@@ -6054,7 +6060,8 @@ S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP* dynamic_meth, SV* const_meth
 }
 
 OP *
-Perl_newMETHOP (pTHX_ I32 type, I32 flags, OP* dynamic_meth) {
+Perl_newMETHOP (pTHX_ I32 type, I32 flags, OP* dynamic_meth)
+{
     PERL_ARGS_ASSERT_NEWMETHOP;
     return newMETHOP_internal(type, flags, dynamic_meth, NULL);
 }
@@ -6073,7 +6080,8 @@ Supported optypes: C<OP_METHOD_NAMED>.
 */
 
 OP *
-Perl_newMETHOP_named (pTHX_ I32 type, I32 flags, SV* const_meth) {
+Perl_newMETHOP_named (pTHX_ I32 type, I32 flags, SV* const_meth)
+{
     PERL_ARGS_ASSERT_NEWMETHOP_NAMED;
     return newMETHOP_internal(type, flags, NULL, const_meth);
 }
@@ -9935,7 +9943,8 @@ Perl_newWHILEOP(pTHX_ I32 flags, I32 debuggable, LOOP *loop,
 
 #define find_argop_from_entersub(op) S_find_argop_from_entersub(op)
 static OP *
-S_find_argop_from_entersub(OP *entersubop) {
+S_find_argop_from_entersub(OP *entersubop)
+{
     assert(entersubop != NULL);
 
     OP *aop = cUNOPx(entersubop)->op_first;
@@ -9950,7 +9959,8 @@ S_find_argop_from_entersub(OP *entersubop) {
 
 #define find_cvop_from_argop(op) S_find_cvop_from_argop(op)
 static OP *
-S_find_cvop_from_argop(OP *cvop)  {
+S_find_cvop_from_argop(OP *cvop)
+{
     assert(cvop != NULL);
 
     /* CV is the last argument to entersub */
@@ -15947,7 +15957,8 @@ Perl_ck_tell(pTHX_ OP *o)
 }
 
 PERL_STATIC_INLINE OP *
-S_last_non_null_kid(OP *o) {
+S_last_non_null_kid(OP *o)
+{
     OP *last = NULL;
     if (cUNOPo->op_flags & OPf_KIDS) {
         OP *k = cLISTOPo->op_first;
@@ -16125,7 +16136,8 @@ Perl_ck_isa(pTHX_ OP *o)
    and modify the optree to make them work inplace */
 
 static void
-S_inplace_aassign(pTHX_ OP *o) {
+S_inplace_aassign(pTHX_ OP *o)
+{
 
     OP *modop, *modop_pushmark;
     OP *oright;
@@ -16804,7 +16816,8 @@ the input content.
 */
 
 char *
-Perl_rcpv_new(pTHX_ const char *pv, STRLEN len, U32 flags) {
+Perl_rcpv_new(pTHX_ const char *pv, STRLEN len, U32 flags)
+{
     RCPV *rcpv;
 
     PERL_ARGS_ASSERT_RCPV_NEW;
@@ -16859,7 +16872,8 @@ Always returns NULL so it can be used like this:
 */
 
 char *
-Perl_rcpv_free(pTHX_ char *pv) {
+Perl_rcpv_free(pTHX_ char *pv)
+{
 
     PERL_ARGS_ASSERT_RCPV_FREE;
 
@@ -16899,7 +16913,8 @@ Returns the same pointer that was passed in.
 
 
 char *
-Perl_rcpv_copy(pTHX_ char *pv) {
+Perl_rcpv_copy(pTHX_ char *pv)
+{
 
     PERL_ARGS_ASSERT_RCPV_COPY;
 

--- a/pad.c
+++ b/pad.c
@@ -192,6 +192,8 @@ flags can be OR'ed together:
 PADLIST *
 Perl_pad_new(pTHX_ int flags)
 {
+    PERL_ARGS_ASSERT_PAD_NEW;
+
     PADLIST *padlist;
     PADNAMELIST *padname;
     PAD *pad;
@@ -723,6 +725,8 @@ but is used for debugging.
 PADOFFSET
 Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype)
 {
+    PERL_ARGS_ASSERT_PAD_ALLOC;
+
     SV *sv;
     PADOFFSET retval;
 
@@ -1059,6 +1063,8 @@ Returns the global variable C<$_>.
 SV *
 Perl_find_rundefsv(pTHX)
 {
+    PERL_ARGS_ASSERT_FIND_RUNDEFSV;
+
     return DEFSV;
 }
 
@@ -1378,6 +1384,8 @@ Use macro C<PAD_SV> instead of calling this function directly.
 SV *
 Perl_pad_sv(pTHX_ PADOFFSET po)
 {
+    PERL_ARGS_ASSERT_PAD_SV;
+
     ASSERT_CURPAD_ACTIVE("pad_sv");
 
     if (!po)
@@ -1425,7 +1433,9 @@ Update the pad compilation state variables on entry to a new block.
 void
 Perl_pad_block_start(pTHX_ int full)
 {
+    PERL_ARGS_ASSERT_PAD_BLOCK_START;
     ASSERT_CURPAD_ACTIVE("pad_block_start");
+
     SAVESTRLEN(PL_comppad_name_floor);
     PL_comppad_name_floor = PadnamelistMAX(PL_comppad_name);
     if (full)
@@ -1460,6 +1470,8 @@ statements.
 U32
 Perl_intro_my(pTHX)
 {
+    PERL_ARGS_ASSERT_INTRO_MY;
+
     PADNAME **svp;
     PADOFFSET i;
     U32 seq;
@@ -1512,6 +1524,8 @@ lexicals in this scope and warn of any lexicals that never got introduced.
 OP *
 Perl_pad_leavemy(pTHX)
 {
+    PERL_ARGS_ASSERT_PAD_LEAVEMY;
+
     PADOFFSET off;
     OP *o = NULL;
     PADNAME * const * const svp = PadnamelistARRAY(PL_comppad_name);
@@ -1568,7 +1582,9 @@ new one.
 void
 Perl_pad_swipe(pTHX_ PADOFFSET po, bool refadjust)
 {
+    PERL_ARGS_ASSERT_PAD_SWIPE;
     ASSERT_CURPAD_LEGAL("pad_swipe");
+
     if (!PL_curpad)
         return;
     if (AvARRAY(PL_comppad) != PL_curpad)
@@ -1624,6 +1640,8 @@ Mark all the current temporaries for reuse
 static void
 S_pad_reset(pTHX)
 {
+    PERL_ARGS_ASSERT_PAD_RESET;
+
 #ifdef USE_PAD_RESET
     if (AvARRAY(PL_comppad) != PL_curpad)
         croak("panic: pad_reset curpad, %p!=%p",
@@ -1661,7 +1679,7 @@ the kind of subroutine:
 void
 Perl_pad_tidy(pTHX_ padtidy_type type)
 {
-
+    PERL_ARGS_ASSERT_PAD_TIDY;
     ASSERT_CURPAD_ACTIVE("pad_tidy");
 
     /* If this CV has had any 'eval-capable' ops planted in it:
@@ -1773,6 +1791,8 @@ Free the SV at offset po in the current pad.
 void
 Perl_pad_free(pTHX_ PADOFFSET po)
 {
+    PERL_ARGS_ASSERT_PAD_FREE;
+
 #ifndef USE_PAD_RESET
     SV *sv;
 #endif
@@ -2656,6 +2676,8 @@ is allocated.
 PADNAMELIST *
 Perl_newPADNAMELIST(size_t max)
 {
+    PERL_ARGS_ASSERT_NEWPADNAMELIST;
+
     PADNAMELIST *pnl;
     Newx(pnl, 1, PADNAMELIST);
     Newxz(PadnamelistARRAY(pnl), max+1, PADNAME *);

--- a/pad.c
+++ b/pad.c
@@ -160,7 +160,8 @@ Points directly to the body of the L</PL_comppad> array.
 
 #ifdef DEBUGGING
 void
-Perl_set_padlist(CV * cv, PADLIST *padlist){
+Perl_set_padlist(CV * cv, PADLIST *padlist)
+{
     PERL_ARGS_ASSERT_SET_PADLIST;
 #  if PTRSIZE == 8
     assert((Size_t)padlist != UINT64_C(0xEFEFEFEFEFEFEFEF));
@@ -2980,7 +2981,8 @@ Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer)
 
 /* interface compatible with SAVEDESTRUCTOR_X */
 static void
-S_suspend_compcv_destruct(pTHX_ void *p) {
+S_suspend_compcv_destruct(pTHX_ void *p)
+{
     suspend_compcv((struct suspended_compcv *)p);
 }
 

--- a/peep.c
+++ b/peep.c
@@ -1214,7 +1214,8 @@ For now it's static, but it may be exposed to the API in the future.
 */
 
 static OP*
-S_traverse_op_tree(pTHX_ OP *top, OP *o) {
+S_traverse_op_tree(pTHX_ OP *top, OP *o)
+{
     OP *sib;
 
     PERL_ARGS_ASSERT_TRAVERSE_OP_TREE;

--- a/peep.c
+++ b/peep.c
@@ -2707,6 +2707,8 @@ S_check_for_bool_cxt(OP*o, bool safe_and, U8 bool_flag, U8 maybe_flag)
 void
 Perl_rpeep(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_RPEEP;
+
     OP* oldop = NULL;
     OP* oldoldop = NULL;
     OP** defer_queue[MAX_DEFERRED] = { NULL }; /* small queue of deferred branches */
@@ -4426,6 +4428,8 @@ Perl_rpeep(pTHX_ OP *o)
 void
 Perl_peep(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_PEEP;
+
     CALL_RPEEP(o);
 }
 

--- a/perl.c
+++ b/perl.c
@@ -160,6 +160,8 @@ Perl_sys_init3(int* argc, char*** argv, char*** env)
 void
 Perl_sys_term(void)
 {
+    PERL_ARGS_ASSERT_SYS_TERM;
+
     if (!PL_veto_cleanup) {
         PERL_SYS_TERM_BODY();
     }
@@ -209,6 +211,8 @@ Allocates a new Perl interpreter.  See L<perlembed>.
 PerlInterpreter *
 perl_alloc(void)
 {
+    PERL_ARGS_ASSERT_PERL_ALLOC;
+
     PerlInterpreter *my_perl = (PerlInterpreter*)PerlMem_calloc(1, sizeof(PerlInterpreter));
 
     S_init_tls_and_interp(my_perl);
@@ -477,7 +481,9 @@ no threads.
 int
 Perl_nothreadhook(pTHX)
 {
+    PERL_ARGS_ASSERT_NOTHREADHOOK;
     PERL_UNUSED_CONTEXT;
+
     return 0;
 }
 
@@ -492,6 +498,7 @@ Stub that provides shutdown hook.
 void
 Perl_noshutdownhook()
 {
+    PERL_ARGS_ASSERT_NOSHUTDOWNHOOK;
 }
 
 #ifdef DEBUG_LEAKING_SCALARS_FORK_DUMP
@@ -1661,6 +1668,8 @@ list is executed each time the current or any descendent thread terminates.
 void
 Perl_call_atexit(pTHX_ ATEXIT_t fn, void *ptr)
 {
+    PERL_ARGS_ASSERT_CALL_ATEXIT;
+
     Renew(PL_exitlist, PL_exitlistlen+1, PerlExitListEntry);
     PL_exitlist[PL_exitlistlen].fn = fn;
     PL_exitlist[PL_exitlistlen].ptr = ptr;
@@ -2200,6 +2209,8 @@ S_moreswitch_m(pTHX_ char option, const char *s)
 static void *
 S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
 {
+    PERL_ARGS_ASSERT_PARSE_BODY;
+
     PerlIO *rsfp;
     int argc = PL_origargc;
     char **argv = PL_origargv;
@@ -2829,6 +2840,8 @@ perl_run(pTHXx)
 static void
 S_run_body(pTHX_ I32 oldscope)
 {
+    PERL_ARGS_ASSERT_RUN_BODY;
+
     DEBUG_r(PerlIO_printf(Perl_debug_log, "%s $` $& $' support (0x%x).\n",
                     PL_sawampersand ? "Enabling" : "Omitting",
                     (unsigned int)(PL_sawampersand)));
@@ -3525,6 +3538,8 @@ Perl_require_pv(pTHX_ const char *pv)
 static void
 S_usage(pTHX)		/* XXX move this out into a module ? */
 {
+    PERL_ARGS_ASSERT_USAGE;
+
     /* This message really ought to be max 23 lines.
      * Removed -h because the user already knows that option. Others? */
 
@@ -3974,6 +3989,8 @@ Perl_moreswitches(pTHX_ const char *s)
 static void
 S_minus_v(pTHX)
 {
+    PERL_ARGS_ASSERT_MINUS_V;
+
         PerlIO * PIO_stdout;
         {
             const char * const level_str = "v" PERL_VERSION_STRING;
@@ -4066,6 +4083,8 @@ Internet, point your browser at https://www.perl.org/, the Perl Home Page.\n\n")
 void
 Perl_my_unexec(pTHX)
 {
+    PERL_ARGS_ASSERT_MY_UNEXEC;
+
 #ifdef UNEXEC
     SV *    prog = newSVpv(BIN_EXP, 0);
     SV *    file = newSVpv(PL_origfilename, 0);
@@ -4094,6 +4113,8 @@ Perl_my_unexec(pTHX)
 static void
 S_init_interp(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_INTERP;
+
 #ifdef MULTIPLICITY
 #  define PERLVAR(prefix,var,type)
 #  define PERLVARA(prefix,var,n,type)
@@ -4126,6 +4147,8 @@ S_init_interp(pTHX)
 static void
 S_init_main_stash(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_MAIN_STASH;
+
     GV *gv;
     HV *hv = newHV();
 
@@ -4368,6 +4391,8 @@ S_find_beginning(pTHX_ SV* linestr_sv, PerlIO *rsfp)
 static void
 S_init_ids(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_IDS;
+
     /* no need to do anything here any more if we don't
      * do tainting. */
 #ifndef NO_TAINT_SUPPORT
@@ -4399,6 +4424,8 @@ S_init_ids(pTHX)
 bool
 Perl_doing_taint(int argc, char *argv[], char *envp[])
 {
+    PERL_ARGS_ASSERT_DOING_TAINT;
+
 #ifdef PERL_IMPLICIT_SYS
     PERL_UNUSED_ARG(envp);
 #else
@@ -4439,6 +4466,8 @@ Perl_doing_taint(int argc, char *argv[], char *envp[])
 static void
 S_forbid_setid(pTHX_ const char flag, const bool suidscript) /* g */
 {
+    PERL_ARGS_ASSERT_FORBID_SETID;
+
     char string[3] = "-x";
     const char *message = "program input from stdin";
 
@@ -4461,6 +4490,8 @@ S_forbid_setid(pTHX_ const char flag, const bool suidscript) /* g */
 void
 Perl_init_dbargs(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_DBARGS;
+
     AV *const args = PL_dbargs = GvAV(gv_AVadd((gv_fetchpvs("DB::args",
                                                             GV_ADDMULTI,
                                                             SVt_PVAV))));
@@ -4479,6 +4510,8 @@ Perl_init_dbargs(pTHX)
 void
 Perl_init_debugger(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_DEBUGGER;
+
     HV * const ostash = PL_curstash;
     MAGIC *mg;
 
@@ -4524,6 +4557,8 @@ Perl_init_debugger(pTHX)
 void
 Perl_init_stacks(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_STACKS;
+
     SSize_t size;
 
 #ifdef PERL_RC_STACK
@@ -4576,6 +4611,8 @@ Perl_init_stacks(pTHX)
 static void
 S_nuke_stacks(pTHX)
 {
+    PERL_ARGS_ASSERT_NUKE_STACKS;
+
     while (PL_curstackinfo->si_next)
         PL_curstackinfo = PL_curstackinfo->si_next;
     while (PL_curstackinfo) {
@@ -4631,6 +4668,8 @@ Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
 static void
 S_init_predump_symbols(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_PREDUMP_SYMBOLS;
+
     GV *tmpgv;
     IO *io;
 
@@ -4893,6 +4932,8 @@ S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
 static void
 S_init_perllib(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_PERLLIB;
+
 #ifndef VMS
     const char *perl5lib = NULL;
 #endif
@@ -5383,6 +5424,8 @@ say to do.
 void
 Perl_my_exit(pTHX_ U32 status)
 {
+    PERL_ARGS_ASSERT_MY_EXIT;
+
     if (PL_exit_flags & PERL_EXIT_ABORT) {
         abort();
     }
@@ -5421,6 +5464,8 @@ On VMS, it takes care to set the appropriate severity bits in the exit status.
 void
 Perl_my_failure_exit(pTHX)
 {
+    PERL_ARGS_ASSERT_MY_FAILURE_EXIT;
+
 #ifdef VMS
      /* We have been called to fall on our sword.  The desired exit code
       * should be already set in STATUS_UNIX, but could be shifted over
@@ -5515,6 +5560,8 @@ Perl_my_failure_exit(pTHX)
 static void
 S_my_exit_jump(pTHX)
 {
+    PERL_ARGS_ASSERT_MY_EXIT_JUMP;
+
     if (PL_e_script) {
         SvREFCNT_dec(PL_e_script);
         PL_e_script = NULL;
@@ -5554,6 +5601,8 @@ read_e_script(pTHX_ int idx, SV *buf_sv, int maxlen)
 void
 Perl_xs_boot_epilog(pTHX_ const SSize_t ax)
 {
+    PERL_ARGS_ASSERT_XS_BOOT_EPILOG;
+
   if (PL_unitcheckav)
         call_list(PL_scopestack_ix, PL_unitcheckav);
     XSRETURN_YES;

--- a/perl.h
+++ b/perl.h
@@ -4641,13 +4641,15 @@ struct ptr_tbl {
    htonl etc they will clash with the declarations in the Win32 headers.  */
 
 PERL_STATIC_INLINE U32
-my_swap32(const U32 x) {
+my_swap32(const U32 x)
+{
     return ((x & 0xFF) << 24) | ((x >> 24) & 0xFF)
         | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8);
 }
 
 PERL_STATIC_INLINE U16
-my_swap16(const U16 x) {
+my_swap16(const U16 x)
+{
     return ((x & 0xFF) << 8) | ((x >> 8) & 0xFF);
 }
 

--- a/perl_siphash.h
+++ b/perl_siphash.h
@@ -219,7 +219,8 @@ do {                                    \
 } while (0)
 
 PERL_STATIC_INLINE
-void S_perl_siphash_seed_state(const unsigned char * const seed_buf, unsigned char * state_buf) {
+void S_perl_siphash_seed_state(const unsigned char * const seed_buf, unsigned char * state_buf)
+{
     U64 *v= (U64*) state_buf;
     SIPHASH_SEED_STATE(seed_buf, v[0],v[1],v[2],v[3]);
 }

--- a/perlio.c
+++ b/perlio.c
@@ -2895,7 +2895,8 @@ S_lockcnt_dec(pTHX_ void* f)
  * this handle, free what we can and return true */
 
 static bool
-S_perlio_async_run(pTHX_ PerlIO* f) {
+S_perlio_async_run(pTHX_ PerlIO* f)
+{
     ENTER;
     SAVEDESTRUCTOR_X(S_lockcnt_dec, (void*)f);
     PerlIO_lockcnt(f)++;

--- a/perlio.c
+++ b/perlio.c
@@ -315,6 +315,8 @@ XS(XS_PerlIO__Layer__find)
 void
 Perl_boot_core_PerlIO(pTHX)
 {
+    PERL_ARGS_ASSERT_BOOT_CORE_PERLIO;
+
     newXS("PerlIO::Layer::find", XS_PerlIO__Layer__find, __FILE__);
 }
 
@@ -1523,6 +1525,8 @@ PerlIO_default_layers(pTHX)
 void
 Perl_boot_core_PerlIO(pTHX)
 {
+    PERL_ARGS_ASSERT_BOOT_CORE_PERLIO;
+
 #ifdef USE_ATTRIBUTES_FOR_PERLIO
     newXS("io::MODIFY_SCALAR_ATTRIBUTES", XS_io_MODIFY_SCALAR_ATTRIBUTES,
           __FILE__);
@@ -1810,6 +1814,8 @@ PerlIO__close(pTHX_ PerlIO *f)
 int
 Perl_PerlIO_close(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_CLOSE;
+
     const int code = PerlIO__close(aTHX_ f);
     while (PerlIOValid(f)) {
         PerlIO_pop(aTHX_ f);
@@ -1823,6 +1829,8 @@ Perl_PerlIO_close(pTHX_ PerlIO *f)
 int
 Perl_PerlIO_fileno(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_FILENO;
+
     Perl_PerlIO_or_Base(f, Fileno, fileno, -1, (aTHX_ f));
 }
 
@@ -2023,18 +2031,24 @@ Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
 int
 Perl_PerlIO_seek(pTHX_ PerlIO *f, Off_t offset, int whence)
 {
+    PERL_ARGS_ASSERT_PERLIO_SEEK;
+
      Perl_PerlIO_or_fail(f, Seek, -1, (aTHX_ f, offset, whence));
 }
 
 Off_t
 Perl_PerlIO_tell(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_TELL;
+
      Perl_PerlIO_or_fail(f, Tell, -1, (aTHX_ f));
 }
 
 int
 Perl_PerlIO_flush(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_FLUSH;
+
     if (f) {
         if (*f) {
             const PerlIO_funcs *tab = PerlIOBase(f)->tab;
@@ -2098,6 +2112,8 @@ PerlIOBase_flush_linebuf(pTHX)
 int
 Perl_PerlIO_fill(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_FILL;
+
      Perl_PerlIO_or_fail(f, Fill, -1, (aTHX_ f));
 }
 
@@ -2115,24 +2131,32 @@ PerlIO_isutf8(PerlIO *f)
 int
 Perl_PerlIO_eof(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_EOF;
+
      Perl_PerlIO_or_Base(f, Eof, eof, -1, (aTHX_ f));
 }
 
 int
 Perl_PerlIO_error(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_ERROR;
+
      Perl_PerlIO_or_Base(f, Error, error, -1, (aTHX_ f));
 }
 
 void
 Perl_PerlIO_clearerr(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_CLEARERR;
+
      Perl_PerlIO_or_Base_void(f, Clearerr, clearerr, (aTHX_ f));
 }
 
 void
 Perl_PerlIO_setlinebuf(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_SETLINEBUF;
+
      Perl_PerlIO_or_Base_void(f, Setlinebuf, setlinebuf, (aTHX_ f));
 }
 
@@ -2193,12 +2217,16 @@ PerlIO_canset_cnt(PerlIO *f)
 STDCHAR *
 Perl_PerlIO_get_base(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_GET_BASE;
+
      Perl_PerlIO_or_fail(f, Get_base, NULL, (aTHX_ f));
 }
 
 SSize_t
 Perl_PerlIO_get_bufsiz(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_GET_BUFSIZ;
+
     /* Note that Get_bufsiz returns a Size_t */
      Perl_PerlIO_or_fail(f, Get_bufsiz, -1, (aTHX_ f));
 }
@@ -2206,24 +2234,32 @@ Perl_PerlIO_get_bufsiz(pTHX_ PerlIO *f)
 STDCHAR *
 Perl_PerlIO_get_ptr(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_GET_PTR;
+
      Perl_PerlIO_or_fail(f, Get_ptr, NULL, (aTHX_ f));
 }
 
 SSize_t
 Perl_PerlIO_get_cnt(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_GET_CNT;
+
      Perl_PerlIO_or_fail(f, Get_cnt, -1, (aTHX_ f));
 }
 
 void
 Perl_PerlIO_set_cnt(pTHX_ PerlIO *f, SSize_t cnt)
 {
+    PERL_ARGS_ASSERT_PERLIO_SET_CNT;
+
      Perl_PerlIO_or_fail_void(f, Set_ptrcnt, (aTHX_ f, NULL, cnt));
 }
 
 void
 Perl_PerlIO_set_ptrcnt(pTHX_ PerlIO *f, STDCHAR * ptr, SSize_t cnt)
 {
+    PERL_ARGS_ASSERT_PERLIO_SET_PTRCNT;
+
      Perl_PerlIO_or_fail_void(f, Set_ptrcnt, (aTHX_ f, ptr, cnt));
 }
 
@@ -5265,6 +5301,8 @@ PERLIO_FUNCS_DECL(PerlIO_crlf) = {
 PerlIO *
 Perl_PerlIO_stdin(pTHX)
 {
+    PERL_ARGS_ASSERT_PERLIO_STDIN;
+
     if (!PL_perlio) {
         PerlIO_stdstreams(aTHX);
     }
@@ -5274,6 +5312,8 @@ Perl_PerlIO_stdin(pTHX)
 PerlIO *
 Perl_PerlIO_stdout(pTHX)
 {
+    PERL_ARGS_ASSERT_PERLIO_STDOUT;
+
     if (!PL_perlio) {
         PerlIO_stdstreams(aTHX);
     }
@@ -5283,6 +5323,8 @@ Perl_PerlIO_stdout(pTHX)
 PerlIO *
 Perl_PerlIO_stderr(pTHX)
 {
+    PERL_ARGS_ASSERT_PERLIO_STDERR;
+
     if (!PL_perlio) {
         PerlIO_stdstreams(aTHX);
     }
@@ -5521,6 +5563,8 @@ PerlIO_tmpfile_flags(int imode)
 void
 Perl_PerlIO_save_errno(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_SAVE_ERRNO;
+
     PERL_UNUSED_CONTEXT;
     if (!PerlIOValid(f))
         return;
@@ -5537,6 +5581,8 @@ Perl_PerlIO_save_errno(pTHX_ PerlIO *f)
 void
 Perl_PerlIO_restore_errno(pTHX_ PerlIO *f)
 {
+    PERL_ARGS_ASSERT_PERLIO_RESTORE_ERRNO;
+
     PERL_UNUSED_CONTEXT;
     if (!PerlIOValid(f))
         return;
@@ -5560,6 +5606,8 @@ Perl_PerlIO_restore_errno(pTHX_ PerlIO *f)
 const char *
 Perl_PerlIO_context_layers(pTHX_ const char *mode)
 {
+    PERL_ARGS_ASSERT_PERLIO_CONTEXT_LAYERS;
+
     /* Returns the layers set by "use open" */
 
     const char *direction = NULL;

--- a/perlstatic.h
+++ b/perlstatic.h
@@ -21,6 +21,8 @@ GCC_DIAG_IGNORE_DECL(-Wunused-function);
 static void
 Perl_croak_memory_wrap(void)
 {
+    PERL_ARGS_ASSERT_CROAK_MEMORY_WRAP;
+
     Perl_croak_nocontext("%s",PL_memory_wrap);
 }
 

--- a/perly.c
+++ b/perly.c
@@ -290,6 +290,8 @@ S_clear_yystack(pTHX_ void *arg)
 int
 Perl_yyparse (pTHX_ int gramtype)
 {
+    PERL_ARGS_ASSERT_YYPARSE;
+
     int yystate;
     int yyn;
     int yyresult;

--- a/perly.h
+++ b/perly.h
@@ -199,7 +199,8 @@ extern int yydebug;
 /* Value type.  */
 #ifdef PERL_IN_TOKE_C
 static bool
-S_is_opval_token(int type) {
+S_is_opval_token(int type)
+{
     switch (type) {
     case ATTRLIST:
     case BAREWORD:

--- a/pp.c
+++ b/pp.c
@@ -5505,6 +5505,8 @@ PP_wrapped(pp_each, 1, 0)
 static OP *
 S_do_delete_local(pTHX)
 {
+    PERL_ARGS_ASSERT_DO_DELETE_LOCAL;
+
     dSP;
     const U8 gimme = GIMME_V;
     const bool sliced = cBOOL(PL_op->op_private & OPpSLICE);

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -1642,6 +1642,8 @@ Deprecated since 5.38
 U8
 Perl_dowantarray(pTHX)
 {
+    PERL_ARGS_ASSERT_DOWANTARRAY;
+
     const U8 gimme = block_gimme();
     return (gimme == G_VOID) ? G_SCALAR : gimme;
 }
@@ -1651,6 +1653,8 @@ Perl_dowantarray(pTHX)
 U8
 Perl_block_gimme(pTHX)
 {
+    PERL_ARGS_ASSERT_BLOCK_GIMME;
+
     const I32 cxix = dopopto_cursub();
     U8 gimme;
     if (cxix < 0)
@@ -1674,6 +1678,8 @@ context.  Returns 0 otherwise.
 I32
 Perl_is_lvalue_sub(pTHX)
 {
+    PERL_ARGS_ASSERT_IS_LVALUE_SUB;
+
     const I32 cxix = dopopto_cursub();
     assert(cxix >= 0);  /* We should only be called from inside subs */
 
@@ -1687,6 +1693,8 @@ Perl_is_lvalue_sub(pTHX)
 I32
 Perl_was_lvalue_sub(pTHX)
 {
+    PERL_ARGS_ASSERT_WAS_LVALUE_SUB;
+
     const I32 cxix = dopoptosub(cxstack_ix-1);
     assert(cxix >= 0);  /* We should only be called from inside subs */
 
@@ -1738,6 +1746,8 @@ S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
 static I32
 S_dopoptoeval(pTHX_ I32 startingblock)
 {
+    PERL_ARGS_ASSERT_DOPOPTOEVAL;
+
     I32 i;
     for (i = startingblock; i >= 0; i--) {
         const PERL_CONTEXT *cx = &cxstack[i];
@@ -1755,6 +1765,8 @@ S_dopoptoeval(pTHX_ I32 startingblock)
 static I32
 S_dopoptoloop(pTHX_ I32 startingblock)
 {
+    PERL_ARGS_ASSERT_DOPOPTOLOOP;
+
     I32 i;
     for (i = startingblock; i >= 0; i--) {
         const PERL_CONTEXT * const cx = &cxstack[i];
@@ -1790,6 +1802,8 @@ S_dopoptoloop(pTHX_ I32 startingblock)
 static I32
 S_dopoptogivenfor(pTHX_ I32 startingblock)
 {
+    PERL_ARGS_ASSERT_DOPOPTOGIVENFOR;
+
     I32 i;
     for (i = startingblock; i >= 0; i--) {
         const PERL_CONTEXT *cx = &cxstack[i];
@@ -1818,6 +1832,8 @@ S_dopoptogivenfor(pTHX_ I32 startingblock)
 static I32
 S_dopoptowhen(pTHX_ I32 startingblock)
 {
+    PERL_ARGS_ASSERT_DOPOPTOWHEN;
+
     I32 i;
     for (i = startingblock; i >= 0; i--) {
         const PERL_CONTEXT *cx = &cxstack[i];
@@ -1842,6 +1858,8 @@ S_dopoptowhen(pTHX_ I32 startingblock)
 void
 Perl_dounwind(pTHX_ I32 cxix)
 {
+    PERL_ARGS_ASSERT_DOUNWIND;
+
     if (!PL_curstackinfo) /* can happen if die during thread cloning */
         return;
 
@@ -1908,6 +1926,8 @@ Perl_dounwind(pTHX_ I32 cxix)
 void
 Perl_rpp_obliterate_stack_to(pTHX_ I32 ix)
 {
+    PERL_ARGS_ASSERT_RPP_OBLITERATE_STACK_TO;
+
 #ifdef PERL_RC_STACK
     I32 nonrc_base = PL_curstackinfo->si_stack_nonrc_base;
     assert(ix >= 0);
@@ -2214,6 +2234,8 @@ frame for the sub call itself.
 const PERL_CONTEXT *
 Perl_caller_cx(pTHX_ I32 count, const PERL_CONTEXT **dbcxp)
 {
+    PERL_ARGS_ASSERT_CALLER_CX;
+
     I32 cxix = dopopto_cursub();
     const PERL_CONTEXT *cx;
     const PERL_CONTEXT *ccstack = cxstack;
@@ -3877,6 +3899,8 @@ See L<perlinterp/"Exception handing"> for further details.
 static OP *
 S_docatch(pTHX_ Perl_ppaddr_t firstpp)
 {
+    PERL_ARGS_ASSERT_DOCATCH;
+
     int ret;
     OP * const oldop = PL_op;
     dJMPENV;
@@ -3937,6 +3961,8 @@ rather than in the scope of the debugger itself.)
 CV*
 Perl_find_runcv(pTHX_ U32 *db_seqp)
 {
+    PERL_ARGS_ASSERT_FIND_RUNCV;
+
     return Perl_find_runcv_where(aTHX_ 0, 0, db_seqp);
 }
 
@@ -3944,6 +3970,8 @@ Perl_find_runcv(pTHX_ U32 *db_seqp)
 CV *
 Perl_find_runcv_where(pTHX_ U8 cond, IV arg, U32 *db_seqp)
 {
+    PERL_ARGS_ASSERT_FIND_RUNCV_WHERE;
+
     PERL_SI	 *si;
     int		 level = 0;
 
@@ -4125,6 +4153,8 @@ S_try_run_unitcheck(pTHX_ OP* caller_op)
 static bool
 S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
 {
+    PERL_ARGS_ASSERT_DOEVAL_COMPILE;
+
     OP * const saveop = PL_op;
     bool clear_hints = saveop->op_type != OP_ENTEREVAL;
     COP * const oldcurcop = PL_curcop;
@@ -5759,6 +5789,8 @@ PP(pp_catch)
 void
 Perl_delete_eval_scope(pTHX)
 {
+    PERL_ARGS_ASSERT_DELETE_EVAL_SCOPE;
+
     PERL_CONTEXT *cx;
         
     cx = CX_CUR();
@@ -5943,6 +5975,8 @@ PP(pp_smartmatch)
 static OP *
 S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
 {
+    PERL_ARGS_ASSERT_DO_SMARTMATCH;
+
     bool object_on_left = FALSE;
     SV *e = PL_stack_sp[0];  /* e is for 'expression' */
     SV *d = PL_stack_sp[-1]; /* d is for 'default', as in PL_defgv */
@@ -6876,6 +6910,8 @@ S_doparseform(pTHX_ SV *sv)
 static bool
 S_num_overflow(NV value, I32 fldsize, I32 frcsize)
 {
+    PERL_ARGS_ASSERT_NUM_OVERFLOW;
+
     /* Can value be printed in fldsize chars, using %*.*f ? */
     NV pwr = 1;
     NV eps = 0.5;

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4052,6 +4052,7 @@ error_is_would_block(int err)
 OP *
 Perl_do_readline(pTHX)
 {
+    PERL_ARGS_ASSERT_DO_READLINE;
 
     const I32 type = PL_op->op_type;
 
@@ -6687,6 +6688,8 @@ Perl_sub_crush_depth(pTHX_ CV *cv)
 void
 Perl_croak_caller(const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_CROAK_CALLER;
+
     dTHX;
     va_list args;
     const PERL_CONTEXT *cx = caller_cx(0, NULL);

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -3997,7 +3997,8 @@ PP(pp_match)
    is non-blocking but would have blocked if blocking
 */
 PERL_STATIC_INLINE bool
-error_is_would_block(int err) {
+error_is_would_block(int err)
+{
 #ifdef EAGAIN
     if (err == EAGAIN)
         return true;

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -356,7 +356,8 @@ S_utf8_to_bytes(pTHX_ const char **s, const char *end, U8 *buf, SSize_t buf_len,
 }
 
 static char *
-S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swap) {
+S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swap)
+{
     PERL_ARGS_ASSERT_MY_BYTES_TO_UTF8;
 
     if (UNLIKELY(needs_swap)) {
@@ -824,7 +825,8 @@ S_need_utf8(const char *pat, const char *patend)
 }
 
 static char
-S_first_symbol(const char *pat, const char *patend) {
+S_first_symbol(const char *pat, const char *patend)
+{
     PERL_ARGS_ASSERT_FIRST_SYMBOL;
 
     while (pat < patend) {
@@ -2029,7 +2031,8 @@ Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, 
 
 /* like sv_utf8_upgrade, but also repoint the group start markers */
 static void
-marked_upgrade(pTHX_ SV *sv, tempsym_t *sym_ptr) {
+marked_upgrade(pTHX_ SV *sv, tempsym_t *sym_ptr)
+{
     STRLEN len;
     tempsym_t *group;
     const char *from_ptr, *from_start, *from_end, **marks, **m;
@@ -2097,7 +2100,8 @@ marked_upgrade(pTHX_ SV *sv, tempsym_t *sym_ptr) {
    Only grows the string if there is an actual lack of space
 */
 static char *
-S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed) {
+S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
+{
     const STRLEN cur = SvCUR(sv);
     const STRLEN len = SvLEN(sv);
     STRLEN extend;

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -4276,6 +4276,8 @@ PP_wrapped(pp_open_dir, 2, 0)
 static void
 S_warn_not_dirhandle(pTHX_ GV *gv)
 {
+    PERL_ARGS_ASSERT_WARN_NOT_DIRHANDLE;
+
     IO *io = GvIOn(gv);
 
     if (IoIFP(io)) {
@@ -4293,6 +4295,7 @@ S_warn_not_dirhandle(pTHX_ GV *gv)
 
 PP_wrapped(pp_readdir, 1, 0)
 {
+
 #if !defined(Direntry_t) || !defined(HAS_READDIR)
     DIE(aTHX_ PL_no_dir_func, "readdir");
 #else
@@ -5225,6 +5228,8 @@ PP_wrapped(pp_semctl, 0, 1)
 static SV *
 S_space_join_names_mortal(pTHX_ char *const *array)
 {
+    PERL_ARGS_ASSERT_SPACE_JOIN_NAMES_MORTAL;
+
     SV *target;
 
     if (array && *array) {

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -3303,7 +3303,8 @@ PP_wrapped(pp_stat, !(PL_op->op_flags & OPf_REF), 0)
 */
 
 static OP *
-S_ft_return_false(pTHX_ SV *ret) {
+S_ft_return_false(pTHX_ SV *ret)
+{
     OP *next = NORMAL;
 
     if (PL_op->op_flags & OPf_REF) {
@@ -3321,7 +3322,8 @@ S_ft_return_false(pTHX_ SV *ret) {
 }
 
 PERL_STATIC_INLINE OP *
-S_ft_return_true(pTHX_ SV *ret) {
+S_ft_return_true(pTHX_ SV *ret)
+{
     if (PL_op->op_flags & OPf_REF) {
         rpp_xpush_1((PL_op->op_private & OPpFT_STACKING)
                     ? (SV*)cGVOP_gv : ret);
@@ -3346,7 +3348,8 @@ S_ft_return_true(pTHX_ SV *ret) {
     } STMT_END
 
 static OP *
-S_try_amagic_ftest(pTHX_ char chr) {
+S_try_amagic_ftest(pTHX_ char chr)
+{
     SV *const arg = *PL_stack_sp;
 
     assert(chr != '?');
@@ -4271,7 +4274,8 @@ PP_wrapped(pp_open_dir, 2, 0)
 }
 
 static void
-S_warn_not_dirhandle(pTHX_ GV *gv) {
+S_warn_not_dirhandle(pTHX_ GV *gv)
+{
     IO *io = GvIOn(gv);
 
     if (IoIFP(io)) {

--- a/proto.h
+++ b/proto.h
@@ -1387,8 +1387,6 @@ Perl_eval_sv(pTHX_ SV *sv, I32 flags)
 #define PERL_ARGS_ASSERT_EVAL_SV                \
         assert(sv)
 
-#define PERL_ARGS_ASSERT_EXPECTED_SIZE
-
 PERL_CALLCONV void
 Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull_aTHX_
@@ -7735,9 +7733,6 @@ Perl_emulate_cop_io(pTHX_ const COP * const c, SV * const sv)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
-PERL_CALLCONV Size_t
-Perl_expected_size(UV size)
-        __attribute__visibility__("hidden");
 PERL_CALLCONV SV *
 Perl_get_and_check_backslash_N_name(pTHX_ const char *s, const char *e, const bool is_utf8, const char **error_msg)
         Perl_attribute_nonnull_aTHX_
@@ -15497,6 +15492,8 @@ Perl_thread_locale_term(pTHX)
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
+/* PERL_CALLCONV Size_t
+Perl_expected_size(UV size); */
 PERL_CALLCONV U8 *
 Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
         Perl_attribute_nonnull_aTHX_

--- a/reentr.c
+++ b/reentr.c
@@ -45,6 +45,7 @@
 
 void
 Perl_reentrant_size(pTHX) {
+        PERL_ARGS_ASSERT_REENTRANT_SIZE;
         PERL_UNUSED_CONTEXT;
 
         /* Set the sizes of the reentrant buffers */
@@ -171,6 +172,7 @@ Perl_reentrant_size(pTHX) {
 
 void
 Perl_reentrant_init(pTHX) {
+        PERL_ARGS_ASSERT_REENTRANT_INIT;
         PERL_UNUSED_CONTEXT;
 
         /* Initialize the whole thing */
@@ -276,6 +278,7 @@ Perl_reentrant_init(pTHX) {
 
 void
 Perl_reentrant_free(pTHX) {
+        PERL_ARGS_ASSERT_REENTRANT_FREE;
         PERL_UNUSED_CONTEXT;
 
         /* Tear down */

--- a/regcomp.c
+++ b/regcomp.c
@@ -350,6 +350,8 @@ Perl_reg_add_data(RExC_state_t* const pRExC_state, const char* const s, const U3
 void
 Perl_reginitcolors(pTHX)
 {
+    PERL_ARGS_ASSERT_REGINITCOLORS;
+
     const char * const s = PerlEnv_getenv("PERL_RE_COLORS");
     if (s) {
         char *t = savepv(s);
@@ -396,6 +398,8 @@ Perl_reginitcolors(pTHX)
 regexp_engine const *
 Perl_current_re_engine(pTHX)
 {
+    PERL_ARGS_ASSERT_CURRENT_RE_ENGINE;
+
     SV *ptr;
     if (IN_PERL_COMPILETIME) {
         HV * const table = GvHV(PL_hintgv);
@@ -8508,6 +8512,7 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 static unsigned  int
 S_regex_set_precedence(const U8 my_operator)
 {
+    PERL_ARGS_ASSERT_REGEX_SET_PRECEDENCE;
 
     /* Returns the precedence in the (?[...]) construct of the input operator,
      * specified by its character representation.  The precedence follows
@@ -13450,6 +13455,8 @@ Perl_re_intuit_string(pTHX_ REGEXP * const r)
 void
 Perl_pregfree(pTHX_ REGEXP *r)
 {
+    PERL_ARGS_ASSERT_PREGFREE;
+
     SvREFCNT_dec(r);
 }
 
@@ -14064,6 +14071,8 @@ S_re_croak(pTHX_ bool utf8, const char* pat,...)
 void
 Perl_save_re_context(pTHX)
 {
+    PERL_ARGS_ASSERT_SAVE_RE_CONTEXT;
+
     I32 nparens = -1;
     I32 i;
 
@@ -14105,6 +14114,7 @@ Perl_save_re_context(pTHX)
 void
 Perl_init_uniprops(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_UNIPROPS;
 
 #  ifdef DEBUGGING
     char * dump_len_string;

--- a/regcomp.c
+++ b/regcomp.c
@@ -1363,7 +1363,8 @@ S_is_ssc_worth_it(const RExC_state_t * pRExC_state, const regnode_ssc * ssc)
 #ifdef PERL_RE_BUILD_AUX
 
 void
-Perl_release_RExC_state(pTHX_ void *vstate) {
+Perl_release_RExC_state(pTHX_ void *vstate)
+{
     PERL_ARGS_ASSERT_RELEASE_REXC_STATE;
 
     RExC_state_t *pRExC_state = (RExC_state_t *)vstate;
@@ -8505,7 +8506,8 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
 #undef ADD_POSIX_WARNING
 
 static unsigned  int
-S_regex_set_precedence(const U8 my_operator) {
+S_regex_set_precedence(const U8 my_operator)
+{
 
     /* Returns the precedence in the (?[...]) construct of the input operator,
      * specified by its character representation.  The precedence follows
@@ -13020,7 +13022,8 @@ S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
 #ifdef DEBUGGING
 
 static regnode_offset
-S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_size) {
+S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN extra_size)
+{
     PERL_ARGS_ASSERT_REGNODE_GUTS_DEBUG;
     assert(extra_size >= REGNODE_ARG_LEN(op) || REGNODE_TYPE(op) == ANYOF);
     return S_regnode_guts(aTHX_ pRExC_state, extra_size);
@@ -13343,7 +13346,8 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
 
 #ifdef PERL_RE_BUILD_AUX
 SV*
-Perl_get_ANYOFM_contents(pTHX_ const regnode * n) {
+Perl_get_ANYOFM_contents(pTHX_ const regnode * n)
+{
 
     /* Returns an inversion list of all the code points matched by the
      * ANYOFM/NANYOFM node 'n' */
@@ -13376,7 +13380,8 @@ Perl_get_ANYOFM_contents(pTHX_ const regnode * n) {
 }
 
 SV *
-Perl_get_ANYOFHbbm_contents(pTHX_ const regnode * n) {
+Perl_get_ANYOFHbbm_contents(pTHX_ const regnode * n)
+{
     PERL_ARGS_ASSERT_GET_ANYOFHBBM_CONTENTS;
 
     SV * cp_list = NULL;

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -315,6 +315,8 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
 static void
 S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
 {
+    PERL_ARGS_ASSERT_REGDUMP_INTFLAGS;
+
     int bit;
     int set = 0;
 
@@ -338,6 +340,8 @@ S_regdump_intflags(pTHX_ const char *lead, const U32 flags)
 static void
 S_regdump_extflags(pTHX_ const char *lead, const U32 flags)
 {
+    PERL_ARGS_ASSERT_REGDUMP_EXTFLAGS;
+
     int bit;
     int set = 0;
     regex_charset cs;

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -330,6 +330,8 @@ S_initialize_invlist_guts(pTHX_ SV* invlist, const Size_t initial_size)
 SV*
 Perl_new_invlist_(pTHX_ IV initial_size)
 {
+    PERL_ARGS_ASSERT_NEW_INVLIST_;
+
 
     /* Return a pointer to a newly constructed inversion list, with enough
      * space to store 'initial_size' elements.  If that number is negative, a
@@ -1104,6 +1106,8 @@ Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV* const a, SV* const b,
 SV*
 Perl_add_range_to_invlist_(pTHX_ SV* invlist, UV start, UV end)
 {
+    PERL_ARGS_ASSERT_ADD_RANGE_TO_INVLIST_;
+
     /* Add the range from 'start' to 'end' inclusive to the inversion list's
      * set.  A pointer to the inversion list is returned.  This may actually be
      * a new list, in which case the passed in one has been destroyed.  The

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -846,6 +846,7 @@ print $c <<"EOF";
 
 void
 Perl_reentrant_size(pTHX) {
+        PERL_ARGS_ASSERT_REENTRANT_SIZE;
         PERL_UNUSED_CONTEXT;
 
         /* Set the sizes of the reentrant buffers */
@@ -861,6 +862,7 @@ Perl_reentrant_size(pTHX) {
 
 void
 Perl_reentrant_init(pTHX) {
+        PERL_ARGS_ASSERT_REENTRANT_INIT;
         PERL_UNUSED_CONTEXT;
 
         /* Initialize the whole thing */
@@ -877,6 +879,7 @@ Perl_reentrant_init(pTHX) {
 
 void
 Perl_reentrant_free(pTHX) {
+        PERL_ARGS_ASSERT_REENTRANT_FREE;
         PERL_UNUSED_CONTEXT;
 
         /* Tear down */

--- a/regexec.c
+++ b/regexec.c
@@ -548,6 +548,8 @@ S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
 static bool
 S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
 {
+    PERL_ARGS_ASSERT_ISFOO_LC;
+
     /* Returns a boolean as to whether or not 'character' is a member of the
      * Posix character class given by 'classnum' that should be equivalent to a
      * value in the typedef 'char_class_number_'.

--- a/regexec.c
+++ b/regexec.c
@@ -361,7 +361,8 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
  * line 4003 or so of regcomp.c where we parse OPEN parens
  * of various types. */
 PERL_STATIC_INLINE void
-S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH) {
+S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
+{
     PERL_ARGS_ASSERT_UNWIND_PAREN;
     U32 n;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -384,7 +385,8 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH) {
 #define UNWIND_PAREN(lp,lcp) unwind_paren(rex,lp,lcp)
 
 PERL_STATIC_INLINE void
-S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma_pDEPTH) {
+S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma_pDEPTH)
+{
     PERL_ARGS_ASSERT_CAPTURE_CLEAR;
     PERL_UNUSED_ARG(str); /* only used for debugging */
     U16 my_ix;
@@ -2181,7 +2183,8 @@ STMT_START {                                                                \
 
 #ifdef DEBUGGING
 static IV
-S_get_break_val_cp_checked(SV* const invlist, const UV cp_in) {
+S_get_break_val_cp_checked(SV* const invlist, const UV cp_in)
+{
   IV cp_out = invlist_search_(invlist, cp_in);
   assert(cp_out >= 0);
   return cp_out;

--- a/reginline.h
+++ b/reginline.h
@@ -8,6 +8,8 @@ PERL_STATIC_INLINE
 regnode *
 Perl_regnext(pTHX_ const regnode *p)
 {
+    PERL_ARGS_ASSERT_REGNEXT;
+
     I32 offset;
 
     if (!p)
@@ -34,6 +36,8 @@ PERL_STATIC_INLINE
 regnode *
 Perl_regnode_after(pTHX_ const regnode *p, const bool varies)
 {
+    PERL_ARGS_ASSERT_REGNODE_AFTER;
+
     assert(p);
     const U8 op = OP(p);
     assert(op < REGNODE_MAX);
@@ -49,6 +53,8 @@ PERL_STATIC_INLINE
 bool
 Perl_check_regnode_after(pTHX_ const regnode *p, const STRLEN extra)
 {
+    PERL_ARGS_ASSERT_CHECK_REGNODE_AFTER;
+
     const regnode *nextoper = regnode_after((regnode *)p,FALSE);
     const regnode *other = REGNODE_AFTER_PLUS(p, extra);
     if (nextoper != other) {

--- a/run.c
+++ b/run.c
@@ -36,6 +36,8 @@
 int
 Perl_runops_standard(pTHX)
 {
+    PERL_ARGS_ASSERT_RUNOPS_STANDARD;
+
     OP *op = PL_op;
     PERL_DTRACE_PROBE_OP(op);
     while ((PL_op = op = op->op_ppaddr(aTHX))) {
@@ -56,6 +58,8 @@ Perl_runops_standard(pTHX)
 int
 Perl_runops_wrap(pTHX)
 {
+    PERL_ARGS_ASSERT_RUNOPS_WRAP;
+
     /* runops loops assume a ref-counted stack. If we have been called via a
      * wrapper (pp_wrap or xs_wrap) with the top half of the stack not
      * reference-counted, or with a non-real stack, temporarily convert it

--- a/scope.c
+++ b/scope.c
@@ -73,6 +73,8 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
 PERL_SI *
 Perl_new_stackinfo(pTHX_ I32 stitems, I32 cxitems)
 {
+    PERL_ARGS_ASSERT_NEW_STACKINFO;
+
     return new_stackinfo_flags(stitems, cxitems, 0);
 }
 
@@ -83,6 +85,8 @@ Perl_new_stackinfo(pTHX_ I32 stitems, I32 cxitems)
 PERL_SI *
 Perl_new_stackinfo_flags(pTHX_ I32 stitems, I32 cxitems, UV flags)
 {
+    PERL_ARGS_ASSERT_NEW_STACKINFO_FLAGS;
+
     PERL_SI *si;
     Newx(si, 1, PERL_SI);
     si->si_stack = newAV();
@@ -110,6 +114,8 @@ Perl_new_stackinfo_flags(pTHX_ I32 stitems, I32 cxitems, UV flags)
 I32
 Perl_cxinc(pTHX)
 {
+    PERL_ARGS_ASSERT_CXINC;
+
     const IV old_max = cxstack_max;
     const IV new_max = GROW(cxstack_max);
     Renew(cxstack, new_max + 1, PERL_CONTEXT);
@@ -132,6 +138,8 @@ Implements L<perlapi/C<ENTER>>
 void
 Perl_push_scope(pTHX)
 {
+    PERL_ARGS_ASSERT_PUSH_SCOPE;
+
     if (UNLIKELY(PL_scopestack_ix == PL_scopestack_max)) {
         const IV new_max = GROW(PL_scopestack_max);
         Renew(PL_scopestack, new_max, I32);
@@ -159,6 +167,8 @@ Implements L<perlapi/C<LEAVE>>
 void
 Perl_pop_scope(pTHX)
 {
+    PERL_ARGS_ASSERT_POP_SCOPE;
+
     const I32 oldsave = PL_scopestack[--PL_scopestack_ix];
     LEAVE_SCOPE(oldsave);
 }
@@ -166,6 +176,8 @@ Perl_pop_scope(pTHX)
 Stack_off_t *
 Perl_markstack_grow(pTHX)
 {
+    PERL_ARGS_ASSERT_MARKSTACK_GROW;
+
     const I32 oldmax = PL_markstack_max - PL_markstack;
     const I32 newmax = GROW(oldmax);
 
@@ -181,6 +193,8 @@ Perl_markstack_grow(pTHX)
 void
 Perl_savestack_grow(pTHX)
 {
+    PERL_ARGS_ASSERT_SAVESTACK_GROW;
+
     const I32 by = PL_savestack_max - PL_savestack_ix;
     Perl_savestack_grow_cnt(aTHX_ by);
 }
@@ -188,6 +202,8 @@ Perl_savestack_grow(pTHX)
 void
 Perl_savestack_grow_cnt(pTHX_ I32 need)
 {
+    PERL_ARGS_ASSERT_SAVESTACK_GROW_CNT;
+
     /* NOTE: PL_savestack_max and PL_savestack_ix are I32.
      *
      * This makes sense when you consider that having I32_MAX items on
@@ -244,6 +260,8 @@ Perl_savestack_grow_cnt(pTHX_ I32 need)
 SSize_t
 Perl_tmps_grow_p(pTHX_ SSize_t ix)
 {
+    PERL_ARGS_ASSERT_TMPS_GROW_P;
+
     SSize_t extend_to = ix;
 #ifndef STRESS_REALLOC
     SSize_t grow_size = PL_tmps_max < 512 ? 128 : PL_tmps_max / 2;
@@ -262,6 +280,8 @@ Perl_tmps_grow_p(pTHX_ SSize_t ix)
 void
 Perl_free_tmps(pTHX)
 {
+    PERL_ARGS_ASSERT_FREE_TMPS;
+
     /* XXX should tmps_floor live in cxstack? */
     const SSize_t myfloor = PL_tmps_floor;
     while (PL_tmps_ix > myfloor) {      /* clean up after last statement */
@@ -320,6 +340,8 @@ S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
 void
 Perl_save_pushptrptr(pTHX_ void *const ptr1, void *const ptr2, const int type)
 {
+    PERL_ARGS_ASSERT_SAVE_PUSHPTRPTR;
+
     dSS_ADD;
     SS_ADD_PTR(ptr1);
     SS_ADD_PTR(ptr2);
@@ -592,6 +614,8 @@ Perl_save_bool(pTHX_ bool *boolp)
 void
 Perl_save_pushi32ptr(pTHX_ const I32 i, void *const ptr, const int type)
 {
+    PERL_ARGS_ASSERT_SAVE_PUSHI32PTR;
+
     dSS_ADD;
 
     SS_ADD_INT(i);
@@ -744,6 +768,8 @@ Implements C<SAVEPADSVANDMORTALIZE>.
 void
 Perl_save_padsv_and_mortalize(pTHX_ PADOFFSET off)
 {
+    PERL_ARGS_ASSERT_SAVE_PADSV_AND_MORTALIZE;
+
     dSS_ADD;
 
     ASSERT_CURPAD_ACTIVE("save_padsv");
@@ -787,6 +813,8 @@ C<SAVEFREESV>.
 void
 Perl_save_pushptr(pTHX_ void *const ptr, const int type)
 {
+    PERL_ARGS_ASSERT_SAVE_PUSHPTR;
+
     dSS_ADD;
     SS_ADD_PTR(ptr);
     SS_ADD_UV(type);
@@ -915,6 +943,8 @@ Perl_save_destructor(pTHX_ DESTRUCTORFUNC_NOCONTEXT_t f, void* p)
 void
 Perl_save_destructor_x(pTHX_ DESTRUCTORFUNC_t f, void* p)
 {
+    PERL_ARGS_ASSERT_SAVE_DESTRUCTOR_X;
+
     dSS_ADD;
 
     SS_ADD_DXPTR(f);
@@ -935,6 +965,8 @@ Implements C<SAVEHINTS>.
 void
 Perl_save_hints(pTHX)
 {
+    PERL_ARGS_ASSERT_SAVE_HINTS;
+
     COPHH *save_cophh = cophh_copy(CopHINTHASH_get(&PL_compiling));
     if (PL_hints & HINT_LOCALIZE_HH) {
         HV *oldhh = GvHV(PL_hintgv);
@@ -958,6 +990,8 @@ static void
 S_save_pushptri32ptr(pTHX_ void *const ptr1, const I32 i, void *const ptr2,
                         const int type)
 {
+    PERL_ARGS_ASSERT_SAVE_PUSHPTRI32PTR;
+
     dSS_ADD;
     SS_ADD_PTR(ptr1);
     SS_ADD_INT(i);
@@ -1085,6 +1119,8 @@ Perl_save_svref(pTHX_ SV **sptr)
 void
 Perl_savetmps(pTHX)
 {
+    PERL_ARGS_ASSERT_SAVETMPS;
+
     dSS_ADD;
     SS_ADD_IV(PL_tmps_floor);
     PL_tmps_floor = PL_tmps_ix;
@@ -1105,6 +1141,8 @@ function.
 SSize_t
 Perl_save_alloc(pTHX_ SSize_t size, I32 pad)
 {
+    PERL_ARGS_ASSERT_SAVE_ALLOC;
+
     const SSize_t start = pad + ((char*)&PL_savestack[PL_savestack_ix]
                           - (char*)PL_savestack);
     const UV elems = 1 + ((size + pad - 1) / sizeof(*PL_savestack));
@@ -1136,6 +1174,8 @@ Implements C<LEAVE_SCOPE> which you should use instead.
 void
 Perl_leave_scope(pTHX_ I32 base)
 {
+    PERL_ARGS_ASSERT_LEAVE_SCOPE;
+
     /* Localise the effects of the TAINT_NOT inside the loop.  */
     bool was = TAINT_get;
 

--- a/scope.c
+++ b/scope.c
@@ -377,7 +377,8 @@ or be prematurely freed.
 =cut
  */
 void
-Perl_save_rcpv(pTHX_ char **prcpv) {
+Perl_save_rcpv(pTHX_ char **prcpv)
+{
     PERL_ARGS_ASSERT_SAVE_RCPV;
     save_pushptrptr(prcpv, rcpv_copy(*prcpv), SAVEt_RCPV);
 }
@@ -393,7 +394,8 @@ on the argument when the current pseudo block is finished.
 =cut
  */
 void
-Perl_save_freercpv(pTHX_ char *rcpv) {
+Perl_save_freercpv(pTHX_ char *rcpv)
+{
     PERL_ARGS_ASSERT_SAVE_FREERCPV;
     save_pushptr(rcpv, SAVEt_FREERCPV);
 }
@@ -1991,7 +1993,8 @@ should not be called directly and has no user serviceable parts.
 */
 
 void
-Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args) {
+Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args)
+{
     PERL_ARGS_ASSERT_MORTAL_DESTRUCTOR_SV;
     assert(
         (SvROK(coderef) && SvTYPE(SvRV(coderef)) == SVt_PVCV) /* perl coderef */
@@ -2005,7 +2008,8 @@ Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args) {
 
 
 void
-Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *sv) {
+Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *sv)
+{
     PERL_ARGS_ASSERT_MORTAL_SVFUNC_X;
     SV *sviv = newSViv(PTR2IV(f));
     mortal_destructor_sv(sviv,sv);
@@ -2013,7 +2017,8 @@ Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *sv) {
 
 
 int
-Perl_magic_freedestruct(pTHX_ SV* sv, MAGIC* mg) {
+Perl_magic_freedestruct(pTHX_ SV* sv, MAGIC* mg)
+{
     PERL_ARGS_ASSERT_MAGIC_FREEDESTRUCT;
     dSP;
     union {

--- a/sv.c
+++ b/sv.c
@@ -272,6 +272,8 @@ Public API:
 SV*
 Perl_more_sv(pTHX)
 {
+    PERL_ARGS_ASSERT_MORE_SV;
+
     SV* sv;
     char *chunk;                /* must use New here to match call to */
     Newx(chunk,PERL_ARENA_SIZE,char);  /* Safefree() in sv_free_arenas() */
@@ -425,6 +427,8 @@ Dump the contents of all SVs not yet freed (debugging aid).
 void
 Perl_sv_report_used(pTHX)
 {
+    PERL_ARGS_ASSERT_SV_REPORT_USED;
+
 #ifdef DEBUGGING
     visit(do_report_used, 0, 0);
 #else
@@ -542,6 +546,8 @@ Attempt to destroy all objects not yet freed.
 void
 Perl_sv_clean_objs(pTHX)
 {
+    PERL_ARGS_ASSERT_SV_CLEAN_OBJS;
+
     GV *olddef, *olderr;
     PL_in_clean_objs = TRUE;
     visit(do_clean_objs, SVf_ROK, SVf_ROK);
@@ -592,6 +598,8 @@ SVs which are in complex self-referential hierarchies.
 SSize_t
 Perl_sv_clean_all(pTHX)
 {
+    PERL_ARGS_ASSERT_SV_CLEAN_ALL;
+
     SSize_t cleaned;
     PL_in_clean_all = TRUE;
     cleaned = visit(do_clean_all, 0,0);
@@ -616,6 +624,8 @@ S_do_sv_mark_arenas(pTHX_ SV *const sv)
 void
 Perl_sv_mark_arenas(pTHX)
 {
+    PERL_ARGS_ASSERT_SV_MARK_ARENAS;
+
     visit(S_do_sv_mark_arenas, 0, 0);
 }
 
@@ -644,6 +654,8 @@ S_do_sv_sweep_arenas(pTHX_ SV *const sv)
 void
 Perl_sv_sweep_arenas(pTHX)
 {
+    PERL_ARGS_ASSERT_SV_SWEEP_ARENAS;
+
     visit(S_do_sv_sweep_arenas, 0, 0);
 }
 
@@ -699,6 +711,8 @@ heads and bodies within the arenas must already have been freed.
 void
 Perl_sv_free_arenas(pTHX)
 {
+    PERL_ARGS_ASSERT_SV_FREE_ARENAS;
+
     SV* sva;
     SV* svanext;
     unsigned int i;
@@ -860,6 +874,8 @@ available in hv.c. Similarly SVt_IV is re-used for HVAUX_ARENA_ROOT_IX.
 void *
 Perl_more_bodies (pTHX_ const svtype sv_type)
 {
+    PERL_ARGS_ASSERT_MORE_BODIES;
+
     void ** const root = &PL_body_roots[sv_type];
 
     const struct body_details *type_details =
@@ -6319,6 +6335,8 @@ modules supporting older perls.
 SV *
 Perl_newSV(pTHX_ const STRLEN len)
 {
+    PERL_ARGS_ASSERT_NEWSV;
+
     SV *sv;
 
     new_SV(sv);
@@ -6349,6 +6367,8 @@ The reference count for the new SV is set to 1.
 SV *
 Perl_newSVpvz(pTHX_ const STRLEN len)
 {
+    PERL_ARGS_ASSERT_NEWSVPVZ;
+
     SV *sv = newSV_type(SVt_PV);
     sv_grow_fresh(sv, len + 1);
 
@@ -7805,7 +7825,9 @@ instead.
 SV *
 Perl_sv_newref(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_NEWREF;
     PERL_UNUSED_CONTEXT;
+
     if (sv)
         (SvREFCNT(sv))++;
     return sv;
@@ -7825,6 +7847,8 @@ Normally called via a wrapper macro C<SvREFCNT_dec>.
 void
 Perl_sv_free(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_FREE;
+
     SvREFCNT_dec(sv);
 }
 
@@ -7917,6 +7941,8 @@ gives raw access to the C<xpv_cur> slot.
 STRLEN
 Perl_sv_len(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_LEN;
+
     STRLEN len;
 
     if (!sv)
@@ -7950,6 +7976,8 @@ C<sv_len_utf8_nomg> skips any magic.
 STRLEN
 Perl_sv_len_utf8(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_LEN_UTF8;
+
     if (!sv)
         return 0;
 
@@ -8664,6 +8692,8 @@ the C<streq> forms treat them as C<undef>
 I32
 Perl_sv_eq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_EQ_FLAGS;
+
     const char *pv1;
     STRLEN cur1;
     const char *pv2;
@@ -8787,7 +8817,10 @@ they are references so do_cmp() can be used safely.
 
 PERL_STATIC_INLINE bool
 S_sv_numcmp_common(pTHX_ SV **sv1, SV **sv2, const U32 flags,
-                   int method, SV **result) {
+                   int method, SV **result)
+{
+    PERL_ARGS_ASSERT_SV_NUMCMP_COMMON;
+
     if(flags & SV_GMAGIC) {
         if(*sv1)
             SvGETMAGIC(*sv1);
@@ -9107,6 +9140,8 @@ See also C<L</sv_cmp_locale>>.
 I32
 Perl_sv_cmp(pTHX_ SV *const sv1, SV *const sv2)
 {
+    PERL_ARGS_ASSERT_SV_CMP;
+
     return sv_cmp_flags(sv1, sv2, SV_GMAGIC);
 }
 
@@ -9114,6 +9149,8 @@ I32
 Perl_sv_cmp_flags(pTHX_ SV *const sv1, SV *const sv2,
                   const U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_CMP_FLAGS;
+
     STRLEN cur1, cur2;
     const char *pv1, *pv2;
     I32  cmp;
@@ -9338,6 +9375,8 @@ See also C<L</sv_cmp>>.
 I32
 Perl_sv_cmp_locale(pTHX_ SV *const sv1, SV *const sv2)
 {
+    PERL_ARGS_ASSERT_SV_CMP_LOCALE;
+
     return sv_cmp_locale_flags(sv1, sv2, SV_GMAGIC);
 }
 
@@ -9345,6 +9384,8 @@ I32
 Perl_sv_cmp_locale_flags(pTHX_ SV *const sv1, SV *const sv2,
                          const U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_CMP_LOCALE_FLAGS;
+
 #ifdef USE_LOCALE_COLLATE
 
     char *pv1, *pv2;
@@ -10079,6 +10120,8 @@ any magic.
 void
 Perl_sv_inc(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_INC;
+
     if (!sv)
         return;
     SvGETMAGIC(sv);
@@ -10088,6 +10131,8 @@ Perl_sv_inc(pTHX_ SV *const sv)
 void
 Perl_sv_inc_nomg(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_INC_NOMG;
+
     char *d;
     int flags;
 
@@ -10264,6 +10309,8 @@ C<sv_dec> handles 'get' magic; C<sv_dec_nomg> skips 'get' magic.
 void
 Perl_sv_dec(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_DEC;
+
     if (!sv)
         return;
     SvGETMAGIC(sv);
@@ -10273,6 +10320,8 @@ Perl_sv_dec(pTHX_ SV *const sv)
 void
 Perl_sv_dec_nomg(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_DEC_NOMG;
+
     int flags;
 
     if (!sv)
@@ -10426,6 +10475,8 @@ C<L</sv_setsv_flags>>.
 SV *
 Perl_sv_mortalcopy_flags(pTHX_ SV *const old, U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_MORTALCOPY_FLAGS;
+
     SV *dsv;
 
     if (!old) {
@@ -10453,6 +10504,8 @@ See also C<L</sv_mortalcopy>> and C<L</sv_2mortal>>.
 SV *
 Perl_sv_newmortal(pTHX)
 {
+    PERL_ARGS_ASSERT_SV_NEWMORTAL;
+
     SV *sv;
 
     new_SV(sv);
@@ -10488,6 +10541,8 @@ C<newSVpvn_utf8()> is a convenience wrapper for this function, defined as
 SV *
 Perl_newSVpvn_flags(pTHX_ const char *const s, const STRLEN len, const U32 flags)
 {
+    PERL_ARGS_ASSERT_NEWSVPVN_FLAGS;
+
     SV *sv;
 
     /* All the flags we don't support must be zero.
@@ -10528,6 +10583,8 @@ C<L</sv_newmortal>> and C<L</sv_mortalcopy>>.
 SV *
 Perl_sv_2mortal(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_2MORTAL;
+
     if (!sv)
         return sv;
     if (SvIMMORTAL(sv))
@@ -10561,6 +10618,8 @@ to call C<strlen> use C<newSVpvn> instead (calling C<strlen> yourself).
 SV *
 Perl_newSVpv(pTHX_ const char *const s, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_NEWSVPV;
+
     SV *sv = newSV_type(SVt_PV);
     sv_setpvn_fresh(sv, s, len || s == NULL ? len : strlen(s));
     return sv;
@@ -10582,6 +10641,8 @@ undefined.
 SV *
 Perl_newSVpvn(pTHX_ const char *const s, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_NEWSVPVN;
+
     SV *sv = newSV_type(SVt_PV);
     sv_setpvn_fresh(sv, s, len);
     return sv;
@@ -10602,6 +10663,8 @@ This is more efficient than using sv_2mortal(newSVhek( ... ))
 SV *
 Perl_newSVhek_mortal(pTHX_ const HEK *const hek)
 {
+    PERL_ARGS_ASSERT_NEWSVHEK_MORTAL;
+
     SV * const sv = newSVhek(hek);
     assert(sv);
     assert(!SvIMMORTAL(sv));
@@ -10624,6 +10687,8 @@ SV if C<hek> is NULL.
 SV *
 Perl_newSVhek(pTHX_ const HEK *const hek)
 {
+    PERL_ARGS_ASSERT_NEWSVHEK;
+
     SV *sv = newSV_type(SVt_PV);
 
     if (LIKELY(hek)) {
@@ -10684,6 +10749,8 @@ C<SvPVX_const == HeKEY> and hash lookup will avoid string compare.
 SV *
 Perl_newSVpvn_share(pTHX_ const char *src, I32 len, U32 hash)
 {
+    PERL_ARGS_ASSERT_NEWSVPVN_SHARE;
+
     SV *sv;
     bool is_utf8 = FALSE;
 
@@ -10724,6 +10791,8 @@ string/length pair.
 SV *
 Perl_newSVpv_share(pTHX_ const char *src, U32 hash)
 {
+    PERL_ARGS_ASSERT_NEWSVPV_SHARE;
+
     return newSVpvn_share(src, strlen(src), hash);
 }
 
@@ -10808,6 +10877,8 @@ The reference count for the SV is set to 1.
 SV *
 Perl_newSVnv(pTHX_ const NV n)
 {
+    PERL_ARGS_ASSERT_NEWSVNV;
+
     SV *sv = newSV_type(SVt_NV);
     (void)SvNOK_on(sv);
 
@@ -10829,6 +10900,8 @@ SV is set to 1.
 SV *
 Perl_newSViv(pTHX_ const IV i)
 {
+    PERL_ARGS_ASSERT_NEWSVIV;
+
     SV *sv = newSV_type(SVt_IV);
     (void)SvIOK_on(sv);
 
@@ -10850,6 +10923,8 @@ The reference count for the SV is set to 1.
 SV *
 Perl_newSVuv(pTHX_ const UV u)
 {
+    PERL_ARGS_ASSERT_NEWSVUV;
+
     SV *sv;
 
     /* Inlining ONLY the small relevant subset of sv_setuv here
@@ -10980,6 +11055,8 @@ Perl_sv_reset(pTHX_ const char *s, HV *const stash)
 void
 Perl_sv_resetpvn(pTHX_ const char *s, STRLEN len, HV * const stash)
 {
+    PERL_ARGS_ASSERT_SV_RESETPVN;
+
     char todo[PERL_UCHAR_MAX+1];
     const char *send;
 
@@ -11206,6 +11283,8 @@ instead use an in-line version.
 I32
 Perl_sv_true(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_TRUE;
+
     if (!sv)
         return 0;
     if (SvPOK(sv)) {
@@ -11448,6 +11527,8 @@ will return false.
 int
 Perl_sv_isobject(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SV_ISOBJECT;
+
     if (!sv)
         return 0;
     SvGETMAGIC(sv);
@@ -15045,6 +15126,8 @@ Create a new pointer-mapping table
 PTR_TBL_t *
 Perl_ptr_table_new(pTHX)
 {
+    PERL_ARGS_ASSERT_PTR_TABLE_NEW;
+
     PTR_TBL_t *tbl;
     PERL_UNUSED_CONTEXT;
 
@@ -15200,6 +15283,8 @@ Clear and free a ptr table
 void
 Perl_ptr_table_free(pTHX_ PTR_TBL_t *const tbl)
 {
+    PERL_ARGS_ASSERT_PTR_TABLE_FREE;
+
     struct ptr_tbl_arena *arena;
 
     PERL_UNUSED_CONTEXT;
@@ -17303,6 +17388,7 @@ Perl_clone_params_new(PerlInterpreter *const from, PerlInterpreter *const to)
 void
 Perl_init_constants(pTHX)
 {
+    PERL_ARGS_ASSERT_INIT_CONSTANTS;
 
     SvREFCNT(&PL_sv_undef)	= SvREFCNT_IMMORTAL;
     SvFLAGS(&PL_sv_undef)	= SVf_READONLY|SVf_PROTECT|SVt_NULL;
@@ -17576,6 +17662,8 @@ SV*
 Perl_varname(pTHX_ const GV *const gv, const char gvtype, PADOFFSET targ,
         const SV *const keyname, SSize_t aindex, int subscript_type)
 {
+    PERL_ARGS_ASSERT_VARNAME;
+
 
     SV * const name = sv_newmortal();
     if (gv && isGV(gv)) {
@@ -18457,6 +18545,8 @@ Print appropriate "Use of uninitialized variable" warning.
 void
 Perl_report_uninit(pTHX_ const SV *uninit_sv)
 {
+    PERL_ARGS_ASSERT_REPORT_UNINIT;
+
     const char *desc = NULL;
     SV* varname = NULL;
 
@@ -18501,6 +18591,8 @@ Perl_report_uninit(pTHX_ const SV *uninit_sv)
 void
 S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
 {
+    PERL_ARGS_ASSERT_CROAK_SV_SETSV_FLAGS;
+
     OP *op = PL_op;
     if (SvIS_FREED(dsv)) {
         croak("panic: attempt to copy value %" SVf

--- a/sv.c
+++ b/sv.c
@@ -523,7 +523,8 @@ do_clean_named_io_objs(pTHX_ SV *const sv)
 
 /* Void wrapper to pass to visit() */
 static void
-do_curse(pTHX_ SV * const sv) {
+do_curse(pTHX_ SV * const sv)
+{
     if ((PL_stderrgv && GvGP(PL_stderrgv) && (SV*)GvIO(PL_stderrgv) == sv)
      || (PL_defoutgv && GvGP(PL_defoutgv) && (SV*)GvIO(PL_defoutgv) == sv))
         return;
@@ -1292,7 +1293,8 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
 }
 
 struct xpvhv_aux*
-Perl_hv_auxalloc(pTHX_ HV *hv) {
+Perl_hv_auxalloc(pTHX_ HV *hv)
+{
     const struct body_details *old_type_details = bodies_by_type + SVt_PVHV;
     void *old_body;
     void *new_body;
@@ -1771,7 +1773,8 @@ Perl_sv_setrv_inc_mg(pTHX_ SV *const sv, SV *const ref)
  */
 
 static const char *
-S_sv_display(pTHX_ SV *const sv, char *tmpbuf, STRLEN tmpbuf_size) {
+S_sv_display(pTHX_ SV *const sv, char *tmpbuf, STRLEN tmpbuf_size)
+{
     const char *pv;
 
      PERL_ARGS_ASSERT_SV_DISPLAY;
@@ -1861,7 +1864,8 @@ S_not_a_number(pTHX_ SV *const sv)
 }
 
 static void
-S_not_incrementable(pTHX_ SV *const sv) {
+S_not_incrementable(pTHX_ SV *const sv)
+{
      char tmpbuf[64];
      const char *pv;
 
@@ -2915,7 +2919,8 @@ Perl_uiv_2buf(char *const buf, const IV iv, UV uv, const int is_uv, char **const
  * shared string constants we point to, instead of generating a new
  * string for each instance. */
 static size_t
-S_infnan_2pv(NV nv, char* buffer, size_t maxlen, char plus) {
+S_infnan_2pv(NV nv, char* buffer, size_t maxlen, char plus)
+{
     char* s = buffer;
     assert(maxlen >= 4);
     if (Perl_isinf(nv)) {
@@ -7664,7 +7669,8 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
    sv does not have to be ROK. */
 
 static bool
-S_curse(pTHX_ SV * const sv, const bool check_refcnt) {
+S_curse(pTHX_ SV * const sv, const bool check_refcnt)
+{
     PERL_ARGS_ASSERT_CURSE;
     assert(SvOBJECT(sv));
 
@@ -12218,7 +12224,8 @@ S_sv_catpvn_simple(pTHX_ SV *const sv, const char* const buf, const STRLEN len)
  * inappropriate "use of uninit" warnings [perl #71000].
  */
 static void
-S_warn_vcatpvfn_missing_argument(pTHX) {
+S_warn_vcatpvfn_missing_argument(pTHX)
+{
     ck_warner(packWARN(WARN_MISSING), "Missing argument in %s",
               PL_op ? OP_DESC(PL_op) : "sv_vcatpvfn()");
 }
@@ -18491,7 +18498,8 @@ Perl_report_uninit(pTHX_ const SV *uninit_sv)
  * The main aim is to keep Perl_sv_setsv_flags as slim as possible and this
  * includes keeping the call sites for this function small.
  */
-void S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
+void
+S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
 {
     OP *op = PL_op;
     if (SvIS_FREED(dsv)) {

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -67,6 +67,8 @@
 PERL_STATIC_INLINE SV*
 Perl_new_sv(pTHX_ const char *file, int line, const char *func)
 {
+    PERL_ARGS_ASSERT_NEW_SV;
+
     SV* sv;
 #if !defined(DEBUG_LEAKING_SCALARS) || \
      (!defined(DEBUGGING) && !defined(PERL_MEM_LOG))
@@ -369,6 +371,8 @@ is set to 1.
 PERL_STATIC_INLINE SV *
 Perl_newSV_type(pTHX_ const svtype type)
 {
+    PERL_ARGS_ASSERT_NEWSV_TYPE;
+
     SV *sv;
     void*      new_body;
     const struct body_details *type_details;
@@ -535,6 +539,8 @@ at some point in the future.)
 PERL_STATIC_INLINE SV *
 Perl_newSV_type_mortal(pTHX_ const svtype type)
 {
+    PERL_ARGS_ASSERT_NEWSV_TYPE_MORTAL;
+
     SV *sv = newSV_type(type);
     SSize_t ix = ++PL_tmps_ix;
     if (UNLIKELY(ix >= PL_tmps_max))
@@ -662,6 +668,8 @@ Perl_SvTRUE_common(pTHX_ SV * sv, const bool sv_2bool_is_fallback)
 PERL_STATIC_INLINE SV *
 Perl_SvREFCNT_inc(SV *sv)
 {
+    PERL_ARGS_ASSERT_SVREFCNT_INC;
+
     if (LIKELY(sv != NULL))
         SvREFCNT(sv)++;
     return sv;
@@ -679,6 +687,8 @@ Perl_SvREFCNT_inc_NN(SV *sv)
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_inc_void(SV *sv)
 {
+    PERL_ARGS_ASSERT_SVREFCNT_INC_VOID;
+
     if (LIKELY(sv != NULL))
         SvREFCNT(sv)++;
 }
@@ -686,6 +696,8 @@ Perl_SvREFCNT_inc_void(SV *sv)
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SVREFCNT_DEC;
+
     if (LIKELY(sv != NULL)) {
         U32 rc = SvREFCNT(sv);
         if (LIKELY(rc > 1))
@@ -921,6 +933,8 @@ Perl_SvPV_helper(pTHX_
                  const U32 return_flags
                 )
 {
+    PERL_ARGS_ASSERT_SVPV_HELPER;
+
     /* 'type' should be known at compile time, so this is reduced to a single
      * conditional at runtime */
     if (   (type == SvPVbyte_type_      && SvPOK_byte_nog(sv))
@@ -1025,6 +1039,8 @@ parameter.
 PERL_STATIC_INLINE SV *
 Perl_newSVsv_flags(pTHX_ SV *const old, I32 flags)
 {
+    PERL_ARGS_ASSERT_NEWSVSV_FLAGS;
+
     if (!old)
         return NULL;
 

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -813,7 +813,8 @@ guaranteed to evaluate C<sv> only once.
 */
 
 PERL_STATIC_INLINE IV
-Perl_SvIV(pTHX_ SV *sv) {
+Perl_SvIV(pTHX_ SV *sv)
+{
     PERL_ARGS_ASSERT_SVIV;
 
     if (SvIOK_nog(sv))
@@ -822,7 +823,8 @@ Perl_SvIV(pTHX_ SV *sv) {
 }
 
 PERL_STATIC_INLINE UV
-Perl_SvUV(pTHX_ SV *sv) {
+Perl_SvUV(pTHX_ SV *sv)
+{
     PERL_ARGS_ASSERT_SVUV;
 
     if (SvUOK_nog(sv))
@@ -831,7 +833,8 @@ Perl_SvUV(pTHX_ SV *sv) {
 }
 
 PERL_STATIC_INLINE NV
-Perl_SvNV(pTHX_ SV *sv) {
+Perl_SvNV(pTHX_ SV *sv)
+{
     PERL_ARGS_ASSERT_SVNV;
 
     if (SvNOK_nog(sv))
@@ -840,7 +843,8 @@ Perl_SvNV(pTHX_ SV *sv) {
 }
 
 PERL_STATIC_INLINE IV
-Perl_SvIV_nomg(pTHX_ SV *sv) {
+Perl_SvIV_nomg(pTHX_ SV *sv)
+{
     PERL_ARGS_ASSERT_SVIV_NOMG;
 
     if (SvIOK(sv))
@@ -849,7 +853,8 @@ Perl_SvIV_nomg(pTHX_ SV *sv) {
 }
 
 PERL_STATIC_INLINE UV
-Perl_SvUV_nomg(pTHX_ SV *sv) {
+Perl_SvUV_nomg(pTHX_ SV *sv)
+{
     PERL_ARGS_ASSERT_SVUV_NOMG;
 
     if (SvUOK(sv))
@@ -858,7 +863,8 @@ Perl_SvUV_nomg(pTHX_ SV *sv) {
 }
 
 PERL_STATIC_INLINE NV
-Perl_SvNV_nomg(pTHX_ SV *sv) {
+Perl_SvNV_nomg(pTHX_ SV *sv)
+{
     PERL_ARGS_ASSERT_SVNV_NOMG;
 
     if (SvNOK(sv))

--- a/t/porting/args_assert.t
+++ b/t/porting/args_assert.t
@@ -33,7 +33,7 @@ unless (-d 't' && -f 'MANIFEST') {
     while (<$fh>) {
         # The trailing '.' distinguishes real from dummy macros that have no
         # real asserts
-	$declared{$1}++ if /^#define\s+(PERL_ARGS_ASSERT[A-Za-z0-9_]+)\s+./;
+	$declared{$1}++ if / ^ \#define \s+ ( PERL_ARGS_ASSERT \w+ ) \s+ . /ax;
     }
 }
 
@@ -44,14 +44,14 @@ if (!@ARGV) {
     open my $fh, '<', $manifest or die "Can't open $manifest: $!";
     while (<$fh>) {
 	# *.c or */*.c
-	push @ARGV, $prefix . $1 if m!^((?:[^/]+/)?[^/]+\.c)\t!;
+	push @ARGV, $prefix . $1 if m! ^ ( (?: [^/]+ / )? [^/]+ \.c ) \t !x;
         # Special case the *inline.h since they behave like *.c
 	push @ARGV, $prefix . $1 if m!^(([^/]+)?inline\.h)\t!;
     }
 }
 
 while (<>) {
-    $used{$1}++ if /^\s+(PERL_ARGS_ASSERT_[A-Za-z0-9_]+);$/;
+    $used{$1}++ if / ^ \s+ (PERL_ARGS_ASSERT_ \w+ ) ; $ /ax;
 }
 
 my %unused;

--- a/t/porting/args_assert.t
+++ b/t/porting/args_assert.t
@@ -33,7 +33,9 @@ unless (-d 't' && -f 'MANIFEST') {
     while (<$fh>) {
         # The trailing '.' distinguishes real from dummy macros that have no
         # real asserts
-	$declared{$1}++ if / ^ \#define \s+ ( PERL_ARGS_ASSERT \w+ ) \s+ . /ax;
+	$declared{$1}++ if / ^ \s* \# \s* define \s+
+                               ( PERL_ARGS_ASSERT \w+ ) \s+ .
+                           /ax;
     }
 }
 
@@ -58,7 +60,7 @@ if (!@ARGV) {
 }
 
 while (<>) {
-    $used{$1}++ if / ^ \s+ (PERL_ARGS_ASSERT_ \w+ ) ; $ /ax;
+    $used{$1}++ if / ^ \s+ (PERL_ARGS_ASSERT_ \w+ ) ; /ax;
 }
 
 my %unused;

--- a/t/porting/args_assert.t
+++ b/t/porting/args_assert.t
@@ -34,7 +34,7 @@ unless (-d 't' && -f 'MANIFEST') {
         # The trailing '.' distinguishes real from dummy macros that have no
         # real asserts
 	$declared{$1}++ if / ^ \s* \# \s* define \s+
-                               ( PERL_ARGS_ASSERT \w+ ) \s+ .
+                               ( PERL_ARGS_ASSERT \w+ ) \b
                            /ax;
     }
 }

--- a/t/porting/args_assert.t
+++ b/t/porting/args_assert.t
@@ -43,10 +43,17 @@ if (!@ARGV) {
     my $manifest = $prefix . 'MANIFEST';
     open my $fh, '<', $manifest or die "Can't open $manifest: $!";
     while (<$fh>) {
-	# *.c or */*.c
-	push @ARGV, $prefix . $1 if m! ^ ( (?: [^/]+ / )? [^/]+ \.c ) \t !x;
-        # Special case the *inline.h since they behave like *.c
-	push @ARGV, $prefix . $1 if m!^(([^/]+)?inline\.h)\t!;
+        # *.c or */*.c; and special case several .h that have functions
+        # defined in them
+	push @ARGV, $prefix . $1 if m! ^
+                                       ( (?: [^/]+ / )? [^/]*
+                                         (?:             \.c
+                                             |     inline\.h
+                                             | perlstatic\.h
+                                         )
+                                       )
+                                       \t
+                                     !x;
     }
 }
 

--- a/taint.c
+++ b/taint.c
@@ -97,6 +97,8 @@ Implements the L</TAINT_ENV> macro, which you should generally use instead.
 void
 Perl_taint_env(pTHX)
 {
+    PERL_ARGS_ASSERT_TAINT_ENV;
+
     /* Don't use directly; instead use TAINT_ENV */
 
     SV** svp;

--- a/toke.c
+++ b/toke.c
@@ -652,6 +652,8 @@ S_printbuf(pTHX_ const char *const fmt, const char *const s)
 static int
 S_ao(pTHX_ int toketype)
 {
+    PERL_ARGS_ASSERT_AO;
+
     if (*PL_bufptr == '=') {
         PL_bufptr++;
 
@@ -771,6 +773,8 @@ S_warn_expect_operator(pTHX_ const char *const what, char *s, I32 pop_oldbufptr)
 static void
 S_missingterm(pTHX_ char *s, STRLEN len)
 {
+    PERL_ARGS_ASSERT_MISSINGTERM;
+
     char tmpbuf[UTF8_MAXBYTES + 1];
     char q;
     bool uni = FALSE;
@@ -897,6 +901,8 @@ used by perl internally, so extensions should always pass zero.
 void
 Perl_lex_start(pTHX_ SV *line, PerlIO *rsfp, U32 flags)
 {
+    PERL_ARGS_ASSERT_LEX_START;
+
     const char *s = NULL;
     yy_parser *parser, *oparser;
 
@@ -1125,6 +1131,8 @@ instead of implementing the logic yourself.
 bool
 Perl_lex_bufutf8(pTHX)
 {
+    PERL_ARGS_ASSERT_LEX_BUFUTF8;
+
     return UTF;
 }
 
@@ -1148,6 +1156,8 @@ into the buffer.
 char *
 Perl_lex_grow_linestr(pTHX_ STRLEN len)
 {
+    PERL_ARGS_ASSERT_LEX_GROW_LINESTR;
+
     SV *linestr;
     char *buf;
     STRLEN bufend_pos, bufptr_pos, oldbufptr_pos, oldoldbufptr_pos;
@@ -1441,6 +1451,8 @@ Perl_lex_discard_to(pTHX_ char *ptr)
 void
 Perl_notify_parser_that_encoding_changed(pTHX)
 {
+    PERL_ARGS_ASSERT_NOTIFY_PARSER_THAT_ENCODING_CHANGED;
+
     /* Called when $^H is changed to indicate that HINT_UTF8 or
      * HINT_ASCII_ENCODING has changed from off to on.  At compile time, this
      * has the effect of entering a 'use utf8' or 'use source::encoding'
@@ -1486,6 +1498,8 @@ buffer has reached the end of the input text.
 bool
 Perl_lex_next_chunk(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_LEX_NEXT_CHUNK;
+
     SV *linestr;
     char *buf;
     STRLEN old_bufend_pos, new_bufend_pos;
@@ -1627,6 +1641,8 @@ is encountered, an exception is generated.
 I32
 Perl_lex_peek_unichar(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_LEX_PEEK_UNICHAR;
+
     char *s, *bufend;
     if (flags & ~(LEX_KEEP_PREVIOUS))
         croak("Lexing code internal error (%s)", "lex_peek_unichar");
@@ -1690,6 +1706,8 @@ is encountered, an exception is generated.
 I32
 Perl_lex_read_unichar(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_LEX_READ_UNICHAR;
+
     I32 c;
     if (flags & ~(LEX_KEEP_PREVIOUS))
         croak("Lexing code internal error (%s)", "lex_read_unichar");
@@ -1728,6 +1746,8 @@ chunk will not be discarded.
 void
 Perl_lex_read_space(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_LEX_READ_SPACE;
+
     char *s, *bufend;
     const bool can_incline = !(flags & LEX_NO_INCLINE);
     bool need_incline = 0;
@@ -2024,6 +2044,8 @@ S_incline(pTHX_ const char *s, const char *end)
 static void
 S_update_debugger_info(pTHX_ SV *orig_sv, const char *const buf, STRLEN len)
 {
+    PERL_ARGS_ASSERT_UPDATE_DEBUGGER_INFO;
+
     AV *av = CopFILEAVx(PL_curcop);
     if (av) {
         SV * sv;
@@ -2095,6 +2117,8 @@ Perl_skipspace_flags(pTHX_ char *s, U32 flags)
 static void
 S_check_unary(pTHX)
 {
+    PERL_ARGS_ASSERT_CHECK_UNARY;
+
     const char *s;
 
     if (PL_oldoldbufptr != PL_last_uni)
@@ -2178,6 +2202,8 @@ S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s)
 static void
 S_force_next(pTHX_ I32 type)
 {
+    PERL_ARGS_ASSERT_FORCE_NEXT;
+
 #ifdef DEBUGGING
     if (DEBUG_T_TEST) {
         PerlIO_printf(Perl_debug_log, "### forced token:\n");
@@ -2232,6 +2258,8 @@ S_postderef(pTHX_ int const funny, char const next)
 void
 Perl_yyunlex(pTHX)
 {
+    PERL_ARGS_ASSERT_YYUNLEX;
+
     int yyc = PL_parser->yychar;
     if (yyc != YYEMPTY) {
         if (yyc) {
@@ -2362,6 +2390,8 @@ S_force_ident(pTHX_ const char *s, int kind)
 static void
 S_force_ident_maybe_lex(pTHX_ char pit)
 {
+    PERL_ARGS_ASSERT_FORCE_IDENT_MAYBE_LEX;
+
     NEXTVAL_NEXTTOKE.ival = pit;
     force_next('p');
 }
@@ -2558,6 +2588,8 @@ S_tokeq(pTHX_ SV *sv)
 static I32
 S_sublex_start(pTHX)
 {
+    PERL_ARGS_ASSERT_SUBLEX_START;
+
     const I32 op_type = pl_yylval.ival;
 
     if (op_type == OP_NULL) {
@@ -2610,6 +2642,8 @@ S_sublex_start(pTHX)
 static I32
 S_sublex_push(pTHX)
 {
+    PERL_ARGS_ASSERT_SUBLEX_PUSH;
+
     LEXSHARED *shared;
     const bool is_heredoc = PL_multi_close == '<';
     ENTER;
@@ -2713,6 +2747,8 @@ S_sublex_push(pTHX)
 static I32
 S_sublex_done(pTHX)
 {
+    PERL_ARGS_ASSERT_SUBLEX_DONE;
+
     if (!PL_lex_starts++) {
         SV * const sv = newSVpvs("");
         if (SvUTF8(PL_linestr))
@@ -5312,6 +5348,8 @@ S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv)
 SV *
 Perl_filter_add(pTHX_ filter_t funcp, SV *datasv)
 {
+    PERL_ARGS_ASSERT_FILTER_ADD;
+
     if (!funcp)
         return NULL;
 
@@ -10154,6 +10192,8 @@ yyl_try(pTHX_ char *s)
 int
 Perl_yylex(pTHX)
 {
+    PERL_ARGS_ASSERT_YYLEX;
+
     char *s = PL_bufptr;
 
     if (UNLIKELY(PL_parser->recheck_charset_validity)) {
@@ -10454,6 +10494,8 @@ Perl_yylex(pTHX)
 static int
 S_pending_ident(pTHX)
 {
+    PERL_ARGS_ASSERT_PENDING_IDENT;
+
     PADOFFSET tmp = 0;
     const char pit = (char)pl_yylval.ival;
     const STRLEN tokenbuf_len = strlen(PL_tokenbuf);
@@ -13512,6 +13554,8 @@ the function;
 I32
 Perl_start_subparse(pTHX_ I32 is_format, U32 flags)
 {
+    PERL_ARGS_ASSERT_START_SUBPARSE;
+
     const I32 oldsavestack_ix = PL_savestack_ix;
     CV* const outsidecv = PL_compcv;
     bool is_method = flags & CVf_IsMETHOD;
@@ -13690,6 +13734,8 @@ Perl_abort_execution(pTHX_ SV* msg_sv, const char * const name)
 void
 Perl_yyquit(pTHX)
 {
+    PERL_ARGS_ASSERT_YYQUIT;
+
     /* Called, after at least one error has been found, to abort the parse now,
      * instead of trying to forge ahead */
 
@@ -13715,6 +13761,8 @@ Perl_yyerror_pv(pTHX_ const char *const s, U32 flags)
 int
 Perl_yyerror_pvn(pTHX_ const char *const s, STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_YYERROR_PVN;
+
     const char *context = NULL;
     int contlen = -1;
     SV *msg;
@@ -14377,6 +14425,8 @@ errors, however, will throw an exception immediately.
 OP *
 Perl_parse_arithexpr(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_ARITHEXPR;
+
     return parse_expr(LEX_FAKEEOF_COMPARE, flags);
 }
 
@@ -14409,6 +14459,8 @@ errors, however, will throw an exception immediately.
 OP *
 Perl_parse_termexpr(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_TERMEXPR;
+
     return parse_expr(LEX_FAKEEOF_COMMA, flags);
 }
 
@@ -14441,6 +14493,8 @@ errors, however, will throw an exception immediately.
 OP *
 Perl_parse_listexpr(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_LISTEXPR;
+
     return parse_expr(LEX_FAKEEOF_LOWLOGIC, flags);
 }
 
@@ -14474,6 +14528,8 @@ errors, however, will throw an exception immediately.
 OP *
 Perl_parse_fullexpr(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_FULLEXPR;
+
     return parse_expr(LEX_FAKEEOF_NONEXPR, flags);
 }
 
@@ -14508,6 +14564,8 @@ be zero.
 OP *
 Perl_parse_block(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_BLOCK;
+
     if (flags)
         croak("Parsing code internal error (%s)", "parse_block");
     return parse_recdescent_for_op(GRAMBLOCK, LEX_FAKEEOF_NEVER);
@@ -14546,6 +14604,8 @@ be zero.
 OP *
 Perl_parse_barestmt(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_BARESTMT;
+
     if (flags)
         croak("Parsing code internal error (%s)", "parse_barestmt");
     return parse_recdescent_for_op(GRAMBARESTMT, LEX_FAKEEOF_NEVER);
@@ -14574,6 +14634,8 @@ level of parsing which covers all the compilation errors that occurred.
 SV *
 Perl_parse_label(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_LABEL;
+
     if (flags & ~PARSE_OPTIONAL)
         croak("Parsing code internal error (%s)", "parse_label");
     if (PL_nexttoke) {
@@ -14652,6 +14714,8 @@ be zero.
 OP *
 Perl_parse_fullstmt(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_FULLSTMT;
+
     if (flags)
         croak("Parsing code internal error (%s)", "parse_fullstmt");
     return parse_recdescent_for_op(GRAMFULLSTMT, LEX_FAKEEOF_NEVER);
@@ -14690,6 +14754,8 @@ be zero.
 OP *
 Perl_parse_stmtseq(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_STMTSEQ;
+
     OP *stmtseqop;
     I32 c;
     if (flags)
@@ -14728,6 +14794,8 @@ be zero.
 OP *
 Perl_parse_subsignature(pTHX_ U32 flags)
 {
+    PERL_ARGS_ASSERT_PARSE_SUBSIGNATURE;
+
     if (flags)
         croak("Parsing code internal error (%s)", "parse_subsignature");
     /* sub signatures might be empty, but perly.y can't cope with the

--- a/toke.c
+++ b/toke.c
@@ -810,7 +810,8 @@ S_missingterm(pTHX_ char *s, STRLEN len)
 }
 
 static char *
-S_scan_terminated(pTHX_ char *s, I32 ival) {
+S_scan_terminated(pTHX_ char *s, I32 ival)
+{
     s = scan_str(s,FALSE,FALSE,FALSE,NULL);
     if (!s)
         missingterm(NULL, 0);
@@ -5578,7 +5579,8 @@ S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
 
 
 static char *
-S_tokenize_use(pTHX_ int is_use, char *s) {
+S_tokenize_use(pTHX_ int is_use, char *s)
+{
     PERL_ARGS_ASSERT_TOKENIZE_USE;
 
     if (PL_expect != XSTATE)
@@ -7682,7 +7684,8 @@ yyl_do(pTHX_ char *s, I32 orig_keyword)
 }
 
 static const char *
-declarator_name(I32 k) {
+declarator_name(I32 k)
+{
     switch (k) {
         case KEY_my:    return "my";
         case KEY_state: return "state";
@@ -11395,7 +11398,8 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
 }
 
 static bool
-S_pmflag(pTHX_ const char* const valid_flags, U32 * pmfl, char** s, char* charset, unsigned int * x_mod_count) {
+S_pmflag(pTHX_ const char* const valid_flags, U32 * pmfl, char** s, char* charset, unsigned int * x_mod_count)
+{
 
     /* Adds, subtracts to/from 'pmfl' based on the next regex modifier flag
      * found in the parse starting at 's', based on the subset that are valid

--- a/universal.c
+++ b/universal.c
@@ -1404,6 +1404,8 @@ optimize_out_native_convert_function(pTHX_ OP* entersubop,
 void
 Perl_boot_core_UNIVERSAL(pTHX)
 {
+    PERL_ARGS_ASSERT_BOOT_CORE_UNIVERSAL;
+
     static const char file[] = __FILE__;
     const struct xsub_details *xsub = these_details;
     const struct xsub_details *end = C_ARRAY_END(these_details);

--- a/utf8.c
+++ b/utf8.c
@@ -3538,18 +3538,24 @@ Perl_utf8_to_utf16_base(pTHX_ U8* s, U8* d, Size_t bytelen, Size_t *newlen,
 bool
 Perl_is_uni_FOO_(pTHX_ const U8 classnum, const UV c)
 {
+    PERL_ARGS_ASSERT_IS_UNI_FOO_;
+
     return invlist_contains_cp_(PL_XPosix_ptrs[classnum], c);
 }
 
 bool
 Perl_is_uni_perl_idcont_(pTHX_ UV c)
 {
+    PERL_ARGS_ASSERT_IS_UNI_PERL_IDCONT_;
+
     return invlist_contains_cp_(PL_utf8_perl_idcont, c);
 }
 
 bool
 Perl_is_uni_perl_idstart_(pTHX_ UV c)
 {
+    PERL_ARGS_ASSERT_IS_UNI_PERL_IDSTART_;
+
     return invlist_contains_cp_(PL_utf8_perl_idstart, c);
 }
 
@@ -3709,6 +3715,8 @@ Perl_to_uni_title(pTHX_ UV c, U8* p, STRLEN *lenp)
 static U8
 S_to_lower_latin1(const U8 c, U8* p, STRLEN *lenp, const char dummy)
 {
+    PERL_ARGS_ASSERT_TO_LOWER_LATIN1;
+
     /* We have the latin1-range values compiled into the core, so just use
      * those, converting the result to UTF-8.  Since the result is always just
      * one character, we allow <p> to be NULL */

--- a/util.c
+++ b/util.c
@@ -2743,7 +2743,8 @@ Perl_atfork_unlock(void)
 }
 
 void
-Perl_atfork_child(void) {
+Perl_atfork_child(void)
+{
 #ifdef USE_ITHREADS
     /* so we can resend signals received in a non-perl thread to the
        new main thread
@@ -5752,7 +5753,8 @@ if not easily emulatable.
 */
 
 int
-Perl_my_dirfd(DIR * dir) {
+Perl_my_dirfd(DIR * dir)
+{
 
     /* Most dirfd implementations have problems when passed NULL. */
     if(!dir)
@@ -5774,7 +5776,8 @@ Perl_my_dirfd(DIR * dir) {
 #define TEMP_FILE_CH_COUNT (sizeof(TEMP_FILE_CH)-1)
 
 static int
-S_my_mkostemp(char *templte, int flags) {
+S_my_mkostemp(char *templte, int flags)
+{
     dTHX;
     STRLEN len = strlen(templte);
     int fd;
@@ -5850,7 +5853,8 @@ Perl_my_mkstemp(char *templte)
 #endif
 
 REGEXP *
-Perl_get_re_arg(pTHX_ SV *sv) {
+Perl_get_re_arg(pTHX_ SV *sv)
+{
 
     if (sv) {
         if (SvMAGICAL(sv))

--- a/util.c
+++ b/util.c
@@ -154,6 +154,8 @@ Paranoid version of system's malloc()
 Malloc_t
 Perl_safesysmalloc(MEM_SIZE size)
 {
+    PERL_ARGS_ASSERT_SAFESYSMALLOC;
+
 #ifdef ALWAYS_NEED_THX
     dTHX;
 #endif
@@ -243,6 +245,8 @@ Paranoid version of system's realloc()
 Malloc_t
 Perl_safesysrealloc(Malloc_t where,MEM_SIZE size)
 {
+    PERL_ARGS_ASSERT_SAFESYSREALLOC;
+
 #ifdef ALWAYS_NEED_THX
     dTHX;
 #endif
@@ -379,6 +383,8 @@ Safe version of system's free()
 Free_t
 Perl_safesysfree(Malloc_t where)
 {
+    PERL_ARGS_ASSERT_SAFESYSFREE;
+
 #ifdef ALWAYS_NEED_THX
     dTHX;
 #endif
@@ -450,6 +456,8 @@ Safe version of system's calloc()
 Malloc_t
 Perl_safesyscalloc(MEM_SIZE count, MEM_SIZE size)
 {
+    PERL_ARGS_ASSERT_SAFESYSCALLOC;
+
 #ifdef ALWAYS_NEED_THX
     dTHX;
 #endif
@@ -1318,6 +1326,8 @@ Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U
 const char *
 Perl_cntrl_to_mnemonic(const U8 c)
 {
+    PERL_ARGS_ASSERT_CNTRL_TO_MNEMONIC;
+
     /* Returns the mnemonic string that represents character 'c', if one
      * exists; NULL otherwise.  The only ones that exist for the purposes of
      * this routine are a few control characters */
@@ -1338,6 +1348,8 @@ Perl_cntrl_to_mnemonic(const U8 c)
 char *
 Perl_savesharedpv(pTHX_ const char *pv)
 {
+    PERL_ARGS_ASSERT_SAVESHAREDPV;
+
     char *newaddr;
     STRLEN pvlen;
 
@@ -1374,6 +1386,8 @@ Perl_savesharedpvn(pTHX_ const char *const pv, const STRLEN len)
 static SV *
 S_mess_alloc(pTHX)
 {
+    PERL_ARGS_ASSERT_MESS_ALLOC;
+
     SV *sv;
     XPVMG *any;
 
@@ -1708,6 +1722,8 @@ S_with_queued_errors(pTHX_ SV *ex)
 bool
 Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
 {
+    PERL_ARGS_ASSERT_INVOKE_EXCEPTION_HOOK;
+
     HV *stash;
     GV *gv;
     CV *cv;
@@ -1769,6 +1785,8 @@ MSVC_DIAG_IGNORE(4646 4645)
 OP *
 Perl_die_nocontext(const char* pat, ...)
 {
+    PERL_ARGS_ASSERT_DIE_NOCONTEXT;
+
     dTHX;
     va_list args;
     va_start(args, pat);
@@ -1786,6 +1804,8 @@ MSVC_DIAG_IGNORE(4646 4645)
 OP *
 Perl_die(pTHX_ const char* pat, ...)
 {
+    PERL_ARGS_ASSERT_DIE;
+
     va_list args;
     va_start(args, pat);
     vcroak(pat, &args);
@@ -1807,6 +1827,8 @@ Perl_croak_sv(pTHX_ SV *baseex)
 void
 Perl_vcroak(pTHX_ const char* pat, va_list *args)
 {
+    PERL_ARGS_ASSERT_VCROAK;
+
     SV *ex = with_queued_errors(pat ? vmess(pat, args) : mess_sv(ERRSV, 0));
     invoke_exception_hook(ex, FALSE);
     die_unwind(ex);
@@ -1865,6 +1887,8 @@ is now true even when called from within core.
 void
 Perl_croak_nocontext(const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_CROAK_NOCONTEXT;
+
     dTHX;
     va_list args;
     va_start(args, pat);
@@ -1877,6 +1901,8 @@ Perl_croak_nocontext(const char *pat, ...)
 void
 Perl_croak(pTHX_ const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_CROAK;
+
     va_list args;
     va_start(args, pat);
     vcroak(pat, &args);
@@ -1900,6 +1926,8 @@ Less code used on exception code paths reduces CPU cache pressure.
 void
 Perl_croak_no_modify(void)
 {
+    PERL_ARGS_ASSERT_CROAK_NO_MODIFY;
+
     Perl_croak_nocontext( "%s", PL_no_modify);
 }
 
@@ -1933,6 +1961,8 @@ Perl_croak_no_mem_ext(const char *context, STRLEN len)
 void
 Perl_croak_no_mem(void)
 {
+    PERL_ARGS_ASSERT_CROAK_NO_MEM;
+
     croak_no_mem_ext(STR_WITH_LEN("???"));
 }
 
@@ -1940,6 +1970,8 @@ Perl_croak_no_mem(void)
 void
 Perl_croak_popstack(void)
 {
+    PERL_ARGS_ASSERT_CROAK_POPSTACK;
+
     dTHX;
     PerlIO_printf(Perl_error_log, "panic: POPSTACK\n");
     my_exit(1);
@@ -2175,6 +2207,8 @@ Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
 bool
 Perl_ckwarn(pTHX_ U32 w)
 {
+    PERL_ARGS_ASSERT_CKWARN;
+
     /* If lexical warnings have not been set, use $^W.  */
     if (isLEXWARN_off)
         return PL_dowarn & G_WARN_ON;
@@ -2187,6 +2221,8 @@ Perl_ckwarn(pTHX_ U32 w)
 bool
 Perl_ckwarn_d(pTHX_ U32 w)
 {
+    PERL_ARGS_ASSERT_CKWARN_D;
+
     /* If lexical warnings have not been set then default classes warn.  */
     if (isLEXWARN_off)
         return TRUE;
@@ -2197,6 +2233,8 @@ Perl_ckwarn_d(pTHX_ U32 w)
 static bool
 S_ckwarn_common(pTHX_ U32 w)
 {
+    PERL_ARGS_ASSERT_CKWARN_COMMON;
+
     if (PL_curcop->cop_warnings == pWARN_ALL)
         return TRUE;
 
@@ -2300,6 +2338,8 @@ version has desirable safeguards
 void
 Perl_my_setenv(pTHX_ const char *nam, const char *val)
 {
+    PERL_ARGS_ASSERT_MY_SETENV;
+
 #  if defined(USE_ITHREADS) && !defined(WIN32)
     /* only parent thread can modify process environment */
     if (PL_curinterp != aTHX)
@@ -2705,6 +2745,8 @@ Perl_atfork_lock(void)
   PERL_TSA_ACQUIRE(PL_op_mutex)
 #endif
 {
+    PERL_ARGS_ASSERT_ATFORK_LOCK;
+
 #if defined(USE_ITHREADS)
     /* locks must be held in locking order (if any) */
 #  ifdef USE_PERLIO
@@ -2730,6 +2772,8 @@ Perl_atfork_unlock(void)
   PERL_TSA_RELEASE(PL_op_mutex)
 #endif
 {
+    PERL_ARGS_ASSERT_ATFORK_UNLOCK;
+
 #if defined(USE_ITHREADS)
     /* locks must be released in same order as in atfork_lock() */
 #  ifdef USE_PERLIO
@@ -2745,6 +2789,8 @@ Perl_atfork_unlock(void)
 void
 Perl_atfork_child(void)
 {
+    PERL_ARGS_ASSERT_ATFORK_CHILD;
+
 #ifdef USE_ITHREADS
     /* so we can resend signals received in a non-perl thread to the
        new main thread
@@ -2770,6 +2816,8 @@ used except through C<PerlProc_fork>.
 Pid_t
 Perl_my_fork(void)
 {
+    PERL_ARGS_ASSERT_MY_FORK;
+
 #if defined(HAS_FORK)
     Pid_t pid;
 #if defined(USE_ITHREADS) && !defined(HAS_PTHREAD_ATFORK)
@@ -2842,6 +2890,8 @@ rest of the perl interpreter.
 Sighandler_t
 Perl_rsignal(pTHX_ int signo, Sighandler_t handler)
 {
+    PERL_ARGS_ASSERT_RSIGNAL;
+
     struct sigaction act, oact;
 
 #ifdef USE_ITHREADS
@@ -2880,6 +2930,8 @@ See L</C<rsignal>>.
 Sighandler_t
 Perl_rsignal_state(pTHX_ int signo)
 {
+    PERL_ARGS_ASSERT_RSIGNAL_STATE;
+
     struct sigaction oact;
     PERL_UNUSED_CONTEXT;
 
@@ -2919,7 +2971,9 @@ Perl_rsignal_save(pTHX_ int signo, Sighandler_t handler, Sigsave_t *save)
 int
 Perl_rsignal_restore(pTHX_ int signo, Sigsave_t *save)
 {
+    PERL_ARGS_ASSERT_RSIGNAL_RESTORE;
     PERL_UNUSED_CONTEXT;
+
 #ifdef USE_ITHREADS
     /* only "parent" interpreter can diddle signals */
     if (PL_curinterp != aTHX)
@@ -2934,6 +2988,8 @@ Perl_rsignal_restore(pTHX_ int signo, Sigsave_t *save)
 Sighandler_t
 Perl_rsignal(pTHX_ int signo, Sighandler_t handler)
 {
+    PERL_ARGS_ASSERT_RSIGNAL;
+
 #if defined(USE_ITHREADS) && !defined(WIN32)
     /* only "parent" interpreter can diddle signals */
     if (PL_curinterp != aTHX)
@@ -2953,6 +3009,8 @@ sig_trap(int signo)
 Sighandler_t
 Perl_rsignal_state(pTHX_ int signo)
 {
+    PERL_ARGS_ASSERT_RSIGNAL_STATE;
+
     Sighandler_t oldsig;
 
 #if defined(USE_ITHREADS) && !defined(WIN32)
@@ -2984,6 +3042,8 @@ Perl_rsignal_save(pTHX_ int signo, Sighandler_t handler, Sigsave_t *save)
 int
 Perl_rsignal_restore(pTHX_ int signo, Sigsave_t *save)
 {
+    PERL_ARGS_ASSERT_RSIGNAL_RESTORE;
+
 #if defined(USE_ITHREADS) && !defined(WIN32)
     /* only "parent" interpreter can diddle signals */
     if (PL_curinterp != aTHX)
@@ -3010,6 +3070,8 @@ version knows things that interact with the rest of the perl interpreter.
 I32
 Perl_my_pclose(pTHX_ PerlIO *ptr)
 {
+    PERL_ARGS_ASSERT_MY_PCLOSE;
+
     int status;
     SV **svp;
     Pid_t pid;
@@ -3060,6 +3122,8 @@ Perl_my_pclose(pTHX_ PerlIO *ptr)
 I32
 Perl_my_pclose(pTHX_ PerlIO *ptr)
 {
+    PERL_ARGS_ASSERT_MY_PCLOSE;
+
     return -1;
 }
 #endif /* !DOSISH */
@@ -3159,6 +3223,8 @@ Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
 static void
 S_pidgone(pTHX_ Pid_t pid, int status)
 {
+    PERL_ARGS_ASSERT_PIDGONE;
+
     SV *sv;
 
     sv = *hv_fetch(PL_pidstatus,(const char*)&pid,sizeof(Pid_t),TRUE);
@@ -3179,6 +3245,8 @@ I32
 Perl_my_pclose(pTHX_ PerlIO *ptr)
 #endif
 {
+    PERL_ARGS_ASSERT_MY_PCLOSE;
+
     /* Needs work for PerlIO ! */
     FILE * const f = PerlIO_findFILE(ptr);
     const I32 result = pclose(f);
@@ -3571,6 +3639,8 @@ Deprecated since 5.38
 char **
 Perl_get_op_names(pTHX)
 {
+    PERL_ARGS_ASSERT_GET_OP_NAMES;
+
     PERL_UNUSED_CONTEXT;
     return (char **)PL_op_name;
 }
@@ -3590,6 +3660,8 @@ Deprecated since 5.38
 char **
 Perl_get_op_descs(pTHX)
 {
+    PERL_ARGS_ASSERT_GET_OP_DESCS;
+
     PERL_UNUSED_CONTEXT;
     return (char **)PL_op_desc;
 }
@@ -3597,6 +3669,8 @@ Perl_get_op_descs(pTHX)
 const char *
 Perl_get_no_modify(pTHX)
 {
+    PERL_ARGS_ASSERT_GET_NO_MODIFY;
+
     PERL_UNUSED_CONTEXT;    /* Deprecated since 5.38 */
     return PL_no_modify;
 }
@@ -3604,6 +3678,8 @@ Perl_get_no_modify(pTHX)
 U32 *
 Perl_get_opargs(pTHX)
 {
+    PERL_ARGS_ASSERT_GET_OPARGS;
+
     PERL_UNUSED_CONTEXT;    /* Deprecated since 5.38 */
     return (U32 *)PL_opargs;
 }
@@ -3611,6 +3687,8 @@ Perl_get_opargs(pTHX)
 PPADDR_t*
 Perl_get_ppaddr(pTHX)
 {
+    PERL_ARGS_ASSERT_GET_PPADDR;
+
     PERL_UNUSED_CONTEXT;    /* Deprecated since 5.38 */
     return (PPADDR_t*)PL_ppaddr;
 }
@@ -3640,6 +3718,8 @@ Implements C<PERL_FLUSHALL_FOR_CHILD> on some platforms.
 I32
 Perl_my_fflush_all(pTHX)
 {
+    PERL_ARGS_ASSERT_MY_FFLUSH_ALL;
+
 #if defined(USE_PERLIO) || defined(FFLUSH_NULL)
     return PerlIO_flush(NULL);
 #else
@@ -3682,6 +3762,8 @@ Perl_my_fflush_all(pTHX)
 void
 Perl_report_wrongway_fh(pTHX_ const GV *gv, const char have)
 {
+    PERL_ARGS_ASSERT_REPORT_WRONGWAY_FH;
+
     if (ckWARN(WARN_IO)) {
         HEK * const name
            = gv && (isGV_with_GP(gv))
@@ -3702,6 +3784,8 @@ Perl_report_wrongway_fh(pTHX_ const GV *gv, const char have)
 void
 Perl_report_evil_fh(pTHX_ const GV *gv)
 {
+    PERL_ARGS_ASSERT_REPORT_EVIL_FH;
+
     const IO *io = gv ? GvIO(gv) : NULL;
     const PERL_BITFIELD16 op = PL_op->op_type;
     const char *vile;
@@ -4422,6 +4506,8 @@ Perl_my_socketpair (int family, int type, int protocol, int fd[2]) {
  * to the my_socketpair in embed.fnc. */
 int
 Perl_my_socketpair (int family, int type, int protocol, int fd[2]) {
+    PERL_ARGS_ASSERT_MY_SOCKETPAIR;
+
 #ifdef HAS_SOCKETPAIR
     return socketpair(family, type, protocol, fd);
 #else
@@ -4446,6 +4532,7 @@ potentially warn under some level of strict-ness.
 void
 Perl_sv_nosharing(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SV_NOSHARING;
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(sv);
 }
@@ -4465,8 +4552,10 @@ could potentially warn under some level of strict-ness.
 bool
 Perl_sv_destroyable(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SV_DESTROYABLE;
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(sv);
+
     return TRUE;
 }
 
@@ -4565,6 +4654,8 @@ splitmix64(U64 *state)
 U64
 Perl_seed(pTHX)
 {
+    PERL_ARGS_ASSERT_SEED;
+
    /*
     * Attempt to read from /dev/urandom to generate a pseudo-random number.
     * If that does not work, or it is unavailable, we fall back to gathering
@@ -5285,6 +5376,8 @@ Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap
 void
 Perl_my_clearenv(pTHX)
 {
+    PERL_ARGS_ASSERT_MY_CLEARENV;
+
 #  if defined(PERL_IMPLICIT_SYS) || defined(WIN32)
     PerlEnv_clearenv();
 #  else /* ! (PERL_IMPLICIT_SYS || WIN32) */
@@ -5755,6 +5848,7 @@ if not easily emulatable.
 int
 Perl_my_dirfd(DIR * dir)
 {
+    PERL_ARGS_ASSERT_MY_DIRFD;
 
     /* Most dirfd implementations have problems when passed NULL. */
     if(!dir)
@@ -5855,6 +5949,7 @@ Perl_my_mkstemp(char *templte)
 REGEXP *
 Perl_get_re_arg(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_GET_RE_ARG;
 
     if (sv) {
         if (SvMAGICAL(sv))
@@ -6298,6 +6393,8 @@ returning at most C<depth> frames.
 Perl_c_backtrace*
 Perl_get_c_backtrace(pTHX_ int depth, int skip)
 {
+    PERL_ARGS_ASSERT_GET_C_BACKTRACE;
+
     /* Note that here we must stay as low-level as possible: Newx(),
      * Copy(), Safefree(); since we may be called from anywhere,
      * so we should avoid higher level constructs like SVs or AVs.
@@ -6567,6 +6664,8 @@ if the optimizer has transformed the code by for example inlining.
 SV*
 Perl_get_c_backtrace_dump(pTHX_ int depth, int skip)
 {
+    PERL_ARGS_ASSERT_GET_C_BACKTRACE_DUMP;
+
     Perl_c_backtrace* bt;
 
     bt = get_c_backtrace(depth, skip + 1 /* Hide ourselves. */);
@@ -6736,6 +6835,8 @@ Perl_dtrace_probe_op(pTHX_ const OP *op)
 void
 Perl_dtrace_probe_phase(pTHX_ enum perl_phase phase)
 {
+    PERL_ARGS_ASSERT_DTRACE_PROBE_PHASE;
+
     const char *ph_old = PL_phase_names[PL_phase];
     const char *ph_new = PL_phase_names[phase];
 

--- a/vms/vms.c
+++ b/vms/vms.c
@@ -13341,11 +13341,14 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src,
 void  
 Perl_sys_intern_clear(pTHX)
 {
+    PERL_ARGS_ASSERT_SYS_INTERN_CLEAR;
 }
 
 void  
 Perl_sys_intern_init(pTHX)
 {
+    PERL_ARGS_ASSERT_SYS_INTERN_INIT;
+
     unsigned int ix = RAND_MAX;
     double x;
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -5686,6 +5686,8 @@ win32_csighandler(int sig)
 void
 Perl_sys_intern_init(pTHX)
 {
+    PERL_ARGS_ASSERT_SYS_INTERN_INIT;
+
     int i;
 
     w32_perlshell_tokens	= NULL;
@@ -5730,6 +5732,7 @@ Perl_sys_intern_init(pTHX)
 void
 Perl_sys_intern_clear(pTHX)
 {
+    PERL_ARGS_ASSERT_SYS_INTERN_CLEAR;
 
     Safefree(w32_perlshell_tokens);
     Safefree(w32_perlshell_vec);


### PR DESCRIPTION
This adds calls for every function missing a generated ARGS_ASSERT macro, fixing the test that was supposed to find missing ones.

Since, now every generated one has a call, it changes the test to fail on even empty ones, so that new functions added to embed.fnc will need to include the ARGS_ASSERT.

* This set of changes does not require a perldelta entry.
