### PR TITLE
dist/IO: Set io_socket_peername during configure() of a Unix socket

### DIFF
--- a/Porting/exclude_contrib.txt
+++ b/Porting/exclude_contrib.txt
@@ -20,4 +20,6 @@
 # sorted.
 ##########################################################################
 dXO3142iRNcbpIKO2qxc1o3lNX8+oOCoyG5si+Sb2Ck
+FG0GLuuu5ntPQBJEp8JMrdZaAyzQ3qASGZxKgQIn2CA
+Ply5itbfmwcKAhWTKCx0ujKk+8UivRDQzE64+EKSH5c
 QvzD7VskxHgLvOy3GdB9zvcqWIH9uM347jNLQS8QfFs

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -11,7 +11,7 @@ use IO::Socket;
 use Carp;
 
 our @ISA = qw(IO::Socket);
-our $VERSION = "1.56";
+our $VERSION = "1.57";
 
 IO::Socket::UNIX->register_domain( AF_UNIX );
 
@@ -45,6 +45,7 @@ sub configure {
     }
     elsif(exists $arg->{Peer}) {
 	my $addr = sockaddr_un($arg->{Peer});
+	${*$sock}{'io_socket_peername'} = $arg->{Peer};
 	$sock->connect($addr) or
 	    return undef;
     }


### PR DESCRIPTION
Some systems (notably GNU/Hurd) do not support getpeername() on a local Unix socket, which breaks read() on them as it tries to set the peer if there is none already. In order to circumvent that, set the peer during configure(), where it is known.

Fixes #24195

This is an alternative (and probably superior) approach to #24201 . In general, both could be applied, but either works for fixing #24195 

