### PR TITLE
Move ARGS_ASSERT lines to top of  their functions

### DIFF
--- a/av.c
+++ b/av.c
@@ -22,9 +22,9 @@
 void
 Perl_av_reify(pTHX_ AV *av)
 {
-    SSize_t key;
-
     PERL_ARGS_ASSERT_AV_REIFY;
+
+    SSize_t key;
 
     if (AvREAL(av))
         return;
@@ -64,9 +64,9 @@ array method with an argument of C<(key+1)>.
 void
 Perl_av_extend(pTHX_ AV *av, SSize_t key)
 {
-    MAGIC *mg;
-
     PERL_ARGS_ASSERT_AV_EXTEND;
+
+    MAGIC *mg;
 
     mg = SvTIED_mg((const SV *)av, PERL_MAGIC_tied);
     if (mg) {
@@ -332,9 +332,9 @@ more information on how to use this function on tied arrays.
 SV**
 Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
 {
-    SV** ary;
-
     PERL_ARGS_ASSERT_AV_STORE;
+
+    SV** ary;
 
     /* S_regclass relies on being able to pass in a NULL sv
        (unicode_alternate may be NULL).
@@ -457,9 +457,10 @@ Perl equivalent: C<my @new_array = ($scalar1, $scalar2, $scalar3...);>
 AV *
 Perl_av_make(pTHX_ SSize_t size, SV **strp)
 {
+    PERL_ARGS_ASSERT_AV_MAKE;
+
     AV * const av = newAV();
     /* sv_upgrade does AvREAL_only()  */
-    PERL_ARGS_ASSERT_AV_MAKE;
     assert(SvTYPE(av) == SVt_PVAV);
 
     if (size) {		/* "defined" was returning undef for size==0 anyway. */
@@ -623,10 +624,10 @@ to it.
 void
 Perl_av_clear(pTHX_ AV *av)
 {
+    PERL_ARGS_ASSERT_AV_CLEAR;
+
     bool real;
     SSize_t orig_ix = 0;
-
-    PERL_ARGS_ASSERT_AV_CLEAR;
 
 #ifdef DEBUGGING
     if (SvREFCNT(av) == 0) {
@@ -696,10 +697,10 @@ return.
 void
 Perl_av_undef(pTHX_ AV *av)
 {
+    PERL_ARGS_ASSERT_AV_UNDEF;
+
     bool real;
     SSize_t orig_ix = PL_tmps_ix; /* silence bogus warning about possible uninitialized use */
-
-    PERL_ARGS_ASSERT_AV_UNDEF;
 
     /* Give any tie a chance to cleanup first */
     if (SvTIED_mg((const SV *)av, PERL_MAGIC_tied)) 
@@ -778,9 +779,9 @@ assumptions may not hold.
 void
 Perl_av_push(pTHX_ AV *av, SV *val)
 {             
-    MAGIC *mg;
-
     PERL_ARGS_ASSERT_AV_PUSH;
+
+    MAGIC *mg;
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -808,10 +809,10 @@ Perl equivalent: C<pop(@myarray);>
 SV *
 Perl_av_pop(pTHX_ AV *av)
 {
+    PERL_ARGS_ASSERT_AV_POP;
+
     SV *retval;
     MAGIC* mg;
-
-    PERL_ARGS_ASSERT_AV_POP;
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -866,10 +867,10 @@ Perl equivalent: S<C<unshift @myarray, ((undef) x $num);>>
 void
 Perl_av_unshift(pTHX_ AV *av, SSize_t num)
 {
+    PERL_ARGS_ASSERT_AV_UNSHIFT;
+
     SSize_t i;
     MAGIC* mg;
-
-    PERL_ARGS_ASSERT_AV_UNSHIFT;
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -932,10 +933,10 @@ Perl equivalent: C<shift(@myarray);>
 SV *
 Perl_av_shift(pTHX_ AV *av)
 {
+    PERL_ARGS_ASSERT_AV_SHIFT;
+
     SV *retval;
     MAGIC* mg;
-
-    PERL_ARGS_ASSERT_AV_SHIFT;
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -1008,9 +1009,9 @@ the same as C<av_clear(av)>.
 void
 Perl_av_fill(pTHX_ AV *av, SSize_t fill)
 {
-    MAGIC *mg;
-
     PERL_ARGS_ASSERT_AV_FILL;
+
+    MAGIC *mg;
 
     if (fill < 0)
         fill = -1;
@@ -1060,9 +1061,9 @@ C<splice> in void context if C<G_DISCARD> is present).
 SV *
 Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags)
 {
-    SV *sv;
-
     PERL_ARGS_ASSERT_AV_DELETE;
+
+    SV *sv;
 
     if (SvREADONLY(av))
         croak_no_modify();
@@ -1192,9 +1193,9 @@ Perl_av_exists(pTHX_ AV *av, SSize_t key)
 static MAGIC *
 S_get_aux_mg(pTHX_ AV *av)
 {
-    MAGIC *mg;
-
     PERL_ARGS_ASSERT_GET_AUX_MG;
+
+    MAGIC *mg;
 
     mg = mg_find((const SV *)av, PERL_MAGIC_arylen_p);
 
@@ -1211,9 +1212,9 @@ S_get_aux_mg(pTHX_ AV *av)
 SV **
 Perl_av_arylen_p(pTHX_ AV *av)
 {
-    MAGIC *const mg = get_aux_mg(av);
-
     PERL_ARGS_ASSERT_AV_ARYLEN_P;
+
+    MAGIC *const mg = get_aux_mg(av);
 
     return &(mg->mg_obj);
 }
@@ -1221,9 +1222,9 @@ Perl_av_arylen_p(pTHX_ AV *av)
 IV *
 Perl_av_iter_p(pTHX_ AV *av)
 {
-    MAGIC *const mg = get_aux_mg(av);
-
     PERL_ARGS_ASSERT_AV_ITER_P;
+
+    MAGIC *const mg = get_aux_mg(av);
 
     if (sizeof(IV) == sizeof(SSize_t)) {
         return (IV *)&(mg->mg_len);
@@ -1241,8 +1242,9 @@ Perl_av_iter_p(pTHX_ AV *av)
 SV *
 Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
 {
-    SV * const sv = newSV_type(SVt_NULL);
     PERL_ARGS_ASSERT_AV_NONELEM;
+
+    SV * const sv = newSV_type(SVt_NULL);
     if (!av_store(av,ix,sv))
         return sv_2mortal(sv); /* has tie magic */
     sv_magic(sv, NULL, PERL_MAGIC_nonelem, NULL, 0);

--- a/builtin.c
+++ b/builtin.c
@@ -496,8 +496,9 @@ static OP *ck_builtin_func1(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)
 void
 Perl_XS_builtin_indexed(pTHX_ CV *cv)
 {
-    dXSARGS;
     PERL_ARGS_ASSERT_XS_BUILTIN_INDEXED;
+
+    dXSARGS;
     PERL_UNUSED_VAR(cv);
 
     switch(GIMME_V) {

--- a/deb.c
+++ b/deb.c
@@ -28,10 +28,11 @@
 void
 Perl_deb_nocontext(const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_DEB_NOCONTEXT;
+
 #ifdef DEBUGGING
     dTHX;
     va_list args;
-    PERL_ARGS_ASSERT_DEB_NOCONTEXT;
     va_start(args, pat);
     vdeb(pat, &args);
     va_end(args);
@@ -63,8 +64,9 @@ C<vdeb> is the same as C<deb> except C<args> is a pointer to a C<va_list>.
 void
 Perl_deb(pTHX_ const char *pat, ...)
 {
-    va_list args;
     PERL_ARGS_ASSERT_DEB;
+
+    va_list args;
     va_start(args, pat);
 #ifdef DEBUGGING
     vdeb(pat, &args);
@@ -77,14 +79,14 @@ Perl_deb(pTHX_ const char *pat, ...)
 void
 Perl_vdeb(pTHX_ const char *pat, va_list *args)
 {
+    PERL_ARGS_ASSERT_VDEB;
+
 #ifdef DEBUGGING
     const char* const file = PL_curcop ? OutCopFILE(PL_curcop) : "<null>";
     const char* const display_file = file ? file : "<free>";
     line_t line = PL_curcop ? CopLINE(PL_curcop) : NOLINE;
     if (line == NOLINE)
         line = 0;
-
-    PERL_ARGS_ASSERT_VDEB;
 
     if (DEBUG_v_TEST)
         PerlIO_printf(Perl_debug_log, "(%ld:%s:%" LINE_Tf ")\t",
@@ -139,11 +141,11 @@ static void
 S_deb_stack_n(pTHX_ SV** stack_base, SSize_t stack_min, SSize_t stack_max,
         SSize_t mark_min, SSize_t mark_max, SSize_t nonrc_base)
 {
+    PERL_ARGS_ASSERT_DEB_STACK_N;
+
 #ifdef DEBUGGING
     SSize_t i = stack_max - 30;
     const Stack_off_t *markscan = PL_markstack + mark_min;
-
-    PERL_ARGS_ASSERT_DEB_STACK_N;
 
     if (i < stack_min)
         i = stack_min;

--- a/doio.c
+++ b/doio.c
@@ -398,9 +398,9 @@ static IO *
 S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp,
               int *savefd,  char *savetype)
 {
-    IO * const io = GvIOn(gv);
-
     PERL_ARGS_ASSERT_OPENN_SETUP;
+
+    IO * const io = GvIOn(gv);
 
     *saveifp = NULL;
     *saveofp = NULL;
@@ -479,6 +479,8 @@ bool
 Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len,
                  int rawmode, int rawperm, Stat_t *statbufp)
 {
+    PERL_ARGS_ASSERT_DO_OPEN_RAW;
+
     PerlIO *saveifp;
     PerlIO *saveofp;
     int savefd;
@@ -487,8 +489,6 @@ Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len,
     IO * const io = openn_setup(gv, mode, &saveifp, &saveofp, &savefd, &savetype);
     int writing = 0;
     PerlIO *fp;
-
-    PERL_ARGS_ASSERT_DO_OPEN_RAW;
 
     /* For ease of blame back to 5.000, keep the existing indenting. */
     {
@@ -548,6 +548,8 @@ bool
 Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
               PerlIO *supplied_fp, SV **svp, U32 num_svs)
 {
+    PERL_ARGS_ASSERT_DO_OPEN6;
+
     PerlIO *saveifp;
     PerlIO *saveofp;
     int savefd;
@@ -558,8 +560,6 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len,
     PerlIO *fp;
     bool was_fdopen = FALSE;
     char *type  = NULL;
-
-    PERL_ARGS_ASSERT_DO_OPEN6;
 
     /* For ease of blame back to 5.000, keep the existing indenting. */
     {
@@ -940,10 +940,10 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
                 PerlIO *saveifp, PerlIO *saveofp, int savefd, char savetype,
                 int writing, bool was_fdopen, const char *type, Stat_t *statbufp)
 {
+    PERL_ARGS_ASSERT_OPENN_CLEANUP;
+
     int fd;
     Stat_t statbuf;
-
-    PERL_ARGS_ASSERT_OPENN_CLEANUP;
 
     Zero(&statbuf, 1, Stat_t);
 
@@ -1345,10 +1345,10 @@ S_is_fork_open(const char *name)
 PerlIO *
 Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
 {
+    PERL_ARGS_ASSERT_NEXTARGV;
+
     IO * const io = GvIOp(gv);
     SV *const old_out_name = PL_inplace ? newSVsv(GvSV(gv)) : NULL;
-
-    PERL_ARGS_ASSERT_NEXTARGV;
 
     if (old_out_name)
         SAVEFREESV(old_out_name);
@@ -1638,10 +1638,11 @@ S_dir_unchanged(pTHX_ const char *orig_pv, MAGIC *mg)
 static bool
 S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explict)
 {
+    PERL_ARGS_ASSERT_ARGVOUT_FINAL;
+
     bool retval;
 
     /* ensure args are checked before we start using them */
-    PERL_ARGS_ASSERT_ARGVOUT_FINAL;
 
     {
         /* handle to an in-place edit work file */
@@ -1877,9 +1878,9 @@ Perl_do_close(pTHX_ GV *gv, bool is_explict)
 bool
 Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explict, bool warn_on_fail)
 {
-    bool retval = FALSE;
-
     PERL_ARGS_ASSERT_IO_CLOSE;
+
+    bool retval = FALSE;
 
     if (IoIFP(io)) {
         if (IoTYPE(io) == IoTYPE_PIPE) {
@@ -1949,9 +1950,9 @@ Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explict, bool warn_on_fail)
 bool
 Perl_do_eof(pTHX_ GV *gv)
 {
-    IO * const io = GvIO(gv);
-
     PERL_ARGS_ASSERT_DO_EOF;
+
+    IO * const io = GvIO(gv);
 
     if (!io)
         return TRUE;
@@ -1993,10 +1994,10 @@ Perl_do_eof(pTHX_ GV *gv)
 Off_t
 Perl_do_tell(pTHX_ GV *gv)
 {
+    PERL_ARGS_ASSERT_DO_TELL;
+
     IO *const io = GvIO(gv);
     PerlIO *fp;
-
-    PERL_ARGS_ASSERT_DO_TELL;
 
     if (io && (fp = IoIFP(io))) {
         return PerlIO_tell(fp);
@@ -2025,10 +2026,10 @@ Perl_do_seek(pTHX_ GV *gv, Off_t pos, int whence)
 Off_t
 Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
 {
+    PERL_ARGS_ASSERT_DO_SYSSEEK;
+
     IO *const io = GvIO(gv);
     PerlIO *fp;
-
-    PERL_ARGS_ASSERT_DO_SYSSEEK;
 
     if (io && (fp = IoIFP(io))) {
         int fd = PerlIO_fileno(fp);
@@ -2386,8 +2387,9 @@ Perl_my_lstat_flags(pTHX_ const U32 flags)
 static void
 S_exec_failed(pTHX_ const char *cmd, int fd, int do_report)
 {
-    const int e = errno;
     PERL_ARGS_ASSERT_EXEC_FAILED;
+
+    const int e = errno;
 
     ck_warner(packWARN(WARN_EXEC), "Can't exec \"%s\": %s",
               cmd, Strerror(e));
@@ -2452,14 +2454,14 @@ Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp,
 bool
 Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)
 {
+    PERL_ARGS_ASSERT_DO_EXEC3;
+
     const char **argv, **a;
     char *s;
     char *buf;
     char *cmd;
     /* Make a copy so we can change it */
     const Size_t cmdlen = strlen(incmd) + 1;
-
-    PERL_ARGS_ASSERT_DO_EXEC3;
 
     ENTER;
     Newx(buf, cmdlen, char);
@@ -2589,6 +2591,8 @@ leave:
 SSize_t
 Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
 {
+    PERL_ARGS_ASSERT_APPLY;
+
     I32 val;
     SSize_t tot = 0;
     const char *const what = PL_op_name[type];
@@ -2596,8 +2600,6 @@ Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
     STRLEN len;
     SV ** const oldmark = mark;
     bool killgp = FALSE;
-
-    PERL_ARGS_ASSERT_APPLY;
 
     PERL_UNUSED_VAR(what); /* may not be used depending on compile options */
 
@@ -3025,11 +3027,12 @@ S_ingroup(pTHX_ Gid_t testgid, bool effective)
 I32
 Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
 {
+    PERL_ARGS_ASSERT_DO_IPCGET;
+
     const key_t key = (key_t)SvNVx(*++mark);
     SV *nsv = optype == OP_MSGGET ? NULL : *++mark;
     const I32 flags = SvIVx(*++mark);
 
-    PERL_ARGS_ASSERT_DO_IPCGET;
     PERL_UNUSED_ARG(sp);
 
     SETERRNO(0,0);
@@ -3059,6 +3062,8 @@ Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
 I32
 Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
 {
+    PERL_ARGS_ASSERT_DO_IPCCTL;
+
     char *a;
     I32 ret = -1;
     const I32 id  = SvIVx(*++mark);
@@ -3070,7 +3075,6 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
     STRLEN infosize = 0;
     I32 getinfo = (cmd == IPC_STAT);
 
-    PERL_ARGS_ASSERT_DO_IPCCTL;
     PERL_UNUSED_ARG(sp);
 
     switch (optype)
@@ -3207,8 +3211,8 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
 I32
 Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
 {
-#ifdef HAS_MSG
     PERL_ARGS_ASSERT_DO_MSGSND;
+#ifdef HAS_MSG
     PERL_UNUSED_ARG(sp);
 
     STRLEN len;
@@ -3241,6 +3245,8 @@ Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
 SSize_t
 Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
 {
+    PERL_ARGS_ASSERT_DO_MSGRCV;
+
 #ifdef HAS_MSG
     char *mbuf;
     long mtype;
@@ -3248,7 +3254,6 @@ Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
     const I32 id = SvIVx(*++mark);
     SV * const mstr = *++mark;
 
-    PERL_ARGS_ASSERT_DO_MSGRCV;
     PERL_UNUSED_ARG(sp);
 
     /* suppress warning when reading into undef var --jhi */
@@ -3290,13 +3295,14 @@ Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
 I32
 Perl_do_semop(pTHX_ SV **mark, SV **sp)
 {
+    PERL_ARGS_ASSERT_DO_SEMOP;
+
 #ifdef HAS_SEM
     STRLEN opsize;
     const I32 id = SvIVx(*++mark);
     SV * const opstr = *++mark;
     const char * const opbuf = SvPVbyte(opstr, opsize);
 
-    PERL_ARGS_ASSERT_DO_SEMOP;
     PERL_UNUSED_ARG(sp);
 
     if (opsize < 3 * SHORTSIZE
@@ -3442,12 +3448,12 @@ Moving it away shrinks F<pp_hot.c>; shrinking F<pp_hot.c> helps speed perl up.
 PerlIO *
 Perl_start_glob (pTHX_ SV *tmpglob, IO *io)
 {
+    PERL_ARGS_ASSERT_START_GLOB;
+
     SV * const tmpcmd = newSV(0);
     PerlIO *fp;
     STRLEN len;
     const char *s = SvPV(tmpglob, len);
-
-    PERL_ARGS_ASSERT_START_GLOB;
 
     if (!IS_SAFE_SYSCALL(s, len, "pattern", "glob"))
         return NULL;

--- a/doop.c
+++ b/doop.c
@@ -38,12 +38,13 @@
 static Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 {
+    PERL_ARGS_ASSERT_DO_TRANS_SIMPLE;
+
     Size_t matches = 0;
     STRLEN len;
     U8 *s = (U8*)SvPV_nomg(sv,len);
     U8 * const send = s+len;
 
-    PERL_ARGS_ASSERT_DO_TRANS_SIMPLE;
     DEBUG_y(PerlIO_printf(Perl_debug_log, "%s: %d: entering do_trans_simple:"
                                           " input sv:\n",
                                           __FILE__, __LINE__));
@@ -127,12 +128,12 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 static Size_t
 S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 {
+    PERL_ARGS_ASSERT_DO_TRANS_COUNT;
+
     STRLEN len;
     const U8 *s = (const U8*)SvPV_nomg_const(sv, len);
     const U8 * const send = s + len;
     Size_t matches = 0;
-
-    PERL_ARGS_ASSERT_DO_TRANS_COUNT;
 
     DEBUG_y(PerlIO_printf(Perl_debug_log, "%s: %d: entering do_trans_count:"
                                           " input sv:\n",
@@ -176,13 +177,13 @@ S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 static Size_t
 S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 {
+    PERL_ARGS_ASSERT_DO_TRANS_COMPLEX;
+
     STRLEN len;
     U8 *s = (U8*)SvPV_nomg(sv, len);
     U8 * const send = s+len;
     Size_t matches = 0;
     const bool complement = cBOOL(PL_op->op_private & OPpTRANS_COMPLEMENT);
-
-    PERL_ARGS_ASSERT_DO_TRANS_COMPLEX;
 
     DEBUG_y(PerlIO_printf(Perl_debug_log, "%s: %d: entering do_trans_complex:"
                                           " input sv:\n",
@@ -335,6 +336,8 @@ S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 static Size_t
 S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
 {
+    PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP;
+
     U8 *s;
     U8 *send;
     Size_t matches = 0;
@@ -344,8 +347,6 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
     SV* from_invlist = *from_invlist_ptr;
     SV* to_invmap_sv = *to_invmap_ptr;
     UV* map = (UV *) SvPVX(to_invmap_sv);
-
-    PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP;
 
     DEBUG_y(PerlIO_printf(Perl_debug_log, "%s: %d:"
                                           "entering do_trans_count_invmap:"
@@ -401,6 +402,8 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
 static Size_t
 S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
 {
+    PERL_ARGS_ASSERT_DO_TRANS_INVMAP;
+
     U8 *s;
     U8 *send;
     U8 *d;
@@ -423,8 +426,6 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
     UV final_map = TR_OOB;
     bool out_is_utf8 = cBOOL(SvUTF8(sv));
     STRLEN s_len;
-
-    PERL_ARGS_ASSERT_DO_TRANS_INVMAP;
 
     /* A third element in the array indicates that the replacement list was
      * shorter than the search list, and this element contains the value to use
@@ -584,12 +585,12 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
 Size_t
 Perl_do_trans(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_DO_TRANS;
+
     STRLEN len;
     const U8 flags = PL_op->op_private;
     bool use_utf8_fcns = cBOOL(flags & OPpTRANS_USE_SVOP);
     bool identical     = cBOOL(flags & OPpTRANS_IDENTICAL);
-
-    PERL_ARGS_ASSERT_DO_TRANS;
 
     if (SvREADONLY(sv) && ! identical) {
         croak_no_modify();
@@ -763,11 +764,12 @@ Magic and tainting are handled.
 void
 Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
 {
+    PERL_ARGS_ASSERT_DO_SPRINTF;
+
     STRLEN patlen;
     const char * const pat = SvPV_const(*sarg, patlen);
     bool do_taint = FALSE;
 
-    PERL_ARGS_ASSERT_DO_SPRINTF;
     assert(len >= 1);
 
     if (SvTAINTED(*sarg))
@@ -790,6 +792,8 @@ Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
 UV
 Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
 {
+    PERL_ARGS_ASSERT_DO_VECGET;
+
     STRLEN srclen;
     const I32 svpv_flags = ((PL_op->op_flags & OPf_MOD || LVRET)
                                           ? SV_UNDEF_RETURNS_NULL : 0);
@@ -800,8 +804,6 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
     if (!s) {
       s = (unsigned char *)"";
     }
-
-    PERL_ARGS_ASSERT_DO_VECGET;
 
     if (size < 1 || ! isPOWER_OF_2(size))
         croak("Illegal number of bits in vec");
@@ -889,6 +891,8 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
 void
 Perl_do_vecset(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_DO_VECSET;
+
     STRLEN offset, bitoffs = 0;
     int size;
     unsigned char *s;
@@ -898,8 +902,6 @@ Perl_do_vecset(pTHX_ SV *sv)
     STRLEN len;
     SV * const targ = LvTARG(sv);
     char errflags = LvFLAGS(sv);
-
-    PERL_ARGS_ASSERT_DO_VECSET;
 
     /* some out-of-range errors have been deferred if/until the LV is
      * actually written to: f(vec($s,-1,8)) is not always fatal */
@@ -985,6 +987,8 @@ Perl_do_vecset(pTHX_ SV *sv)
 void
 Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
 {
+    PERL_ARGS_ASSERT_DO_VOP;
+
     long *dl;
     long *ll;
     long *rl;
@@ -1001,8 +1005,6 @@ Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
     bool result_needs_to_be_utf8 = FALSE;
     bool left_utf8 = FALSE;
     bool right_utf8 = FALSE;
-
-    PERL_ARGS_ASSERT_DO_VOP;
 
     if (sv != left || (optype != OP_BIT_AND && !SvOK(sv)))
         SvPVCLEAR(sv);        /* avoid undef warning on |= and ^= */

--- a/dquote.c
+++ b/dquote.c
@@ -87,6 +87,8 @@ Perl_form_alien_digit_msg(pTHX_
         const bool UTF,               /* Is it in UTF-8? */
         const bool braced)            /* Is it enclosed in {} */
 {
+    PERL_ARGS_ASSERT_FORM_ALIEN_DIGIT_MSG;
+
     /* Generate a mortal SV containing an appropriate warning message about
      * alien characters found in an octal or hex constant given by the inputs,
      * and return a pointer to that SV's string.  The message looks like:
@@ -103,7 +105,6 @@ Perl_form_alien_digit_msg(pTHX_
     SV * message_sv = sv_newmortal();
     char symbol;
 
-    PERL_ARGS_ASSERT_FORM_ALIEN_DIGIT_MSG;
     assert(which == 8 || which == 16);
 
     /* Calculate the display form of the character */
@@ -184,6 +185,8 @@ Perl_form_cp_too_large_msg(pTHX_
         const UV cp)           /* 0 if 'string' not NULL; else the too-large
                                   code point */
 {
+    PERL_ARGS_ASSERT_FORM_CP_TOO_LARGE_MSG;
+
     /* Generate a mortal SV containing an appropriate warning message about
      * code points that are too large for this system, given by the inputs,
      * and return a pointer to that SV's string.  Either the text of the string
@@ -200,7 +203,6 @@ Perl_form_cp_too_large_msg(pTHX_
     const char * format;
     const char * prefix;
 
-    PERL_ARGS_ASSERT_FORM_CP_TOO_LARGE_MSG;
     assert(which == 8 || which == 16);
 
     /* One but not both must be non-zero */
@@ -237,6 +239,7 @@ Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv,
                       const bool allow_UV_MAX,
                       const bool UTF)
 {
+    PERL_ARGS_ASSERT_GROK_BSLASH_O;
 
 /*  Documentation to be supplied when interface nailed down finally
  *  This returns FALSE if there is an error the caller should probably die
@@ -276,8 +279,6 @@ Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv,
               | PERL_SCAN_SILENT_NON_PORTABLE
               | PERL_SCAN_SILENT_ILLDIGIT
               | PERL_SCAN_SILENT_OVERFLOW;
-
-    PERL_ARGS_ASSERT_GROK_BSLASH_O;
 
     assert(*(*s - 1) == '\\');
     assert(* *s       == 'o');
@@ -379,6 +380,7 @@ Perl_grok_bslash_x(pTHX_ char ** s, const char * const send, UV *uv,
                       const bool allow_UV_MAX,
                       const bool UTF)
 {
+    PERL_ARGS_ASSERT_GROK_BSLASH_X;
 
 /*  Documentation to be supplied when interface nailed down finally
  *  This returns FALSE if there is an error the caller should probably die
@@ -423,8 +425,6 @@ Perl_grok_bslash_x(pTHX_ char ** s, const char * const send, UV *uv,
               | PERL_SCAN_NOTIFY_ILLDIGIT
               | PERL_SCAN_SILENT_NON_PORTABLE
               | PERL_SCAN_SILENT_OVERFLOW;
-
-    PERL_ARGS_ASSERT_GROK_BSLASH_X;
 
     assert(*(*s - 1) == '\\');
     assert(* *s      == 'x');

--- a/dump.c
+++ b/dump.c
@@ -166,6 +166,7 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
                 const STRLEN count, STRLEN max,
                 STRLEN * const escaped, U32 flags )
 {
+    PERL_ARGS_ASSERT_PV_ESCAPE;
 
     bool use_uc_hex = false;
     if (flags & PERL_PV_ESCAPE_DWIM_ALL_HEX) {
@@ -215,8 +216,6 @@ Perl_pv_escape( pTHX_ SV *dsv, char const * const str,
     }
 
     octbuf[0] = esc;
-
-    PERL_ARGS_ASSERT_PV_ESCAPE;
 
     if (dsv && !(flags & PERL_PV_ESCAPE_NOCLEAR)) {
             /* This won't alter the UTF-8 flag */
@@ -361,14 +360,14 @@ Perl_pv_pretty( pTHX_ SV *dsv, char const * const str, const STRLEN count,
   const STRLEN max, char const * const start_color, char const * const end_color, 
   const U32 flags ) 
 {
+    PERL_ARGS_ASSERT_PV_PRETTY;
+
     const U8 *quotes = (U8*)((flags & PERL_PV_PRETTY_QUOTE) ? "\"\"" :
                              (flags & PERL_PV_PRETTY_LTGT)  ? "<>" : NULL);
     STRLEN escaped;
     STRLEN max_adjust= 0;
     STRLEN orig_cur;
  
-    PERL_ARGS_ASSERT_PV_PRETTY;
-   
     if (!(flags & PERL_PV_PRETTY_NOCLEAR)) {
         /* This won't alter the UTF-8 flag */
         SvPVCLEAR(dsv);
@@ -623,8 +622,9 @@ Perl_sv_peek(pTHX_ SV *sv)
 void
 Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char* pat, ...)
 {
-    va_list args;
     PERL_ARGS_ASSERT_DUMP_INDENT;
+
+    va_list args;
     va_start(args, pat);
     dump_vindent(level, file, pat, &args);
     va_end(args);
@@ -764,9 +764,9 @@ function at once, or a single line may be split across multiple calls.
 void
 Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
 {
-    va_list args;
-
     PERL_ARGS_ASSERT_OPDUMP_PRINTF;
+
+    va_list args;
 
     va_start(args, pat);
     SV *msg_sv = sv_2mortal(vnewSVpvf(pat, &args));
@@ -840,9 +840,9 @@ Perl_dump_packsubs(pTHX_ const HV *stash)
 void
 Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
 {
-    I32	i;
-
     PERL_ARGS_ASSERT_DUMP_PACKSUBS_PERL;
+
+    I32	i;
 
     if (!HvTOTALKEYS(stash))
         return;
@@ -885,9 +885,9 @@ S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
 void
 Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
 {
-    CV *cv;
-
     PERL_ARGS_ASSERT_DUMP_SUB_PERL;
+
+    CV *cv;
 
     cv = isGV_with_GP(gv) ? GvCV(gv) : CV_FROM_REF((SV*)gv);
     if (justperl && (CvISXSUB(cv) || !CvROOT(cv)))
@@ -927,9 +927,9 @@ message that one doesn't exist.
 void
 Perl_dump_form(pTHX_ const GV *gv)
 {
-    SV * const sv = sv_newmortal();
-
     PERL_ARGS_ASSERT_DUMP_FORM;
+
+    SV * const sv = sv_newmortal();
 
     gv_fullname3(sv, gv, NULL);
     Perl_dump_indent(aTHX_ 0, Perl_debug_log, "\nFORMAT %s = ", SvPVX_const(sv));
@@ -1062,11 +1062,11 @@ const struct flag_to_name pmflags_flags_names[] = {
 static SV *
 S_pm_description(pTHX_ const PMOP *pm)
 {
+    PERL_ARGS_ASSERT_PM_DESCRIPTION;
+
     SV * const desc = newSVpvs("");
     const REGEXP * const regex = PM_GETRE(pm);
     const U32 pmflags = pm->op_pmflags;
-
-    PERL_ARGS_ASSERT_PM_DESCRIPTION;
 
     if (pmflags & PMf_ONCE)
         sv_catpvs(desc, ",ONCE");
@@ -1346,9 +1346,9 @@ static void
 S_do_op_dump_bar(pTHX_ I32 level, UV bar, PerlIO *file, const OP *o,
                  CV* rootcv)
 {
-    const OPCODE optype = o->op_type;
-
     PERL_ARGS_ASSERT_DO_OP_DUMP;
+
+    const OPCODE optype = o->op_type;
 
     /* print op header line */
 
@@ -2127,9 +2127,9 @@ Perl_magic_dump(pTHX_ const MAGIC *mg)
 void
 Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
 {
-    const char *hvname;
-
     PERL_ARGS_ASSERT_DO_HV_DUMP;
+
+    const char *hvname;
 
     Perl_dump_indent(aTHX_ level, file, "%s = 0x%" UVxf, name, PTR2UV(sv));
     if (sv && (hvname = HvNAME_get(sv)))
@@ -2342,12 +2342,12 @@ const struct flag_to_name regexp_core_intflags_names[] = {
 void
 Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
 {
+    PERL_ARGS_ASSERT_DO_SV_DUMP;
+
     SV *d;
     const char *s;
     U32 flags;
     U32 type;
-
-    PERL_ARGS_ASSERT_DO_SV_DUMP;
 
     if (!sv) {
         Perl_dump_indent(aTHX_ level, file, "SV = 0\n");
@@ -3435,6 +3435,8 @@ S_append_gv_name(pTHX_ GV *gv, SV *out)
 SV*
 Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
 {
+    PERL_ARGS_ASSERT_MULTIDEREF_STRINGIFY;
+
     UNOP_AUX_item *items = cUNOP_AUXo->op_aux;
     UV actions = items->uv;
     SV *sv;
@@ -3452,8 +3454,6 @@ Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
     else
         comppad = NULL;
 #endif
-
-    PERL_ARGS_ASSERT_MULTIDEREF_STRINGIFY;
 
     while (!last) {
         switch (actions & MDEREF_ACTION_MASK) {
@@ -3579,14 +3579,14 @@ Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
 SV*
 Perl_multiconcat_stringify(pTHX_ const OP *o)
 {
+    PERL_ARGS_ASSERT_MULTICONCAT_STRINGIFY;
+
     UNOP_AUX_item *aux = cUNOP_AUXo->op_aux;
     UNOP_AUX_item *lens;
     STRLEN len;
     SSize_t nargs;
     char *s;
     SV *out = newSVpvn_flags("", 0, SVs_TEMP);
-
-    PERL_ARGS_ASSERT_MULTICONCAT_STRINGIFY;
 
     nargs = aux[PERL_MULTICONCAT_IX_NARGS].ssize;
     s   = aux[PERL_MULTICONCAT_IX_PLAIN_PV].pv;

--- a/embed.fnc
+++ b/embed.fnc
@@ -6071,6 +6071,11 @@ CRip	|bool	|check_regnode_after					\
 CRip	|regnode *|regnext	|NULLOK const regnode *p
 CRip	|regnode *|regnode_after|NULLOK const regnode *p		\
 				|bool varies
+Ep	|void	|regprop	|NULLOK const regexp *prog		\
+				|NN SV *sv				\
+				|NN const regnode *o			\
+				|NULLOK const regmatch_info *reginfo	\
+				|NULLOK const RExC_state_t *pRExC_state
 # if defined(DEBUGGING)
 Ep	|void	|debug_peep	|NN const char *str			\
 				|NN const RExC_state_t *pRExC_state	\
@@ -6097,11 +6102,6 @@ Ep	|const regnode *|dumpuntil					\
 				|NN SV *sv				\
 				|I32 indent				\
 				|U32 depth
-Ep	|void	|regprop	|NULLOK const regexp *prog		\
-				|NN SV *sv				\
-				|NN const regnode *o			\
-				|NULLOK const regmatch_info *reginfo	\
-				|NULLOK const RExC_state_t *pRExC_state
 EFp	|int	|re_indentf	|NN const char *fmt			\
 				|U32 depth				\
 				|...

--- a/embed.fnc
+++ b/embed.fnc
@@ -1389,14 +1389,14 @@ p	|char * |find_script	|NN const char *scriptname			\
 				|bool dosearch					\
 				|NULLOK const char * const * const search_ext	\
 				|I32 flags
-Adip	|I32	|foldEQ 	|NN const char *a			\
-				|NN const char *b			\
+Adip	|I32	|foldEQ 	|NN const char *s1			\
+				|NN const char *s2			\
 				|I32 len
-Cip	|I32	|foldEQ_latin1	|NN const char *a			\
-				|NN const char *b			\
+Cip	|I32	|foldEQ_latin1	|NN const char *s1			\
+				|NN const char *s2			\
 				|I32 len
-Adip	|I32	|foldEQ_locale	|NN const char *a			\
-				|NN const char *b			\
+Adip	|I32	|foldEQ_locale	|NN const char *s1			\
+				|NN const char *s2			\
 				|I32 len
 Admp	|I32	|foldEQ_utf8	|NN const char *s1			\
 				|NULLOK char **pe1			\
@@ -1606,7 +1606,7 @@ Adp	|GV *	|gv_fetchpv	|NN const char *nambeg			\
 				|const svtype sv_type
 
 Adp	|GV *	|gv_fetchpvn_flags					\
-				|NN const char *name			\
+				|NN const char *nambeg			\
 				|STRLEN len				\
 				|I32 flags				\
 				|const svtype sv_type
@@ -2924,28 +2924,28 @@ EXp	|SV *	|reg_named_buff |NN REGEXP * const rx			\
 				|NULLOK SV * const value		\
 				|const U32 flags
 Cp	|SV *	|reg_named_buff_all					\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const r			\
 				|const U32 flags
 Cp	|bool	|reg_named_buff_exists					\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const r			\
 				|NN SV * const key			\
 				|const U32 flags
 Cp	|SV *	|reg_named_buff_fetch					\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const r			\
 				|NN SV * const namesv			\
 				|const U32 flags
 Cp	|SV *	|reg_named_buff_firstkey				\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const r			\
 				|const U32 flags
 EXp	|SV *	|reg_named_buff_iter					\
 				|NN REGEXP * const rx			\
 				|NULLOK const SV * const lastkey	\
 				|const U32 flags
 Cp	|SV *	|reg_named_buff_nextkey 				\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const r			\
 				|const U32 flags
 Cp	|SV *	|reg_named_buff_scalar					\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const r			\
 				|const U32 flags
 : FIXME - is anything in re using this now?
 EXp	|void	|reg_numbered_buff_fetch				\
@@ -2961,7 +2961,7 @@ EXp	|void	|reg_numbered_buff_fetch_flags				\
 				|U32 flags
 : FIXME - is anything in re using this now?
 EXp	|I32	|reg_numbered_buff_length				\
-				|NN REGEXP * const rx			\
+				|NN REGEXP * const r			\
 				|NN const SV * const sv 		\
 				|const I32 paren
 : FIXME - is anything in re using this now?
@@ -3205,7 +3205,7 @@ p	|OP *	|sawparens	|NULLOK OP *o
 : Used in perly.y
 p	|OP *	|scalar 	|NULLOK OP *o
 : Used in pp_ctl.c
-p	|OP *	|scalarvoid	|NN OP *o
+p	|OP *	|scalarvoid	|NN OP *arg
 Adp	|NV	|scan_bin	|NN const char *start			\
 				|STRLEN len				\
 				|NN STRLEN *retlen
@@ -5974,8 +5974,8 @@ ERST	|U8 *	|find_span_end_mask					\
 				|const U8 span_byte			\
 				|const U8 mask
 Ei	|I32	|foldEQ_latin1_s2_folded				\
-				|NN const char *a			\
-				|NN const char *b			\
+				|NN const char *s1			\
+				|NN const char *s2			\
 				|I32 len
 ERS	|bool	|isFOO_lc	|const U8 classnum			\
 				|const U8 character
@@ -6203,7 +6203,7 @@ S	|STRLEN |sv_pos_u2b_cached					\
 ST	|STRLEN |sv_pos_u2b_forwards					\
 				|SPTR const U8 * const start		\
 				|EPTRgt const U8 * const send		\
-				|NN STRLEN * const uoffset		\
+				|NN STRLEN * const uoffset_p		\
 				|NN bool * const at_end 		\
 				|NN bool *canonical_position
 ST	|STRLEN |sv_pos_u2b_midway					\
@@ -6659,7 +6659,7 @@ Adp	|void	|re_dup_guts	|NN const REGEXP *sstr			\
 				|NN REGEXP *dstr			\
 				|NN CLONE_PARAMS *param
 Cp	|void * |regdupe_internal					\
-				|NN REGEXP * const r			\
+				|NN REGEXP * const rx			\
 				|NN CLONE_PARAMS *param
 Cp	|void	|rvpv_dup	|NN SV * const dsv			\
 				|NN const SV * const ssv		\

--- a/embed.h
+++ b/embed.h
@@ -2197,22 +2197,22 @@
 #   define check_regnode_after(a,b)             Perl_check_regnode_after(aTHX_ a,b)
 #   define regnext(a)                           Perl_regnext(aTHX_ a)
 #   define regnode_after(a,b)                   Perl_regnode_after(aTHX_ a,b)
-#   if defined(DEBUGGING) && ( defined(PERL_CORE) || defined(PERL_EXT) )
-#     define debug_peep(a,b,c,d,e)              Perl_debug_peep(aTHX_ a,b,c,d,e)
-#     define debug_show_study_flags(a,b,c)      Perl_debug_show_study_flags(aTHX_ a,b,c)
-#     define debug_studydata(a,b,c,d,e,f,g)     Perl_debug_studydata(aTHX_ a,b,c,d,e,f,g)
-#     define dumpuntil(a,b,c,d,e,f,g,h)         Perl_dumpuntil(aTHX_ a,b,c,d,e,f,g,h)
-#     define re_indentf(a,...)                  Perl_re_indentf(aTHX_ a,__VA_ARGS__)
-#     define re_printf(...)                     Perl_re_printf(aTHX_ __VA_ARGS__)
+#   if defined(PERL_CORE) || defined(PERL_EXT)
 #     define regprop(a,b,c,d,e)                 Perl_regprop(aTHX_ a,b,c,d,e)
-#   endif
-#   if defined(PERL_EXT_RE_BUILD)
-#     if defined(PERL_CORE) || defined(PERL_EXT)
-#       define get_re_gclass_aux_data(a,b,c,d,e,f) Perl_get_re_gclass_aux_data(aTHX_ a,b,c,d,e,f)
+#     if defined(DEBUGGING)
+#       define debug_peep(a,b,c,d,e)            Perl_debug_peep(aTHX_ a,b,c,d,e)
+#       define debug_show_study_flags(a,b,c)    Perl_debug_show_study_flags(aTHX_ a,b,c)
+#       define debug_studydata(a,b,c,d,e,f,g)   Perl_debug_studydata(aTHX_ a,b,c,d,e,f,g)
+#       define dumpuntil(a,b,c,d,e,f,g,h)       Perl_dumpuntil(aTHX_ a,b,c,d,e,f,g,h)
+#       define re_indentf(a,...)                Perl_re_indentf(aTHX_ a,__VA_ARGS__)
+#       define re_printf(...)                   Perl_re_printf(aTHX_ __VA_ARGS__)
 #     endif
-#   elif defined(PERL_CORE) || defined(PERL_EXT)
-#     define get_regclass_aux_data(a,b,c,d,e,f) Perl_get_regclass_aux_data(aTHX_ a,b,c,d,e,f)
-#   endif
+#     if defined(PERL_EXT_RE_BUILD)
+#       define get_re_gclass_aux_data(a,b,c,d,e,f) Perl_get_re_gclass_aux_data(aTHX_ a,b,c,d,e,f)
+#     else
+#       define get_regclass_aux_data(a,b,c,d,e,f) Perl_get_regclass_aux_data(aTHX_ a,b,c,d,e,f)
+#     endif
+#   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # endif /* defined(PERL_IN_REGEX_ENGINE) */
 # if defined(PERL_MEM_LOG)
 #   define mem_log_alloc                        Perl_mem_log_alloc

--- a/gv.c
+++ b/gv.c
@@ -138,12 +138,13 @@ GV *
 Perl_gv_fetchfile_flags(pTHX_ const char *const name, const STRLEN namelen,
                         const U32 flags)
 {
+    PERL_ARGS_ASSERT_GV_FETCHFILE_FLAGS;
+
     char smallbuf[128];
     char *tmpbuf;
     const STRLEN tmplen = namelen + 2;
     GV *gv;
 
-    PERL_ARGS_ASSERT_GV_FETCHFILE_FLAGS;
     PERL_UNUSED_ARG(flags);
 
     if (!PL_defstash)
@@ -200,12 +201,13 @@ Perl_gv_const_sv(pTHX_ GV *gv)
 GP *
 Perl_newGP(pTHX_ GV *const gv)
 {
+    PERL_ARGS_ASSERT_NEWGP;
+
     GP *gp;
     U32 hash;
     const char *file;
     STRLEN len;
 
-    PERL_ARGS_ASSERT_NEWGP;
     Newxz(gp, 1, GP);
     gp->gp_egv = gv; /* allow compiler to reuse gv after this */
 
@@ -242,9 +244,10 @@ Perl_newGP(pTHX_ GV *const gv)
 void
 Perl_cvgv_set(pTHX_ CV* cv, GV* gv)
 {
+    PERL_ARGS_ASSERT_CVGV_SET;
+
     GV * const oldgv = CvNAMED(cv) ? NULL : SvANY(cv)->xcv_gv_u.xcv_gv;
     HEK *hek;
-    PERL_ARGS_ASSERT_CVGV_SET;
 
     if (oldgv == gv)
         return;
@@ -292,9 +295,10 @@ Perl_cvgv_set(pTHX_ CV* cv, GV* gv)
 GV *
 Perl_cvgv_from_hek(pTHX_ CV *cv)
 {
+    PERL_ARGS_ASSERT_CVGV_FROM_HEK;
+
     GV *gv;
     SV **svp;
-    PERL_ARGS_ASSERT_CVGV_FROM_HEK;
     assert(SvTYPE(cv) == SVt_PVCV);
     if (!CvSTASH(cv)) return NULL;
     ASSUME(CvNAME_HEK(cv));
@@ -321,8 +325,9 @@ Perl_cvgv_from_hek(pTHX_ CV *cv)
 void
 Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
 {
-    HV *oldstash = CvSTASH(cv);
     PERL_ARGS_ASSERT_CVSTASH_SET;
+
+    HV *oldstash = CvSTASH(cv);
     if (oldstash == stash)
         return;
     if (oldstash)
@@ -387,9 +392,10 @@ forms.
 void
 Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV* namesv, U32 flags)
 {
+   PERL_ARGS_ASSERT_GV_INIT_SV;
+
    char *namepv;
    STRLEN namelen;
-   PERL_ARGS_ASSERT_GV_INIT_SV;
    namepv = SvPV(namesv, namelen);
    if (SvUTF8(namesv))
        flags |= SVf_UTF8;
@@ -452,6 +458,8 @@ Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
 void
 Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_GV_INIT_PVN;
+
     const U32 old_type = SvTYPE(gv);
     const bool doproto = old_type > SVt_NULL;
     char * const proto = (doproto && SvPOK(gv))
@@ -465,7 +473,6 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
         has_constant && SvTYPE(has_constant) == SVt_PVCV;
     COP * const old = PL_curcop;
 
-    PERL_ARGS_ASSERT_GV_INIT_PVN;
     assert (!(proto && has_constant));
 
     if (has_constant) {
@@ -829,9 +836,10 @@ not so marked.
 GV *
 Perl_gv_fetchmeth_sv(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
 {
+    PERL_ARGS_ASSERT_GV_FETCHMETH_SV;
+
     char *namepv;
     STRLEN namelen;
-    PERL_ARGS_ASSERT_GV_FETCHMETH_SV;
     if (LIKELY(SvPOK_nog(namesv))) /* common case */
         return gv_fetchmeth_internal(stash, namesv, NULL, 0, level,
                                      flags | SvUTF8(namesv));
@@ -1051,9 +1059,10 @@ Perl_gv_fetchmeth_pvn(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, 
 GV *
 Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
 {
+   PERL_ARGS_ASSERT_GV_FETCHMETH_SV_AUTOLOAD;
+
    char *namepv;
    STRLEN namelen;
-   PERL_ARGS_ASSERT_GV_FETCHMETH_SV_AUTOLOAD;
    namepv = SvPV(namesv, namelen);
    if (SvUTF8(namesv))
        flags |= SVf_UTF8;
@@ -1070,9 +1079,9 @@ Perl_gv_fetchmeth_pv_autoload(pTHX_ HV *stash, const char *name, I32 level, U32 
 GV *
 Perl_gv_fetchmeth_pvn_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
 {
-    GV *gv = gv_fetchmeth_pvn(stash, name, len, level, flags);
-
     PERL_ARGS_ASSERT_GV_FETCHMETH_PVN_AUTOLOAD;
+
+    GV *gv = gv_fetchmeth_pvn(stash, name, len, level, flags);
 
     if (!gv) {
         CV *cv;
@@ -1140,9 +1149,10 @@ Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
 GV *
 Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
 {
+    PERL_ARGS_ASSERT_GV_FETCHMETHOD_SV_FLAGS;
+
     char *namepv;
     STRLEN namelen;
-    PERL_ARGS_ASSERT_GV_FETCHMETHOD_SV_FLAGS;
     namepv = SvPV(namesv, namelen);
     if (SvUTF8(namesv))
        flags |= SVf_UTF8;
@@ -1159,6 +1169,8 @@ Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
 GV *
 Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_GV_FETCHMETHOD_PVN_FLAGS;
+
     const char * const origname = name;
     const char * const name_end = name + len;
     const char *last_separator = NULL;
@@ -1168,8 +1180,6 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
     const U32 autoload = flags & GV_AUTOLOAD;
     const U32 do_croak = flags & GV_CROAK;
     const U32 is_utf8  = flags & SVf_UTF8;
-
-    PERL_ARGS_ASSERT_GV_FETCHMETHOD_PVN_FLAGS;
 
     if (SvTYPE(stash) < SVt_PVHV)
         stash = NULL;
@@ -1352,9 +1362,10 @@ to indicate, if set, to skip searching for the name in C<stash>.
 GV*
 Perl_gv_autoload_sv(pTHX_ HV *stash, SV* namesv, U32 flags)
 {
+   PERL_ARGS_ASSERT_GV_AUTOLOAD_SV;
+
    char *namepv;
    STRLEN namelen;
-   PERL_ARGS_ASSERT_GV_AUTOLOAD_SV;
    namepv = SvPV(namesv, namelen);
    if (SvUTF8(namesv))
        flags |= SVf_UTF8;
@@ -1371,6 +1382,8 @@ Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
 GV*
 Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_GV_AUTOLOAD_PVN;
+
     GV* gv;
     CV* cv;
     HV* varstash;
@@ -1378,8 +1391,6 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
     SV* varsv;
     SV *packname = NULL;
     U32 is_utf8 = flags & SVf_UTF8 ? SVf_UTF8 : 0;
-
-    PERL_ARGS_ASSERT_GV_AUTOLOAD_PVN;
 
     if (len == S_autolen && memEQ(name, S_autoload, S_autolen))
         return NULL;
@@ -1516,9 +1527,9 @@ static void
 S_require_tie_mod(pTHX_ GV *gv, const char varname, const char * name,
                         STRLEN len, const U32 flags)
 {
-    const SV * const target = varname == '[' ? GvSV(gv) : (SV *)GvHV(gv);
-
     PERL_ARGS_ASSERT_REQUIRE_TIE_MOD;
+
+    const SV * const target = varname == '[' ? GvSV(gv) : (SV *)GvHV(gv);
 
     /* If it is not tied */
     if (!target || !SvRMAGICAL(target)
@@ -1639,13 +1650,13 @@ gv_stashsvpvn_cached().
 PERL_STATIC_INLINE HV*
 S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags)
 {
+    PERL_ARGS_ASSERT_GV_STASHPVN_INTERNAL;
+
     char smallbuf[128];
     char *tmpbuf;
     HV *stash;
     GV *tmpgv;
     U32 tmplen = namelen + 2;
-
-    PERL_ARGS_ASSERT_GV_STASHPVN_INTERNAL;
 
     if (tmplen <= sizeof smallbuf)
         tmpbuf = smallbuf;
@@ -1760,19 +1771,20 @@ Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type)
 GV *
 Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
 {
+    PERL_ARGS_ASSERT_GV_FETCHSV;
+
     STRLEN len;
     const char * const nambeg =
        SvPV_flags_const(name, len, flags & GV_NO_SVGMAGIC ? 0 : SV_GMAGIC);
-    PERL_ARGS_ASSERT_GV_FETCHSV;
     return gv_fetchpvn_flags(nambeg, len, flags | SvUTF8(name), sv_type);
 }
 
 PERL_STATIC_INLINE void
 S_gv_magicalize_isa(pTHX_ GV *gv)
 {
-    AV* av;
-
     PERL_ARGS_ASSERT_GV_MAGICALIZE_ISA;
+
+    AV* av;
 
     av = GvAVn(gv);
     GvMULTI_on(gv);
@@ -1799,13 +1811,13 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name,
                STRLEN *len, const char *nambeg, STRLEN full_len,
                const U32 is_utf8, const I32 add)
 {
+    PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME;
+
     char *tmpfullbuf = NULL; /* only malloc one big chunk of memory when the smallbuff is not large enough */
     const char *name_cursor;
     const char *const name_end = nambeg + full_len;
     const char *const name_em1 = name_end - 1;
     char smallbuf[64]; /* small buffer to avoid a malloc when possible */
-
-    PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME;
 
     if (   full_len > 2
         && **name == '*'
@@ -2078,9 +2090,9 @@ PERL_STATIC_INLINE bool
 S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len,
                       const svtype sv_type)
 {
-    SSize_t paren;
-
     PERL_ARGS_ASSERT_GV_MAGICALIZE;
+
+    SSize_t paren;
 
     if (len == 0) {
         return false;
@@ -2567,6 +2579,8 @@ GV *
 Perl_gv_fetchpvn_flags(pTHX_ const char *nambeg, STRLEN full_len, I32 flags,
                        const svtype sv_type)
 {
+    PERL_ARGS_ASSERT_GV_FETCHPVN_FLAGS;
+
     const char *name = nambeg;
     GV *gv = NULL;
     GV**gvp;
@@ -2579,8 +2593,6 @@ Perl_gv_fetchpvn_flags(pTHX_ const char *nambeg, STRLEN full_len, I32 flags,
     bool addmg = cBOOL(flags & GV_ADDMG);
     const char *const name_end = nambeg + full_len;
     U32 faking_it;
-
-    PERL_ARGS_ASSERT_GV_FETCHPVN_FLAGS;
 
      /* If we have GV_NOTQUAL, the caller promised that
       * there is no stash, so we can skip the check.
@@ -2725,10 +2737,10 @@ kept; if C<false> it is stripped.  With the C<*3> forms, it is always kept.
 void
 Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
 {
+    PERL_ARGS_ASSERT_GV_FULLNAME4;
+
     const char *name;
     const HV * const hv = GvSTASH(gv);
-
-    PERL_ARGS_ASSERT_GV_FULLNAME4;
 
     sv_setpv(sv, prefix ? prefix : "");
 
@@ -2746,9 +2758,9 @@ Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
 void
 Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
 {
-    const GV * const egv = GvEGVx(gv);
-
     PERL_ARGS_ASSERT_GV_EFULLNAME4;
+
+    const GV * const egv = GvEGVx(gv);
 
     gv_fullname4(sv, egv ? egv : gv, prefix, keepmain);
 }
@@ -2761,9 +2773,9 @@ Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain
 void
 Perl_gv_check(pTHX_ HV *stash)
 {
-    I32 i;
-
     PERL_ARGS_ASSERT_GV_CHECK;
+
+    I32 i;
 
     if (!HvHasAUX(stash))
         return;
@@ -3094,10 +3106,10 @@ Perl_gp_free(pTHX_ GV *gv)
 int
 Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
 {
-    AMT * const amtp = (AMT*)mg->mg_ptr;
+    PERL_ARGS_ASSERT_MAGIC_FREEOVRLD;
     PERL_UNUSED_ARG(sv);
 
-    PERL_ARGS_ASSERT_MAGIC_FREEOVRLD;
+    AMT * const amtp = (AMT*)mg->mg_ptr;
 
     if (amtp && AMT_AMAGIC(amtp)) {
         int i;
@@ -3136,12 +3148,12 @@ is true).
 int
 Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
 {
+  PERL_ARGS_ASSERT_GV_AMUPDATE;
+
   MAGIC* const mg = mg_find((const SV *)stash, PERL_MAGIC_overload_table);
   AMT amt;
   const struct mro_meta* stash_meta = HvMROMETA(stash);
   U32 newgen;
-
-  PERL_ARGS_ASSERT_GV_AMUPDATE;
 
   newgen = PL_sub_generation + stash_meta->pkg_gen + stash_meta->cache_gen;
   if (mg) {
@@ -3677,10 +3689,10 @@ If overloading is inactive on C<ref>, returns C<ref> itself.
 SV *
 Perl_amagic_deref_call(pTHX_ SV *ref, int method)
 {
+    PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL;
+
     SV *tmpsv = NULL;
     HV *stash;
-
-    PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL;
 
     if (!SvAMAGIC(ref))
         return ref;
@@ -3782,6 +3794,8 @@ Perform overloading even in the context of C<no overloading;>.
 SV*
 Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
 {
+  PERL_ARGS_ASSERT_AMAGIC_CALL;
+
   MAGIC *mg;
   CV *cv=NULL;
   CV **cvp=NULL, **ocvp=NULL;
@@ -3796,8 +3810,6 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int flags)
   int fl=0;
 #endif
   HV* stash=NULL;
-
-  PERL_ARGS_ASSERT_AMAGIC_CALL;
 
   if ( (PL_curcop->cop_hints & HINT_NO_AMAGIC)
        && !(flags & AMGf_force_overload)) {
@@ -4311,9 +4323,9 @@ UTF-8; otherwise not.
 void
 Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
 {
-    U32 hash;
-
     PERL_ARGS_ASSERT_GV_NAME_SET;
+
+    U32 hash;
 
     if (len > I32_MAX)
         croak("panic: gv name too long (%" UVuf ")", (UV) len);
@@ -4349,11 +4361,12 @@ more compactly represents the same thing.
 void
 Perl_gv_try_downgrade(pTHX_ GV *gv)
 {
+    PERL_ARGS_ASSERT_GV_TRY_DOWNGRADE;
+
     HV *stash;
     CV *cv;
     HEK *namehek;
     SV **gvp;
-    PERL_ARGS_ASSERT_GV_TRY_DOWNGRADE;
 
     /* XXX Why and where does this leave dangling pointers during global
        destruction? */
@@ -4407,9 +4420,10 @@ Perl_gv_try_downgrade(pTHX_ GV *gv)
 GV *
 Perl_gv_override(pTHX_ const char * const name, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_GV_OVERRIDE;
+
     GV *gv = gv_fetchpvn(name, len, GV_NOTQUAL, SVt_PVCV);
     GV * const *gvp;
-    PERL_ARGS_ASSERT_GV_OVERRIDE;
     if (gv && GvCVu(gv) && GvIMPORTED_CV(gv)) return gv;
     gvp = (GV**)hv_fetch(PL_globalstash, name, len, FALSE);
     gv = gvp ? *gvp : NULL;

--- a/hv.c
+++ b/hv.c
@@ -182,10 +182,10 @@ S_new_he(pTHX)
 static HEK *
 S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
 {
+    PERL_ARGS_ASSERT_SAVE_HEK_FLAGS;
+
     char *k;
     HEK *hek;
-
-    PERL_ARGS_ASSERT_SAVE_HEK_FLAGS;
 
     Newx(k, HEK_BASESIZE + len + 2, char);
     hek = (HEK*)k;
@@ -222,10 +222,10 @@ Perl_free_tied_hv_pool(pTHX)
 HEK *
 Perl_hek_dup(pTHX_ HEK *source, CLONE_PARAMS* param)
 {
-    HEK *shared;
-
     PERL_ARGS_ASSERT_HEK_DUP;
     PERL_UNUSED_ARG(param);
+
+    HEK *shared;
 
     if (!source)
         return NULL;
@@ -247,9 +247,9 @@ Perl_hek_dup(pTHX_ HEK *source, CLONE_PARAMS* param)
 HE *
 Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS* param)
 {
-    HE *ret;
-
     PERL_ARGS_ASSERT_HE_DUP;
+
+    HE *ret;
 
     /* All the *_dup functions are deemed to be API, despite most being deeply
        tied to the internals. Hence we can't simply remove the parameter
@@ -307,11 +307,11 @@ static void
 S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen,
                 const char *msg)
 {
+    PERL_ARGS_ASSERT_HV_NOTALLOWED;
+
    /* Straight to SVt_PVN here, as needed by sv_setpvn_fresh and
     * sv_usepvn would otherwise call it */
     SV * const sv = newSV_type_mortal(SVt_PV);
-
-    PERL_ARGS_ASSERT_HV_NOTALLOWED;
 
     if (!(flags & HVhek_FREEKEY)) {
         sv_setpvn_fresh(sv, key, klen);
@@ -1097,9 +1097,9 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
 static void
 S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
 {
-    const MAGIC *mg = SvMAGIC(hv);
-
     PERL_ARGS_ASSERT_HV_MAGIC_CHECK;
+
+    const MAGIC *mg = SvMAGIC(hv);
 
     *needs_copy = FALSE;
     *needs_store = TRUE;
@@ -1133,10 +1133,10 @@ returned by the hv_bucket_ratio() function.
 SV *
 Perl_hv_scalar(pTHX_ HV *hv)
 {
+    PERL_ARGS_ASSERT_HV_SCALAR;
+
     SV *sv;
     UV u;
-
-    PERL_ARGS_ASSERT_HV_SCALAR;
 
     if (SvRMAGICAL(hv)) {
         MAGIC * const mg = mg_find((const SV *)hv, PERL_MAGIC_tied);
@@ -1183,13 +1183,14 @@ I might unroll the non-tied hv_iternext() in here at some point - DAPM
 void
 Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
 {
+    PERL_ARGS_ASSERT_HV_PUSHKV;
+
     HE *entry;
     bool tied = SvRMAGICAL(hv) && (mg_find(MUTABLE_SV(hv), PERL_MAGIC_tied)
 #ifdef DYNAMIC_ENV_FETCH  /* might not know number of keys yet */
                                    || mg_find(MUTABLE_SV(hv), PERL_MAGIC_env)
 #endif
                                   );
-    PERL_ARGS_ASSERT_HV_PUSHKV;
     assert(flags); /* must be pushing at least one of keys and values */
 
     (void)hv_iterinit(hv);
@@ -1250,9 +1251,9 @@ In a large hash this could be a lot of buckets.
 SV *
 Perl_hv_bucket_ratio(pTHX_ HV *hv)
 {
-    SV *sv;
-
     PERL_ARGS_ASSERT_HV_BUCKET_RATIO;
+
+    SV *sv;
 
     if (SvRMAGICAL(hv)) {
         MAGIC * const mg = mg_find((const SV *)hv, PERL_MAGIC_tied);
@@ -1653,11 +1654,12 @@ S_large_hash_heuristic(pTHX_ HV *hv, STRLEN size)
 static void
 S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
 {
+    PERL_ARGS_ASSERT_HSPLIT;
+
     STRLEN i = 0;
     char *a = (char*) HvARRAY(hv);
     HE **aep;
 
-    PERL_ARGS_ASSERT_HSPLIT;
     if (newsize > MAX_BUCKET_MAX+1)
             return;
 
@@ -1750,14 +1752,14 @@ This is the same as doing the following in Perl code:
 void
 Perl_hv_ksplit(pTHX_ HV *hv, IV newmax)
 {
+    PERL_ARGS_ASSERT_HV_KSPLIT;
+
     XPVHV* xhv = (XPVHV*)SvANY(hv);
     const I32 oldsize = (I32) xhv->xhv_max+1;       /* HvMAX(hv)+1 */
     I32 newsize;
     I32 wantsize;
     I32 trysize;
     char *a;
-
-    PERL_ARGS_ASSERT_HV_KSPLIT;
 
     wantsize = (I32) newmax;                            /* possible truncation here */
     if (wantsize != newmax)
@@ -2125,9 +2127,9 @@ use.
 void
 Perl_hv_clear_placeholders(pTHX_ HV *hv)
 {
-    const U32 items = (U32)HvPLACEHOLDERS_get(hv);
-
     PERL_ARGS_ASSERT_HV_CLEAR_PLACEHOLDERS;
+
+    const U32 items = (U32)HvPLACEHOLDERS_get(hv);
 
     if (items)
         clear_placeholders(hv, items);
@@ -2136,10 +2138,10 @@ Perl_hv_clear_placeholders(pTHX_ HV *hv)
 static void
 S_clear_placeholders(pTHX_ HV *hv, const U32 placeholders)
 {
+    PERL_ARGS_ASSERT_CLEAR_PLACEHOLDERS;
+
     I32 i;
     U32 to_find = placeholders;
-
-    PERL_ARGS_ASSERT_CLEAR_PLACEHOLDERS;
 
     assert(to_find);
 
@@ -2182,10 +2184,10 @@ S_clear_placeholders(pTHX_ HV *hv, const U32 placeholders)
 static void
 S_hv_free_entries(pTHX_ HV *hv)
 {
+    PERL_ARGS_ASSERT_HV_FREE_ENTRIES;
+
     STRLEN index = 0;
     SV *sv;
-
-    PERL_ARGS_ASSERT_HV_FREE_ENTRIES;
 
     while ((sv = Perl_hfree_next_entry(aTHX_ hv, &index)) || HvTOTALKEYS(hv)) {
         SvREFCNT_dec(sv);
@@ -2205,14 +2207,14 @@ S_hv_free_entries(pTHX_ HV *hv)
 SV*
 Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
 {
+    PERL_ARGS_ASSERT_HFREE_NEXT_ENTRY;
+
     struct xpvhv_aux *iter;
     HE *entry;
     HE ** array;
 #ifdef DEBUGGING
     STRLEN orig_index = *indexp;
 #endif
-
-    PERL_ARGS_ASSERT_HFREE_NEXT_ENTRY;
 
     if (HvHasAUX(hv) && ((iter = HvAUX(hv)))) {
         if ((entry = iter->xhv_eiter)) {
@@ -2437,12 +2439,12 @@ hash.
 STRLEN
 Perl_hv_fill(pTHX_ HV *const hv)
 {
+    PERL_ARGS_ASSERT_HV_FILL;
+
     STRLEN count = 0;
     HE **ents = HvARRAY(hv);
 
     PERL_UNUSED_CONTEXT;
-    PERL_ARGS_ASSERT_HV_FILL;
-
     /* No keys implies no buckets used.
        One key can only possibly mean one bucket used.  */
     if (HvTOTALKEYS(hv) < 2)
@@ -2468,9 +2470,9 @@ Perl_hv_fill(pTHX_ HV *const hv)
 static struct xpvhv_aux*
 S_hv_auxinit(pTHX_ HV *hv)
 {
-    struct xpvhv_aux *iter;
-
     PERL_ARGS_ASSERT_HV_AUXINIT;
+
+    struct xpvhv_aux *iter;
 
     if (!HvHasAUX(hv)) {
         char *array = (char *) HvARRAY(hv);
@@ -2551,9 +2553,9 @@ Implements C<HvRITER> which you should use instead.
 I32 *
 Perl_hv_riter_p(pTHX_ HV *hv)
 {
-    struct xpvhv_aux *iter;
-
     PERL_ARGS_ASSERT_HV_RITER_P;
+
+    struct xpvhv_aux *iter;
 
     iter = HvHasAUX(hv) ? HvAUX(hv) : hv_auxinit(hv);
     return &(iter->xhv_riter);
@@ -2570,9 +2572,9 @@ Implements C<HvEITER> which you should use instead.
 HE **
 Perl_hv_eiter_p(pTHX_ HV *hv)
 {
-    struct xpvhv_aux *iter;
-
     PERL_ARGS_ASSERT_HV_EITER_P;
+
+    struct xpvhv_aux *iter;
 
     iter = HvHasAUX(hv) ? HvAUX(hv) : hv_auxinit(hv);
     return &(iter->xhv_eiter);
@@ -2589,9 +2591,9 @@ Implements C<HvRITER_set> which you should use instead.
 void
 Perl_hv_riter_set(pTHX_ HV *hv, I32 riter)
 {
-    struct xpvhv_aux *iter;
-
     PERL_ARGS_ASSERT_HV_RITER_SET;
+
+    struct xpvhv_aux *iter;
 
     if (HvHasAUX(hv)) {
         iter = HvAUX(hv);
@@ -2607,9 +2609,9 @@ Perl_hv_riter_set(pTHX_ HV *hv, I32 riter)
 void
 Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand)
 {
-    struct xpvhv_aux *iter;
-
     PERL_ARGS_ASSERT_HV_RAND_SET;
+
+    struct xpvhv_aux *iter;
 
 #ifdef PERL_HASH_RANDOMIZE_KEYS
     if (HvHasAUX(hv)) {
@@ -2634,9 +2636,9 @@ Implements C<HvEITER_set> which you should use instead.
 void
 Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter)
 {
-    struct xpvhv_aux *iter;
-
     PERL_ARGS_ASSERT_HV_EITER_SET;
+
+    struct xpvhv_aux *iter;
 
     if (HvHasAUX(hv)) {
         iter = HvAUX(hv);
@@ -2678,11 +2680,11 @@ are set.
 void
 Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 {
+    PERL_ARGS_ASSERT_HV_NAME_SET;
+
     struct xpvhv_aux *iter;
     U32 hash;
     HEK **spot;
-
-    PERL_ARGS_ASSERT_HV_NAME_SET;
 
     if (len > I32_MAX)
         croak("panic: hv name too long (%" UVuf ")", (UV) len);
@@ -2784,10 +2786,10 @@ table.
 void
 Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 {
+    PERL_ARGS_ASSERT_HV_ENAME_ADD;
+
     struct xpvhv_aux *aux = HvHasAUX(hv) ? HvAUX(hv) : hv_auxinit(hv);
     U32 hash;
-
-    PERL_ARGS_ASSERT_HV_ENAME_ADD;
 
     if (len > I32_MAX)
         croak("panic: hv name too long (%" UVuf ")", (UV) len);
@@ -2847,9 +2849,9 @@ This is called when a stash is deleted from the symbol table.
 void
 Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
 {
-    struct xpvhv_aux *aux;
-
     PERL_ARGS_ASSERT_HV_ENAME_DELETE;
+
+    struct xpvhv_aux *aux;
 
     if (len > I32_MAX)
         croak("panic: hv name too long (%" UVuf ")", (UV) len);
@@ -2923,9 +2925,9 @@ Perl_hv_backreferences_p(pTHX_ HV *hv)
 void
 Perl_hv_kill_backrefs(pTHX_ HV *hv)
 {
-    AV *av;
-
     PERL_ARGS_ASSERT_HV_KILL_BACKREFS;
+
+    AV *av;
 
     if (!HvHasAUX(hv))
         return;
@@ -2975,12 +2977,12 @@ insufficiently abstracted for any change to be tidy.
 HE *
 Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
 {
+    PERL_ARGS_ASSERT_HV_ITERNEXT_FLAGS;
+
     HE *entry;
     HE *oldentry;
     MAGIC* mg;
     struct xpvhv_aux *iter;
-
-    PERL_ARGS_ASSERT_HV_ITERNEXT_FLAGS;
 
     if (!HvHasAUX(hv)) {
         /* Too many things (well, pp_each at least) merrily assume that you can
@@ -3237,9 +3239,9 @@ operation.
 SV *
 Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
 {
-    HE * const he = hv_iternext_flags(hv, 0);
-
     PERL_ARGS_ASSERT_HV_ITERNEXTSV;
+
+    HE * const he = hv_iternext_flags(hv, 0);
 
     if (!he)
         return NULL;
@@ -3383,9 +3385,9 @@ S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash)
 HEK *
 Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
 {
-    int flags = 0;
-
     PERL_ARGS_ASSERT_SHARE_HEK;
+
+    int flags = 0;
 
     if (len < 0) {
         len = -len;
@@ -3417,11 +3419,12 @@ Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
 static HEK *
 S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
 {
+    PERL_ARGS_ASSERT_SHARE_HEK_FLAGS;
+
     HE *entry;
     const U8 flags_masked = flags & HVhek_STORAGE_MASK;
     const U32 hindex = hash & (I32) HvMAX(PL_strtab);
 
-    PERL_ARGS_ASSERT_SHARE_HEK_FLAGS;
     assert(!(flags & HVhek_NOTSHARED));
 
     if (UNLIKELY(len > (STRLEN) I32_MAX)) {
@@ -3506,9 +3509,9 @@ S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
 SSize_t *
 Perl_hv_placeholders_p(pTHX_ HV *hv)
 {
-    MAGIC *mg = mg_find((const SV *)hv, PERL_MAGIC_rhash);
-
     PERL_ARGS_ASSERT_HV_PLACEHOLDERS_P;
+
+    MAGIC *mg = mg_find((const SV *)hv, PERL_MAGIC_rhash);
 
     if (!mg) {
         mg = sv_magicext(MUTABLE_SV(hv), 0, PERL_MAGIC_rhash, 0, 0, 0);
@@ -3531,10 +3534,10 @@ Implements C<HvPLACEHOLDERS_get>, which you should use instead.
 I32
 Perl_hv_placeholders_get(pTHX_ const HV *hv)
 {
-    MAGIC * const mg = mg_find((const SV *)hv, PERL_MAGIC_rhash);
-
     PERL_ARGS_ASSERT_HV_PLACEHOLDERS_GET;
     PERL_UNUSED_CONTEXT;
+
+    MAGIC * const mg = mg_find((const SV *)hv, PERL_MAGIC_rhash);
 
     return mg ? mg->mg_len : 0;
 }
@@ -3550,9 +3553,9 @@ Implements C<HvPLACEHOLDERS_set>, which you should use instead.
 void
 Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
 {
-    MAGIC * const mg = mg_find((const SV *)hv, PERL_MAGIC_rhash);
-
     PERL_ARGS_ASSERT_HV_PLACEHOLDERS_SET;
+
+    MAGIC * const mg = mg_find((const SV *)hv, PERL_MAGIC_rhash);
 
     if (mg) {
         mg->mg_len = ph;
@@ -3566,9 +3569,9 @@ Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
 static SV *
 S_refcounted_he_value(pTHX_ const struct refcounted_he *he)
 {
-    SV *value;
-
     PERL_ARGS_ASSERT_REFCOUNTED_HE_VALUE;
+
+    SV *value;
 
     switch(he->refcounted_he_data[0] & HVrhek_typemask) {
     case HVrhek_undef:
@@ -3814,9 +3817,10 @@ SV *
 Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain,
                          SV *key, U32 hash, U32 flags)
 {
+    PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_SV;
+
     const char *keypv;
     STRLEN keylen;
-    PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_SV;
     if (flags & REFCOUNTED_HE_KEY_UTF8)
         croak("panic: refcounted_he_fetch_sv bad flags %" UVxf,
             (UV)flags);
@@ -3965,9 +3969,10 @@ struct refcounted_he *
 Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent,
         SV *key, U32 hash, SV *value, U32 flags)
 {
+    PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_SV;
+
     const char *keypv;
     STRLEN keylen;
-    PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_SV;
     if (flags & REFCOUNTED_HE_KEY_UTF8)
         croak("panic: refcounted_he_new_sv bad flags %" UVxf,
             (UV)flags);
@@ -4062,10 +4067,10 @@ or if you additionally don't need to know the length, C<L</CopLABEL>>.
 const char *
 Perl_cop_fetch_label(pTHX_ COP *const cop, STRLEN *len, U32 *flags)
 {
-    struct refcounted_he *const chain = cop->cop_hints_hash;
-
     PERL_ARGS_ASSERT_COP_FETCH_LABEL;
     PERL_UNUSED_CONTEXT;
+
+    struct refcounted_he *const chain = cop->cop_hints_hash;
 
     if (!chain)
         return NULL;
@@ -4109,8 +4114,9 @@ void
 Perl_cop_store_label(pTHX_ COP *const cop, const char *label, STRLEN len,
                      U32 flags)
 {
-    SV *labelsv;
     PERL_ARGS_ASSERT_COP_STORE_LABEL;
+
+    SV *labelsv;
 
     if (flags & ~(SVf_UTF8))
         croak("panic: cop_store_label illegal flag bits 0x%" UVxf,
@@ -4136,6 +4142,8 @@ Check that a hash is in an internally consistent state.
 void
 Perl_hv_assert(pTHX_ HV *hv)
 {
+    PERL_ARGS_ASSERT_HV_ASSERT;
+
     HE* entry;
     int withflags = 0;
     int placeholders = 0;
@@ -4143,8 +4151,6 @@ Perl_hv_assert(pTHX_ HV *hv)
     int bad = 0;
     const I32 riter = HvRITER_get(hv);
     HE *eiter = HvEITER_get(hv);
-
-    PERL_ARGS_ASSERT_HV_ASSERT;
 
     (void)hv_iterinit(hv);
 

--- a/inline.h
+++ b/inline.h
@@ -96,9 +96,10 @@ Approximate Perl equivalent: C<splice(@myarray, $key, 1, $val)>.
 PERL_STATIC_INLINE SV**
 Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val)
 {
+    PERL_ARGS_ASSERT_AV_STORE_SIMPLE;
+
     SV** ary;
 
-    PERL_ARGS_ASSERT_AV_STORE_SIMPLE;
     assert(!SvMAGICAL(av));
     assert(!SvREADONLY(av));
     assert(AvREAL(av));
@@ -1257,9 +1258,10 @@ Perl_sv_can_existdelete(pTHX_ SV *sv)
 PERL_STATIC_INLINE struct regexp *
 Perl_ReANY(const REGEXP * const re)
 {
+    PERL_ARGS_ASSERT_REANY;
+
     XPV* const p = (XPV*)SvANY(re);
 
-    PERL_ARGS_ASSERT_REANY;
     assert(isREGEXP(re));
 
     return SvTYPE(re) == SVt_PVLV ? p->xpv_len_u.xpvlenu_rx
@@ -1275,10 +1277,10 @@ Perl_ReANY(const REGEXP * const re)
 PERL_STATIC_INLINE void
 Perl_append_utf8_from_native_byte(const U8 byte, U8** dest)
 {
+    PERL_ARGS_ASSERT_APPEND_UTF8_FROM_NATIVE_BYTE;
+
     /* Takes an input 'byte' (Latin1 or EBCDIC) and appends it to the UTF-8
      * encoded string at '*dest', updating '*dest' to include it */
-
-    PERL_ARGS_ASSERT_APPEND_UTF8_FROM_NATIVE_BYTE;
 
     if (NATIVE_BYTE_IS_INVARIANT(byte))
         *((*dest)++) = byte;
@@ -2226,9 +2228,9 @@ at this low a level.  A valid use case could change that.
 PERL_STATIC_INLINE bool
 Perl_is_utf8_non_invariant_string(const U8* const s, STRLEN len)
 {
-    const U8 * first_variant;
-
     PERL_ARGS_ASSERT_IS_UTF8_NON_INVARIANT_STRING;
+
+    const U8 * first_variant;
 
     if (is_utf8_invariant_string_loc(s, len, &first_variant)) {
         return FALSE;
@@ -2324,9 +2326,10 @@ C<L</is_utf8_fixed_width_buf_flags>>,
 PERL_STATIC_INLINE bool
 Perl_is_utf8_string_flags(const U8 *s, STRLEN len, const U32 flags)
 {
+    PERL_ARGS_ASSERT_IS_UTF8_STRING_FLAGS;
+
     const U8 * first_variant;
 
-    PERL_ARGS_ASSERT_IS_UTF8_STRING_FLAGS;
     assert(0 == (flags & ~UTF8_DISALLOW_ILLEGAL_INTERCHANGE));
 
     if (len == 0) {
@@ -2371,9 +2374,9 @@ Perl_is_utf8_string_flags(const U8 *s, STRLEN len, const U32 flags)
 PERL_STATIC_INLINE bool
 Perl_is_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
 {
-    const U8 * first_variant;
-
     PERL_ARGS_ASSERT_IS_UTF8_STRING_LOCLEN;
+
+    const U8 * first_variant;
 
     if (len == 0) {
         len = strlen((const char *) s);
@@ -2660,9 +2663,9 @@ Perl_isC9_STRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
 PERL_STATIC_INLINE bool
 Perl_is_strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
 {
-    const U8 * first_variant;
-
     PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOCLEN;
+
+    const U8 * first_variant;
 
     if (len == 0) {
         len = strlen((const char *) s);
@@ -2710,9 +2713,9 @@ Perl_is_strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN
 PERL_STATIC_INLINE bool
 Perl_is_c9strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
 {
-    const U8 * first_variant;
-
     PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOCLEN;
+
+    const U8 * first_variant;
 
     if (len == 0) {
         len = strlen((const char *) s);
@@ -2765,9 +2768,10 @@ Perl_is_c9strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRL
 PERL_STATIC_INLINE bool
 Perl_is_utf8_string_loclen_flags(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el, const U32 flags)
 {
+    PERL_ARGS_ASSERT_IS_UTF8_STRING_LOCLEN_FLAGS;
+
     const U8 * first_variant;
 
-    PERL_ARGS_ASSERT_IS_UTF8_STRING_LOCLEN_FLAGS;
     assert(0 == (flags & ~UTF8_DISALLOW_ILLEGAL_INTERCHANGE));
 
     if (flags == 0) {
@@ -3283,9 +3287,9 @@ Perl_is_utf8_fixed_width_buf_loclen_flags(const U8 * const s,
                                        STRLEN *el,
                                        const U32 flags)
 {
-    const U8 * maybe_partial;
-
     PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOCLEN_FLAGS;
+
+    const U8 * maybe_partial;
 
     if (! ep) {
         ep  = &maybe_partial;
@@ -3502,11 +3506,11 @@ Allows one ending \0
 PERL_STATIC_INLINE bool
 Perl_is_safe_syscall(pTHX_ const char *pv, STRLEN len, const char *what, const char *op_name)
 {
+    PERL_ARGS_ASSERT_IS_SAFE_SYSCALL;
+
     /* While the Windows CE API provides only UCS-16 (or UTF-16) APIs
      * perl itself uses xce*() functions which accept 8-bit strings.
      */
-
-    PERL_ARGS_ASSERT_IS_SAFE_SYSCALL;
 
     if (len > 1) {
         char *null_at;
@@ -3544,9 +3548,9 @@ then calling:
 PERL_STATIC_INLINE bool
 S_should_warn_nl(const char *pv)
 {
-    STRLEN len;
-
     PERL_ARGS_ASSERT_SHOULD_WARN_NL;
+
+    STRLEN len;
 
     len = strlen(pv);
 
@@ -3560,12 +3564,12 @@ S_should_warn_nl(const char *pv)
 PERL_STATIC_INLINE bool
 S_lossless_NV_to_IV(const NV nv, IV *ivp)
 {
+    PERL_ARGS_ASSERT_LOSSLESS_NV_TO_IV;
+
     /* This function determines if the input NV 'nv' may be converted without
      * loss of data to an IV.  If not, it returns FALSE taking no other action.
      * But if it is possible, it does the conversion, returning TRUE, and
      * storing the converted result in '*ivp' */
-
-    PERL_ARGS_ASSERT_LOSSLESS_NV_TO_IV;
 
 #  if defined(NAN_COMPARE_BROKEN) && defined(Perl_isnan)
     /* Normally any comparison with a NaN returns false; if we can't rely
@@ -3968,9 +3972,9 @@ Return false if any get magic is on the SV other than taint magic.
 PERL_STATIC_INLINE bool
 Perl_sv_only_taint_gmagic(SV *sv)
 {
-    MAGIC *mg = SvMAGIC(sv);
-
     PERL_ARGS_ASSERT_SV_ONLY_TAINT_GMAGIC;
+
+    MAGIC *mg = SvMAGIC(sv);
 
     while (mg) {
         if (mg->mg_type != PERL_MAGIC_taint
@@ -4011,9 +4015,9 @@ Perl_gimme_V(pTHX)
 PERL_STATIC_INLINE PERL_CONTEXT *
 Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV** sp, I32 saveix)
 {
-    PERL_CONTEXT * cx;
-
     PERL_ARGS_ASSERT_CX_PUSHBLOCK;
+
+    PERL_CONTEXT * cx;
 
     CXINC;
     cx = CX_CUR();
@@ -4080,9 +4084,9 @@ Perl_cx_topblock(pTHX_ PERL_CONTEXT *cx)
 PERL_STATIC_INLINE void
 Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
 {
-    U8 phlags = CX_PUSHSUB_GET_LVALUE_MASK(Perl_was_lvalue_sub);
-
     PERL_ARGS_ASSERT_CX_PUSHSUB;
+
+    U8 phlags = CX_PUSHSUB_GET_LVALUE_MASK(Perl_was_lvalue_sub);
 
     PERL_DTRACE_PROBE_ENTRY(cv);
     cx->blk_sub.old_cxsubix     = PL_curstackinfo->si_cxsubix;
@@ -4102,9 +4106,10 @@ Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
 PERL_STATIC_INLINE void
 Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx)
 {
+    PERL_ARGS_ASSERT_CX_POPSUB_COMMON;
+
     CV *cv;
 
-    PERL_ARGS_ASSERT_CX_POPSUB_COMMON;
     assert(CxTYPE(cx) == CXt_SUB);
 
     PL_comppad = cx->blk_sub.prevcomppad;
@@ -4122,9 +4127,10 @@ Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx)
 PERL_STATIC_INLINE void
 Perl_cx_popsub_args(pTHX_ PERL_CONTEXT *cx)
 {
+    PERL_ARGS_ASSERT_CX_POPSUB_ARGS;
+
     AV *av;
 
-    PERL_ARGS_ASSERT_CX_POPSUB_ARGS;
     assert(CxTYPE(cx) == CXt_SUB);
     assert(AvARRAY(MUTABLE_AV(
         PadlistARRAY(CvPADLIST(cx->blk_sub.cv))[
@@ -4181,10 +4187,11 @@ Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
 PERL_STATIC_INLINE void
 Perl_cx_popformat(pTHX_ PERL_CONTEXT *cx)
 {
+    PERL_ARGS_ASSERT_CX_POPFORMAT;
+
     CV *cv;
     GV *dfout;
 
-    PERL_ARGS_ASSERT_CX_POPFORMAT;
     assert(CxTYPE(cx) == CXt_FORMAT);
 
     dfout = cx->blk_format.dfoutgv;
@@ -4244,9 +4251,10 @@ Perl_cx_pushtry(pTHX_ PERL_CONTEXT *cx, OP *retop)
 PERL_STATIC_INLINE void
 Perl_cx_popeval(pTHX_ PERL_CONTEXT *cx)
 {
+    PERL_ARGS_ASSERT_CX_POPEVAL;
+
     SV *sv;
 
-    PERL_ARGS_ASSERT_CX_POPEVAL;
     assert(CxTYPE(cx) == CXt_EVAL);
 
     PL_in_eval = CxOLD_IN_EVAL(cx);
@@ -4431,9 +4439,10 @@ Perl_cx_pushgiven(pTHX_ PERL_CONTEXT *cx, SV *orig_defsv)
 PERL_STATIC_INLINE void
 Perl_cx_popgiven(pTHX_ PERL_CONTEXT *cx)
 {
+    PERL_ARGS_ASSERT_CX_POPGIVEN;
+
     SV *sv;
 
-    PERL_ARGS_ASSERT_CX_POPGIVEN;
     assert(CxTYPE(cx) == CXt_GIVEN);
 
     sv = GvSV(PL_defgv);
@@ -4620,12 +4629,11 @@ instead.
 PERL_STATIC_INLINE I32
 Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
 {
+    PERL_ARGS_ASSERT_FOLDEQ;
     PERL_UNUSED_CONTEXT;
 
     const U8 *a = (const U8 *)s1;
     const U8 *b = (const U8 *)s2;
-
-    PERL_ARGS_ASSERT_FOLDEQ;
 
     assert(len >= 0);
 
@@ -4640,6 +4648,8 @@ Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
 PERL_STATIC_INLINE I32
 Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
 {
+    PERL_ARGS_ASSERT_FOLDEQ_LATIN1;
+
     /* Compare non-UTF-8 using Unicode (Latin1) semantics.  Works on all folds
      * representable without UTF-8, except for LATIN_SMALL_LETTER_SHARP_S, and
      * does not check for this.  Nor does it check that the strings each have
@@ -4649,8 +4659,6 @@ Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
 
     const U8 *a = (const U8 *)s1;
     const U8 *b = (const U8 *)s2;
-
-    PERL_ARGS_ASSERT_FOLDEQ_LATIN1;
 
     assert(len >= 0);
 
@@ -4666,10 +4674,10 @@ Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
 PERL_STATIC_INLINE I32
 Perl_foldEQ_locale(pTHX_ const char *s1, const char *s2, I32 len)
 {
+    PERL_ARGS_ASSERT_FOLDEQ_LOCALE;
+
     const U8 *a = (const U8 *)s1;
     const U8 *b = (const U8 *)s2;
-
-    PERL_ARGS_ASSERT_FOLDEQ_LOCALE;
 
     assert(len >= 0);
 
@@ -4723,11 +4731,11 @@ Perl_my_strnlen(const char *str, Size_t maxlen)
 PERL_STATIC_INLINE void *
 S_my_memrchr(const char * s, const char c, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_MY_MEMRCHR;
+
     /* memrchr(), since many platforms lack it */
 
     const char * t = s + len - 1;
-
-    PERL_ARGS_ASSERT_MY_MEMRCHR;
 
     while (t >= s) {
         if (*t == c) {
@@ -4744,6 +4752,8 @@ S_my_memrchr(const char * s, const char c, const STRLEN len)
 PERL_STATIC_INLINE char *
 Perl_mortal_getenv(const char * str)
 {
+    PERL_ARGS_ASSERT_MORTAL_GETENV;
+
     /* This implements a (mostly) thread-safe, sequential-call-safe getenv().
      *
      * It's (mostly) thread-safe because it uses a mutex to prevent other
@@ -4780,8 +4790,6 @@ Perl_mortal_getenv(const char * str)
 
     char * ret;
     dTHX;
-
-    PERL_ARGS_ASSERT_MORTAL_GETENV;
 
     /* Can't mortalize without stacks.  khw believes that no other threads
      * should be running, so no need to lock things, and this may be during a
@@ -4954,7 +4962,6 @@ Perl_sv_isbool(pTHX_ const SV *sv)
 PERL_STATIC_INLINE AV *
 Perl_cop_file_avn(pTHX_ const COP *cop)
 {
-
     PERL_ARGS_ASSERT_COP_FILE_AVN;
 
     const char *file = CopFILE(cop);
@@ -5103,11 +5110,11 @@ Perl_savepvn(pTHX_ const char *pv, Size_t len)
 PERL_STATIC_INLINE char *
 Perl_savesvpv(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SAVESVPV;
+
     STRLEN len;
     const char * const pv = SvPV_const(sv, len);
     char *newaddr;
-
-    PERL_ARGS_ASSERT_SAVESVPV;
 
     ++len;
     Newx(newaddr,len,char);
@@ -5117,10 +5124,10 @@ Perl_savesvpv(pTHX_ SV *sv)
 PERL_STATIC_INLINE char *
 Perl_savesharedsvpv(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SAVESHAREDSVPV;
+
     STRLEN len;
     const char * const pv = SvPV_const(sv, len);
-
-    PERL_ARGS_ASSERT_SAVESHAREDSVPV;
 
     return savesharedpvn(pv, len);
 }

--- a/invlist_inline.h
+++ b/invlist_inline.h
@@ -37,9 +37,10 @@ S_is_invlist(const SV* const invlist)
 PERL_STATIC_INLINE bool*
 S_get_invlist_offset_addr(SV* invlist)
 {
+    PERL_ARGS_ASSERT_GET_INVLIST_OFFSET_ADDR;
+
     /* Return the address of the field that says whether the inversion list is
      * offset (it contains 1) or not (contains 0) */
-    PERL_ARGS_ASSERT_GET_INVLIST_OFFSET_ADDR;
 
     assert(is_invlist(invlist));
 
@@ -49,10 +50,10 @@ S_get_invlist_offset_addr(SV* invlist)
 PERL_STATIC_INLINE UV
 S_invlist_len_(SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_LEN_;
+
     /* Returns the current number of elements stored in the inversion list's
      * array */
-
-    PERL_ARGS_ASSERT_INVLIST_LEN_;
 
     assert(is_invlist(invlist));
 
@@ -64,11 +65,11 @@ S_invlist_len_(SV* const invlist)
 PERL_STATIC_INLINE bool
 S_invlist_contains_cp_(SV* const invlist, const UV cp)
 {
+    PERL_ARGS_ASSERT_INVLIST_CONTAINS_CP_;
+
     /* Does <invlist> contain code point <cp> as part of the set? */
 
     IV index = invlist_search_(invlist, cp);
-
-    PERL_ARGS_ASSERT_INVLIST_CONTAINS_CP_;
 
     return index >= 0 && ELEMENT_RANGE_MATCHES_INVLIST(index);
 }
@@ -76,11 +77,11 @@ S_invlist_contains_cp_(SV* const invlist, const UV cp)
 PERL_STATIC_INLINE UV*
 S_invlist_array(SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_ARRAY;
+
     /* Returns the pointer to the inversion list's array.  Every time the
      * length changes, this needs to be called in case malloc or realloc moved
      * it */
-
-    PERL_ARGS_ASSERT_INVLIST_ARRAY;
 
     /* Must not be empty.  If these fail, you probably didn't check for <len>
      * being non-zero before trying to get the array */
@@ -100,9 +101,9 @@ S_invlist_array(SV* const invlist)
 PERL_STATIC_INLINE void
 S_invlist_extend(pTHX_ SV* const invlist, const UV new_max)
 {
-    /* Grow the maximum size of an inversion list */
-
     PERL_ARGS_ASSERT_INVLIST_EXTEND;
+
+    /* Grow the maximum size of an inversion list */
 
     assert(SvTYPE(invlist) == SVt_INVLIST);
 
@@ -114,10 +115,11 @@ S_invlist_extend(pTHX_ SV* const invlist, const UV new_max)
 PERL_STATIC_INLINE void
 S_invlist_set_len(pTHX_ SV* const invlist, const UV len, const bool offset)
 {
+    PERL_ARGS_ASSERT_INVLIST_SET_LEN;
+
     /* Sets the current number of elements stored in the inversion list.
      * Updates SvCUR correspondingly */
     PERL_UNUSED_CONTEXT;
-    PERL_ARGS_ASSERT_INVLIST_SET_LEN;
 
     assert(SvTYPE(invlist) == SVt_INVLIST);
 
@@ -139,6 +141,7 @@ S_add_cp_to_invlist(pTHX_ SV* invlist, const UV cp)
 PERL_STATIC_INLINE UV
 S_invlist_highest(SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_HIGHEST;
 
     /* Returns the highest code point that matches an inversion list.  This API
      * has an ambiguity, as it returns 0 under either the highest is actually
@@ -147,8 +150,6 @@ S_invlist_highest(SV* const invlist)
 
     UV len = invlist_len_(invlist);
     UV *array;
-
-    PERL_ARGS_ASSERT_INVLIST_HIGHEST;
 
     if (len == 0) {
         return 0;
@@ -172,6 +173,8 @@ S_invlist_highest(SV* const invlist)
 PERL_STATIC_INLINE UV
 S_invlist_highest_range_start(SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_HIGHEST_RANGE_START;
+
     /* Returns the lowest code point of the highest range in the inversion
      * list parameter.  This API has an ambiguity: it returns 0 either when
      * the lowest such point is actually 0 or when the list is empty.  If this
@@ -180,8 +183,6 @@ S_invlist_highest_range_start(SV* const invlist)
 
     UV len = invlist_len_(invlist);
     UV *array;
-
-    PERL_ARGS_ASSERT_INVLIST_HIGHEST_RANGE_START;
 
     if (len == 0) {
         return 0;
@@ -210,10 +211,10 @@ S_invlist_highest_range_start(SV* const invlist)
 PERL_STATIC_INLINE STRLEN*
 S_get_invlist_iter_addr(SV* invlist)
 {
+    PERL_ARGS_ASSERT_GET_INVLIST_ITER_ADDR;
+
     /* Return the address of the UV that contains the current iteration
      * position */
-
-    PERL_ARGS_ASSERT_GET_INVLIST_ITER_ADDR;
 
     assert(is_invlist(invlist));
 
@@ -231,6 +232,8 @@ S_invlist_iterinit(SV* invlist)	/* Initialize iterator for invlist */
 PERL_STATIC_INLINE void
 S_invlist_iterfinish(SV* invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_ITERFINISH;
+
     /* Terminate iterator for invlist.  This is to catch development errors.
      * Any iteration that is interrupted before completed should call this
      * function.  Functions that add code points anywhere else but to the end
@@ -239,14 +242,14 @@ S_invlist_iterfinish(SV* invlist)
      * problematical: if the iteration hadn't reached the place where things
      * were being added, it would be ok */
 
-    PERL_ARGS_ASSERT_INVLIST_ITERFINISH;
-
     *get_invlist_iter_addr(invlist) = (STRLEN) UV_MAX;
 }
 
 static bool
 S_invlist_iternext(SV* invlist, UV* start, UV* end)
 {
+    PERL_ARGS_ASSERT_INVLIST_ITERNEXT;
+
     /* An C<invlist_iterinit> call on <invlist> must be used to set this up.
      * This call sets in <*start> and <*end>, the next range in <invlist>.
      * Returns <TRUE> if successful and the next call will return the next
@@ -257,8 +260,6 @@ S_invlist_iternext(SV* invlist, UV* start, UV* end)
     STRLEN* pos = get_invlist_iter_addr(invlist);
     UV len = invlist_len_(invlist);
     UV *array;
-
-    PERL_ARGS_ASSERT_INVLIST_ITERNEXT;
 
     if (*pos >= len) {
         *pos = (STRLEN) UV_MAX;	/* Force iterinit() to be required next time */
@@ -305,6 +306,8 @@ PERL_STATIC_INLINE
 SV *
 S_invlist_contents(pTHX_ SV* const invlist, const bool traditional_style)
 {
+    PERL_ARGS_ASSERT_INVLIST_CONTENTS;
+
     /* Get the contents of an inversion list into a string SV so that they can
      * be printed out.  If 'traditional_style' is TRUE, it uses the format
      * traditionally done for debug tracing; otherwise it uses a format
@@ -322,8 +325,6 @@ S_invlist_contents(pTHX_ SV* const invlist, const bool traditional_style)
     else {
         output = newSVpvs("");
     }
-
-    PERL_ARGS_ASSERT_INVLIST_CONTENTS;
 
     assert(! invlist_is_iterating(invlist));
 
@@ -357,6 +358,8 @@ PERL_STATIC_INLINE
 UV
 S_invlist_lowest(SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_LOWEST;
+
     /* Returns the lowest code point that matches an inversion list.  This API
      * has an ambiguity, as it returns 0 under either the lowest is actually
      * 0, or if the list is empty.  If this distinction matters to you, check
@@ -364,8 +367,6 @@ S_invlist_lowest(SV* const invlist)
 
     UV len = invlist_len_(invlist);
     UV *array;
-
-    PERL_ARGS_ASSERT_INVLIST_LOWEST;
 
     if (len == 0) {
         return 0;

--- a/locale.c
+++ b/locale.c
@@ -1969,9 +1969,9 @@ S_setlocale_i(pTHX_ const int category, const char * locale)
 static const char *
 S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale)
 {
-    const char * retval;
-
     PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R;
+
+    const char * retval;
 
     STDIZED_SETLOCALE_LOCK;
 
@@ -1992,9 +1992,9 @@ S_less_dicey_setlocale_r(pTHX_ const int category, const char * locale)
 static bool
 S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 {
-    bool retval;
-
     PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R;
+
+    bool retval;
 
     /* Unlikely, but potentially possible that another thread could zap the
      * buffer from true to false or vice-versa, so need to lock here */
@@ -2808,10 +2808,10 @@ S_update_PL_curlocales_i(pTHX_
                          const char * new_locale,
                          const line_t caller_line)
 {
+    PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I;
+
     /* Update PL_curlocales[], which is parallel to the other ones indexed by
      * our mapping of libc category number to our internal equivalents. */
-
-    PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I;
 
     if (index == LC_ALL_INDEX_) {
 
@@ -4748,11 +4748,11 @@ S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index,
                                  const char * restore_locale,
                                  const line_t caller_line)
 {
+    PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I;
+
     /* Restores the locale for LC_category corresponding to cat_index to
      * 'restore_locale' (which is a copy that will be freed by this function),
      * or do nothing if the latter parameter is NULL */
-
-    PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I;
 
     if (restore_locale == NULL) {
         DEBUG_Lv(PerlIO_printf(Perl_debug_log,
@@ -5000,11 +5000,11 @@ S_is_locale_utf8(pTHX_ const char * locale)
 static bool
 S_is_codeset_name_UTF8(const char * name)
 {
+    PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8;
+
     /* Return a boolean as to if the passed-in name indicates it is a UTF-8
      * code set.  Several variants are possible */
     const Size_t len = strlen(name);
-
-    PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8;
 
 #    ifdef WIN32
 
@@ -7892,6 +7892,8 @@ S_maybe_override_codeset(pTHX_ const char * codeset,
                                const char * locale,
                                const char ** new_codeset)
 {
+    PERL_ARGS_ASSERT_MY_STRFTIME;
+
 #  define NAME_INDICATES_UTF8       0x1
 #  define MB_CUR_MAX_SUGGESTS_UTF8  0x2
 
@@ -8360,7 +8362,6 @@ Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour,
                        int mday, int mon, int year, int wday, int yday,
                        int isdst)
 {   /* Documented above */
-    PERL_ARGS_ASSERT_MY_STRFTIME;
     PERL_UNUSED_ARG(wday);
     PERL_UNUSED_ARG(yday);
 
@@ -10468,7 +10469,6 @@ S_print_collxfrm_input_and_return(pTHX_
                                   const STRLEN xlen,
                                   const bool is_utf8)
 {
-
     PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN;
 
     PerlIO_printf(Perl_debug_log,

--- a/malloc.c
+++ b/malloc.c
@@ -1166,11 +1166,11 @@ cmp_pat_4bytes(unsigned char *s, size_t nbytes, const unsigned char *fill)
 static int
 S_adjust_size_and_find_bucket(size_t *nbytes_p)
 {
+        PERL_ARGS_ASSERT_ADJUST_SIZE_AND_FIND_BUCKET;
+
         MEM_SIZE shiftr;
         int bucket;
         size_t nbytes;
-
-        PERL_ARGS_ASSERT_ADJUST_SIZE_AND_FIND_BUCKET;
 
         nbytes = *nbytes_p;
 
@@ -2147,11 +2147,11 @@ Perl_putenv(char *a)
 MEM_SIZE
 Perl_malloced_size(void *p)
 {
+    PERL_ARGS_ASSERT_MALLOCED_SIZE;
+
     union overhead * const ovp = (union overhead *)
         ((caddr_t)p - sizeof (union overhead) * CHUNK_SHIFT);
     const int bucket = OV_INDEX(ovp);
-
-    PERL_ARGS_ASSERT_MALLOCED_SIZE;
 
 #ifdef RCHECK
     /* The caller wants to have a complete control over the chunk,
@@ -2183,12 +2183,12 @@ Perl_malloc_good_size(size_t wanted)
 int
 Perl_get_mstats(pTHX_ perl_mstats_t *buf, int buflen, int level)
 {
+        PERL_ARGS_ASSERT_GET_MSTATS;
+
 #ifdef DEBUGGING_MSTATS
         int i, j;
         union overhead *p;
         struct chunk_chain_s* nextchain;
-
-        PERL_ARGS_ASSERT_GET_MSTATS;
 
         buf->topbucket = buf->topbucket_ev = buf->topbucket_odd 
             = buf->totfree = buf->total = buf->total_chain = 0;
@@ -2253,13 +2253,13 @@ S<"after compilation">.
 void
 Perl_dump_mstats(pTHX_ const char *s)
 {
+        PERL_ARGS_ASSERT_DUMP_MSTATS;
+
 #ifdef DEBUGGING_MSTATS
         int i;
         perl_mstats_t buffer;
         UV nf[NBUCKETS];
         UV nt[NBUCKETS];
-
-        PERL_ARGS_ASSERT_DUMP_MSTATS;
 
         buffer.nfree  = nf;
         buffer.ntotal = nt;

--- a/mg.c
+++ b/mg.c
@@ -89,10 +89,10 @@ struct magic_state {
 static void
 S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags)
 {
+    PERL_ARGS_ASSERT_SAVE_MAGIC_FLAGS;
+
     MGS* mgs;
     bool bumped = FALSE;
-
-    PERL_ARGS_ASSERT_SAVE_MAGIC_FLAGS;
 
     assert(SvMAGICAL(sv));
 
@@ -132,8 +132,9 @@ Turns on the magical status of an SV.  See C<L</sv_magic>>.
 void
 Perl_mg_magical(SV *sv)
 {
-    const MAGIC* mg;
     PERL_ARGS_ASSERT_MG_MAGICAL;
+
+    const MAGIC* mg;
 
     SvMAGICAL_off(sv);
     if ((mg = SvMAGIC(sv))) {
@@ -165,13 +166,13 @@ be >= C<SVt_PVMG>.  See C<L</sv_magic>>.
 int
 Perl_mg_get(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_MG_GET;
+
     const SSize_t mgs_ix = SSNEW(sizeof(MGS));
     bool saved = FALSE;
     bool have_new = 0;
     bool taint_only = TRUE; /* the only get method seen is taint */
     MAGIC *newmg, *head, *cur, *mg;
-
-    PERL_ARGS_ASSERT_MG_GET;
 
     if (PL_localizing == 1 && sv == DEFSV) return 0;
 
@@ -269,11 +270,11 @@ Do magic after a value is assigned to the SV.  See C<L</sv_magic>>.
 int
 Perl_mg_set(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_MG_SET;
+
     const SSize_t mgs_ix = SSNEW(sizeof(MGS));
     MAGIC* mg;
     MAGIC* nextmg;
-
-    PERL_ARGS_ASSERT_MG_SET;
 
     if (PL_localizing == 2 && sv == DEFSV) return 0;
 
@@ -300,9 +301,9 @@ Perl_mg_set(pTHX_ SV *sv)
 I32
 Perl_mg_size(pTHX_ SV *sv)
 {
-    MAGIC* mg;
-
     PERL_ARGS_ASSERT_MG_SIZE;
+
+    MAGIC* mg;
 
     for (mg = SvMAGIC(sv); mg; mg = mg->mg_moremagic) {
         const MGVTBL* const vtbl = mg->mg_virtual;
@@ -340,11 +341,11 @@ Clear something magical that the SV represents.  See C<L</sv_magic>>.
 int
 Perl_mg_clear(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_MG_CLEAR;
+
     const SSize_t mgs_ix = SSNEW(sizeof(MGS));
     MAGIC* mg;
     MAGIC *nextmg;
-
-    PERL_ARGS_ASSERT_MG_CLEAR;
 
     save_magic(mgs_ix, sv);
 
@@ -439,10 +440,10 @@ Copies the magic from one SV to another.  See C<L</sv_magic>>.
 int
 Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen)
 {
+    PERL_ARGS_ASSERT_MG_COPY;
+
     int count = 0;
     MAGIC* mg;
-
-    PERL_ARGS_ASSERT_MG_COPY;
 
     for (mg = SvMAGIC(sv); mg; mg = mg->mg_moremagic) {
         const MGVTBL* const vtbl = mg->mg_virtual;
@@ -482,9 +483,9 @@ and that will handle the magic.
 void
 Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
 {
-    MAGIC *mg;
-
     PERL_ARGS_ASSERT_MG_LOCALIZE;
+
+    MAGIC *mg;
 
     if (nsv == DEFSV)
         return;
@@ -550,10 +551,10 @@ Free any magic storage used by the SV.  See C<L</sv_magic>>.
 int
 Perl_mg_free(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_MG_FREE;
+
     MAGIC* mg;
     MAGIC* moremagic;
-
-    PERL_ARGS_ASSERT_MG_FREE;
 
     for (mg = SvMAGIC(sv); mg; mg = moremagic) {
         moremagic = mg->mg_moremagic;
@@ -576,8 +577,9 @@ Remove any magic of type C<how> from the SV C<sv>.  See L</sv_magic>.
 void
 Perl_mg_free_type(pTHX_ SV *sv, int how)
 {
-    MAGIC *mg, *prevmg, *moremg;
     PERL_ARGS_ASSERT_MG_FREE_TYPE;
+
+    MAGIC *mg, *prevmg, *moremg;
     for (prevmg = NULL, mg = SvMAGIC(sv); mg; prevmg = mg, mg = moremg) {
         moremg = mg->mg_moremagic;
         if (mg->mg_type == how) {
@@ -612,8 +614,9 @@ C<mg_freeext(sv, how, NULL)> is equivalent to C<mg_free_type(sv, how)>.
 void
 Perl_mg_freeext(pTHX_ SV *sv, int how, const MGVTBL *vtbl)
 {
-    MAGIC *mg, *prevmg, *moremg;
     PERL_ARGS_ASSERT_MG_FREEEXT;
+
+    MAGIC *mg, *prevmg, *moremg;
     for (prevmg = NULL, mg = SvMAGIC(sv); mg; prevmg = mg, mg = moremg) {
         MAGIC *newhead;
         moremg = mg->mg_moremagic;
@@ -824,10 +827,10 @@ Perl_get_extended_os_errno(void)
 static void
 S_fixup_errno_string(pTHX_ SV* sv)
 {
+    PERL_ARGS_ASSERT_FIXUP_ERRNO_STRING;
+
     /* Do what is necessary to fixup the non-empty string in 'sv' for return to
      * Perl space. */
-
-    PERL_ARGS_ASSERT_FIXUP_ERRNO_STRING;
 
     assert(SvOK(sv));
 
@@ -898,12 +901,12 @@ Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv)
 int
 Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_GET;
+
     I32 paren;
     const char *s = NULL;
     REGEXP *rx;
     char nextchar;
-
-    PERL_ARGS_ASSERT_MAGIC_GET;
 
     const char * const remaining = (mg->mg_ptr)
                                    ? mg->mg_ptr + 1
@@ -1305,9 +1308,9 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
 {
-    struct ufuncs * const uf = (struct ufuncs *)mg->mg_ptr;
-
     PERL_ARGS_ASSERT_MAGIC_GETUVAR;
+
+    struct ufuncs * const uf = (struct ufuncs *)mg->mg_ptr;
 
     if (uf && uf->uf_val)
         (*uf->uf_val)(aTHX_ uf->uf_index, sv);
@@ -1317,6 +1320,8 @@ Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SETENV;
+
     STRLEN len = 0, klen;
 
     const char *key;
@@ -1335,8 +1340,6 @@ Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
 
         key = SvPV_const(keysv,klen);
     }
-
-    PERL_ARGS_ASSERT_MAGIC_SETENV;
 
     SvGETMAGIC(sv);
     if (SvOK(sv)) {
@@ -1500,10 +1503,10 @@ restore_sigmask(pTHX_ void *ptr)
 int
 Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_GETSIG;
+
     /* Are we fetching a signal entry? */
     int i = (I16)mg->mg_private;
-
-    PERL_ARGS_ASSERT_MAGIC_GETSIG;
 
     if (!i) {
         STRLEN siglen;
@@ -1758,6 +1761,8 @@ Perl_despatch_signals(pTHX)
 int
 Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SETSIG;
+
     I32 i;
     SV** svp = NULL;
     /* Need to be careful with SvREFCNT_dec(), because that can have side
@@ -1771,8 +1776,6 @@ Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
     SV* save_sv;
 #endif
     const char *s = MgPV_const(mg,len);
-
-    PERL_ARGS_ASSERT_MAGIC_SETSIG;
 
     if (*s == '_') {
         if (memEQs(s, len, "__DIE__"))
@@ -1942,11 +1945,11 @@ Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SETHOOK;
+
     SV** svp = NULL;
     STRLEN len;
     const char *s = MgPV_const(mg,len);
-
-    PERL_ARGS_ASSERT_MAGIC_SETHOOK;
 
     if (memEQs(s, len, "require__before")) {
         svp = &PL_hook__require__before;
@@ -2032,8 +2035,9 @@ Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
 {
-    HV* stash;
     PERL_ARGS_ASSERT_MAGIC_CLEARISA;
+
+    HV* stash;
 
     /* Bail out if destruction is going on */
     if(PL_phase == PERL_PHASE_DESTRUCT) return 0;
@@ -2073,10 +2077,11 @@ Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_GETNKEYS;
+
     HV * const hv = MUTABLE_HV(LvTARG(sv));
     I32 i = 0;
 
-    PERL_ARGS_ASSERT_MAGIC_GETNKEYS;
     PERL_UNUSED_ARG(mg);
 
     if (hv) {
@@ -2135,10 +2140,10 @@ SV*
 Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
                     U32 argc, ...)
 {
+    PERL_ARGS_ASSERT_MAGIC_METHCALL;
+
     dSP;
     SV* ret = NULL;
-
-    PERL_ARGS_ASSERT_MAGIC_METHCALL;
 
     ENTER;
 
@@ -2193,9 +2198,9 @@ static SV*
 S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
     int n, SV *val)
 {
-    SV* arg1 = NULL;
-
     PERL_ARGS_ASSERT_MAGIC_METHCALL1;
+
+    SV* arg1 = NULL;
 
     if (mg->mg_ptr) {
         if (mg->mg_len >= 0) {
@@ -2217,9 +2222,9 @@ S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags,
 static int
 S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
 {
-    SV* ret;
-
     PERL_ARGS_ASSERT_MAGIC_METHPACK;
+
+    SV* ret;
 
     ret = magic_methcall1(sv, mg, meth, 0, 1, NULL);
     if (ret)
@@ -2241,10 +2246,10 @@ Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SETPACK;
+
     MAGIC *tmg;
     SV    *val;
-
-    PERL_ARGS_ASSERT_MAGIC_SETPACK;
 
     /* in the code C<$tied{foo} = $val>, the "thing" that gets passed to
      * STORE() is not $val, but rather a PVLV (the sv in this call), whose
@@ -2282,10 +2287,10 @@ Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
 U32
 Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SIZEPACK;
+
     I32 retval = 0;
     SV* retsv;
-
-    PERL_ARGS_ASSERT_MAGIC_SIZEPACK;
 
     retsv = magic_methcall1(sv, mg, SV_CONST(FETCHSIZE), 0, 1, NULL);
     if (retsv) {
@@ -2308,9 +2313,9 @@ Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
 {
-    SV* ret;
-
     PERL_ARGS_ASSERT_MAGIC_NEXTPACK;
+
+    SV* ret;
 
     ret = SvOK(key) ? Perl_magic_methcall(aTHX_ sv, mg, SV_CONST(NEXTKEY), 0, 1, key)
         : Perl_magic_methcall(aTHX_ sv, mg, SV_CONST(FIRSTKEY), 0, 0);
@@ -2330,12 +2335,12 @@ Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
 SV *
 Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SCALARPACK;
+
     SV *retval;
     SV * const tied = SvTIED_obj(MUTABLE_SV(hv), mg);
     HV * const pkg = SvSTASH((const SV *)SvRV(tied));
    
-    PERL_ARGS_ASSERT_MAGIC_SCALARPACK;
-
     if (!gv_fetchmethod_autoload(pkg, "SCALAR", FALSE)) {
         SV *key;
         if (HvEITER_get(hv))
@@ -2358,9 +2363,9 @@ Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
 int
 Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
 {
-    SV **svp;
-
     PERL_ARGS_ASSERT_MAGIC_SETDBLINE;
+
+    SV **svp;
 
     /* The magic ptr/len for the debugger's hash should always be an SV.  */
     if (UNLIKELY(mg->mg_len != HEf_SVKEY)) {
@@ -2395,9 +2400,9 @@ Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
 {
-    AV * const obj = MUTABLE_AV(mg->mg_obj);
-
     PERL_ARGS_ASSERT_MAGIC_GETARYLEN;
+
+    AV * const obj = MUTABLE_AV(mg->mg_obj);
 
     if (obj) {
         sv_setiv(sv, AvFILL(obj));
@@ -2410,9 +2415,9 @@ Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
 {
-    AV * const obj = MUTABLE_AV(mg->mg_obj);
-
     PERL_ARGS_ASSERT_MAGIC_SETARYLEN;
+
+    AV * const obj = MUTABLE_AV(mg->mg_obj);
 
     if (obj) {
         av_fill(obj, SvIV(sv));
@@ -2467,10 +2472,10 @@ Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
 {
-    SV* const lsv = LvTARG(sv);
-
     PERL_ARGS_ASSERT_MAGIC_GETPOS;
     PERL_UNUSED_ARG(mg);
+
+    SV* const lsv = LvTARG(sv);
 
     STRLEN pos;
     if (sv_regex_global_pos_get(lsv, &pos, 0)) {
@@ -2484,10 +2489,10 @@ Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
 {
-    SV* const lsv = LvTARG(sv);
-
     PERL_ARGS_ASSERT_MAGIC_SETPOS;
     PERL_UNUSED_ARG(mg);
+
+    SV* const lsv = LvTARG(sv);
 
     if(SvOK(sv))
         sv_regex_global_pos_set(lsv, SvIV(sv), 0);
@@ -2500,6 +2505,8 @@ Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_GETSUBSTR;
+
     STRLEN len;
     SV * const lsv = LvTARG(sv);
     const char * const tmps = SvPV_const(lsv,len);
@@ -2508,7 +2515,6 @@ Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
     const bool negoff = LvFLAGS(sv) & LVf_NEG_OFF;
     const bool negrem = LvFLAGS(sv) & LVf_NEG_LEN;
 
-    PERL_ARGS_ASSERT_MAGIC_GETSUBSTR;
     PERL_UNUSED_ARG(mg);
 
     if (!translate_substr_offsets(
@@ -2532,6 +2538,8 @@ Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SETSUBSTR;
+
     STRLEN len, lsv_len, oldtarglen, newtarglen;
     const char * const tmps = SvPV_const(sv, len);
     SV * const lsv = LvTARG(sv);
@@ -2540,7 +2548,6 @@ Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
     const bool negoff = LvFLAGS(sv) & LVf_NEG_OFF;
     const bool neglen = LvFLAGS(sv) & LVf_NEG_LEN;
 
-    PERL_ARGS_ASSERT_MAGIC_SETSUBSTR;
     PERL_UNUSED_ARG(mg);
 
     SvGETMAGIC(lsv);
@@ -2612,12 +2619,12 @@ Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_GETVEC;
+
     SV * const lsv = LvTARG(sv);
     char errflags = LvFLAGS(sv);
 
-    PERL_ARGS_ASSERT_MAGIC_GETVEC;
     PERL_UNUSED_ARG(mg);
-
     /* non-zero errflags implies deferred out-of-range condition */
     assert(!(errflags & ~(LVf_NEG_OFF|LVf_OUT_OF_RANGE)));
     sv_setuv(sv, errflags ? 0 : do_vecget(lsv, LvTARGOFF(sv), LvTARGLEN(sv)));
@@ -2637,8 +2644,9 @@ Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
 SV *
 Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
 {
-    SV *targ = NULL;
     PERL_ARGS_ASSERT_DEFELEM_TARGET;
+
+    SV *targ = NULL;
     if (!mg) mg = mg_find(sv, PERL_MAGIC_defelem);
     assert(mg);
     if (LvTARGLEN(sv)) {
@@ -2710,10 +2718,10 @@ Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
 void
 Perl_vivify_defelem(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_VIVIFY_DEFELEM;
+
     MAGIC *mg;
     SV *value = NULL;
-
-    PERL_ARGS_ASSERT_VIVIFY_DEFELEM;
 
     if (!LvTARGLEN(sv) || !(mg = mg_find(sv, PERL_MAGIC_defelem)))
         return;
@@ -2792,9 +2800,9 @@ Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
 {
-    const struct ufuncs * const uf = (struct ufuncs *)mg->mg_ptr;
-
     PERL_ARGS_ASSERT_MAGIC_SETUVAR;
+
+    const struct ufuncs * const uf = (struct ufuncs *)mg->mg_ptr;
 
     if (uf && uf->uf_set)
         (*uf->uf_set)(aTHX_ uf->uf_index, sv);
@@ -2804,9 +2812,9 @@ Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
 {
-    const char type = mg->mg_type;
-
     PERL_ARGS_ASSERT_MAGIC_SETREGEXP;
+
+    const char type = mg->mg_type;
 
     assert(    type == PERL_MAGIC_fm
             || type == PERL_MAGIC_qr
@@ -2885,8 +2893,9 @@ Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
 int
 Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
 {
-    const char *bad = NULL;
     PERL_ARGS_ASSERT_MAGIC_SETLVREF;
+
+    const char *bad = NULL;
     if (!SvROK(sv)) croak("Assigned value is not a reference");
     switch (mg->mg_private & OPpLVREF_TYPE) {
     case OPpLVREF_SV:
@@ -3019,13 +3028,13 @@ S_set_dollarzero(pTHX_ SV *sv)
 int
 Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SET;
+
     I32 paren;
     const REGEXP * rx;
     I32 i;
     STRLEN len;
     MAGIC *tmg;
-
-    PERL_ARGS_ASSERT_MAGIC_SET;
 
     if (!mg->mg_ptr) {
         paren = mg->mg_len;
@@ -3588,9 +3597,10 @@ C<whichsig_sv> takes the name from the PV stored in the SV C<sigsv>.
 I32
 Perl_whichsig_sv(pTHX_ SV *sigsv)
 {
+    PERL_ARGS_ASSERT_WHICHSIG_SV;
+
     const char *sigpv;
     STRLEN siglen;
-    PERL_ARGS_ASSERT_WHICHSIG_SV;
     sigpv = SvPV_const(sigsv, siglen);
     return whichsig_pvn(sigpv, siglen);
 }
@@ -3605,10 +3615,10 @@ Perl_whichsig_pv(pTHX_ const char *sig)
 I32
 Perl_whichsig_pvn(pTHX_ const char *sig, STRLEN len)
 {
-    char* const* sigv;
-
     PERL_ARGS_ASSERT_WHICHSIG_PVN;
     PERL_UNUSED_CONTEXT;
+
+    char* const* sigv;
 
     for (sigv = (char* const*)PL_sig_name; *sigv; sigv++)
         if (strlen(*sigv) == len && memEQ(sig,*sigv, len))
@@ -3945,10 +3955,10 @@ reference.
 int
 Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
 {
+    PERL_ARGS_ASSERT_MAGIC_SETHINT;
+
     SV *key = (mg->mg_len == HEf_SVKEY) ? MUTABLE_SV(mg->mg_ptr)
         : newSVpvn_flags(mg->mg_ptr, mg->mg_len, SVs_TEMP);
-
-    PERL_ARGS_ASSERT_MAGIC_SETHINT;
 
     /* mg->mg_obj isn't being used.  If needed, it would be possible to store
        an alternative leaf in there, with PL_compiling.cop_hints being used if
@@ -4016,12 +4026,12 @@ int
 Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv,
                                  const char *name, I32 namlen)
 {
-    MAGIC *nmg;
-
     PERL_ARGS_ASSERT_MAGIC_COPYCALLCHECKER;
     PERL_UNUSED_ARG(sv);
     PERL_UNUSED_ARG(name);
     PERL_UNUSED_ARG(namlen);
+
+    MAGIC *nmg;
 
     sv_magic(nsv, &PL_sv_undef, mg->mg_type, NULL, 0);
     nmg = mg_find(nsv, mg->mg_type);

--- a/mro_core.c
+++ b/mro_core.c
@@ -38,8 +38,9 @@ SV *
 Perl_mro_get_private_data(pTHX_ struct mro_meta *const smeta,
                           const struct mro_alg *const which)
 {
-    SV **data;
     PERL_ARGS_ASSERT_MRO_GET_PRIVATE_DATA;
+
+    SV **data;
 
     data = (SV **)Perl_hv_common(aTHX_ smeta->mro_linear_all, NULL,
                                  which->name, which->length, which->kflags,
@@ -115,9 +116,9 @@ registered.  See L</C<mro_register>>.
 const struct mro_alg *
 Perl_mro_get_from_name(pTHX_ SV *name)
 {
-    SV **data;
-
     PERL_ARGS_ASSERT_MRO_GET_FROM_NAME;
+
+    SV **data;
 
     data = (SV **)Perl_hv_common(aTHX_ PL_registered_mros, name, NULL, 0, 0,
                                  HV_FETCH_JUST_SV, NULL, 0);
@@ -155,9 +156,10 @@ Perl_mro_register(pTHX_ const struct mro_alg *mro) {
 struct mro_meta*
 Perl_mro_meta_init(pTHX_ HV* stash)
 {
+    PERL_ARGS_ASSERT_MRO_META_INIT;
+
     struct mro_meta* newmeta;
 
-    PERL_ARGS_ASSERT_MRO_META_INIT;
     PERL_UNUSED_CONTEXT;
     assert(HvAUX(stash));
     assert(!(HvAUX(stash)->xhv_mro_meta));
@@ -176,9 +178,9 @@ Perl_mro_meta_init(pTHX_ HV* stash)
 struct mro_meta*
 Perl_mro_meta_dup(pTHX_ struct mro_meta* smeta, CLONE_PARAMS* param)
 {
-    struct mro_meta* newmeta;
-
     PERL_ARGS_ASSERT_MRO_META_DUP;
+
+    struct mro_meta* newmeta;
 
     Newx(newmeta, 1, struct mro_meta);
     Copy(smeta, newmeta, 1, struct mro_meta);
@@ -233,6 +235,8 @@ invalidated).
 static AV*
 S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
 {
+    PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA_DFS;
+
     AV* retval;
     GV** gvp;
     GV* gv;
@@ -242,7 +246,6 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
     SV *our_name;
     HV *stored = NULL;
 
-    PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA_DFS;
     assert(HvAUX(stash));
 
     stashhek
@@ -414,10 +417,11 @@ invalidated).
 AV*
 Perl_mro_get_linear_isa(pTHX_ HV *stash)
 {
+    PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA;
+
     struct mro_meta* meta;
     AV *isa;
 
-    PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA;
     if(!HvHasAUX(stash))
         croak("Can't linearize anonymous symbol table");
 
@@ -506,6 +510,8 @@ by the C<setisa> magic, should not need to invoke directly.
 void
 Perl_mro_isa_changed_in(pTHX_ HV* stash)
 {
+    PERL_ARGS_ASSERT_MRO_ISA_CHANGED_IN;
+
     HV* isarev;
     AV* linear_mro;
     HE* iter;
@@ -518,8 +524,6 @@ Perl_mro_isa_changed_in(pTHX_ HV* stash)
     const HEK * const stashhek = HvENAME_HEK(stash);
     const char * const stashname = HvENAME_get(stash);
     const STRLEN stashname_len = HvENAMELEN_get(stash);
-
-    PERL_ARGS_ASSERT_MRO_ISA_CHANGED_IN;
 
     if(!stashname)
         croak("Can't call mro_isa_changed_in() on anonymous symbol table");
@@ -707,9 +711,9 @@ S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name,
                          const STRLEN len, HV * const exceptions, U32 hash,
                          U32 flags)
 {
-    HE* iter;
-
     PERL_ARGS_ASSERT_MRO_CLEAN_ISAREV;
+
+    HE* iter;
 
     assert(HvTOTALKEYS(isa));
     /* Delete our name from our former parents' isarevs. */
@@ -758,13 +762,14 @@ void
 Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash,
                        const GV * const gv, U32 flags)
 {
+    PERL_ARGS_ASSERT_MRO_PACKAGE_MOVED;
+
     SV *namesv;
     HEK **namep;
     I32 name_count;
     HV *stashes;
     HE* iter;
 
-    PERL_ARGS_ASSERT_MRO_PACKAGE_MOVED;
     assert(stash || oldstash);
 
     /* Determine the name(s) of the location that stash was assigned to
@@ -902,6 +907,8 @@ static void
 S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
                               HV *stash, HV *oldstash, SV *namesv)
 {
+    PERL_ARGS_ASSERT_MRO_GATHER_AND_RENAME;
+
     XPVHV* xhv;
     HE *entry;
     I32 riter = -1;
@@ -911,8 +918,6 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes,
     HV *seen = NULL;
     HV *isarev = NULL;
     SV **svp = NULL;
-
-    PERL_ARGS_ASSERT_MRO_GATHER_AND_RENAME;
 
     /* We use the seen_stashes hash to keep track of which packages have
        been encountered so far. This must be separate from the main list of
@@ -1396,9 +1401,9 @@ Croaks if C<name> hasn't been registered
 void
 Perl_mro_set_mro(pTHX_ struct mro_meta *const meta, SV *const name)
 {
-    const struct mro_alg *const which = Perl_mro_get_from_name(aTHX_ name);
-
     PERL_ARGS_ASSERT_MRO_SET_MRO;
+
+    const struct mro_alg *const which = Perl_mro_get_from_name(aTHX_ name);
 
     if (!which)
         croak("Invalid mro name: '%" SVf "'", name);

--- a/numeric.c
+++ b/numeric.c
@@ -112,9 +112,9 @@ These are are available even on platforms that lack plain strtod().
 NV
 Perl_my_strtod(const char * const s, char **e)
 {
-    dTHX;
-
     PERL_ARGS_ASSERT_MY_STRTOD;
+
+    dTHX;
 
 #ifdef Perl_strtod
 
@@ -862,11 +862,11 @@ For backwards compatibility.  Use C<grok_oct> instead.
 NV
 Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 {
+    PERL_ARGS_ASSERT_SCAN_BIN;
+
     NV rnv;
     I32 flags = *retlen ? PERL_SCAN_ALLOW_UNDERSCORES : 0;
     const UV ruv = grok_bin (start, &len, &flags, &rnv);
-
-    PERL_ARGS_ASSERT_SCAN_BIN;
 
     *retlen = len;
     return (flags & PERL_SCAN_GREATER_THAN_UV_MAX) ? rnv : (NV)ruv;
@@ -875,11 +875,11 @@ Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 NV
 Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 {
+    PERL_ARGS_ASSERT_SCAN_OCT;
+
     NV rnv;
     I32 flags = *retlen ? PERL_SCAN_ALLOW_UNDERSCORES : 0;
     const UV ruv = grok_oct (start, &len, &flags, &rnv);
-
-    PERL_ARGS_ASSERT_SCAN_OCT;
 
     *retlen = len;
     return (flags & PERL_SCAN_GREATER_THAN_UV_MAX) ? rnv : (NV)ruv;
@@ -888,11 +888,11 @@ Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 NV
 Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
 {
+    PERL_ARGS_ASSERT_SCAN_HEX;
+
     NV rnv;
     I32 flags = *retlen ? PERL_SCAN_ALLOW_UNDERSCORES : 0;
     const UV ruv = grok_hex (start, &len, &flags, &rnv);
-
-    PERL_ARGS_ASSERT_SCAN_HEX;
 
     *retlen = len;
     return (flags & PERL_SCAN_GREATER_THAN_UV_MAX) ? rnv : (NV)ruv;
@@ -1297,12 +1297,12 @@ static const U8 uv_max_mod_10 = UV_MAX % 10;
 int
 Perl_grok_number_flags(pTHX_ const char *pv, STRLEN len, UV *valuep, U32 flags)
 {
+  PERL_ARGS_ASSERT_GROK_NUMBER_FLAGS;
+
   const char *s = pv;
   const char * const send = pv + len;
   const char *d;
   int numtype = 0;
-
-  PERL_ARGS_ASSERT_GROK_NUMBER_FLAGS;
 
   if (UNLIKELY(isSPACE(*s))) {
       s++;
@@ -1660,6 +1660,7 @@ S_mulexp10(NV value, I32 exponent)
 NV
 Perl_my_atof(pTHX_ const char* s)
 {
+    PERL_ARGS_ASSERT_MY_ATOF;
 
 /*
 =for apidoc      my_atof
@@ -1676,8 +1677,6 @@ N.B. C<s> must be NUL terminated.
 */
 
     NV x = 0.0;
-
-    PERL_ARGS_ASSERT_MY_ATOF;
 
 #if ! defined(USE_LOCALE_NUMERIC)
 
@@ -1821,6 +1820,8 @@ Perl_my_atof2(pTHX_ const char* orig, NV* value)
 char*
 Perl_my_atof3(pTHX_ const char* orig, NV* value, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_MY_ATOF3;
+
     const char* s = orig;
     NV result[3] = {0.0, 0.0, 0.0};
 #if defined(USE_PERL_ATOF) || defined(Perl_strtod)
@@ -1843,7 +1844,6 @@ Perl_my_atof3(pTHX_ const char* orig, NV* value, const STRLEN len)
 #endif
 
 #if defined(USE_PERL_ATOF) || defined(Perl_strtod)
-    PERL_ARGS_ASSERT_MY_ATOF3;
 
     /* leading whitespace */
     while (s < send && isSPACE(*s))

--- a/op.c
+++ b/op.c
@@ -475,9 +475,9 @@ Perl_Slab_to_ro(pTHX_ OPSLAB *slab)
 void
 Perl_Slab_to_rw(pTHX_ OPSLAB *const slab)
 {
-    OPSLAB *slab2;
-
     PERL_ARGS_ASSERT_SLAB_TO_RW;
+
+    OPSLAB *slab2;
 
     if (!slab->opslab_readonly) return;
     slab2 = slab;
@@ -514,10 +514,10 @@ S_pp_freed(pTHX)
 void
 Perl_Slab_Free(pTHX_ void *op)
 {
+    PERL_ARGS_ASSERT_SLAB_FREE;
+
     OP * const o = (OP *)op;
     OPSLAB *slab;
-
-    PERL_ARGS_ASSERT_SLAB_FREE;
 
 #ifdef DEBUGGING
     o->op_ppaddr = S_pp_freed;
@@ -542,8 +542,9 @@ Perl_Slab_Free(pTHX_ void *op)
 void
 Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
 {
-    const bool havepad = cBOOL(PL_comppad);
     PERL_ARGS_ASSERT_OPSLAB_FREE_NOPAD;
+
+    const bool havepad = cBOOL(PL_comppad);
     if (havepad) {
         ENTER;
         PAD_SAVE_SETNULLPAD();
@@ -565,9 +566,10 @@ Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
 void
 Perl_opslab_free(pTHX_ OPSLAB *slab)
 {
-    OPSLAB *slab2;
     PERL_ARGS_ASSERT_OPSLAB_FREE;
     PERL_UNUSED_CONTEXT;
+
+    OPSLAB *slab2;
     DEBUG_S_warn((aTHX_ "freeing slab %p", (void*)slab));
     assert(slab->opslab_refcnt == 1);
     PerlMemShared_free(slab->opslab_freed);
@@ -597,11 +599,12 @@ Perl_opslab_free(pTHX_ OPSLAB *slab)
 void
 Perl_opslab_force_free(pTHX_ OPSLAB *slab)
 {
+    PERL_ARGS_ASSERT_OPSLAB_FORCE_FREE;
+
     OPSLAB *slab2;
 #ifdef DEBUGGING
     size_t savestack_count = 0;
 #endif
-    PERL_ARGS_ASSERT_OPSLAB_FORCE_FREE;
     slab2 = slab;
     do {
         OPSLOT *slot = OpSLOToff(slab2, slab2->opslab_free_space);
@@ -658,10 +661,10 @@ Perl_op_refcnt_inc(pTHX_ OP *o)
 PADOFFSET
 Perl_op_refcnt_dec(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_OP_REFCNT_DEC;
+
     PADOFFSET result;
     OPSLAB *const slab = o->op_slabbed ? OpSLAB(o) : NULL;
-
-    PERL_ARGS_ASSERT_OP_REFCNT_DEC;
 
     if (slab && slab->opslab_readonly) {
         Slab_to_rw(slab);
@@ -725,8 +728,9 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
 static void
 S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
 {
-    SV * const namesv = cv_name((CV *)gv, NULL, 0);
     PERL_ARGS_ASSERT_BAD_TYPE_GV;
+
+    SV * const namesv = cv_name((CV *)gv, NULL, 0);
 
     yyerror_pv(form("Type of arg %d to %" SVf " must be %s (not %s)",
                  (int)n, SVfARG(namesv), t, OP_DESC(kid)), SvUTF8(namesv));
@@ -777,14 +781,13 @@ Perl_no_bareword_filehandle(pTHX_ const char *fhname)
 PADOFFSET
 Perl_allocmy(pTHX_ const char *const name, const STRLEN len, const U32 flags)
 {
+    PERL_ARGS_ASSERT_ALLOCMY;
+    assert(len >= 2);
+    assert(name[0] && name[1]);
 
     PADOFFSET off;
     bool is_idfirst, is_default;
     const bool is_our = (PL_parser->in_my == KEY_our);
-
-    PERL_ARGS_ASSERT_ALLOCMY;
-    assert(len >= 2);
-    assert(name[0] && name[1]);
 
     if (flags & ~SVf_UTF8)
         croak("panic: allocmy illegal flag bits 0x%" U32xf, flags);
@@ -861,10 +864,10 @@ C<PL_stashpad> for the stash passed to it.
 PADOFFSET
 Perl_alloccopstash(pTHX_ HV *hv)
 {
+    PERL_ARGS_ASSERT_ALLOCCOPSTASH;
+
     PADOFFSET off = 0, o = 1;
     bool found_slot = FALSE;
-
-    PERL_ARGS_ASSERT_ALLOCCOPSTASH;
 
     if (PL_stashpad[PL_stashpadix] == hv) return PL_stashpadix;
 
@@ -1101,8 +1104,6 @@ void S_op_clear_gv(pTHX_ OP *o, SV**svp)
 void
 Perl_op_clear(pTHX_ OP *o)
 {
-
-
     PERL_ARGS_ASSERT_OP_CLEAR;
 
     switch (o->op_type) {
@@ -1441,9 +1442,9 @@ S_cop_free(pTHX_ COP* cop)
 static void
 S_forget_pmop(pTHX_ PMOP *const o)
 {
-    HV * const pmstash = PmopSTASH(o);
-
     PERL_ARGS_ASSERT_FORGET_PMOP;
+
+    HV * const pmstash = PmopSTASH(o);
 
     if (pmstash && !SvIS_FREED(pmstash) && SvMAGICAL(pmstash)) {
         MAGIC * const mg = mg_find((const SV *)pmstash, PERL_MAGIC_symtab);
@@ -1477,9 +1478,9 @@ S_forget_pmop(pTHX_ PMOP *const o)
 static void
 S_find_and_forget_pmops(pTHX_ OP *o)
 {
-    OP* top_op = o;
-
     PERL_ARGS_ASSERT_FIND_AND_FORGET_PMOPS;
+
+    OP* top_op = o;
 
     while (1) {
         switch (o->op_type) {
@@ -1520,7 +1521,6 @@ other ops.
 void
 Perl_op_null(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_OP_NULL;
 
     if (o->op_type == OP_NULL)
@@ -1832,12 +1832,11 @@ not be called directly.
 OP *
 Perl_op_linklist(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_OP_LINKLIST;
 
     OP **prevp;
     OP *kid;
     OP * top_op = o;
-
-    PERL_ARGS_ASSERT_OP_LINKLIST;
 
     while (1) {
         /* Descend down the tree looking for any unprocessed subtrees to
@@ -2174,11 +2173,11 @@ Perl_scalar(pTHX_ OP *o)
 OP *
 Perl_scalarvoid(pTHX_ OP *arg)
 {
+    PERL_ARGS_ASSERT_SCALARVOID;
+
     OP *kid;
     SV* sv;
     OP *o = arg;
-
-    PERL_ARGS_ASSERT_SCALARVOID;
 
     while (1) {
         U8 want;
@@ -2910,8 +2909,9 @@ S_process_optree(pTHX_ CV *cv, OP *optree, OP* start)
 void
 Perl_op_relocate_sv(pTHX_ SV** svp, PADOFFSET* targp)
 {
-    PADOFFSET ix;
     PERL_ARGS_ASSERT_OP_RELOCATE_SV;
+
+    PADOFFSET ix;
     if (!*svp) return;
     ix = pad_alloc(OP_CONST, SVf_READONLY);
     SvREFCNT_dec(PAD_SVl(ix));
@@ -3817,9 +3817,9 @@ S_refkids(pTHX_ OP *o, I32 type)
 OP *
 Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref)
 {
-    OP * top_op = o;
-
     PERL_ARGS_ASSERT_DOREF;
+
+    OP * top_op = o;
 
     if (PL_parser && PL_parser->error_count)
         return o;
@@ -3931,9 +3931,9 @@ Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref)
 static OP *
 S_dup_attrlist(pTHX_ OP *o)
 {
-    OP *rop;
-
     PERL_ARGS_ASSERT_DUP_ATTRLIST;
+
+    OP *rop;
 
     /* An attrlist is either a simple OP_CONST or an OP_LIST with kids,
      * where the first kid is OP_PUSHMARK and the remaining ones
@@ -3982,10 +3982,10 @@ S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
 static void
 S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
 {
+    PERL_ARGS_ASSERT_APPLY_ATTRS_MY;
+
     OP *pack, *imop, *arg;
     SV *meth, *stashsv, **svp;
-
-    PERL_ARGS_ASSERT_APPLY_ATTRS_MY;
 
     if (!attrs)
         return;
@@ -4049,9 +4049,9 @@ void
 Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv,
                         const char *attrstr, STRLEN len)
 {
-    OP *attrs = NULL;
-
     PERL_ARGS_ASSERT_APPLY_ATTRS_STRING;
+
+    OP *attrs = NULL;
 
     if (!len) {
         len = strlen(attrstr);
@@ -4082,12 +4082,12 @@ static void
 S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV * name,
                         bool curstash)
 {
+    PERL_ARGS_ASSERT_MOVE_PROTO_ATTR;
+
     OP *new_proto = NULL;
     STRLEN pvlen;
     char *pv;
     OP *o;
-
-    PERL_ARGS_ASSERT_MOVE_PROTO_ATTR;
 
     if (!*attrs)
         return;
@@ -4197,10 +4197,10 @@ S_cant_declare(pTHX_ OP *o)
 static OP *
 S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
 {
+    PERL_ARGS_ASSERT_MY_KID;
+
     I32 type;
     const bool stately = PL_parser && PL_parser->in_my == KEY_state;
-
-    PERL_ARGS_ASSERT_MY_KID;
 
     if (!o || (PL_parser && PL_parser->error_count))
         return o;
@@ -4270,10 +4270,10 @@ S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
 OP *
 Perl_my_attrs(pTHX_ OP *o, OP *attrs)
 {
+    PERL_ARGS_ASSERT_MY_ATTRS;
+
     OP *rops;
     int maybe_scalar = 0;
-
-    PERL_ARGS_ASSERT_MY_ATTRS;
 
 /* [perl #17376]: this appears to be premature, and results in code such as
    C< our(%x); > executing in list mode rather than void mode */
@@ -4328,12 +4328,12 @@ Perl_sawparens(pTHX_ OP *o)
 OP *
 Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
 {
+    PERL_ARGS_ASSERT_BIND_MATCH;
+
     OP *o;
     bool ismatchop = 0;
     const OPCODE ltype = left->op_type;
     const OPCODE rtype = right->op_type;
-
-    PERL_ARGS_ASSERT_BIND_MATCH;
 
     if ( (ltype == OP_RV2AV || ltype == OP_RV2HV || ltype == OP_PADAV
           || ltype == OP_PADHV) && ckWARN(WARN_MISC))
@@ -4500,10 +4500,11 @@ Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
 OP *
 Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
 {
+    PERL_ARGS_ASSERT_CMPCHAIN_EXTEND;
+
     BINOP *bop;
     OP *op;
 
-    PERL_ARGS_ASSERT_CMPCHAIN_EXTEND;
     if (!right)
         right = newOP(OP_NULL, 0);
     scalar(right);
@@ -4539,8 +4540,8 @@ Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
 OP *
 Perl_cmpchain_finish(pTHX_ OP *ch)
 {
-
     PERL_ARGS_ASSERT_CMPCHAIN_FINISH;
+
     if (ch->op_type != OP_NULL) {
         OPCODE cmpoptype = ch->op_type;
         ch = CHECKOP(cmpoptype, ch);
@@ -4822,9 +4823,9 @@ Perl_blockhook_register(pTHX_ BHK *hk)
 void
 Perl_newPROG(pTHX_ OP *o)
 {
-    OP *start;
-
     PERL_ARGS_ASSERT_NEWPROG;
+
+    OP *start;
 
     if (PL_in_eval) {
         PERL_CONTEXT *cx;
@@ -5000,9 +5001,9 @@ Perl_jmaybe(pTHX_ OP *o)
 PERL_STATIC_INLINE OP *
 S_op_std_init(pTHX_ OP *o)
 {
-    I32 type = o->op_type;
-
     PERL_ARGS_ASSERT_OP_STD_INIT;
+
+    I32 type = o->op_type;
 
     if (PL_opargs[type] & OA_RETSCALAR)
         scalar(o);
@@ -5015,9 +5016,9 @@ S_op_std_init(pTHX_ OP *o)
 PERL_STATIC_INLINE OP *
 S_op_integerize(pTHX_ OP *o)
 {
-    I32 type = o->op_type;
-
     PERL_ARGS_ASSERT_OP_INTEGERIZE;
+
+    I32 type = o->op_type;
 
     /* integerize op. */
     if ((PL_opargs[type] & OA_OTHERINT) && (PL_hints & HINT_INTEGER))
@@ -5056,6 +5057,8 @@ S_fold_constants_eval(pTHX)
 static OP *
 S_fold_constants(pTHX_ OP *const o)
 {
+    PERL_ARGS_ASSERT_FOLD_CONSTANTS;
+
     OP *curop;
     OP *newop;
     I32 type = o->op_type;
@@ -5068,8 +5071,6 @@ S_fold_constants(pTHX_ OP *const o)
     COP not_compiling;
     U8 oldwarn = PL_dowarn;
     I32 old_cxix;
-
-    PERL_ARGS_ASSERT_FOLD_CONSTANTS;
 
     if (!(PL_opargs[type] & OA_FOLDCONST))
         goto nope;
@@ -6383,6 +6384,8 @@ S_get_displayable_tr_operand(pTHX_ const U8 * s, STRLEN len, bool is_utf8)
 static OP *
 S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
 {
+    PERL_ARGS_ASSERT_PMTRANS;
+
     /* This function compiles a tr///, from data gathered from toke.c, into a
      * form suitable for use by do_trans() in doop.c at runtime.
      *
@@ -6708,8 +6711,6 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
      * points that can be done in place.  One could examine at runtime to see,
      * but this could be as expensive as just doing the copy.
      */
-
-    PERL_ARGS_ASSERT_PMTRANS;
 
     PL_hints |= HINT_BLOCK_SCOPE;
 
@@ -7853,6 +7854,8 @@ S_set_haseval(pTHX)
 OP *
 Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
 {
+    PERL_ARGS_ASSERT_PMRUNTIME;
+
     PMOP *pm;
     LOGOP *rcop;
     I32 repl_has_vars = 0;
@@ -7861,8 +7864,6 @@ Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
     bool has_code;
     bool isreg    = cBOOL(flags & 1);
     bool is_split = cBOOL(flags & 2);
-
-    PERL_ARGS_ASSERT_PMRUNTIME;
 
     if (is_trans) {
         return pmtrans(o, expr, repl);
@@ -8239,9 +8240,9 @@ takes ownership of one reference to it.
 OP *
 Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
 {
-    SVOP *svop;
-
     PERL_ARGS_ASSERT_NEWSVOP;
+
+    SVOP *svop;
 
     /* OP_RUNCV is allowed specially so rpeep has room to convert it into an
      * OP_CONST */
@@ -8299,9 +8300,9 @@ This function only exists if Perl has been compiled to use ithreads.
 OP *
 Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
 {
-    PADOP *padop;
-
     PERL_ARGS_ASSERT_NEWPADOP;
+
+    PADOP *padop;
 
     assert((PL_opargs[type] & OA_CLASS_MASK) == OA_SVOP
         || (PL_opargs[type] & OA_CLASS_MASK) == OA_PVOP_OR_SVOP
@@ -8473,12 +8474,12 @@ static U16 S_extract_shortver(pTHX_ SV *sv)
 void
 Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
 {
+    PERL_ARGS_ASSERT_UTILIZE;
+
     OP *pack;
     OP *imop;
     OP *veop;
     SV *use_version = NULL;
-
-    PERL_ARGS_ASSERT_UTILIZE;
 
     if (idop->op_type != OP_CONST)
         croak("Module name must be constant");
@@ -8702,9 +8703,9 @@ are a C<va_list>.
 void
 Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...)
 {
-    va_list args;
-
     PERL_ARGS_ASSERT_LOAD_MODULE;
+
+    va_list args;
 
     va_start(args, ver);
     vload_module(flags, name, ver, &args);
@@ -8715,9 +8716,10 @@ Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...)
 void
 Perl_load_module_nocontext(U32 flags, SV *name, SV *ver, ...)
 {
+    PERL_ARGS_ASSERT_LOAD_MODULE_NOCONTEXT;
+
     dTHX;
     va_list args;
-    PERL_ARGS_ASSERT_LOAD_MODULE_NOCONTEXT;
     va_start(args, ver);
     vload_module(flags, name, ver, &args);
     va_end(args);
@@ -8727,11 +8729,11 @@ Perl_load_module_nocontext(U32 flags, SV *name, SV *ver, ...)
 void
 Perl_vload_module(pTHX_ U32 flags, SV *name, SV *ver, va_list *args)
 {
+    PERL_ARGS_ASSERT_VLOAD_MODULE;
+
     OP *veop, *imop;
     OP * modname;
     I32 floor;
-
-    PERL_ARGS_ASSERT_VLOAD_MODULE;
 
     /* utilize() fakes up a BEGIN { require ..; import ... }, so make sure
      * that it has a PL_parser to play with while doing that, and also
@@ -8789,10 +8791,10 @@ S_new_entersubop(pTHX_ GV *gv, OP *arg)
 OP *
 Perl_dofile(pTHX_ OP *term, I32 force_builtin)
 {
+    PERL_ARGS_ASSERT_DOFILE;
+
     OP *doop;
     GV *gv;
-
-    PERL_ARGS_ASSERT_DOFILE;
 
     if (!force_builtin && (gv = gv_override("do", 2))) {
         doop = S_new_entersubop(aTHX_ gv, term);
@@ -9448,14 +9450,14 @@ S_search_const(pTHX_ OP *o)
 static OP *
 S_new_logop(pTHX_ I32 type, I32 flags, OP** firstp, OP** otherp)
 {
+    PERL_ARGS_ASSERT_NEW_LOGOP;
+
     LOGOP *logop;
     OP *o;
     OP *first;
     OP *other;
     OP *cstop = NULL;
     int prepend_not = 0;
-
-    PERL_ARGS_ASSERT_NEW_LOGOP;
 
     first = *firstp;
     other = *otherp;
@@ -9627,12 +9629,12 @@ this function and become part of the constructed op tree.
 OP *
 Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
 {
+    PERL_ARGS_ASSERT_NEWCONDOP;
+
     LOGOP *logop;
     OP *start;
     OP *o;
     OP *cstop;
-
-    PERL_ARGS_ASSERT_NEWCONDOP;
 
     if (!falseop)
         return newLOGOP(OP_AND, flags, first, trueop);
@@ -9710,9 +9712,10 @@ The C<flags> argument is currently ignored.
 OP *
 Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
 {
+    PERL_ARGS_ASSERT_NEWTRYCATCHOP;
+
     OP *catchop;
 
-    PERL_ARGS_ASSERT_NEWTRYCATCHOP;
     assert(catchvar->op_type == OP_PADSV);
 
     PERL_UNUSED_ARG(flags);
@@ -9765,13 +9768,13 @@ and become part of the constructed op tree.
 OP *
 Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
 {
+    PERL_ARGS_ASSERT_NEWRANGE;
+
     LOGOP *range;
     OP *flip;
     OP *flop;
     OP *leftstart;
     OP *o;
-
-    PERL_ARGS_ASSERT_NEWRANGE;
 
     range = alloc_LOGOP(OP_RANGE, left, LINKLIST(right));
     range->op_flags = OPf_KIDS;
@@ -10145,6 +10148,8 @@ automatically.
 OP *
 Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
 {
+    PERL_ARGS_ASSERT_NEWFOROP;
+
     LOOP *loop;
     OP *iter;
     PADOFFSET padoff = 0;
@@ -10154,8 +10159,6 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
     U8 iterpflags = 0;
     bool parens = 0;
     U32 refalias_mask = 0;
-
-    PERL_ARGS_ASSERT_NEWFOROP;
 
     if (sv) {
         if (sv->op_type == OP_RV2SV) {	/* symbol table variable */
@@ -10458,9 +10461,9 @@ becomes part of the constructed op tree.
 OP*
 Perl_newLOOPEX(pTHX_ I32 type, OP *label)
 {
-    OP *o = NULL;
-
     PERL_ARGS_ASSERT_NEWLOOPEX;
+
+    OP *o = NULL;
 
     assert((PL_opargs[type] & OA_CLASS_MASK) == OA_LOOPEXOP
         || type == OP_CUSTOM);
@@ -10549,10 +10552,11 @@ S_newGIVWHENOP(pTHX_ OP *cond, OP *block,
                    I32 enter_opcode, I32 leave_opcode,
                    PADOFFSET entertarg)
 {
+    PERL_ARGS_ASSERT_NEWGIVWHENOP;
+
     LOGOP *enterop;
     OP *o;
 
-    PERL_ARGS_ASSERT_NEWGIVWHENOP;
     PERL_UNUSED_ARG(entertarg); /* used to indicate targ of lexical $_ */
 
     enterop = alloc_LOGOP(enter_opcode, block, NULL);
@@ -10720,10 +10724,10 @@ and may be null to generate a C<default> block.
 OP *
 Perl_newWHENOP(pTHX_ OP *cond, OP *block)
 {
+    PERL_ARGS_ASSERT_NEWWHENOP;
+
     const bool cond_llb = (!cond || looks_like_bool(cond));
     OP *cond_op;
-
-    PERL_ARGS_ASSERT_NEWWHENOP;
 
     if (cond_llb)
         cond_op = cond;
@@ -10752,9 +10756,9 @@ including the C<op_private> field.
 OP *
 Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
 {
-    OP *o, *start, *blockfirst;
-
     PERL_ARGS_ASSERT_NEWDEFEROP;
+
+    OP *o, *start, *blockfirst;
 
     forbid_outofblock_ops(block,
         (flags & (OPpDEFER_FINALLY << 8)) ? "a \"finally\" block" : "a \"defer\" block");
@@ -10811,6 +10815,8 @@ void
 Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p,
                     const STRLEN len, const U32 flags)
 {
+    PERL_ARGS_ASSERT_CV_CKPROTO_LEN_FLAGS;
+
     SV *name = NULL, *msg;
     const char * cvp = SvROK(cv)
                         ? SvTYPE(SvRV_const(cv)) == SVt_PVCV
@@ -10818,8 +10824,6 @@ Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p,
                            : ""
                         : CvPROTO(cv);
     STRLEN clen = CvPROTOLEN(cv), plen = len;
-
-    PERL_ARGS_ASSERT_CV_CKPROTO_LEN_FLAGS;
 
     if (p == NULL && cvp == NULL)
         return;
@@ -11050,6 +11054,8 @@ Similar in action to L<perlintern/C<newATTRSUB_x>>.
 CV *
 Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
 {
+    PERL_ARGS_ASSERT_NEWMYSUB;
+
     CV **spot;
     SV **svspot;
     const char *ps;
@@ -11068,8 +11074,6 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
 #ifdef PERL_DEBUG_READONLY_OPS
     OPSLAB *slab = NULL;
 #endif
-
-    PERL_ARGS_ASSERT_NEWMYSUB;
 
     PL_hints |= HINT_BLOCK_SCOPE;
 
@@ -12044,10 +12048,10 @@ S_process_special_blocks(pTHX_ I32 floor, const char *const fullname,
                          GV *const gv,
                          CV *const cv)
 {
+    PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS;
+
     const char *const colon = strrchr(fullname,':');
     const char *const name = colon ? colon + 1 : fullname;
-
-    PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS;
 
     if (*name == 'B') {
         if (strEQ(name, "BEGIN")) {
@@ -12486,11 +12490,11 @@ Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len,
                            const char *const proto, SV **const_svp,
                            U32 flags)
 {
+    PERL_ARGS_ASSERT_NEWXS_LEN_FLAGS;
+
     CV *cv;
     bool interleave = FALSE;
     bool evanescent = FALSE;
-
-    PERL_ARGS_ASSERT_NEWXS_LEN_FLAGS;
 
     {
         GV * const gv = gv_fetchpvn(
@@ -12583,9 +12587,10 @@ Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len,
 CV *
 Perl_newSTUB(pTHX_ GV *gv, bool fake)
 {
+    PERL_ARGS_ASSERT_NEWSTUB;
+
     CV *cv = MUTABLE_CV(newSV_type(SVt_PVCV));
     GV *cvgv;
-    PERL_ARGS_ASSERT_NEWSTUB;
     assert(!GvCVu(gv));
     GvCV_set(gv, cv);
     GvCVGEN(gv) = 0;
@@ -12766,7 +12771,6 @@ Perl_newANONATTRSUB(pTHX_ I32 floor, OP *proto, OP *attrs, OP *block)
 OP *
 Perl_oopsAV(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_OOPSAV;
 
     switch (o->op_type) {
@@ -12791,7 +12795,6 @@ Perl_oopsAV(pTHX_ OP *o)
 OP *
 Perl_oopsHV(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_OOPSHV;
 
     switch (o->op_type) {
@@ -12826,7 +12829,6 @@ Constructs, checks, and returns an arrary reference op.
 OP *
 Perl_newAVREF(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_NEWAVREF;
 
     if (o->op_type == OP_PADANY) {
@@ -12883,7 +12885,6 @@ Constructs, checks, and returns a hash reference op.
 OP *
 Perl_newHVREF(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_NEWHVREF;
 
     if (o->op_type == OP_PADANY) {
@@ -12926,7 +12927,6 @@ Constructs, checks, and returns a scalar reference op.
 OP *
 Perl_newSVREF(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_NEWSVREF;
 
     if (o->op_type == OP_PADANY) {
@@ -12998,10 +12998,11 @@ S_io_hints(pTHX_ OP *o)
 OP *
 Perl_ck_backtick(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_BACKTICK;
+
     GV *gv;
     OP *newop = NULL;
     OP *sibl;
-    PERL_ARGS_ASSERT_CK_BACKTICK;
     o = ck_fun(o);
     /* qx and `` have a null pushmark; CORE::readpipe has only one kid. */
     if (o->op_flags & OPf_KIDS && (sibl = OpSIBLING(cUNOPo->op_first))
@@ -13094,6 +13095,8 @@ is_dollar_bracket(pTHX_ const OP * const o)
 OP *
 Perl_ck_cmp(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_CMP;
+
     bool is_eq;
     bool neg;
     bool reverse;
@@ -13101,8 +13104,6 @@ Perl_ck_cmp(pTHX_ OP *o)
     OP *indexop, *constop, *start;
     SV *sv;
     IV iv;
-
-    PERL_ARGS_ASSERT_CK_CMP;
 
     is_eq = (   o->op_type == OP_EQ
              || o->op_type == OP_NE
@@ -13221,9 +13222,10 @@ Perl_ck_scmp(pTHX_ OP *o)
 OP *
 Perl_ck_concat(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_CONCAT;
+
     const OP * const kid = cUNOPo->op_first;
 
-    PERL_ARGS_ASSERT_CK_CONCAT;
     PERL_UNUSED_CONTEXT;
 
     /* reuse the padtmp returned by the concat child */
@@ -13239,7 +13241,6 @@ Perl_ck_concat(pTHX_ OP *o)
 OP *
 Perl_ck_spair(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_CK_SPAIR;
 
     if (o->op_flags & OPf_KIDS) {
@@ -13337,7 +13338,6 @@ Perl_ck_eof(pTHX_ OP *o)
 OP *
 Perl_ck_eval(pTHX_ OP *o)
 {
-
     PERL_ARGS_ASSERT_CK_EVAL;
 
     PL_hints |= HINT_BLOCK_SCOPE;
@@ -13401,12 +13401,12 @@ Perl_ck_eval(pTHX_ OP *o)
 OP *
 Perl_ck_trycatch(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_TRYCATCH;
+
     LOGOP *enter;
     OP *to_free = NULL;
     OP *trykid, *catchkid;
     OP *catchroot, *catchstart;
-
-    PERL_ARGS_ASSERT_CK_TRYCATCH;
 
     trykid = cUNOPo->op_first;
     if(trykid->op_type == OP_NULL || trykid->op_type == OP_PUSHMARK) {
@@ -13536,9 +13536,9 @@ Perl_ck_helemexistsor(pTHX_ OP *o)
 OP *
 Perl_ck_rvconst(pTHX_ OP *o)
 {
-    SVOP * const kid = cSVOPx(cUNOPo->op_first);
-
     PERL_ARGS_ASSERT_CK_RVCONST;
+
+    SVOP * const kid = cSVOPx(cUNOPo->op_first);
 
     if (o->op_type == OP_RV2HV)
         /* rv2hv steals the bottom bit for its own uses */
@@ -13630,9 +13630,9 @@ Perl_ck_rvconst(pTHX_ OP *o)
 OP *
 Perl_ck_ftst(pTHX_ OP *o)
 {
-    const I32 type = o->op_type;
-
     PERL_ARGS_ASSERT_CK_FTST;
+
+    const I32 type = o->op_type;
 
     if (o->op_flags & OPf_REF) {
         NOOP;
@@ -13692,10 +13692,10 @@ Perl_ck_ftst(pTHX_ OP *o)
 OP *
 Perl_ck_fun(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_FUN;
+
     const int type = o->op_type;
     I32 oa = PL_opargs[type] >> OASHIFT;
-
-    PERL_ARGS_ASSERT_CK_FUN;
 
     if (o->op_flags & OPf_STACKED) {
         if ((oa & OA_OPTIONAL) && (oa >> 4) && !((oa >> 4) & OA_OPTIONAL))
@@ -13956,9 +13956,9 @@ Perl_ck_fun(pTHX_ OP *o)
 OP *
 Perl_ck_glob(pTHX_ OP *o)
 {
-    GV *gv;
-
     PERL_ARGS_ASSERT_CK_GLOB;
+
+    GV *gv;
 
     o = ck_fun(o);
     if ((o->op_flags & OPf_KIDS) && !OpHAS_SIBLING(cLISTOPo->op_first))
@@ -14006,14 +14006,14 @@ Perl_ck_glob(pTHX_ OP *o)
 OP *
 Perl_ck_grep(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_GREP;
+
     LOGOP *gwop;
     OP *kid;
     const OPCODE type =
         o->op_type == OP_GREPSTART ? OP_GREPWHILE :
         o->op_type == OP_MAPSTART  ? OP_MAPWHILE  :
                                      OP_ANYWHILE;  /* any and all both share this */
-
-    PERL_ARGS_ASSERT_CK_GREP;
 
     /* don't allocate gwop here, as we may leak it if PL_parser->error_count > 0 */
 
@@ -14081,9 +14081,9 @@ Perl_ck_index(pTHX_ OP *o)
 OP *
 Perl_ck_lfun(pTHX_ OP *o)
 {
-    const OPCODE type = o->op_type;
-
     PERL_ARGS_ASSERT_CK_LFUN;
+
+    const OPCODE type = o->op_type;
 
     return modkids(ck_fun(o), type);
 }
@@ -14141,9 +14141,9 @@ Perl_ck_readline(pTHX_ OP *o)
 OP *
 Perl_ck_rfun(pTHX_ OP *o)
 {
-    const OPCODE type = o->op_type;
-
     PERL_ARGS_ASSERT_CK_RFUN;
+
+    const OPCODE type = o->op_type;
 
     return refkids(ck_fun(o), type);
 }
@@ -14151,9 +14151,9 @@ Perl_ck_rfun(pTHX_ OP *o)
 OP *
 Perl_ck_listiob(pTHX_ OP *o)
 {
-    OP *kid;
-
     PERL_ARGS_ASSERT_CK_LISTIOB;
+
+    OP *kid;
 
     kid = cLISTOPo->op_first;
     if (!kid) {
@@ -14264,9 +14264,9 @@ S_maybe_targlex(pTHX_ OP *o)
 OP *
 Perl_ck_sassign(pTHX_ OP *o)
 {
-    OP * const kid = cBINOPo->op_first;
-
     PERL_ARGS_ASSERT_CK_SASSIGN;
+
+    OP * const kid = cBINOPo->op_first;
 
     if (OpHAS_SIBLING(kid)) {
         OP *kkid = OpSIBLING(kid);
@@ -14387,8 +14387,9 @@ Perl_ck_anonhash(pTHX_ OP *o)
 OP *
 Perl_ck_match(pTHX_ OP *o)
 {
-    PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_CK_MATCH;
+
+    PERL_UNUSED_CONTEXT;
 
     return o;
 }
@@ -14396,6 +14397,8 @@ Perl_ck_match(pTHX_ OP *o)
 OP *
 Perl_ck_method(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_METHOD;
+
     SV *sv, *methsv, *rclass;
     const char* method;
     char* compatptr;
@@ -14404,7 +14407,6 @@ Perl_ck_method(pTHX_ OP *o)
     OP* new_op;
     OP * const kid = cUNOPo->op_first;
 
-    PERL_ARGS_ASSERT_CK_METHOD;
     if (kid->op_type != OP_CONST) return o;
 
     sv = kSVOP->op_sv;
@@ -14539,12 +14541,13 @@ Perl_ck_prototype(pTHX_ OP *o)
 OP *
 Perl_ck_refassign(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_REFASSIGN;
+
     OP * const right = cLISTOPo->op_first;
     OP * const left = OpSIBLING(right);
     OP *varop = cUNOPx(cUNOPx(left)->op_first)->op_first;
     bool stacked = 0;
 
-    PERL_ARGS_ASSERT_CK_REFASSIGN;
     assert (left);
     assert (left->op_type == OP_SREFGEN);
 
@@ -14662,9 +14665,9 @@ Perl_ck_repeat(pTHX_ OP *o)
 OP *
 Perl_ck_require(pTHX_ OP *o)
 {
-    GV* gv;
-
     PERL_ARGS_ASSERT_CK_REQUIRE;
+
+    GV* gv;
 
     if (o->op_flags & OPf_KIDS) {	/* Shall we supply missing .pm? */
         SVOP * const kid = cSVOPx(cUNOPo->op_first);
@@ -14755,9 +14758,9 @@ Perl_ck_require(pTHX_ OP *o)
 OP *
 Perl_ck_return(pTHX_ OP *o)
 {
-    OP *kid;
-
     PERL_ARGS_ASSERT_CK_RETURN;
+
+    OP *kid;
 
     if (o->op_flags & OPf_STACKED) {
         kid = cUNOPx(OpSIBLING(cLISTOPo->op_first))->op_first;
@@ -14778,9 +14781,9 @@ Perl_ck_return(pTHX_ OP *o)
 OP *
 Perl_ck_select(pTHX_ OP *o)
 {
-    OP* kid;
-
     PERL_ARGS_ASSERT_CK_SELECT;
+
+    OP* kid;
 
     if (o->op_flags & OPf_KIDS) {
         kid = OpSIBLING(cLISTOPo->op_first);     /* get past pushmark */
@@ -14800,9 +14803,9 @@ Perl_ck_select(pTHX_ OP *o)
 OP *
 Perl_ck_shift(pTHX_ OP *o)
 {
-    const I32 type = o->op_type;
-
     PERL_ARGS_ASSERT_CK_SHIFT;
+
+    const I32 type = o->op_type;
 
     if (!(o->op_flags & OPf_KIDS)) {
         OP *argop;
@@ -14822,11 +14825,11 @@ Perl_ck_shift(pTHX_ OP *o)
 OP *
 Perl_ck_sort(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_SORT;
+
     OP *firstkid;
     OP *kid;
     U8 stacked;
-
-    PERL_ARGS_ASSERT_CK_SORT;
 
     if (o->op_flags & OPf_STACKED)
         simplify_sort(o);
@@ -14906,14 +14909,14 @@ Perl_ck_sort(pTHX_ OP *o)
 static void
 S_simplify_sort(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_SIMPLIFY_SORT;
+
     OP *kid = OpSIBLING(cLISTOPo->op_first);	/* get past pushmark */
     OP *k;
     int descending;
     GV *gv;
     const char *gvname;
     bool have_scopeop;
-
-    PERL_ARGS_ASSERT_SIMPLIFY_SORT;
 
     kid = kUNOP->op_first;				/* get past null */
     if (!(have_scopeop = kid->op_type == OP_SCOPE)
@@ -15006,10 +15009,10 @@ S_simplify_sort(pTHX_ OP *o)
 OP *
 Perl_ck_split(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_SPLIT;
+
     OP *kid;
     OP *sibs;
-
-    PERL_ARGS_ASSERT_CK_SPLIT;
 
     assert(o->op_type == OP_LIST);
 
@@ -15087,8 +15090,9 @@ Perl_ck_split(pTHX_ OP *o)
 OP *
 Perl_ck_stringify(pTHX_ OP *o)
 {
-    OP * const kid = OpSIBLING(cUNOPo->op_first);
     PERL_ARGS_ASSERT_CK_STRINGIFY;
+
+    OP * const kid = OpSIBLING(cUNOPo->op_first);
     if ((   kid->op_type == OP_JOIN || kid->op_type == OP_QUOTEMETA
          || kid->op_type == OP_LC   || kid->op_type == OP_LCFIRST
          || kid->op_type == OP_UC   || kid->op_type == OP_UCFIRST)
@@ -15104,9 +15108,9 @@ Perl_ck_stringify(pTHX_ OP *o)
 OP *
 Perl_ck_join(pTHX_ OP *o)
 {
-    OP * const kid = OpSIBLING(cLISTOPo->op_first);
-
     PERL_ARGS_ASSERT_CK_JOIN;
+
+    OP * const kid = OpSIBLING(cLISTOPo->op_first);
 
     if (kid && kid->op_type == OP_MATCH) {
         if (ckWARN(WARN_SYNTAX)) {
@@ -15234,10 +15238,11 @@ Perl_find_lexical_cv(pTHX_ PADOFFSET off)
 CV *
 Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags)
 {
+    PERL_ARGS_ASSERT_RV2CV_OP_CV;
+
     OP *rvop;
     CV *cv;
     GV *gv;
-    PERL_ARGS_ASSERT_RV2CV_OP_CV;
     if (flags & ~RV2CVOPCV_FLAG_MASK)
         croak("panic: rv2cv_op_cv bad flags %x", (unsigned)flags);
     if (cvop->op_type != OP_RV2CV)
@@ -15317,9 +15322,9 @@ or a call where the callee has no prototype.
 OP *
 Perl_ck_entersub_args_list(pTHX_ OP *entersubop)
 {
-    OP *aop;
-
     PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_LIST;
+
+    OP *aop;
 
     for (aop = find_argop_from_entersub(entersubop); OpHAS_SIBLING(aop); aop = OpSIBLING(aop)) {
         /* skip the extra attributes->import() call implicitly added in
@@ -15366,6 +15371,8 @@ by the name defined by the C<namegv> parameter.
 OP *
 Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
 {
+    PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO;
+
     STRLEN proto_len;
     const char *proto, *proto_end;
     OP *aop, *prev, *parent;
@@ -15373,7 +15380,6 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
     I32 arg = 0;
     I32 contextclass = 0;
     const char *e = NULL;
-    PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO;
     if (SvTYPE(protosv) == SVt_PVCV ? !SvPOK(protosv) : !SvOK(protosv))
         croak("panic: ck_entersub_args_proto CV with no proto, "
                    "flags=%lx", (unsigned long) SvFLAGS(protosv));
@@ -15795,9 +15801,10 @@ void
 Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags,
         Perl_call_checker *ckfun_p, SV **ckobj_p, U32 *ckflags_p)
 {
-    MAGIC *callmg;
     PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER_FLAGS;
     PERL_UNUSED_CONTEXT;
+
+    MAGIC *callmg;
     callmg = SvMAGICAL((SV*)cv) ? mg_find((SV*)cv, PERL_MAGIC_checkcall) : NULL;
     if (callmg) {
         *ckfun_p = DPTR2FPTR(Perl_call_checker, callmg->mg_ptr);
@@ -15813,9 +15820,10 @@ Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags,
 void
 Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
 {
-    U32 ckflags;
     PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER;
     PERL_UNUSED_CONTEXT;
+
+    U32 ckflags;
     cv_get_call_checker_flags(cv, CALL_CHECKER_REQUIRE_GV, ckfun_p, ckobj_p,
         &ckflags);
 }
@@ -15912,10 +15920,10 @@ S_entersub_alloc_targ(pTHX_ OP * const o)
 OP *
 Perl_ck_subr(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_SUBR;
+
     SV **const_class = NULL;
     OP *const_op = NULL;
-
-    PERL_ARGS_ASSERT_CK_SUBR;
 
     OP *aop = find_argop_from_entersub(o);
     OP *cvop = find_cvop_from_argop(aop);
@@ -16011,8 +16019,9 @@ Perl_ck_subr(pTHX_ OP *o)
 OP *
 Perl_ck_svconst(pTHX_ OP *o)
 {
-    SV * const sv = cSVOPo->op_sv;
     PERL_ARGS_ASSERT_CK_SVCONST;
+
+    SV * const sv = cSVOPo->op_sv;
     PERL_UNUSED_CONTEXT;
 #ifdef PERL_COPY_ON_WRITE
     /* Since the read-only flag may be used to protect a string buffer, we
@@ -16110,10 +16119,10 @@ S_last_non_null_kid(OP *o)
 OP *
 Perl_ck_each(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_CK_EACH;
+
     OP *kid = o->op_flags & OPf_KIDS ? cUNOPo->op_first : NULL;
     const unsigned orig_type  = o->op_type;
-
-    PERL_ARGS_ASSERT_CK_EACH;
 
     if (kid) {
         switch (kid->op_type) {
@@ -16272,12 +16281,11 @@ Perl_ck_isa(pTHX_ OP *o)
 static void
 S_inplace_aassign(pTHX_ OP *o)
 {
+    PERL_ARGS_ASSERT_INPLACE_AASSIGN;
 
     OP *modop, *modop_pushmark;
     OP *oright;
     OP *oleft, *oleft_pushmark;
-
-    PERL_ARGS_ASSERT_INPLACE_AASSIGN;
 
     assert((o->op_flags & OPf_WANT) == OPf_WANT_VOID);
 
@@ -16399,13 +16407,14 @@ static const MGVTBL custom_op_register_vtbl = {
 XOPRETANY
 Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
 {
+    PERL_ARGS_ASSERT_CUSTOM_OP_GET_FIELD;
+
     SV *keysv;
     HE *he = NULL;
     XOP *xop;
 
     static const XOP xop_null = { 0, 0, 0, 0, 0, 0 };
 
-    PERL_ARGS_ASSERT_CUSTOM_OP_GET_FIELD;
     assert(o->op_type == OP_CUSTOM);
 
     /* This is wrong. It assumes a function pointer can be cast to IV,
@@ -16524,9 +16533,9 @@ Register a custom op.  See L<perlguts/"Custom Operators">.
 void
 Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
 {
-    SV *keysv;
-
     PERL_ARGS_ASSERT_CUSTOM_OP_REGISTER;
+
+    SV *keysv;
 
     /* see the comment in custom_op_xop */
     keysv = sv_2mortal(newSViv(PTR2IV(ppaddr)));
@@ -16556,13 +16565,13 @@ SV *
 Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code,
                           int * const opnum)
 {
+    PERL_ARGS_ASSERT_CORE_PROTOTYPE;
+
     int i = 0, n = 0, seen_question = 0, defgv = 0;
     I32 oa;
 #define MAX_ARGS_OP ((sizeof(I32) - 1) * 2)
     char str[ MAX_ARGS_OP * 2 + 2 ]; /* One ';', one '\0' */
     bool nullret = FALSE;
-
-    PERL_ARGS_ASSERT_CORE_PROTOTYPE;
 
     assert (code);
 
@@ -16653,11 +16662,11 @@ OP *
 Perl_coresub_op(pTHX_ SV * const coreargssv, const int code,
                       const int opnum)
 {
+    PERL_ARGS_ASSERT_CORESUB_OP;
+
     OP * const argop = (opnum == OP_SELECT && code) ? NULL :
                                         newSVOP(OP_COREARGS,0,coreargssv);
     OP *o;
-
-    PERL_ARGS_ASSERT_CORESUB_OP;
 
     switch(opnum) {
     case 0: {
@@ -16740,11 +16749,11 @@ void
 Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv,
                                SV * const *new_const_svp)
 {
+    PERL_ARGS_ASSERT_REPORT_REDEFINED_CV;
+
     const char *hvname;
     bool is_const = cBOOL(CvCONST(old_cv));
     SV *old_const_sv = is_const ? cv_const_sv_or_av(old_cv) : NULL;
-
-    PERL_ARGS_ASSERT_REPORT_REDEFINED_CV;
 
     if (is_const && new_const_svp && old_const_sv == *new_const_svp)
         return;
@@ -16849,9 +16858,9 @@ void
 Perl_wrap_op_checker(pTHX_ Optype opcode,
     Perl_check_t new_checker, Perl_check_t *old_checker_p)
 {
-
     PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_WRAP_OP_CHECKER;
+
     if (*old_checker_p) return;
     OP_CHECK_MUTEX_LOCK;
     if (!*old_checker_p) {
@@ -16954,11 +16963,10 @@ the input content.
 char *
 Perl_rcpv_new(pTHX_ const char *pv, STRLEN len, U32 flags)
 {
-    RCPV *rcpv;
-
     PERL_ARGS_ASSERT_RCPV_NEW;
 
     PERL_UNUSED_CONTEXT;
+    RCPV *rcpv;
 
     /* Musn't use both at the same time */
     assert((flags & (RCPVf_NO_COPY|RCPVf_USE_STRLEN))!=

--- a/pad.c
+++ b/pad.c
@@ -306,6 +306,8 @@ Perl_cv_undef(pTHX_ CV *cv)
 void
 Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
 {
+    PERL_ARGS_ASSERT_CV_UNDEF_FLAGS;
+
     CV cvbody;/*CV body will never be realloced inside this func,
                so don't read it more than once, use fake CV so existing macros
                will work, the indirection and CV head struct optimized away*/
@@ -313,8 +315,6 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
     SvFLAGS(&cvbody) = SVt_PVCV;
 #endif
     SvANY(&cvbody) = SvANY(cv);
-
-    PERL_ARGS_ASSERT_CV_UNDEF_FLAGS;
 
     DEBUG_X(PerlIO_printf(Perl_debug_log,
           "CV undef: cv=0x%" UVxf " comppad=0x%" UVxf "\n",
@@ -558,9 +558,9 @@ static PADOFFSET
 S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash,
                        HV *ourstash)
 {
-    const PADOFFSET offset = pad_alloc(OP_PADSV, SVs_PADMY);
-
     PERL_ARGS_ASSERT_PAD_ALLOC_NAME;
+
+    const PADOFFSET offset = pad_alloc(OP_PADSV, SVs_PADMY);
 
     ASSERT_CURPAD_ACTIVE("pad_alloc_name");
 
@@ -631,10 +631,10 @@ PADOFFSET
 Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen,
                 U32 flags, HV *typestash, HV *ourstash)
 {
+    PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN;
+
     PADOFFSET offset;
     PADNAME *name;
-
-    PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN;
 
     if (flags & ~(padadd_OUR|padadd_STATE|padadd_NO_DUP_CHECK|padadd_FIELD))
         croak("panic: pad_add_name_pvn illegal flag bits 0x%" UVxf,
@@ -689,9 +689,10 @@ Perl_pad_add_name_pv(pTHX_ const char *name,
 PADOFFSET
 Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
 {
+    PERL_ARGS_ASSERT_PAD_ADD_NAME_SV;
+
     char *namepv;
     STRLEN namelen;
-    PERL_ARGS_ASSERT_PAD_ADD_NAME_SV;
     namepv = SvPVutf8(name, namelen);
     return pad_add_name_pvn(namepv, namelen, flags, typestash, ourstash);
 }
@@ -819,10 +820,11 @@ but is used for debugging.
 PADOFFSET
 Perl_pad_add_anon(pTHX_ CV* func, I32 optype)
 {
+    PERL_ARGS_ASSERT_PAD_ADD_ANON;
+
     PADOFFSET ix;
     PADNAME * const name = newPADNAMEpvn("&", 1);
 
-    PERL_ARGS_ASSERT_PAD_ADD_ANON;
     assert (SvTYPE(func) == SVt_PVCV);
 
     /* These two aren't used; just make sure they're not equal to
@@ -846,11 +848,11 @@ Perl_pad_add_anon(pTHX_ CV* func, I32 optype)
 void
 Perl_pad_add_weakref(pTHX_ CV* func)
 {
+    PERL_ARGS_ASSERT_PAD_ADD_WEAKREF;
+
     const PADOFFSET ix = pad_alloc(OP_NULL, SVs_PADMY);
     PADNAME * const name = newPADNAMEpvn("&", 1);
     SV * const rv = newRV_inc((SV *)func);
-
-    PERL_ARGS_ASSERT_PAD_ADD_WEAKREF;
 
     /* These two aren't used; just make sure they're not equal to
      * PERL_PADSEQ_INTRO.  They should be 0 by default.  */
@@ -878,12 +880,12 @@ C<is_our> indicates that the name to check is an C<"our"> declaration.
 static void
 S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
 {
+    PERL_ARGS_ASSERT_PAD_CHECK_DUP;
+
     PADNAME	**svp;
     PADOFFSET	top, off;
     const U32	is_our = flags & padadd_OUR;
     bool        is_field = flags & padadd_FIELD;
-
-    PERL_ARGS_ASSERT_PAD_CHECK_DUP;
 
     ASSERT_CURPAD_ACTIVE("pad_check_dup");
 
@@ -990,13 +992,13 @@ C<flags> is reserved and must be zero.
 PADOFFSET
 Perl_pad_findmy_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags)
 {
+    PERL_ARGS_ASSERT_PAD_FINDMY_PVN;
+
     PADNAME *out_pn;
     int out_flags;
     PADOFFSET offset;
     const PADNAMELIST *namelist;
     PADNAME **name_p;
-
-    PERL_ARGS_ASSERT_PAD_FINDMY_PVN;
 
     if (flags)
         croak("panic: pad_findmy_pvn illegal flag bits 0x%" UVxf,
@@ -1045,9 +1047,10 @@ Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags)
 PADOFFSET
 Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags)
 {
+    PERL_ARGS_ASSERT_PAD_FINDMY_SV;
+
     char *namepv;
     STRLEN namelen;
-    PERL_ARGS_ASSERT_PAD_FINDMY_SV;
     namepv = SvPVutf8(name, namelen);
     return pad_findmy_pvn(namepv, namelen, flags);
 }
@@ -1116,14 +1119,14 @@ static PADOFFSET
 S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv, U32 seq,
         int warn, SV** out_capture, PADNAME** out_name, int *out_flags)
 {
+    PERL_ARGS_ASSERT_PAD_FINDLEX;
+
     PADOFFSET offset, new_offset;
     SV *new_capture;
     SV **new_capturep;
     const PADLIST * const padlist = CvPADLIST(cv);
     const bool staleok = cBOOL(flags & padadd_STALEOK);
     const bool fieldok = cBOOL(flags & padfind_FIELD_OK);
-
-    PERL_ARGS_ASSERT_PAD_FINDLEX;
 
     flags &= ~(padadd_STALEOK|padfind_FIELD_OK); /* one-shot flags */
     if (flags)
@@ -1831,13 +1834,13 @@ Dump the contents of a padlist
 void
 Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
 {
+    PERL_ARGS_ASSERT_DO_DUMP_PAD;
+
     const PADNAMELIST *pad_name;
     const AV *pad;
     PADNAME **pname;
     SV **ppad;
     PADOFFSET ix;
-
-    PERL_ARGS_ASSERT_DO_DUMP_PAD;
 
     if (!padlist) {
         return;
@@ -1903,9 +1906,9 @@ dump the contents of a CV
 static void
 S_cv_dump(pTHX_ const CV *cv, const char *title)
 {
-    const CV * const outside = CvOUTSIDE(cv);
-
     PERL_ARGS_ASSERT_CV_DUMP;
+
+    const CV * const outside = CvOUTSIDE(cv);
 
     PerlIO_printf(Perl_debug_log,
                   "  %s: CV=0x%" UVxf " (%s), OUTSIDE=0x%" UVxf " (%s)\n",
@@ -2383,13 +2386,14 @@ moved to a pre-existing CV struct.
 void
 Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
 {
+    PERL_ARGS_ASSERT_PAD_FIXUP_INNER_ANONS;
+
     PADOFFSET ix;
     PADNAMELIST * const comppad_name = PadlistNAMES(padlist);
     AV * const comppad = PadlistARRAY(padlist)[1];
     PADNAME ** const namepad = PadnamelistARRAY(comppad_name);
     SV ** const curpad = AvARRAY(comppad);
 
-    PERL_ARGS_ASSERT_PAD_FIXUP_INNER_ANONS;
     PERL_UNUSED_ARG(old_cv);
 
     for (ix = PadnamelistMAX(comppad_name); ix > 0; ix--) {
@@ -2534,11 +2538,11 @@ Duplicates a pad.
 PADLIST *
 Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
 {
+    PERL_ARGS_ASSERT_PADLIST_DUP;
+
     PADLIST *dstpad;
     bool cloneall;
     PADOFFSET max;
-
-    PERL_ARGS_ASSERT_PADLIST_DUP;
 
     cloneall = cBOOL(param->flags & CLONEf_COPY_STACKS);
     assert (SvREFCNT(PadlistARRAY(srcpad)[1]) == 1);
@@ -2644,10 +2648,10 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
 PAD **
 Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
 {
+    PERL_ARGS_ASSERT_PADLIST_STORE;
+
     PAD **ary;
     SSize_t const oldmax = PadlistMAX(padlist);
-
-    PERL_ARGS_ASSERT_PADLIST_STORE;
 
     assert(key >= 0);
 
@@ -2700,9 +2704,9 @@ existing pad name in that slot.
 PADNAME **
 Perl_padnamelist_store(pTHX_ PADNAMELIST *pnl, SSize_t key, PADNAME *val)
 {
-    PADNAME **ary;
-
     PERL_ARGS_ASSERT_PADNAMELIST_STORE;
+
+    PADNAME **ary;
 
     assert(key >= 0);
 
@@ -2811,10 +2815,11 @@ C<L</newPADNAMEouter>>.
 PADNAME *
 Perl_newPADNAMEpvn(const char *s, STRLEN len)
 {
+    PERL_ARGS_ASSERT_NEWPADNAMEPVN;
+
     struct padname_with_str *alloc;
     char *alloc2; /* for Newxz */
     PADNAME *pn;
-    PERL_ARGS_ASSERT_NEWPADNAMEPVN;
     Newxz(alloc2,
           STRUCT_OFFSET(struct padname_with_str, xpadn_str[0]) + len + 1,
           char);
@@ -2843,8 +2848,9 @@ C<PADNAMEf_OUTER> flag already set.
 PADNAME *
 Perl_newPADNAMEouter(PADNAME *outer)
 {
-    PADNAME *pn;
     PERL_ARGS_ASSERT_NEWPADNAMEOUTER;
+
+    PADNAME *pn;
     Newxz(pn, 1, PADNAME);
     PadnameREFCNT(pn) = 1;
     PadnamePV(pn) = PadnamePV(outer);
@@ -2903,9 +2909,9 @@ Duplicates a pad name.
 PADNAME *
 Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
 {
-    PADNAME *dst;
-
     PERL_ARGS_ASSERT_PADNAME_DUP;
+
+    PADNAME *dst;
 
     /* look for it in the table first */
     dst = (PADNAME *)ptr_table_fetch(PL_ptr_table, src);

--- a/peep.c
+++ b/peep.c
@@ -1070,9 +1070,9 @@ S_warn_implicit_snail_cvsig(pTHX_ OP *o)
 static void
 S_optimize_op(pTHX_ OP* o)
 {
-    OP *top_op = o;
-
     PERL_ARGS_ASSERT_OPTIMIZE_OP;
+
+    OP *top_op = o;
 
     while (1) {
         OP * next_kid = NULL;
@@ -1216,9 +1216,9 @@ For now it's static, but it may be exposed to the API in the future.
 static OP*
 S_traverse_op_tree(pTHX_ OP *top, OP *o)
 {
-    OP *sib;
-
     PERL_ARGS_ASSERT_TRAVERSE_OP_TREE;
+
+    OP *sib;
 
     if ((o->op_flags & OPf_KIDS) && cUNOPo->op_first) {
         return cUNOPo->op_first;
@@ -1243,8 +1243,9 @@ S_traverse_op_tree(pTHX_ OP *top, OP *o)
 static void
 S_finalize_op(pTHX_ OP* o)
 {
-    OP * const top = o;
     PERL_ARGS_ASSERT_FINALIZE_OP;
+
+    OP * const top = o;
 
     do {
         assert(o->op_type != OP_FREED);

--- a/perl.c
+++ b/perl.c
@@ -137,7 +137,6 @@ S_init_tls_and_interp(PerlInterpreter *my_perl)
 void
 Perl_sys_init(int* argc, char*** argv)
 {
-
     PERL_ARGS_ASSERT_SYS_INIT;
 
     PERL_UNUSED_ARG(argc); /* may not be used depending on _BODY macro */
@@ -148,7 +147,6 @@ Perl_sys_init(int* argc, char*** argv)
 void
 Perl_sys_init3(int* argc, char*** argv, char*** env)
 {
-
     PERL_ARGS_ASSERT_SYS_INIT3;
 
     PERL_UNUSED_ARG(argc); /* may not be used depending on _BODY macro */
@@ -176,9 +174,9 @@ perl_alloc_using(const struct IPerlMem** ipM, const struct IPerlMem** ipMS,
                  const struct IPerlDir** ipD, const struct IPerlSock** ipS,
                  const struct IPerlProc** ipP)
 {
-    PerlInterpreter *my_perl;
-
     PERL_ARGS_ASSERT_PERL_ALLOC_USING;
+
+    PerlInterpreter *my_perl;
 
     /* Newx() needs interpreter, so call malloc() instead */
     my_perl = (PerlInterpreter*)((*ipM)->pCalloc)(ipM, 1, sizeof(PerlInterpreter));
@@ -232,7 +230,6 @@ Initializes a new Perl interpreter.  See L<perlembed>.
 void
 perl_construct(pTHXx)
 {
-
     PERL_ARGS_ASSERT_PERL_CONSTRUCT;
 
 #ifdef MULTIPLICITY
@@ -505,6 +502,8 @@ Perl_noshutdownhook()
 void
 Perl_dump_sv_child(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_DUMP_SV_CHILD;
+
     ssize_t got;
     const int sock = PL_dumper_fd;
     const int debug_fd = PerlIO_fileno(Perl_debug_log);
@@ -514,8 +513,6 @@ Perl_dump_sv_child(pTHX_ SV *sv)
     struct cmsghdr *cmptr;
     int returned_errno;
     unsigned char buffer[256];
-
-    PERL_ARGS_ASSERT_DUMP_SV_CHILD;
 
     if(sock == -1 || debug_fd == -1)
         return;
@@ -636,6 +633,8 @@ interpret specific numeric values as having specific meanings.
 int
 perl_destruct(pTHXx)
 {
+    PERL_ARGS_ASSERT_PERL_DESTRUCT;
+
     volatile signed char destruct_level;  /* see possible values in intrpvar.h */
     HV *hv;
 #ifdef DEBUG_LEAKING_SCALARS_FORK_DUMP
@@ -643,7 +642,6 @@ perl_destruct(pTHXx)
 #endif
     int i;
 
-    PERL_ARGS_ASSERT_PERL_DESTRUCT;
 #ifndef MULTIPLICITY
     PERL_UNUSED_ARG(my_perl);
 #endif
@@ -1582,7 +1580,6 @@ Releases a Perl interpreter.  See L<perlembed>.
 void
 perl_free(pTHXx)
 {
-
     PERL_ARGS_ASSERT_PERL_FREE;
 
     if (PL_veto_cleanup)
@@ -1790,11 +1787,12 @@ code: one should get that from L</perl_destruct>.
 int
 perl_parse(pTHXx_ XSINIT_t xsinit, int argc, char **argv, char **env)
 {
+    PERL_ARGS_ASSERT_PERL_PARSE;
+
     I32 oldscope;
     int ret;
     dJMPENV;
 
-    PERL_ARGS_ASSERT_PERL_PARSE;
 #ifndef MULTIPLICITY
     PERL_UNUSED_ARG(my_perl);
 #endif
@@ -2783,11 +2781,12 @@ one should get that from L</perl_destruct>.
 int
 perl_run(pTHXx)
 {
+    PERL_ARGS_ASSERT_PERL_RUN;
+
     I32 oldscope;
     int ret = 0;
     dJMPENV;
 
-    PERL_ARGS_ASSERT_PERL_RUN;
 #ifndef MULTIPLICITY
     PERL_UNUSED_ARG(my_perl);
 #endif
@@ -2913,9 +2912,9 @@ and the variable does not exist then NULL is returned.
 SV*
 Perl_get_sv(pTHX_ const char *name, I32 flags)
 {
-    GV *gv;
-
     PERL_ARGS_ASSERT_GET_SV;
+
+    GV *gv;
 
     gv = gv_fetchpv(name, flags, SVt_PV);
     if (gv)
@@ -2943,9 +2942,9 @@ Perl equivalent: C<@{"$name"}>.
 AV*
 Perl_get_av(pTHX_ const char *name, I32 flags)
 {
-    GV* const gv = gv_fetchpv(name, flags, SVt_PVAV);
-
     PERL_ARGS_ASSERT_GET_AV;
+
+    GV* const gv = gv_fetchpv(name, flags, SVt_PVAV);
 
     if (flags & ~SVf_UTF8)
         return GvAVn(gv);
@@ -2971,9 +2970,9 @@ returned.
 HV*
 Perl_get_hv(pTHX_ const char *name, I32 flags)
 {
-    GV* const gv = gv_fetchpv(name, flags, SVt_PVHV);
-
     PERL_ARGS_ASSERT_GET_HV;
+
+    GV* const gv = gv_fetchpv(name, flags, SVt_PVHV);
 
     if (flags & ~SVf_UTF8)
         return GvHVn(gv);
@@ -3009,9 +3008,9 @@ and its length in bytes is contained in the C<len> parameter.
 CV*
 Perl_get_cvn_flags(pTHX_ const char *name, STRLEN len, I32 flags)
 {
-    GV* const gv = gv_fetchpvn_flags(name, len, flags, SVt_PVCV);
-
     PERL_ARGS_ASSERT_GET_CVN_FLAGS;
+
+    GV* const gv = gv_fetchpvn_flags(name, len, flags, SVt_PVCV);
 
     if (gv && UNLIKELY(SvROK(gv)) && SvTYPE(SvRV((SV *)gv)) == SVt_PVCV)
         return (CV*)SvRV((SV *)gv);
@@ -3130,9 +3129,10 @@ Perl_call_method(pTHX_ const char *methname, I32 flags)
                         /* name of the subroutine */
                         /* See G_* flags in cop.h */
 {
+    PERL_ARGS_ASSERT_CALL_METHOD;
+
     STRLEN len;
     SV* sv;
-    PERL_ARGS_ASSERT_CALL_METHOD;
 
     len = strlen(methname);
     sv = flags & G_METHOD_NAMED
@@ -3172,6 +3172,8 @@ SSize_t
 Perl_call_sv(pTHX_ SV *sv, I32 arg_flags)
                         /* See G_* flags in cop.h */
 {
+    PERL_ARGS_ASSERT_CALL_SV;
+
     LOGOP myop;		/* fake syntax tree node */
     METHOP method_op;
     SSize_t oldmark;
@@ -3184,8 +3186,6 @@ Perl_call_sv(pTHX_ SV *sv, I32 arg_flags)
      */
     volatile I32 flags = arg_flags;
     dJMPENV;
-
-    PERL_ARGS_ASSERT_CALL_SV;
 
     if (flags & G_DISCARD) {
         ENTER;
@@ -3346,14 +3346,14 @@ Perl_eval_sv(pTHX_ SV *sv, I32 flags)
 
                         /* See G_* flags in cop.h */
 {
+    PERL_ARGS_ASSERT_EVAL_SV;
+
     UNOP myop;		/* fake syntax tree node */
     volatile SSize_t oldmark;
     volatile SSize_t retval = 0;
     int ret;
     OP* const oldop = PL_op;
     dJMPENV;
-
-    PERL_ARGS_ASSERT_EVAL_SV;
 
     if (flags & G_DISCARD) {
         ENTER;
@@ -3481,9 +3481,9 @@ Tells Perl to C<eval> the given string in scalar context and return an SV* resul
 SV*
 Perl_eval_pv(pTHX_ const char *p, I32 croak_on_error)
 {
-    SV* sv = newSVpv(p, 0);
-
     PERL_ARGS_ASSERT_EVAL_PV;
+
+    SV* sv = newSVpv(p, 0);
 
     if (croak_on_error) {
         sv_2mortal(sv);
@@ -3524,10 +3524,10 @@ implemented that way; consider using C<L</load_module>> instead.
 void
 Perl_require_pv(pTHX_ const char *pv)
 {
+    PERL_ARGS_ASSERT_REQUIRE_PV;
+
     dSP;
     SV* sv;
-
-    PERL_ARGS_ASSERT_REQUIRE_PV;
 
     PUSHSTACKi(PERLSI_REQUIRE);
     sv = Perl_newSVpvf(aTHX_ "require q%c%s%c", 0, pv, 0);
@@ -3597,6 +3597,8 @@ NULL
 int
 Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
 {
+    PERL_ARGS_ASSERT_GET_DEBUG_OPTS;
+
     static const char * const usage_msgd[] = {
       " Debugging flag values: (see also -d)\n"
       "  p  Tokenizing and parsing (with v, displays parse stack)\n"
@@ -3631,8 +3633,6 @@ Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
       NULL
     };
     UV uv = 0;
-
-    PERL_ARGS_ASSERT_GET_DEBUG_OPTS;
 
     if (isALPHA(**s)) {
         /* NOTE:
@@ -3680,10 +3680,10 @@ Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
 const char *
 Perl_moreswitches(pTHX_ const char *s)
 {
+    PERL_ARGS_ASSERT_MORESWITCHES;
+
     UV rschar;
     const char option = *s; /* used to remember option in -m/-M code */
-
-    PERL_ARGS_ASSERT_MORESWITCHES;
 
     switch (*s) {
     case '0':
@@ -4196,12 +4196,12 @@ S_init_main_stash(pTHX)
 static PerlIO *
 S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
 {
+    PERL_ARGS_ASSERT_OPEN_SCRIPT;
+
     int fdscript = -1;
     PerlIO *rsfp = NULL;
     Stat_t tmpstatbuf;
     int fd;
-
-    PERL_ARGS_ASSERT_OPEN_SCRIPT;
 
     if (PL_e_script) {
         PL_origfilename = savepvs("-e");
@@ -4334,12 +4334,12 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
 static void
 S_validate_suid(pTHX_ PerlIO *rsfp)
 {
+    PERL_ARGS_ASSERT_VALIDATE_SUID;
+
     const Uid_t  my_uid = PerlProc_getuid();
     const Uid_t my_euid = PerlProc_geteuid();
     const Gid_t  my_gid = PerlProc_getgid();
     const Gid_t my_egid = PerlProc_getegid();
-
-    PERL_ARGS_ASSERT_VALIDATE_SUID;
 
     if (my_euid != my_uid || my_egid != my_gid) {	/* (suidperl doesn't exist, in fact) */
         int fd = PerlIO_fileno(rsfp);
@@ -4362,10 +4362,10 @@ FIX YOUR KERNEL, PUT A C WRAPPER AROUND THIS SCRIPT, OR USE -u AND UNDUMP!\n");
 static void
 S_find_beginning(pTHX_ SV* linestr_sv, PerlIO *rsfp)
 {
+    PERL_ARGS_ASSERT_FIND_BEGINNING;
+
     const char *s;
     const char *s2;
-
-    PERL_ARGS_ASSERT_FIND_BEGINNING;
 
     /* skip forward in input to the real script? */
 
@@ -4634,11 +4634,11 @@ S_nuke_stacks(pTHX)
 void
 Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
 {
+    PERL_ARGS_ASSERT_POPULATE_ISA;
+
     GV *const gv = gv_fetchpvn(name, len, GV_ADD | GV_ADDMULTI, SVt_PVAV);
     AV *const isa = GvAVn(gv);
     va_list args;
-
-    PERL_ARGS_ASSERT_POPULATE_ISA;
 
     if(AvFILLp(isa) != -1)
         return;
@@ -4784,9 +4784,9 @@ Perl_init_argv_symbols(pTHX_ int argc, char **argv)
 static void
 S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
 {
-    GV* tmpgv;
-
     PERL_ARGS_ASSERT_INIT_POSTDUMP_SYMBOLS;
+
+    GV* tmpgv;
 
     PL_toptarget = newSV_type(SVt_PVIV);
     SvPVCLEAR(PL_toptarget);
@@ -5021,9 +5021,9 @@ S_init_perllib(pTHX)
 static SV *
 S_incpush_if_exists(pTHX_ AV *const av, SV *dir, SV *const stem)
 {
-    Stat_t tmpstatbuf;
-
     PERL_ARGS_ASSERT_INCPUSH_IF_EXISTS;
+
+    Stat_t tmpstatbuf;
 
     if (PerlLIO_stat(SvPVX_const(dir), &tmpstatbuf) >= 0 &&
         S_ISDIR(tmpstatbuf.st_mode)) {
@@ -5040,10 +5040,11 @@ S_incpush_if_exists(pTHX_ AV *const av, SV *dir, SV *const stem)
 static SV *
 S_mayberelocate(pTHX_ const char *const dir, STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_MAYBERELOCATE;
+
     const U8 canrelocate = (U8)flags & INCPUSH_CAN_RELOCATE;
     SV *libdir;
 
-    PERL_ARGS_ASSERT_MAYBERELOCATE;
     assert(len > 0);
 
     /* I am not convinced that this is valid when PERLLIB_MANGLE is
@@ -5175,6 +5176,8 @@ S_mayberelocate(pTHX_ const char *const dir, STRLEN len, U32 flags)
 static void
 S_incpush(pTHX_ const char *const dir, STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_INCPUSH;
+
 #ifndef PERL_IS_MINIPERL
     const U8 using_sub_dirs
         = (U8)flags & (INCPUSH_ADD_VERSIONED_SUB_DIRS
@@ -5191,7 +5194,6 @@ S_incpush(pTHX_ const char *const dir, STRLEN len, U32 flags)
     const U8 push_basedir = (flags & INCPUSH_NOT_BASEDIR) ? 0 : 1;
     AV *const inc = GvAVn(PL_incgv);
 
-    PERL_ARGS_ASSERT_INCPUSH;
     assert(len > 0);
 
     /* Could remove this vestigial extra block, if we don't mind a lot of
@@ -5292,12 +5294,12 @@ S_incpush(pTHX_ const char *const dir, STRLEN len, U32 flags)
 static void
 S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_INCPUSH_USE_SEP;
+
     const char *s;
     const char *end;
     /* This logic has been broken out from S_incpush(). It may be possible to
        simplify it.  */
-
-    PERL_ARGS_ASSERT_INCPUSH_USE_SEP;
 
     /* perl compiled with -DPERL_RELOCATABLE_INCPUSH will ignore the len
      * argument to incpush_use_sep.  This allows creation of relocatable
@@ -5333,14 +5335,14 @@ S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags)
 void
 Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
 {
+    PERL_ARGS_ASSERT_CALL_LIST;
+
     SV *atsv;
     volatile const line_t oldline = PL_curcop ? CopLINE(PL_curcop) : 0;
     CV *cv;
     STRLEN len;
     int ret;
     dJMPENV;
-
-    PERL_ARGS_ASSERT_CALL_LIST;
 
     while (av_count(paramList) > 0) {
         cv = MUTABLE_CV(av_shift(paramList));

--- a/perlio.c
+++ b/perlio.c
@@ -5712,8 +5712,9 @@ PerlIO_getpos(PerlIO *f, SV *pos)
 void
 Perl_noperl_die(const char* pat, ...)
 {
-    va_list arglist;
     PERL_ARGS_ASSERT_NOPERL_DIE;
+
+    va_list arglist;
     va_start(arglist, pat);
     vfprintf(stderr, pat, arglist);
     va_end(arglist);

--- a/pp.c
+++ b/pp.c
@@ -217,9 +217,9 @@ GV *
 Perl_softref2xv(pTHX_ SV *const sv, const char *const what,
                 const svtype type)
 {
-    GV *gv;
-
     PERL_ARGS_ASSERT_SOFTREF2XV;
+
+    GV *gv;
 
     if (PL_op->op_private & HINT_STRICT_REFS) {
         if (SvOK(sv))
@@ -502,9 +502,9 @@ PP(pp_refgen)
 static SV*
 S_refto(pTHX_ SV *sv)
 {
-    SV* rv;
-
     PERL_ARGS_ASSERT_REFTO;
+
+    SV* rv;
 
     if (SvTYPE(sv) == SVt_PVLV && LvTYPE(sv) == 'y') {
         if (LvTARGLEN(sv))
@@ -758,11 +758,11 @@ PP_wrapped(pp_trans, ((PL_op->op_flags & OPf_STACKED) ? 1 : 0), 0)
 static size_t
 S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
 {
+    PERL_ARGS_ASSERT_DO_CHOMP;
+
     STRLEN len;
     char *s;
     size_t count = 0;
-
-    PERL_ARGS_ASSERT_DO_CHOMP;
 
     if (chomping && (RsSNARF(PL_rs) || RsRECORD(PL_rs)))
         return 0;
@@ -3443,10 +3443,10 @@ Perl_translate_substr_offsets( STRLEN curlen, IV pos1_iv,
                                 bool len_is_uv, STRLEN *posp,
                                 STRLEN *lenp)
 {
+    PERL_ARGS_ASSERT_TRANSLATE_SUBSTR_OFFSETS;
+
     IV pos2_iv;
     int    pos2_is_uv;
-
-    PERL_ARGS_ASSERT_TRANSLATE_SUBSTR_OFFSETS;
 
     if (!pos1_is_uv && pos1_iv < 0 && curlen) {
         pos1_is_uv = curlen-1 > ~(UV)pos1_iv;

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -417,10 +417,11 @@ PP(pp_substcont)
 void
 Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
 {
+    PERL_ARGS_ASSERT_RXRES_SAVE;
+
     UV *p = (UV*)*rsp;
     U32 i;
 
-    PERL_ARGS_ASSERT_RXRES_SAVE;
     PERL_UNUSED_CONTEXT;
 
     /* deal with regexp_paren_pair items */
@@ -460,12 +461,12 @@ Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
 static void
 S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
 {
+    PERL_ARGS_ASSERT_RXRES_RESTORE;
+
     UV *p = (UV*)*rsp;
     U32 i;
 
-    PERL_ARGS_ASSERT_RXRES_RESTORE;
     PERL_UNUSED_CONTEXT;
-
     RX_MATCH_COPY_FREE(rx);
     RX_MATCH_COPIED_set(rx, *p);
     *p++ = 0;
@@ -491,10 +492,10 @@ S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
 static void
 S_rxres_free(pTHX_ void **rsp)
 {
-    UV * const p = (UV*)*rsp;
-
     PERL_ARGS_ASSERT_RXRES_FREE;
     PERL_UNUSED_CONTEXT;
+
+    UV * const p = (UV*)*rsp;
 
     if (p) {
         void *tmp = INT2PTR(char*,*p);
@@ -1574,9 +1575,9 @@ static const char * const context_name[] = {
 static I32
 S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
 {
-    I32 i;
-
     PERL_ARGS_ASSERT_DOPOPTOLABEL;
+
+    I32 i;
 
     for (i = cxstack_ix; i >= 0; i--) {
         const PERL_CONTEXT * const cx = &cxstack[i];
@@ -1707,9 +1708,10 @@ Perl_was_lvalue_sub(pTHX)
 static I32
 S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
 {
+    PERL_ARGS_ASSERT_DOPOPTOSUB_AT;
+
     I32 i;
 
-    PERL_ARGS_ASSERT_DOPOPTOSUB_AT;
 #ifndef DEBUGGING
     PERL_UNUSED_CONTEXT;
 #endif
@@ -2060,9 +2062,10 @@ S_pop_eval_context_maybe_croak(pTHX_ PERL_CONTEXT *cx, SV *errsv, int action)
 void
 Perl_die_unwind(pTHX_ SV *msv)
 {
+    PERL_ARGS_ASSERT_DIE_UNWIND;
+
     SV *exceptsv = msv;
     U8 in_eval = PL_in_eval;
-    PERL_ARGS_ASSERT_DIE_UNWIND;
 
     if (in_eval) {
         I32 cxix;
@@ -3185,10 +3188,10 @@ PP(pp_redo)
 static OP *
 S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstack, OP **oplimit)
 {
+    PERL_ARGS_ASSERT_DOFINDLABEL;
+
     OP **ops = opstack;
     static const char* const too_deep = "Target of goto is too deeply nested";
-
-    PERL_ARGS_ASSERT_DOFINDLABEL;
 
     if (ops >= oplimit)
         croak("%s", too_deep);
@@ -3809,11 +3812,11 @@ PP_wrapped(pp_exit, 1, 0)
 static void
 S_save_lines(pTHX_ AV *array, SV *sv)
 {
+    PERL_ARGS_ASSERT_SAVE_LINES;
+
     const char *s = SvPVX_const(sv);
     const char * const send = SvPVX_const(sv) + SvCUR(sv);
     I32 line = 1;
-
-    PERL_ARGS_ASSERT_SAVE_LINES;
 
     while (s && s < send) {
         const char *t;
@@ -4413,13 +4416,13 @@ S_doeval_compile(pTHX_ U8 gimme, CV* outside, U32 seq, HV *hh)
 static PerlIO *
 S_check_type_and_open(pTHX_ SV *name)
 {
+    PERL_ARGS_ASSERT_CHECK_TYPE_AND_OPEN;
+
     Stat_t st;
     STRLEN len;
     PerlIO * retio;
     const char *p = SvPV_const(name, len);
     int st_rc;
-
-    PERL_ARGS_ASSERT_CHECK_TYPE_AND_OPEN;
 
     /* checking here captures a reasonable error message when
      * PERL_DISABLE_PMC is true, but when PMC checks are enabled, the
@@ -4487,10 +4490,10 @@ S_check_type_and_open(pTHX_ SV *name)
 static PerlIO *
 S_doopen_pm(pTHX_ SV *name)
 {
+    PERL_ARGS_ASSERT_DOOPEN_PM;
+
     STRLEN namelen;
     const char *p = SvPV_const(name, namelen);
-
-    PERL_ARGS_ASSERT_DOOPEN_PM;
 
     /* check the name before trying for the .pmc name to avoid the
      * warning referring to the .pmc which the user probably doesn't
@@ -5805,11 +5808,11 @@ Perl_delete_eval_scope(pTHX)
 void
 Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
 {
+    PERL_ARGS_ASSERT_CREATE_EVAL_SCOPE;
+
     PERL_CONTEXT *cx;
     const U8 gimme = GIMME_V;
 
-    PERL_ARGS_ASSERT_CREATE_EVAL_SCOPE;
-        
     cx = cx_pushblock((CXt_EVAL|CXp_EVALBLOCK), gimme,
                     sp, PL_savestack_ix);
     cx_pusheval(cx, retop, NULL);
@@ -5923,9 +5926,9 @@ PP(pp_leavegiven)
 static PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
 {
-    PMOP *matcher = cPMOPx(newPMOP(OP_MATCH, OPf_WANT_SCALAR | OPf_STACKED));
-
     PERL_ARGS_ASSERT_MAKE_MATCHER;
+
+    PMOP *matcher = cPMOPx(newPMOP(OP_MATCH, OPf_WANT_SCALAR | OPf_STACKED));
 
     PM_SETRE(matcher, ReREFCNT_inc(re));
 
@@ -5938,10 +5941,10 @@ S_make_matcher(pTHX_ REGEXP *re)
 static bool
 S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
 {
+    PERL_ARGS_ASSERT_MATCHER_MATCHES_SV;
+
     bool result;
 
-    PERL_ARGS_ASSERT_MATCHER_MATCHES_SV;
-    
     PL_op = (OP *) matcher;
     rpp_xpush_1(sv);
     (void) Perl_pp_match(aTHX);
@@ -6657,6 +6660,8 @@ PP(pp_pushdefer)
 static MAGIC *
 S_doparseform(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_DOPARSEFORM;
+
     STRLEN len;
     char *s = SvPV(sv, len);
     char *send;
@@ -6674,8 +6679,6 @@ S_doparseform(pTHX_ SV *sv)
     int maxops = 12; /* FF_LINEMARK + FF_END + 10 (\0 without preceding \n) */
     MAGIC *mg = NULL;
     SV *sv_copy;
-
-    PERL_ARGS_ASSERT_DOPARSEFORM;
 
     if (len == 0)
         croak("Null picture in formline");
@@ -6939,6 +6942,8 @@ S_num_overflow(NV value, I32 fldsize, I32 frcsize)
 static I32
 S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
 {
+    PERL_ARGS_ASSERT_RUN_USER_FILTER;
+
     SV * const datasv = FILTER_DATA(idx);
     const int filter_has_file = IoLINES(datasv);
     SV * const filter_state = MUTABLE_SV(IoTOP_GV(datasv));
@@ -6951,8 +6956,6 @@ S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
     bool read_from_cache = FALSE;
     STRLEN umaxlen;
     SV *err = NULL;
-
-    PERL_ARGS_ASSERT_RUN_USER_FILTER;
 
     assert(maxlen >= 0);
     umaxlen = maxlen;

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -192,7 +192,6 @@ void
 Perl_rpp_free_2_(pTHX_ SV *const sv1,  SV *const sv2,
                        const U32 rc1,  const U32 rc2)
 {
-
     PERL_ARGS_ASSERT_RPP_FREE_2_;
 
 #ifdef PERL_RC_STACK
@@ -5911,10 +5910,10 @@ PP(pp_grepwhile)
 void
 Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int pass)
 {
+    PERL_ARGS_ASSERT_LEAVE_ADJUST_STACKS;
+
     SSize_t tmps_base; /* lowest index into tmps stack that needs freeing now */
     SSize_t nargs;
-
-    PERL_ARGS_ASSERT_LEAVE_ADJUST_STACKS;
 
     TAINT_NOT;
 
@@ -6825,6 +6824,8 @@ Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
 PERL_STATIC_INLINE HV *
 S_opmethod_stash(pTHX_ SV* meth)
 {
+    PERL_ARGS_ASSERT_OPMETHOD_STASH;
+
     SV* ob;
     HV* stash;
 
@@ -6833,8 +6834,6 @@ S_opmethod_stash(pTHX_ SV* meth)
                             "package or object reference", SVfARG(meth)),
            (SV *)NULL)
         : *(PL_stack_base + TOPMARK + 1);
-
-    PERL_ARGS_ASSERT_OPMETHOD_STASH;
 
     if (UNLIKELY(!sv))
        undefined:

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -185,11 +185,11 @@ STMT_START {						\
 static SV *
 S_mul128(pTHX_ SV *sv, U8 m)
 {
+  PERL_ARGS_ASSERT_MUL128;
+
   STRLEN          len;
   char           *s = SvPV(sv, len);
   char           *t;
-
-  PERL_ARGS_ASSERT_MUL128;
 
   if (! memBEGINs(s, len, "0000")) {  /* need to grow sv */
     SV * const tmpNew = newSVpvs("0000000000");
@@ -459,9 +459,9 @@ static const char *action_( const tempsym_t* symptr )
 static SSize_t
 S_measure_struct(pTHX_ tempsym_t* symptr)
 {
-    SSize_t total = 0;
-
     PERL_ARGS_ASSERT_MEASURE_STRUCT;
+
+    SSize_t total = 0;
 
     while (next_symbol(symptr)) {
         SSize_t len, size;
@@ -603,9 +603,9 @@ S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
 static const char *
 S_get_num(pTHX_ const char *patptr, SSize_t *lenptr )
 {
-  SSize_t len = *patptr++ - '0';
-
   PERL_ARGS_ASSERT_GET_NUM;
+
+  SSize_t len = *patptr++ - '0';
 
   while (isDIGIT(*patptr)) {
     SSize_t nlen = (len * 10) + (*patptr++ - '0');
@@ -623,10 +623,10 @@ S_get_num(pTHX_ const char *patptr, SSize_t *lenptr )
 static bool
 S_next_symbol(pTHX_ tempsym_t* symptr )
 {
+  PERL_ARGS_ASSERT_NEXT_SYMBOL;
+
   const char* patptr = symptr->patptr;
   const char* const patend = symptr->patend;
-
-  PERL_ARGS_ASSERT_NEXT_SYMBOL;
 
   symptr->flags &= ~FLAG_SLASH;
 
@@ -807,9 +807,9 @@ S_next_symbol(pTHX_ tempsym_t* symptr )
 static bool
 S_need_utf8(const char *pat, const char *patend)
 {
-    bool first = TRUE;
-
     PERL_ARGS_ASSERT_NEED_UTF8;
+
+    bool first = TRUE;
 
     while (pat < patend) {
         if (pat[0] == '#') {
@@ -864,9 +864,9 @@ example).
 SSize_t
 Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags)
 {
-    tempsym_t sym;
-
     PERL_ARGS_ASSERT_UNPACKSTRING;
+
+    tempsym_t sym;
 
     if (flags & FLAG_DO_UTF8) flags |= FLAG_WAS_UTF8;
     else if (need_utf8(pat, patend)) {
@@ -889,6 +889,8 @@ Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, cons
 static SSize_t
 S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const char *strend, const char **new_s )
 {
+    PERL_ARGS_ASSERT_UNPACK_REC;
+
     dSP;
     SV *sv = NULL;
     const SSize_t start_sp_offset = SP - PL_stack_base;
@@ -901,8 +903,6 @@ S_unpack_rec(pTHX_ tempsym_t* symptr, const char *s, const char *strbeg, const c
     bool explicit_length;
     const bool unpack_only_one = (symptr->flags & FLAG_UNPACK_ONLY_ONE) != 0;
     bool utf8 = (symptr->flags & FLAG_PARSE_UTF8) ? 1 : 0;
-
-    PERL_ARGS_ASSERT_UNPACK_REC;
 
     symptr->strbeg = s - strbeg;
 
@@ -1930,13 +1930,13 @@ doencodes(U8 *h, const U8 *s, SSize_t len)
 static SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)
 {
+  PERL_ARGS_ASSERT_IS_AN_INT;
+
   SV *result = newSVpvn(s, l);
   char *const result_c = SvPV_nolen(result);	/* convenience */
   char *out = result_c;
   bool skip = 1;
   bool ignore = 0;
-
-  PERL_ARGS_ASSERT_IS_AN_INT;
 
   while (*s) {
     switch (*s) {
@@ -1981,12 +1981,12 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
 static int
 S_div128(pTHX_ SV *pnum, bool *done)
 {
+    PERL_ARGS_ASSERT_DIV128;
+
     STRLEN len;
     char * const s = SvPV(pnum, len);
     char *t = s;
     int m = 0;
-
-    PERL_ARGS_ASSERT_DIV128;
 
     *done = 1;
     while (*t) {
@@ -2014,9 +2014,9 @@ The engine implementing C<pack()> Perl function.
 void
 Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist )
 {
-    tempsym_t sym;
-
     PERL_ARGS_ASSERT_PACKLIST;
+
+    tempsym_t sym;
 
     TEMPSYM_INIT(&sym, pat, patend, FLAG_PACK);
 
@@ -2102,11 +2102,11 @@ marked_upgrade(pTHX_ SV *sv, tempsym_t *sym_ptr)
 static char *
 S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
 {
+    PERL_ARGS_ASSERT_SV_EXP_GROW;
+
     const STRLEN cur = SvCUR(sv);
     const STRLEN len = SvLEN(sv);
     STRLEN extend;
-
-    PERL_ARGS_ASSERT_SV_EXP_GROW;
 
     if (len - cur > needed) return SvPVX(sv);
     extend = needed > len ? needed : len;
@@ -2139,14 +2139,14 @@ static
 SV **
 S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
 {
+    PERL_ARGS_ASSERT_PACK_REC;
+
     tempsym_t lookahead;
     SSize_t items  = endlist - beglist;
     bool found = next_symbol(symptr);
     bool utf8 = (symptr->flags & FLAG_PARSE_UTF8) ? 1 : 0;
     bool warn_utf8 = ckWARN(WARN_UTF8);
     char* from;
-
-    PERL_ARGS_ASSERT_PACK_REC;
 
     if (symptr->level == 0 && found && symptr->code == 'U') {
         marked_upgrade(aTHX_ cat, symptr);

--- a/pp_sort.c
+++ b/pp_sort.c
@@ -333,6 +333,8 @@ typedef struct {
 PERL_STATIC_FORCE_INLINE void
 S_sortsv_flags_impl(pTHX_ gptr *base, size_t nmemb, SVCOMPARE_t cmp, U32 flags)
 {
+    PERL_ARGS_ASSERT_SORTSV_FLAGS_IMPL;
+
     IV i, run, offset;
     I32 sense, level;
     gptr *f1, *f2, *t, *b, *p;
@@ -344,7 +346,6 @@ S_sortsv_flags_impl(pTHX_ gptr *base, size_t nmemb, SVCOMPARE_t cmp, U32 flags)
     off_runs stack[60], *stackp;
 
     PERL_UNUSED_ARG(flags);
-    PERL_ARGS_ASSERT_SORTSV_FLAGS_IMPL;
     if (nmemb <= 1) return;                     /* sorted trivially */
 
     if (nmemb <= SMALLSORT) aux = small;        /* use stack for aux array */
@@ -1173,13 +1174,13 @@ PP(pp_sort)
 static I32
 S_sortcv(pTHX_ SV *const a, SV *const b)
 {
+    PERL_ARGS_ASSERT_SORTCV;
+
     const I32 oldsaveix = PL_savestack_ix;
     PMOP * const pm = PL_curpm;
     COP * const cop = PL_curcop;
     SV *olda, *oldb;
  
-    PERL_ARGS_ASSERT_SORTCV;
-
 #ifdef PERL_RC_STACK
     assert(rpp_stack_is_rc());
 #endif
@@ -1215,12 +1216,12 @@ S_sortcv(pTHX_ SV *const a, SV *const b)
 static I32
 S_sortcv_stacked(pTHX_ SV *const a, SV *const b)
 {
+    PERL_ARGS_ASSERT_SORTCV_STACKED;
+
     const I32 oldsaveix = PL_savestack_ix;
     AV * const av = GvAV(PL_defgv);
     PMOP * const pm = PL_curpm;
     COP * const cop = PL_curcop;
-
-    PERL_ARGS_ASSERT_SORTCV_STACKED;
 
 #ifdef PERL_RC_STACK
     assert(rpp_stack_is_rc());
@@ -1284,11 +1285,11 @@ S_sortcv_stacked(pTHX_ SV *const a, SV *const b)
 static I32
 S_sortcv_xsub(pTHX_ SV *const a, SV *const b)
 {
+    PERL_ARGS_ASSERT_SORTCV_XSUB;
+
     const I32 oldsaveix = PL_savestack_ix;
     CV * const cv=MUTABLE_CV(PL_sortcop);
     PMOP * const pm = PL_curpm;
-
-    PERL_ARGS_ASSERT_SORTCV_XSUB;
 
 #ifdef PERL_RC_STACK
     assert(rpp_stack_is_rc());
@@ -1353,10 +1354,10 @@ S_sv_ncmp_desc(pTHX_ SV *const a, SV *const b)
 PERL_STATIC_FORCE_INLINE I32
 S_sv_i_ncmp(pTHX_ SV *const a, SV *const b)
 {
+    PERL_ARGS_ASSERT_SV_I_NCMP;
+
     const IV iv1 = SvIV(a);
     const IV iv2 = SvIV(b);
-
-    PERL_ARGS_ASSERT_SV_I_NCMP;
 
     return iv1 < iv2 ? -1 : iv1 > iv2 ? 1 : 0;
 }
@@ -1379,9 +1380,9 @@ S_sv_i_ncmp_desc(pTHX_ SV *const a, SV *const b)
 PERL_STATIC_FORCE_INLINE I32
 S_amagic_ncmp(pTHX_ SV *a, SV *b)
 {
-    SV * const tmpsv = tryCALL_AMAGICbin(a,b,ncmp_amg);
-
     PERL_ARGS_ASSERT_AMAGIC_NCMP;
+
+    SV * const tmpsv = tryCALL_AMAGICbin(a,b,ncmp_amg);
 
     if (tmpsv) {
         if (SvIOK(tmpsv)) {
@@ -1408,9 +1409,9 @@ S_amagic_ncmp_desc(pTHX_ SV *const a, SV *const b)
 PERL_STATIC_FORCE_INLINE I32
 S_amagic_i_ncmp(pTHX_ SV *const a, SV *const b)
 {
-    SV * const tmpsv = tryCALL_AMAGICbin(a,b,ncmp_amg);
-
     PERL_ARGS_ASSERT_AMAGIC_I_NCMP;
+
+    SV * const tmpsv = tryCALL_AMAGICbin(a,b,ncmp_amg);
 
     if (tmpsv) {
         if (SvIOK(tmpsv)) {
@@ -1436,9 +1437,9 @@ S_amagic_i_ncmp_desc(pTHX_ SV *const a, SV *const b)
 PERL_STATIC_FORCE_INLINE I32
 S_amagic_cmp(pTHX_ SV *const str1, SV *const str2)
 {
-    SV * const tmpsv = tryCALL_AMAGICbin(str1,str2,scmp_amg);
-
     PERL_ARGS_ASSERT_AMAGIC_CMP;
+
+    SV * const tmpsv = tryCALL_AMAGICbin(str1,str2,scmp_amg);
 
     if (tmpsv) {
         if (SvIOK(tmpsv)) {
@@ -1474,9 +1475,9 @@ S_cmp_desc(pTHX_ SV *const str1, SV *const str2)
 PERL_STATIC_FORCE_INLINE I32
 S_amagic_cmp_locale(pTHX_ SV *const str1, SV *const str2)
 {
-    SV * const tmpsv = tryCALL_AMAGICbin(str1,str2,scmp_amg);
-
     PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE;
+
+    SV * const tmpsv = tryCALL_AMAGICbin(str1,str2,scmp_amg);
 
     if (tmpsv) {
         if (SvIOK(tmpsv)) {

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -670,13 +670,13 @@ OP *
 Perl_tied_method(pTHX_ SV *methname, SV **mark, SV *const sv,
                  const MAGIC *const mg, const U32 flags, U32 argc, ...)
 {
+    PERL_ARGS_ASSERT_TIED_METHOD;
+
     I32 ret_args;
     SSize_t extend_size;
 #ifdef PERL_RC_STACK
     bool was_rc = rpp_stack_is_rc();
 #endif
-
-    PERL_ARGS_ASSERT_TIED_METHOD;
 
     /* Ensure that our flag bits do not overlap.  */
     STATIC_ASSERT_STMT((TIED_METHOD_MORTALIZE_NOT_NEEDED & G_WANT) == 0);
@@ -1544,9 +1544,9 @@ See C<L</setdefout>>.
 void
 Perl_setdefout(pTHX_ GV *gv)
 {
-    GV *oldgv = PL_defoutgv;
-
     PERL_ARGS_ASSERT_SETDEFOUT;
+
+    GV *oldgv = PL_defoutgv;
 
     SvREFCNT_inc_simple_void_NN(gv);
     PL_defoutgv = gv;
@@ -1635,10 +1635,10 @@ PP_wrapped(pp_getc, MAXARG, 0)
 static OP *
 S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
 {
+    PERL_ARGS_ASSERT_DOFORM;
+
     PERL_CONTEXT *cx;
     const U8 gimme = GIMME_V;
-
-    PERL_ARGS_ASSERT_DOFORM;
 
     if (CvCLONE(cv))
         cv = MUTABLE_CV(sv_2mortal(MUTABLE_SV(cv_clone(cv))));
@@ -4097,14 +4097,14 @@ PP_wrapped(pp_readlink, 1, 0)
 static int
 S_dooneliner(pTHX_ const char *cmd, const char *filename)
 {
+    PERL_ARGS_ASSERT_DOONELINER;
+
     char * const save_filename = filename;
     char *cmdline;
     char *s;
     PerlIO *myfp;
     int anum = 1;
     Size_t size = strlen(cmd) + (strlen(filename) * 2) + 10;
-
-    PERL_ARGS_ASSERT_DOONELINER;
 
     Newx(cmdline, size, char);
     my_strlcpy(cmdline, cmd, size);

--- a/proto.h
+++ b/proto.h
@@ -1850,11 +1850,11 @@ Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type)
         assert(nambeg)
 
 PERL_CALLCONV GV *
-Perl_gv_fetchpvn_flags(pTHX_ const char *name, STRLEN len, I32 flags, const svtype sv_type)
+Perl_gv_fetchpvn_flags(pTHX_ const char *nambeg, STRLEN len, I32 flags, const svtype sv_type)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPVN_FLAGS      \
-        assert(name)
+        assert(nambeg)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
@@ -4813,51 +4813,51 @@ Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash,
         assert(rx)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_all(pTHX_ REGEXP * const rx, const U32 flags)
+Perl_reg_named_buff_all(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ALL     \
-        assert(rx)
+        assert(r)
 
 PERL_CALLCONV bool
-Perl_reg_named_buff_exists(pTHX_ REGEXP * const rx, SV * const key, const U32 flags)
+Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key, const U32 flags)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_EXISTS  \
-        assert(rx); assert(key)
+        assert(r); assert(key)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_fetch(pTHX_ REGEXP * const rx, SV * const namesv, const U32 flags)
+Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv, const U32 flags)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FETCH   \
-        assert(rx); assert(namesv)
+        assert(r); assert(namesv)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const rx, const U32 flags)
+Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FIRSTKEY \
-        assert(rx)
+        assert(r)
 
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ITER    \
         assert(rx)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const rx, const U32 flags)
+Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_NEXTKEY \
-        assert(rx)
+        assert(r)
 
 PERL_CALLCONV SV *
-Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags)
+Perl_reg_named_buff_scalar(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_SCALAR  \
-        assert(rx)
+        assert(r)
 
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH \
         assert(re)
@@ -4866,7 +4866,7 @@ Perl_reg_named_buff_scalar(pTHX_ REGEXP * const rx, const U32 flags)
         assert(re)
 
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_LENGTH \
-        assert(rx); assert(sv)
+        assert(r); assert(sv)
 
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_STORE \
         assert(rx)
@@ -5364,12 +5364,12 @@ Perl_scalar(pTHX_ OP *o)
 #define PERL_ARGS_ASSERT_SCALAR
 
 PERL_CALLCONV OP *
-Perl_scalarvoid(pTHX_ OP *o)
+Perl_scalarvoid(pTHX_ OP *arg)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SCALARVOID             \
-        assert(o)
+        assert(arg)
 
 PERL_CALLCONV NV
 Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
@@ -7813,7 +7813,7 @@ Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren, SV 
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1);
 PERL_CALLCONV I32
-Perl_reg_numbered_buff_length(pTHX_ REGEXP * const rx, const SV * const sv, const I32 paren)
+Perl_reg_numbered_buff_length(pTHX_ REGEXP * const r, const SV * const sv, const I32 paren)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
@@ -11950,7 +11950,7 @@ Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
         assert(rex); assert(str)
 
 #   define PERL_ARGS_ASSERT_FOLDEQ_LATIN1_S2_FOLDED \
-        assert(a); assert(b)
+        assert(s1); assert(s2)
 
 #   define PERL_ARGS_ASSERT_UNWIND_PAREN        \
         assert(rex)
@@ -11962,7 +11962,7 @@ S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_4);
 PERL_STATIC_INLINE I32
-S_foldEQ_latin1_s2_folded(pTHX_ const char *a, const char *b, I32 len)
+S_foldEQ_latin1_s2_folded(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
@@ -12258,14 +12258,14 @@ S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const st
         assert(start < send)
 
 static STRLEN
-S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * const uoffset, bool * const at_end, bool *canonical_position)
+S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * const uoffset_p, bool * const at_end, bool *canonical_position)
         Perl_attribute_nonnull_(1)
         Perl_attribute_nonnull_(2)
         Perl_attribute_nonnull_(3)
         Perl_attribute_nonnull_(4)
         Perl_attribute_nonnull_(5);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS   \
-        assert(start); assert(send); assert(uoffset); assert(at_end); \
+        assert(start); assert(send); assert(uoffset_p); assert(at_end); \
         assert(canonical_position); assert(start < send)
 
 static STRLEN
@@ -13180,28 +13180,28 @@ Perl_clear_defarray_simple(pTHX_ AV *av)
         assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE I32
-Perl_foldEQ(pTHX_ const char *a, const char *b, I32 len)
+Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ                \
-        assert(a); assert(b)
+        assert(s1); assert(s2)
 
 PERL_STATIC_INLINE I32
-Perl_foldEQ_latin1(pTHX_ const char *a, const char *b, I32 len)
+Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LATIN1         \
-        assert(a); assert(b)
+        assert(s1); assert(s2)
 
 PERL_STATIC_INLINE I32
-Perl_foldEQ_locale(pTHX_ const char *a, const char *b, I32 len)
+Perl_foldEQ_locale(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LOCALE         \
-        assert(a); assert(b)
+        assert(s1); assert(s2)
 
 PERL_STATIC_INLINE MGVTBL *
 Perl_get_vtbl(pTHX_ int vtbl_id)
@@ -14436,12 +14436,12 @@ Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
         assert(sstr); assert(dstr); assert(param)
 
 PERL_CALLCONV void *
-Perl_regdupe_internal(pTHX_ REGEXP * const r, CLONE_PARAMS *param)
+Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
         Perl_attribute_nonnull_aTHX_
         Perl_attribute_nonnull_(pTHX_1)
         Perl_attribute_nonnull_(pTHX_2);
 # define PERL_ARGS_ASSERT_REGDUPE_INTERNAL      \
-        assert(r); assert(param)
+        assert(rx); assert(param)
 
 PERL_CALLCONV void
 Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const param)

--- a/proto.h
+++ b/proto.h
@@ -11975,6 +11975,9 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
 #endif /* defined(PERL_IN_REGEXEC_C) */
 #if defined(PERL_IN_REGEX_ENGINE)
 
+# define PERL_ARGS_ASSERT_REGPROP               \
+        assert(sv); assert(o)
+
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DEBUG_PEEP          \
         assert(str); assert(pRExC_state)
@@ -11994,10 +11997,15 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
 #   define PERL_ARGS_ASSERT_RE_PRINTF           \
         assert(fmt)
 
-#   define PERL_ARGS_ASSERT_REGPROP             \
-        assert(sv); assert(o)
-
-#   if defined(PERL_CORE) || defined(PERL_EXT)
+# endif /* defined(DEBUGGING) */
+# if defined(PERL_CORE) || defined(PERL_EXT)
+PERL_CALLCONV void
+Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_info *reginfo, const RExC_state_t *pRExC_state)
+        Perl_attribute_nonnull_aTHX_
+        Perl_attribute_nonnull_(pTHX_2)
+        Perl_attribute_nonnull_(pTHX_3)
+        __attribute__visibility__("hidden");
+#   if defined(DEBUGGING)
 PERL_CALLCONV void
 Perl_debug_peep(pTHX_ const char *str, const RExC_state_t *pRExC_state, regnode *scan, U32 depth, U32 flags)
         Perl_attribute_nonnull_aTHX_
@@ -12034,14 +12042,8 @@ Perl_re_printf(pTHX_ const char *fmt, ...)
         Perl_attribute_nonnull_(pTHX_1)
         __attribute__visibility__("hidden")
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
-PERL_CALLCONV void
-Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_info *reginfo, const RExC_state_t *pRExC_state)
-        Perl_attribute_nonnull_aTHX_
-        Perl_attribute_nonnull_(pTHX_2)
-        Perl_attribute_nonnull_(pTHX_3)
-        __attribute__visibility__("hidden");
-#   endif /* defined(PERL_CORE) || defined(PERL_EXT) */
-# endif /* defined(DEBUGGING) */
+#   endif /* defined(DEBUGGING) */
+# endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_EXT_RE_BUILD)
 #   define PERL_ARGS_ASSERT_GET_RE_GCLASS_AUX_DATA \
         assert(node)

--- a/reentr.c
+++ b/reentr.c
@@ -374,6 +374,8 @@ Perl_reentrant_free(pTHX) {
 void*
 Perl_reentrant_retry(const char *f, ...)
 {
+    PERL_ARGS_ASSERT_REENTRANT_RETRY;
+
     /* This function is set up to be called if the normal function returns
      * failure with errno ERANGE, which indicates the buffer is too small.
      * This function calls the failing one again with a larger buffer.
@@ -399,7 +401,6 @@ Perl_reentrant_retry(const char *f, ...)
 
     /* Easier to special case this here than in embed.pl. (Look at what it
        generates for proto.h) */
-    PERL_ARGS_ASSERT_REENTRANT_RETRY;
 
 #endif
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -232,12 +232,12 @@ S_edit_distance(const UV* src,
                 const SSize_t maxDistance
 )
 {
+    PERL_ARGS_ASSERT_EDIT_DISTANCE;
+
     item *head = NULL;
     UV swapCount, swapScore, targetCharCount, i, j;
     UV *scores;
     UV score_ceil = x + y;
-
-    PERL_ARGS_ASSERT_EDIT_DISTANCE;
 
     /* initialize matrix start values */
     Newx(scores, ( (x + 2) * (y + 2)), UV);
@@ -299,9 +299,9 @@ S_edit_distance(const UV* src,
 U32
 Perl_reg_add_data(RExC_state_t* const pRExC_state, const char* const s, const U32 n)
 {
-    U32 count = RExC_rxi->data ? RExC_rxi->data->count : 1;
-
     PERL_ARGS_ASSERT_REG_ADD_DATA;
+
+    U32 count = RExC_rxi->data ? RExC_rxi->data->count : 1;
 
     /* in the below expression we have (count + n - 1), the minus one is there
      * because the struct that we allocate already contains a slot for 1 data
@@ -435,10 +435,10 @@ Perl_current_re_engine(pTHX)
 REGEXP *
 Perl_pregcomp(pTHX_ SV * const pattern, const U32 flags)
 {
+    PERL_ARGS_ASSERT_PREGCOMP;
+
     regexp_engine const *eng = current_re_engine();
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_PREGCOMP;
 
     /* Dispatch a request to compile a regexp to correct regexp engine. */
     DEBUG_COMPILE_r({
@@ -478,9 +478,9 @@ all begin with C<RXf_>.
 REGEXP *
 Perl_re_compile(pTHX_ SV * const pattern, U32 rx_flags)
 {
-    SV *pat = pattern; /* defeat constness! */
-
     PERL_ARGS_ASSERT_RE_COMPILE;
+
+    SV *pat = pattern; /* defeat constness! */
 
     return Perl_re_op_compile(aTHX_ &pat, 1, NULL,
 #ifdef PERL_IN_XSUB_RE
@@ -884,7 +884,6 @@ S_has_runtime_code(pTHX_ RExC_state_t * const pRExC_state,
 {
     int n = 0;
     STRLEN s;
-
     PERL_UNUSED_CONTEXT;
 
     for (s = 0; s < plen; s++) {
@@ -1182,6 +1181,8 @@ S_setup_longest(pTHX_ RExC_state_t *pRExC_state,
 static void
 S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx)
 {
+    PERL_ARGS_ASSERT_SET_REGEX_PV;
+
     /* Calculates and sets in the compiled pattern 'Rx' the string to compile,
      * properly wrapped with the right modifiers */
 
@@ -1212,8 +1213,6 @@ S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx)
             /* If needs a character set specifier */
         + ((has_charset) ? MAX_CHARSET_NAME_LENGTH : 0)
         + (sizeof("(?:)") - 1);
-
-    PERL_ARGS_ASSERT_SET_REGEX_PV;
 
     /* make sure PL_bitcount bounds not exceeded */
     STATIC_ASSERT_STMT(sizeof(STD_PAT_MODS) <= 8);
@@ -1271,14 +1270,14 @@ S_set_regex_pv(pTHX_ RExC_state_t *pRExC_state, REGEXP *Rx)
 static void
 S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc)
 {
+    PERL_ARGS_ASSERT_SSC_FINALIZE;
+
     /* The inversion list in the SSC is marked mortal; now we need a more
      * permanent copy, which is stored the same way that is done in a regular
      * ANYOF node, with the first NUM_ANYOF_CODE_POINTS code points in a bit
      * map */
 
     SV* invlist = invlist_clone(ssc->invlist, NULL);
-
-    PERL_ARGS_ASSERT_SSC_FINALIZE;
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -1312,6 +1311,8 @@ S_ssc_finalize(pTHX_ RExC_state_t *pRExC_state, regnode_ssc *ssc)
 static bool
 S_is_ssc_worth_it(const RExC_state_t * pRExC_state, const regnode_ssc * ssc)
 {
+    PERL_ARGS_ASSERT_IS_SSC_WORTH_IT;
+
     /* The synthetic start class is used to hopefully quickly winnow down
      * places where a pattern could start a match in the target string.  If it
      * doesn't really narrow things down that much, there isn't much point to
@@ -1345,8 +1346,6 @@ S_is_ssc_worth_it(const RExC_state_t * pRExC_state, const regnode_ssc * ssc)
                                   ? 128
                                   : NON_OTHER_COUNT);
     const U32 max_match = max_code_points / 2;
-
-    PERL_ARGS_ASSERT_IS_SSC_WORTH_IT;
 
     invlist_iterinit(ssc->invlist);
     while (invlist_iternext(ssc->invlist, &start, &end)) {
@@ -1449,6 +1448,8 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
                     OP *expr, const regexp_engine* eng, REGEXP *old_re,
                      bool *is_bare_re, const U32 orig_rx_flags, const U32 pm_flags)
 {
+    PERL_ARGS_ASSERT_RE_OP_COMPILE;
+
     REGEXP *Rx;         /* Capital 'R' means points to a REGEXP */
     STRLEN plen;
     char *exp;
@@ -1477,8 +1478,6 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     RExC_state_t copyRExC_state;
 #endif
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_RE_OP_COMPILE;
 
     DEBUG_r(if (!PL_colorset) reginitcolors());
 
@@ -2625,6 +2624,8 @@ S_reg_scan_name(pTHX_ RExC_state_t *pRExC_state, U32 flags)
 static void
 S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
 {
+    PERL_ARGS_ASSERT_PARSE_LPAREN_QUESTION_FLAGS;
+
     /* This parses the flags that are in either the '(?foo)' or '(?foo:bar)'
      * constructs, and updates RExC_flags with them.  On input, RExC_parse
      * should point to the first flag; it is updated on output to point to the
@@ -2646,8 +2647,6 @@ S_parse_lparen_question_flags(pTHX_ RExC_state_t *pRExC_state)
     bool has_use_defaults = false;
     const char* const seqstart = RExC_parse - 1; /* Point to the '?' */
     int x_mod_count = 0;
-
-    PERL_ARGS_ASSERT_PARSE_LPAREN_QUESTION_FLAGS;
 
     /* '^' as an initial flag sets certain defaults */
     if (UCHARAT(RExC_parse) == '^') {
@@ -2898,13 +2897,13 @@ S_handle_named_backref(pTHX_ RExC_state_t *pRExC_state,
                              char ch
                       )
 {
+    PERL_ARGS_ASSERT_HANDLE_NAMED_BACKREF;
+
     regnode_offset ret;
     char* name_start = RExC_parse;
     U32 num = 0;
     SV *sv_dat = reg_scan_name(pRExC_state, REG_RSN_RETURN_DATA);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_HANDLE_NAMED_BACKREF;
 
     if (RExC_parse != name_start && ch == '}') {
         while (isBLANK(*RExC_parse)) {
@@ -2968,7 +2967,6 @@ static regnode_offset
 S_reg_la_NOTHING(pTHX_ RExC_state_t *pRExC_state, U32 flags,
     const char *type)
 {
-
     PERL_ARGS_ASSERT_REG_LA_NOTHING;
 
     /* false below so we do not force /x */
@@ -3017,7 +3015,6 @@ static regnode_offset
 S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags,
     const char *type)
 {
-
     PERL_ARGS_ASSERT_REG_LA_OPFAIL;
 
     /* false so we don't force to /x below */;
@@ -3102,6 +3099,8 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
      * RExC_parse beyond the '('.  Things like '(?' are indivisible tokens, and
      * this flag alerts us to the need to check for that */
 {
+    PERL_ARGS_ASSERT_REG;
+
     regnode_offset ret = 0;    /* Will be the head of the group. */
     regnode_offset br;
     regnode_offset lastbr;
@@ -3132,7 +3131,6 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_REG;
     DEBUG_PARSE("reg ");
 
     max_open = get_sv(RE_COMPILE_RECURSION_LIMIT, GV_ADD);
@@ -4553,14 +4551,14 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
 static regnode_offset
 S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
 {
+    PERL_ARGS_ASSERT_REGBRANCH;
+
     regnode_offset ret;
     regnode_offset chain = 0;
     regnode_offset latest;
     regnode *branch_node = NULL;
     I32 flags = 0, c = 0;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGBRANCH;
 
     DEBUG_PARSE("brnc");
 
@@ -4629,6 +4627,8 @@ S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
 bool
 Perl_regcurly(const char *s, const char *e, const char * result[5])
 {
+    PERL_ARGS_ASSERT_REGCURLY;
+
     /* This function matches a {m,n} quantifier.  When called with a NULL final
      * argument, it simply parses the input from 's' up through 'e-1', and
      * returns a boolean as to whether or not this input is syntactically a
@@ -4667,8 +4667,6 @@ Perl_regcurly(const char *s, const char *e, const char * result[5])
     const char * max_end = NULL;
 
     bool has_comma = false;
-
-    PERL_ARGS_ASSERT_REGCURLY;
 
     if (s >= e || *s++ != '{')
         return false;
@@ -4747,6 +4745,8 @@ U32
 S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state,
                        const char * start, const char * end)
 {
+    PERL_ARGS_ASSERT_GET_QUANTIFIER_VALUE;
+
     /* This is a helper function for regpiece() to compute, given the
      * quantifier {m,n}, the value of either m or n, based on the starting
      * position 'start' in the string, through the byte 'end-1', returning it
@@ -4755,8 +4755,6 @@ S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state,
 
     UV uv;
     STATIC_ASSERT_DECL(REG_INFTY <= U32_MAX);
-
-    PERL_ARGS_ASSERT_GET_QUANTIFIER_VALUE;
 
     if (grok_atoUV(start, &uv, &end)) {
         if (uv < REG_INFTY) {   /* A valid, small-enough number */
@@ -4802,6 +4800,8 @@ S_get_quantifier_value(pTHX_ RExC_state_t *pRExC_state,
 static regnode_offset
 S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 {
+    PERL_ARGS_ASSERT_REGPIECE;
+
     regnode_offset ret;
     char op;
     I32 flags;
@@ -4814,8 +4814,6 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
     const regnode_offset orig_emit = RExC_emit;
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGPIECE;
 
     DEBUG_PARSE("piec");
 
@@ -5063,6 +5061,8 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
                 const U32 depth
     )
 {
+    PERL_ARGS_ASSERT_GROK_BSLASH_N;
+
  /* This routine teases apart the various meanings of \N and returns
   * accordingly.  The input parameters constrain which meaning(s) is/are valid
   * in the current context.
@@ -5152,8 +5152,6 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
     I32 flags;
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_GROK_BSLASH_N;
 
     assert(cBOOL(node_p) ^ cBOOL(code_point_p));  /* Exactly one should be set */
     assert(! (node_p && cp_count));               /* At most 1 should be set */
@@ -5510,9 +5508,9 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
 static U8
 S_compute_EXACTish(RExC_state_t *pRExC_state)
 {
-    U8 op;
-
     PERL_ARGS_ASSERT_COMPUTE_EXACTISH;
+
+    U8 op;
 
     if (! FOLD) {
         return (LOC)
@@ -5622,6 +5620,8 @@ S_backref_value(const char *p, const char *e, char **pe)
 static regnode_offset
 S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 {
+    PERL_ARGS_ASSERT_REGATOM;
+
     regnode_offset ret = 0;
     I32 flags = 0;
     char *atom_parse_start;
@@ -5633,8 +5633,6 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
     *flagp = 0;		/* Initialize. */
 
     DEBUG_PARSE("atom");
-
-    PERL_ARGS_ASSERT_REGATOM;
 
   tryagain:
     atom_parse_start = RExC_parse;
@@ -7627,12 +7625,12 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
 void
 Perl_populate_anyof_bitmap_from_invlist(pTHX_ regnode *node, SV** invlist_ptr)
 {
+    PERL_ARGS_ASSERT_POPULATE_ANYOF_BITMAP_FROM_INVLIST;
+
     /* Uses the inversion list '*invlist_ptr' to populate the ANYOF 'node'.  It
      * sets up the bitmap and any flags, removing those code points from the
      * inversion list, setting it to NULL should it become completely empty */
 
-
-    PERL_ARGS_ASSERT_POPULATE_ANYOF_BITMAP_FROM_INVLIST;
 
     /* There is no bitmap for this node type */
     if (REGNODE_TYPE(OP(node))  != ANYOF) {
@@ -7741,6 +7739,8 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
     const bool check_only      /* Don't die if error */
 )
 {
+    PERL_ARGS_ASSERT_HANDLE_POSSIBLE_POSIX;
+
     /* This parses what the caller thinks may be one of the three POSIX
      * constructs:
      *  1) a character class, like [:blank:]
@@ -7853,8 +7853,6 @@ S_handle_possible_posix(pTHX_ RExC_state_t *pRExC_state,
      * sizeof("alphanumeric") */
     UV input_text[15];
     STATIC_ASSERT_DECL(C_ARRAY_LENGTH(input_text) >= sizeof "alphanumeric");
-
-    PERL_ARGS_ASSERT_HANDLE_POSSIBLE_POSIX;
 
     CLEAR_POSIX_WARNINGS();
 
@@ -8543,6 +8541,8 @@ static regnode_offset
 S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV** return_invlist,
                     I32 *flagp, U32 depth)
 {
+    PERL_ARGS_ASSERT_HANDLE_REGEX_SETS;
+
     /* Handle the (?[...]) construct to do set operations */
 
     U8 curchar;                     /* Current character being parsed */
@@ -8568,8 +8568,6 @@ S_handle_regex_sets(pTHX_ RExC_state_t *pRExC_state, SV** return_invlist,
     const bool in_locale = LOC;     /* we turn off /l during processing */
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_HANDLE_REGEX_SETS;
 
     DEBUG_PARSE("xcls");
 
@@ -9286,6 +9284,8 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
 void
 Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV** invlist)
 {
+    PERL_ARGS_ASSERT_ADD_ABOVE_LATIN1_FOLDS;
+
     /* This adds the Latin1/above-Latin1 folding rules.
      *
      * This should be called only for a Latin1-range code points, cp, which is
@@ -9293,8 +9293,6 @@ Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV** i
      * Latin1.  It would give false results if /aa has been specified.
      * Multi-char folds are outside the scope of this, and must be handled
      * specially. */
-
-    PERL_ARGS_ASSERT_ADD_ABOVE_LATIN1_FOLDS;
 
     assert(HAS_NONLATIN1_SIMPLE_FOLD_CLOSURE(cp));
 
@@ -9376,13 +9374,13 @@ Perl_add_above_Latin1_folds(pTHX_ RExC_state_t *pRExC_state, const U8 cp, SV** i
 static void
 S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV* posix_warnings)
 {
+    PERL_ARGS_ASSERT_OUTPUT_POSIX_WARNINGS;
+
     /* Output the elements of the array given by '*posix_warnings' as REGEXP
      * warnings. */
 
     SV * msg;
     const bool first_is_fatal = ckDEAD(packWARN(WARN_REGEXP));
-
-    PERL_ARGS_ASSERT_OUTPUT_POSIX_WARNINGS;
 
     if (! TO_OUTPUT_WARNINGS(RExC_parse)) {
         CLEAR_POSIX_WARNINGS();
@@ -9406,10 +9404,10 @@ S_output_posix_warnings(pTHX_ RExC_state_t *pRExC_state, AV* posix_warnings)
 PERL_STATIC_INLINE Size_t
 S_find_first_differing_byte_pos(const U8 * s1, const U8 * s2, const Size_t max)
 {
+    PERL_ARGS_ASSERT_FIND_FIRST_DIFFERING_BYTE_POS;
+
     const U8 * const start = s1;
     const U8 * const send = start + max;
-
-    PERL_ARGS_ASSERT_FIND_FIRST_DIFFERING_BYTE_POS;
 
     while (s1 < send && *s1  == *s2) {
         s1++; s2++;
@@ -9421,6 +9419,8 @@ S_find_first_differing_byte_pos(const U8 * s1, const U8 * s2, const Size_t max)
 static AV *
 S_add_multi_match(pTHX_ AV* multi_char_matches, SV* multi_string, const STRLEN cp_count)
 {
+    PERL_ARGS_ASSERT_ADD_MULTI_MATCH;
+
     /* This adds the string scalar <multi_string> to the array
      * <multi_char_matches>.  <multi_string> is known to have exactly
      * <cp_count> code points in it.  This is used when constructing a
@@ -9444,8 +9444,6 @@ S_add_multi_match(pTHX_ AV* multi_char_matches, SV* multi_string, const STRLEN c
 
     AV* this_array;
     AV** this_array_ptr;
-
-    PERL_ARGS_ASSERT_ADD_MULTI_MATCH;
 
     if (! multi_char_matches) {
         multi_char_matches = newAV();
@@ -9533,6 +9531,9 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
                  SV** ret_invlist  /* Return an inversion list, not a node */
           )
 {
+    PERL_ARGS_ASSERT_REGCLASS;
+    assert(! (ret_invlist && allow_mutiple_chars));
+
     /* parse a bracketed class specification.  Most of these will produce an
      * ANYOF node; but something like [a] will produce an EXACT node; [aA], an
      * EXACTFish node; [[:ascii:]], a POSIXA node; etc.  It is more complex
@@ -9660,11 +9661,9 @@ S_regclass(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth,
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_REGCLASS;
 #ifndef DEBUGGING
     PERL_UNUSED_ARG(depth);
 #endif
-
     assert(! (ret_invlist && allow_mutiple_chars));
 
     /* If wants an inversion list returned, we can't optimize to something
@@ -11420,6 +11419,8 @@ S_optimize_regclass(pTHX_
                     I32 *flagp
                   )
 {
+    PERL_ARGS_ASSERT_OPTIMIZE_REGCLASS;
+
     /* This function exists just to make S_regclass() smaller.  It extracts out
      * the code that looks for potential optimizations away from a full generic
      * ANYOF node.  The parameter names are the same as the corresponding
@@ -11441,8 +11442,6 @@ S_optimize_regclass(pTHX_
     UV   end[MAX_FOLD_FROMS+1] = { 0 };
     bool single_range = false;
     UV lowest_cp = 0, highest_cp = 0;
-
-    PERL_ARGS_ASSERT_OPTIMIZE_REGCLASS;
 
     if (cp_list) { /* Count the code points in enough ranges that we would see
                       all the ones possible in any fold in this version of
@@ -12354,6 +12353,8 @@ Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
                 SV* const runtime_defns,
                 SV* const only_utf8_locale_list)
 {
+    PERL_ARGS_ASSERT_SET_ANYOF_ARG;
+
     /* Sets the arg field of an ANYOF-type node 'node', using information about
      * the node passed-in.  If only the bitmap is needed to determine what
      * matches, the arg is set appropriately to either
@@ -12371,8 +12372,6 @@ Perl_set_ANYOF_arg(pTHX_ RExC_state_t* const pRExC_state,
      *        definitions aren't known at this time, or no entry if none. */
 
     UV n;
-
-    PERL_ARGS_ASSERT_SET_ANYOF_ARG;
 
     /* If this is set, the final disposition won't be known until runtime, so
      * we can't do any of the compile time optimizations */
@@ -12514,6 +12513,14 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
 #endif
 
 {
+
+#if !defined(PERL_IN_XSUB_RE) || defined(PLUGGABLE_RE_EXTENSION)
+    PERL_ARGS_ASSERT_GET_REGCLASS_AUX_DATA;
+#else
+    PERL_ARGS_ASSERT_GET_RE_GCLASS_AUX_DATA;
+#endif
+    assert(! output_invlist || listsvp);
+
     /* For internal core use only.
      * Returns the inversion list for the input 'node' in the regex 'prog'.
      * If <doinit> is 'true', will attempt to create the inversion list if not
@@ -12549,13 +12556,6 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const regnode* node, bool 
 
     RXi_GET_DECL_NULL(prog, progi);
     const struct reg_data * const data = prog ? progi->data : NULL;
-
-#if !defined(PERL_IN_XSUB_RE) || defined(PLUGGABLE_RE_EXTENSION)
-    PERL_ARGS_ASSERT_GET_REGCLASS_AUX_DATA;
-#else
-    PERL_ARGS_ASSERT_GET_RE_GCLASS_AUX_DATA;
-#endif
-    assert(! output_invlist || listsvp);
 
     if (data && data->count) {
         const U32 n = ARG1u(node);
@@ -12897,14 +12897,14 @@ S_skip_to_be_ignored_text(pTHX_ RExC_state_t *pRExC_state,
                                 const bool force_to_xmod
                          )
 {
+    PERL_ARGS_ASSERT_SKIP_TO_BE_IGNORED_TEXT;
+
     /* If the text at the current parse position '*p' is a '(?#...)' comment,
      * or if we are under /x or 'force_to_xmod' is true, and the text at '*p'
      * is /x whitespace, advance '*p' so that on exit it points to the first
      * byte past all such white space and comments */
 
     const bool use_xmod = force_to_xmod || (RExC_flags & RXf_PMf_EXTENDED);
-
-    PERL_ARGS_ASSERT_SKIP_TO_BE_IGNORED_TEXT;
 
     assert( ! UTF || UTF8_IS_INVARIANT(**p) || UTF8_IS_START(**p));
 
@@ -12982,11 +12982,11 @@ S_nextchar(pTHX_ RExC_state_t *pRExC_state)
 static void
 S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size)
 {
+    PERL_ARGS_ASSERT_CHANGE_ENGINE_SIZE;
+
     /* 'size' is the delta number of smallest regnode equivalents to add or
      * subtract from the current memory allocated to the regex engine being
      * constructed. */
-
-    PERL_ARGS_ASSERT_CHANGE_ENGINE_SIZE;
 
     RExC_size += size;
 
@@ -13008,6 +13008,8 @@ S_change_engine_size(pTHX_ RExC_state_t *pRExC_state, const ptrdiff_t size)
 static regnode_offset
 S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
 {
+    PERL_ARGS_ASSERT_REGNODE_GUTS;
+
     /* Allocate a regnode that is (1 + extra_size) times as big as the
      * smallest regnode worth of space, and also aligns and increments
      * RExC_size appropriately.
@@ -13015,8 +13017,6 @@ S_regnode_guts(pTHX_ RExC_state_t *pRExC_state, const STRLEN extra_size)
      * It returns the regnode's offset into the regex engine program */
 
     const regnode_offset ret = RExC_emit;
-
-    PERL_ARGS_ASSERT_REGNODE_GUTS;
 
     SIZE_ALIGN(RExC_size);
     change_engine_size(pRExC_state, (ptrdiff_t) 1 + extra_size);
@@ -13044,10 +13044,10 @@ S_regnode_guts_debug(pTHX_ RExC_state_t *pRExC_state, const U8 op, const STRLEN 
 static regnode_offset /* Location. */
 S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
 {
+    PERL_ARGS_ASSERT_REG_NODE;
+
     const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
-
-    PERL_ARGS_ASSERT_REG_NODE;
 
     assert(REGNODE_ARG_LEN(op) == 0);
 
@@ -13062,10 +13062,10 @@ S_reg_node(pTHX_ RExC_state_t *pRExC_state, U8 op)
 static regnode_offset /* Location. */
 S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
 {
+    PERL_ARGS_ASSERT_REG1NODE;
+
     const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
-
-    PERL_ARGS_ASSERT_REG1NODE;
 
     /* ANYOF are special cased to allow non-length 1 args */
     assert(REGNODE_ARG_LEN(op) == 1);
@@ -13081,10 +13081,10 @@ S_reg1node(pTHX_ RExC_state_t *pRExC_state, U8 op, U32 arg)
 static regnode_offset /* Location. */
 S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV * arg)
 {
+    PERL_ARGS_ASSERT_REGPNODE;
+
     const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
-
-    PERL_ARGS_ASSERT_REGPNODE;
 
     FILL_ADVANCE_NODE_ARGp(ptr, op, arg);
     RExC_emit = ptr;
@@ -13094,12 +13094,12 @@ S_regpnode(pTHX_ RExC_state_t *pRExC_state, U8 op, SV * arg)
 static regnode_offset
 S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I32 arg2)
 {
+    PERL_ARGS_ASSERT_REG2NODE;
+
     /* emit a node with U32 and I32 arguments */
 
     const regnode_offset ret = REGNODE_GUTS(pRExC_state, op, REGNODE_ARG_LEN(op));
     regnode_offset ptr = ret;
-
-    PERL_ARGS_ASSERT_REG2NODE;
 
     assert(REGNODE_ARG_LEN(op) == 2);
 
@@ -13126,6 +13126,8 @@ static void
 S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
                   const regnode_offset operand, const U32 depth)
 {
+    PERL_ARGS_ASSERT_REGINSERT;
+
     regnode *src;
     regnode *dst;
     regnode *place;
@@ -13133,7 +13135,6 @@ S_reginsert(pTHX_ RExC_state_t *pRExC_state, const U8 op,
     const int size = NODE_STEP_REGNODE + offset;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_REGINSERT;
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(depth);
     DEBUG_PARSE_FMT("inst"," - %s", REGNODE_NAME(op));
@@ -13201,14 +13202,14 @@ S_regtail(pTHX_ RExC_state_t * pRExC_state,
                 const regnode_offset val,
                 const U32 depth)
 {
+    PERL_ARGS_ASSERT_REGTAIL;
+
     regnode_offset scan;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_REGTAIL;
 #ifndef DEBUGGING
     PERL_UNUSED_ARG(depth);
 #endif
-
     /* The final node in the chain is the first one with a nonzero next pointer
      * */
     scan = (regnode_offset) p;
@@ -13273,14 +13274,14 @@ static bool
 S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
                       const regnode_offset val, U32 depth)
 {
+    PERL_ARGS_ASSERT_REGTAIL_STUDY;
+
     regnode_offset scan;
     U8 exact = PSEUDO;
 #ifdef EXPERIMENTAL_INPLACESCAN
     I32 min = 0;
 #endif
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGTAIL_STUDY;
 
 
     /* Find last node. */
@@ -13353,6 +13354,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
 SV*
 Perl_get_ANYOFM_contents(pTHX_ const regnode * n)
 {
+    PERL_ARGS_ASSERT_GET_ANYOFM_CONTENTS;
 
     /* Returns an inversion list of all the code points matched by the
      * ANYOFM/NANYOFM node 'n' */
@@ -13362,8 +13364,6 @@ Perl_get_ANYOFM_contents(pTHX_ const regnode * n)
     unsigned int i;
     U8 count = 0;
     U8 needed = 1U << PL_bitcount[ (U8) ~ FLAGS(n)];
-
-    PERL_ARGS_ASSERT_GET_ANYOFM_CONTENTS;
 
     /* Starting with the lowest code point, any code point that ANDed with the
      * mask yields the lowest code point is in the set */
@@ -13463,10 +13463,10 @@ Perl_pregfree(pTHX_ REGEXP *r)
 void
 Perl_pregfree2(pTHX_ REGEXP *rx)
 {
+    PERL_ARGS_ASSERT_PREGFREE2;
+
     struct regexp *const r = ReANY(rx);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_PREGFREE2;
 
     if (! r)
         return;
@@ -13529,11 +13529,11 @@ Perl_pregfree2(pTHX_ REGEXP *rx)
 REGEXP *
 Perl_reg_temp_copy(pTHX_ REGEXP *dsv, REGEXP *ssv)
 {
+    PERL_ARGS_ASSERT_REG_TEMP_COPY;
+
     struct regexp *drx;
     struct regexp *const srx = ReANY(ssv);
     const bool islv = dsv && SvTYPE(dsv) == SVt_PVLV;
-
-    PERL_ARGS_ASSERT_REG_TEMP_COPY;
 
     if (!dsv)
         dsv = (REGEXP*) newSV_type(SVt_REGEXP);
@@ -13659,11 +13659,11 @@ Perl_reg_temp_copy(pTHX_ REGEXP *dsv, REGEXP *ssv)
 void
 Perl_regfree_internal(pTHX_ REGEXP * const rx)
 {
+    PERL_ARGS_ASSERT_REGFREE_INTERNAL;
+
     struct regexp *const r = ReANY(rx);
     RXi_GET_DECL(r, ri);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGFREE_INTERNAL;
 
     if (! ri) {
         return;
@@ -13796,11 +13796,11 @@ any duplication they need to do.
 void
 Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
 {
+    PERL_ARGS_ASSERT_RE_DUP_GUTS;
+
     I32 npar;
     const struct regexp *r = ReANY(sstr);
     struct regexp *ret = ReANY(dstr);
-
-    PERL_ARGS_ASSERT_RE_DUP_GUTS;
 
     npar = r->nparens+1;
     NewCopy(RXp_OFFSp(r), RXp_OFFSp(ret), npar, regexp_paren_pair);
@@ -13910,12 +13910,12 @@ Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
 void *
 Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
 {
+    PERL_ARGS_ASSERT_REGDUPE_INTERNAL;
+
     struct regexp *const r = ReANY(rx);
     regexp_internal *reti;
     int len;
     RXi_GET_DECL(r, ri);
-
-    PERL_ARGS_ASSERT_REGDUPE_INTERNAL;
 
     len = ProgLen(ri);
 
@@ -14041,13 +14041,13 @@ Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
 static void
 S_re_croak(pTHX_ bool utf8, const char* pat,...)
 {
+    PERL_ARGS_ASSERT_RE_CROAK;
+
     va_list args;
     STRLEN len = strlen(pat);
     char buf[512];
     SV *msv;
     const char *message;
-
-    PERL_ARGS_ASSERT_RE_CROAK;
 
     if (len > 510)
         len = 510;
@@ -14287,6 +14287,8 @@ static REGEXP *
 S_compile_wildcard(pTHX_ const char * subpattern, const STRLEN len,
                          const bool ignore_case)
 {
+    PERL_ARGS_ASSERT_COMPILE_WILDCARD;
+
     /* Pretends that the input subpattern is qr/subpattern/aam, compiling it
      * possibly with /i if the 'ignore_case' parameter is true.  Use /aa
      * because nothing outside of ASCII will match.  Use /m because the input
@@ -14299,8 +14301,6 @@ S_compile_wildcard(pTHX_ const char * subpattern, const STRLEN len,
     SV * subpattern_sv = newSVpvn_flags(subpattern, len, SVs_TEMP);
     REGEXP * subpattern_re;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_COMPILE_WILDCARD;
 
     if (ignore_case) {
         flags |= PMf_FOLD;
@@ -14359,10 +14359,10 @@ static I32
 S_execute_wildcard(pTHX_ REGEXP * const prog, char* stringarg, char *strend,
          char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
 {
+    PERL_ARGS_ASSERT_EXECUTE_WILDCARD;
+
     I32 result;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_EXECUTE_WILDCARD;
 
     ENTER;
 
@@ -14419,6 +14419,8 @@ S_handle_user_defined_property(pTHX_
                                    this */
     const STRLEN level)         /* Recursion level of this call */
 {
+    PERL_ARGS_ASSERT_HANDLE_USER_DEFINED_PROPERTY;
+
     STRLEN len;
     const char * string         = SvPV_const(contents, len);
     const char * const e        = string + len;
@@ -14429,8 +14431,6 @@ S_handle_user_defined_property(pTHX_
                                    being parsed in 'string' */
     const char * const overflow_msg = "Code point too large in \"";
     SV* running_definition = NULL;
-
-    PERL_ARGS_ASSERT_HANDLE_USER_DEFINED_PROPERTY;
 
     *user_defined_ptr = true;
 
@@ -14794,6 +14794,8 @@ S_parse_uniprop_string(pTHX_
                                    this */
     const STRLEN level)         /* Recursion level of this call */
 {
+    PERL_ARGS_ASSERT_PARSE_UNIPROP_STRING;
+
     char* lookup_name;          /* normalized name for lookup in our tables */
     unsigned lookup_len;        /* Its length */
     enum { Not_Strict = 0,      /* Some properties have stricter name */
@@ -14838,8 +14840,6 @@ S_parse_uniprop_string(pTHX_
      * we've seen that marker.  If not, what we're parsing can't be such an
      * official Unicode property whose expansion was deferred */
     bool could_be_deferred_official = false;
-
-    PERL_ARGS_ASSERT_PARSE_UNIPROP_STRING;
 
     /* The input will be normalized into 'lookup_name' */
     Newx(lookup_name, name_len, char);
@@ -16191,6 +16191,8 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
                               SV ** prop_definition,
                               AV ** strings)
 {
+    PERL_ARGS_ASSERT_HANDLE_NAMES_WILDCARD;
+
     /* Deal with Name property wildcard subpatterns; returns true if there were
      * any matches, adding them to prop_definition */
 
@@ -16222,8 +16224,6 @@ S_handle_names_wildcard(pTHX_ const char * wname, /* wildcard name to match */
     const STRLEN syl_max_len = hangul_prefix_len + 7;
 
     IV i;
-
-    PERL_ARGS_ASSERT_HANDLE_NAMES_WILDCARD;
 
     /* Make sure _charnames is loaded.  (The parameters give context
      * for any errors generated */

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -22,10 +22,11 @@
 int
 Perl_re_printf(pTHX_ const char *fmt, ...)
 {
+    PERL_ARGS_ASSERT_RE_PRINTF;
+
     va_list ap;
     int result;
     PerlIO *f= Perl_debug_log;
-    PERL_ARGS_ASSERT_RE_PRINTF;
     va_start(ap, fmt);
     result = PerlIO_vprintf(f, fmt, ap);
     va_end(ap);
@@ -35,10 +36,11 @@ Perl_re_printf(pTHX_ const char *fmt, ...)
 int
 Perl_re_indentf(pTHX_ const char *fmt, U32 depth, ...)
 {
+    PERL_ARGS_ASSERT_RE_INDENTF;
+
     va_list ap;
     int result;
     PerlIO *f= Perl_debug_log;
-    PERL_ARGS_ASSERT_RE_INDENTF;
     va_start(ap, depth);
     PerlIO_printf(f, "%*s", ( (int)depth % 20 ) * 2, "");
     result = PerlIO_vprintf(f, fmt, ap);
@@ -163,13 +165,13 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
             const regnode *last, const regnode *plast,
             SV* sv, I32 indent, U32 depth)
 {
+    PERL_ARGS_ASSERT_DUMPUNTIL;
+
     const regnode *next;
     const regnode *optstart= NULL;
 
     RXi_GET_DECL(r, ri);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_DUMPUNTIL;
 
 #ifdef DEBUG_DUMPUNTIL
     Perl_re_printf( aTHX_  "--- %d : %d - %d - %d\n", indent, node-start,
@@ -392,6 +394,8 @@ S_regdump_extflags(pTHX_ const char *lead, const U32 flags)
 void
 Perl_regdump(pTHX_ const regexp *r)
 {
+    PERL_ARGS_ASSERT_REGDUMP;
+
 #ifdef DEBUGGING
     int i;
     SV * const sv = sv_newmortal();
@@ -475,10 +479,10 @@ Perl_regdump(pTHX_ const regexp *r)
         regdump_intflags("r->intflags: ", r->intflags);
     });
 #else
-    PERL_ARGS_ASSERT_REGDUMP;
     PERL_UNUSED_CONTEXT;
     PERL_UNUSED_ARG(r);
 #endif  /* DEBUGGING */
+
 }
 
 /* Should be synchronized with ANYOF_ #defines in regcomp.h */
@@ -535,13 +539,13 @@ static const char * const anyofs[] = {
 void
 Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_info *reginfo, const RExC_state_t *pRExC_state)
 {
+    PERL_ARGS_ASSERT_REGPROP;
+
 #ifdef DEBUGGING
     U8 k;
     const U8 op = OP(o);
     RXi_GET_DECL(prog, progi);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGPROP;
 
     SvPVCLEAR(sv);
 
@@ -1089,6 +1093,8 @@ S_put_code_point(pTHX_ SV *sv, UV c)
 static void
 S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
 {
+    PERL_ARGS_ASSERT_PUT_RANGE;
+
     /* Appends to 'sv' a displayable version of the range of code points from
      * 'start' to 'end'.  Mnemonics (like '\r') are used for the few controls
      * that have them, when they occur at the beginning or end of the range.
@@ -1103,8 +1109,6 @@ S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
     const unsigned int min_range_count = 3;
 
     assert(start <= end);
-
-    PERL_ARGS_ASSERT_PUT_RANGE;
 
     while (start <= end) {
         UV this_end;
@@ -1271,13 +1275,13 @@ S_put_range(pTHX_ SV *sv, UV start, const UV end, const bool allow_literals)
 static void
 S_put_charclass_bitmap_innards_invlist(pTHX_ SV *sv, SV* invlist)
 {
+    PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_INVLIST;
+
     /* Concatenate onto the PV in 'sv' a displayable form of the inversion list
      * 'invlist' */
 
     UV start, end;
     bool allow_literals = true;
-
-    PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_INVLIST;
 
     /* Generally, it is more readable if printable characters are output as
      * literals, but if a range (nearly) spans all of them, it's best to output
@@ -1333,14 +1337,14 @@ S_put_charclass_bitmap_innards_common(pTHX_
         const bool invert       /* Is the result to be inverted? */
 )
 {
+    PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_COMMON;
+
     /* Create and return an SV containing a displayable version of the bitmap
      * and associated information determined by the input parameters.  If the
      * output would have been only the inversion indicator '^', NULL is instead
      * returned. */
 
     SV * output;
-
-    PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_COMMON;
 
     if (invert) {
         output = newSVpvs("^");
@@ -1411,6 +1415,8 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
                                      const U8 flags,
                                      const bool force_as_is_display)
 {
+    PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS;
+
     /* Appends to 'sv' a displayable version of the innards of the bracketed
      * character class defined by the other arguments:
      *  'bitmap' points to the bitmap, or NULL if to ignore that.
@@ -1470,8 +1476,6 @@ S_put_charclass_bitmap_innards(pTHX_ SV *sv,
     /* We are biased in favor of displaying things without them being inverted,
      * as that is generally easier to understand */
     const int bias = 5;
-
-    PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS;
 
     /* Start off with whatever code points are passed in.  (We clone, so we
      * don't change the caller's list) */

--- a/regcomp_invlist.c
+++ b/regcomp_invlist.c
@@ -135,6 +135,8 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 * bitmap, const Size_t bitmap_l
 PERL_STATIC_INLINE UV*
 S_invlist_array_init_(SV* const invlist, const bool will_have_0)
 {
+    PERL_ARGS_ASSERT_INVLIST_ARRAY_INIT_;
+
     /* Returns a pointer to the first element in the inversion list's array.
      * This is called upon initialization of an inversion list.  Where the
      * array begins depends on whether the list has the code point U+0000 in it
@@ -145,8 +147,6 @@ S_invlist_array_init_(SV* const invlist, const bool will_have_0)
 
     bool* offset = get_invlist_offset_addr(invlist);
     UV* zero_addr = (UV *) SvPVX(invlist);
-
-    PERL_ARGS_ASSERT_INVLIST_ARRAY_INIT_;
 
     /* Must be empty */
     assert(! invlist_len_(invlist));
@@ -161,6 +161,8 @@ S_invlist_array_init_(SV* const invlist, const bool will_have_0)
 static void
 S_invlist_replace_list_destroys_src(pTHX_ SV * dest, SV * src)
 {
+    PERL_ARGS_ASSERT_INVLIST_REPLACE_LIST_DESTROYS_SRC;
+
     /* Replaces the inversion list in 'dest' with the one from 'src'.  It
      * steals the list from 'src', so 'src' is made to have a NULL list.  This
      * is similar to what SvSetMagicSV() would do, if it were implemented on
@@ -174,8 +176,6 @@ S_invlist_replace_list_destroys_src(pTHX_ SV * dest, SV * src)
 #ifndef NO_TAINT_SUPPORT
     const int oldtainted = TAINT_get;
 #endif
-
-    PERL_ARGS_ASSERT_INVLIST_REPLACE_LIST_DESTROYS_SRC;
 
     assert(is_invlist(src));
     assert(is_invlist(dest));
@@ -209,9 +209,10 @@ S_invlist_replace_list_destroys_src(pTHX_ SV * dest, SV * src)
 PERL_STATIC_INLINE IV*
 S_get_invlist_previous_index_addr(SV* invlist)
 {
+    PERL_ARGS_ASSERT_GET_INVLIST_PREVIOUS_INDEX_ADDR;
+
     /* Return the address of the IV that is reserved to hold the cached index
      * */
-    PERL_ARGS_ASSERT_GET_INVLIST_PREVIOUS_INDEX_ADDR;
 
     assert(is_invlist(invlist));
 
@@ -221,9 +222,9 @@ S_get_invlist_previous_index_addr(SV* invlist)
 PERL_STATIC_INLINE IV
 S_invlist_previous_index(SV* const invlist)
 {
-    /* Returns cached index of previous search */
-
     PERL_ARGS_ASSERT_INVLIST_PREVIOUS_INDEX;
+
+    /* Returns cached index of previous search */
 
     return *get_invlist_previous_index_addr(invlist);
 }
@@ -231,9 +232,9 @@ S_invlist_previous_index(SV* const invlist)
 PERL_STATIC_INLINE void
 S_invlist_set_previous_index(SV* const invlist, const IV index)
 {
-    /* Caches <index> for later retrieval */
-
     PERL_ARGS_ASSERT_INVLIST_SET_PREVIOUS_INDEX;
+
+    /* Caches <index> for later retrieval */
 
     assert(index == 0 || index < (int) invlist_len_(invlist));
 
@@ -243,6 +244,8 @@ S_invlist_set_previous_index(SV* const invlist, const IV index)
 PERL_STATIC_INLINE void
 S_invlist_trim(SV* invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_TRIM;
+
     /* Free the not currently-being-used space in an inversion list */
 
     /* But don't free up the space needed for the 0 UV that is always at the
@@ -251,8 +254,6 @@ S_invlist_trim(SV* invlist)
      * the malloc implementation in use. */
 
     const STRLEN min_size = MAX(PERL_STRLEN_NEW_MIN, TO_INTERNAL_SIZE(1) + 1);
-
-    PERL_ARGS_ASSERT_INVLIST_TRIM;
 
     assert(is_invlist(invlist));
 
@@ -296,10 +297,10 @@ S_invlist_clear(pTHX_ SV* invlist)    /* Empty the inversion list */
 PERL_STATIC_INLINE UV
 S_invlist_max(const SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_MAX;
+
     /* Returns the maximum number of elements storable in the inversion list's
      * array, without having to realloc() */
-
-    PERL_ARGS_ASSERT_INVLIST_MAX;
 
     assert(is_invlist(invlist));
 
@@ -352,6 +353,8 @@ Perl_new_invlist_(pTHX_ IV initial_size)
 SV*
 Perl_new_invlist_C_array_(pTHX_ const UV* const list)
 {
+    PERL_ARGS_ASSERT_NEW_INVLIST_C_ARRAY_;
+
     /* Return a pointer to a newly constructed inversion list, initialized to
      * point to <list>, which has to be in the exact correct inversion list
      * form, including internal fields.  Thus this is a dangerous routine that
@@ -374,8 +377,6 @@ Perl_new_invlist_C_array_(pTHX_ const UV* const list)
                                        */
 
     SV* invlist = newSV_type(SVt_INVLIST);
-
-    PERL_ARGS_ASSERT_NEW_INVLIST_C_ARRAY_;
 
     if (version_id != INVLIST_VERSION_ID) {
         croak("panic: Incorrect version for previously generated inversion list");
@@ -410,6 +411,8 @@ static void
 S_append_range_to_invlist_(pTHX_ SV* const invlist,
                                  const UV start, const UV end)
 {
+    PERL_ARGS_ASSERT_APPEND_RANGE_TO_INVLIST_;
+
    /* Subject to change or removal.  Append the range from 'start' to 'end' at
     * the end of the inversion list.  The range must be above any existing
     * ones. */
@@ -418,8 +421,6 @@ S_append_range_to_invlist_(pTHX_ SV* const invlist,
     UV max = invlist_max(invlist);
     UV len = invlist_len_(invlist);
     bool offset;
-
-    PERL_ARGS_ASSERT_APPEND_RANGE_TO_INVLIST_;
 
     if (len == 0) { /* Empty lists must be initialized */
         offset = start != 0;
@@ -497,6 +498,8 @@ S_append_range_to_invlist_(pTHX_ SV* const invlist,
 SSize_t
 Perl_invlist_search_(SV* const invlist, const UV cp)
 {
+    PERL_ARGS_ASSERT_INVLIST_SEARCH_;
+
     /* Searches the inversion list for the entry that contains the input code
      * point <cp>.  If <cp> is not in the list, -1 is returned.  Otherwise, the
      * return value is the index into the list's array of the range that
@@ -509,8 +512,6 @@ Perl_invlist_search_(SV* const invlist, const UV cp)
     IV high = invlist_len_(invlist);
     const IV highest_element = high - 1;
     const UV* array;
-
-    PERL_ARGS_ASSERT_INVLIST_SEARCH_;
 
     /* If list is empty, return failure. */
     if (UNLIKELY(high == 0)) {
@@ -591,6 +592,8 @@ void
 Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV* const a, SV* const b,
                                          const bool complement_b, SV** output)
 {
+    PERL_ARGS_ASSERT_INVLIST_UNION_MAYBE_COMPLEMENT_2ND_;
+
     /* Take the union of two inversion lists and point '*output' to it.  On
      * input, '*output' MUST POINT TO NULL OR TO AN SV* INVERSION LIST (possibly
      * even 'a' or 'b').  If to an inversion list, the contents of the original
@@ -629,7 +632,6 @@ Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV* const a, SV* const b,
      * inputs are in their sets.  */
     UV count = 0;
 
-    PERL_ARGS_ASSERT_INVLIST_UNION_MAYBE_COMPLEMENT_2ND_;
     assert(a != b);
     assert(*output == NULL || is_invlist(*output));
 
@@ -869,6 +871,8 @@ void
 Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV* const a, SV* const b,
                                                const bool complement_b, SV** i)
 {
+    PERL_ARGS_ASSERT_INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND_;
+
     /* Take the intersection of two inversion lists and point '*i' to it.  On
      * input, '*i' MUST POINT TO NULL OR TO AN SV* INVERSION LIST (possibly
      * even 'a' or 'b').  If to an inversion list, the contents of the original
@@ -907,7 +911,6 @@ Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV* const a, SV* const b,
      * Only when it is 2 are we in the intersection. */
     UV count = 0;
 
-    PERL_ARGS_ASSERT_INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND_;
     assert(a != b);
     assert(*i == NULL || is_invlist(*i));
 
@@ -1369,6 +1372,8 @@ SV*
 Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0,
                                  UV** other_elements_ptr)
 {
+    PERL_ARGS_ASSERT_SETUP_CANNED_INVLIST_;
+
     /* Create and return an inversion list whose contents are to be populated
      * by the caller.  The caller gives the number of elements (in 'size') and
      * the very first element ('element0').  This function will set
@@ -1384,8 +1389,6 @@ Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0,
     SV* invlist = new_invlist_(size);
     bool offset;
 
-    PERL_ARGS_ASSERT_SETUP_CANNED_INVLIST_;
-
     invlist = add_cp_to_invlist(invlist, element0);
     offset = *get_invlist_offset_addr(invlist);
 
@@ -1400,11 +1403,11 @@ Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0,
 void
 Perl_invlist_invert_(pTHX_ SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_INVERT_;
+
     /* Complement the input inversion list.  This adds a 0 if the list didn't
      * have a zero; removes it otherwise.  As described above, the data
      * structure is set up so that this is very efficient */
-
-    PERL_ARGS_ASSERT_INVLIST_INVERT_;
 
     assert(! invlist_is_iterating(invlist));
 
@@ -1420,14 +1423,14 @@ Perl_invlist_invert_(pTHX_ SV* const invlist)
 SV*
 Perl_invlist_clone(pTHX_ SV* const invlist, SV* new_invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_CLONE;
+
     /* Return a new inversion list that is a copy of the input one, which is
      * unchanged.  The new list will not be mortal even if the old one was. */
 
     const STRLEN nominal_length = invlist_len_(invlist);
     const STRLEN physical_length = SvCUR(invlist);
     const bool offset = *(get_invlist_offset_addr(invlist));
-
-    PERL_ARGS_ASSERT_INVLIST_CLONE;
 
     if (new_invlist == NULL) {
         new_invlist = new_invlist_(nominal_length);
@@ -1452,6 +1455,8 @@ void
 Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level,
                          const char * const indent, SV* const invlist)
 {
+    PERL_ARGS_ASSERT_INVLIST_DUMP_;
+
     /* Designed to be called only by do_sv_dump().  Dumps out the ranges of the
      * inversion list 'invlist' to 'file' at 'level'  Each line is prefixed by
      * the string 'indent'.  The output looks like this:
@@ -1468,8 +1473,6 @@ Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level,
 
     UV start, end;
     STRLEN count = 0;
-
-    PERL_ARGS_ASSERT_INVLIST_DUMP_;
 
     if (invlist_is_iterating(invlist)) {
         Perl_dump_indent(aTHX_ level, file,
@@ -1504,6 +1507,8 @@ Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level,
 bool
 Perl_invlistEQ_(pTHX_ SV* const a, SV* const b, const bool complement_b)
 {
+    PERL_ARGS_ASSERT_INVLISTEQ_;
+
     /* Return a boolean as to if the two passed in inversion lists are
      * identical.  The final argument, if true, says to take the complement of
      * the second inversion list before doing the comparison */
@@ -1513,8 +1518,6 @@ Perl_invlistEQ_(pTHX_ SV* const a, SV* const b, const bool complement_b)
 
     const UV* array_a = NULL;
     const UV* array_b = NULL;
-
-    PERL_ARGS_ASSERT_INVLISTEQ_;
 
     /* This code avoids accessing the arrays unless it knows the length is
      * non-zero */

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -84,13 +84,13 @@ S_rck_elide_nothing(pTHX_ regnode *node)
 static SV*
 S_make_exactf_invlist(pTHX_ RExC_state_t *pRExC_state, regnode *node)
 {
+    PERL_ARGS_ASSERT_MAKE_EXACTF_INVLIST;
+
     const U8 * s = (U8*)STRING(node);
     SSize_t bytelen = STR_LEN(node);
     UV uc;
     /* Start out big enough for 2 separate code points */
     SV* invlist = new_invlist_(4);
-
-    PERL_ARGS_ASSERT_MAKE_EXACTF_INVLIST;
 
     if (! UTF) {
         uc = *s;
@@ -252,12 +252,12 @@ void
 Perl_scan_commit(pTHX_ const RExC_state_t *pRExC_state, scan_data_t *data,
                     SSize_t *minlenp, int is_inf)
 {
+    PERL_ARGS_ASSERT_SCAN_COMMIT;
+
     const STRLEN l = CHR_SVLEN(data->last_found);
     SV * const longest_sv = data->substrs[data->cur_is_floating].str;
     const STRLEN old_l = CHR_SVLEN(longest_sv);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_SCAN_COMMIT;
 
     if ((l >= old_l) && ((l > old_l) || (data->flags & SF_BEFORE_EOL))) {
         const U8 i = data->cur_is_floating;
@@ -303,9 +303,9 @@ Perl_scan_commit(pTHX_ const RExC_state_t *pRExC_state, scan_data_t *data,
 static void
 S_ssc_anything(pTHX_ regnode_ssc *ssc)
 {
-    /* Set the SSC 'ssc' to match an empty string or any code point */
-
     PERL_ARGS_ASSERT_SSC_ANYTHING;
+
+    /* Set the SSC 'ssc' to match an empty string or any code point */
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -317,6 +317,8 @@ S_ssc_anything(pTHX_ regnode_ssc *ssc)
 static int
 S_ssc_is_anything(const regnode_ssc *ssc)
 {
+    PERL_ARGS_ASSERT_SSC_IS_ANYTHING;
+
     /* Returns true if the SSC 'ssc' can match the empty string and any code
      * point; false otherwise.  Thus, this is used to see if using 'ssc' buys
      * us anything: if the function returns true, 'ssc' hasn't been restricted
@@ -324,8 +326,6 @@ S_ssc_is_anything(const regnode_ssc *ssc)
 
     UV start = 0, end = 0;  /* Initialize due to messages from dumb compiler */
     bool ret;
-
-    PERL_ARGS_ASSERT_SSC_IS_ANYTHING;
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -361,10 +361,10 @@ S_ssc_is_anything(const regnode_ssc *ssc)
 void
 Perl_ssc_init(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc)
 {
+    PERL_ARGS_ASSERT_SSC_INIT;
+
     /* Initializes the SSC 'ssc'.  This includes setting it to match an empty
      * string, any code point, or any posix class under locale */
-
-    PERL_ARGS_ASSERT_SSC_INIT;
 
     Zero(ssc, 1, regnode_ssc);
     set_ANYOF_SYNTHETIC(ssc);
@@ -390,14 +390,14 @@ static int
 S_ssc_is_cp_posixl_init(const RExC_state_t *pRExC_state,
                         const regnode_ssc *ssc)
 {
+    PERL_ARGS_ASSERT_SSC_IS_CP_POSIXL_INIT;
+
     /* Returns true if the SSC 'ssc' is in its initial state with regard only
      * to the list of code points matched, and locale posix classes; hence does
      * not check its flags) */
 
     UV start = 0, end = 0;  /* Initialize due to messages from dumb compiler */
     bool ret;
-
-    PERL_ARGS_ASSERT_SSC_IS_CP_POSIXL_INIT;
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -424,6 +424,8 @@ static SV*
 S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
                                const regnode_charclass* const node)
 {
+    PERL_ARGS_ASSERT_GET_ANYOF_CP_LIST_FOR_SSC;
+
     /* Returns a mortal inversion list defining which code points are matched
      * by 'node', which is of ANYOF-ish type .  Handles complementing the
      * result if appropriate.  If some code points aren't knowable at this
@@ -436,8 +438,6 @@ S_get_ANYOF_cp_list_for_ssc(pTHX_ const RExC_state_t *pRExC_state,
     const U8 flags = (REGNODE_TYPE(OP(node)) == ANYOF)
                       ? ANYOF_FLAGS(node)
                       : 0;
-
-    PERL_ARGS_ASSERT_GET_ANYOF_CP_LIST_FOR_SSC;
 
     /* Look at the data structure created by S_set_ANYOF_arg() */
     if (ANYOF_MATCHES_ALL_OUTSIDE_BITMAP(node)) {
@@ -576,6 +576,8 @@ static void
 S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
                 const regnode_charclass *and_with)
 {
+    PERL_ARGS_ASSERT_SSC_AND;
+
     /* Accumulate into SSC 'ssc' its 'AND' with 'and_with', which is either
      * another SSC or a regular ANYOF class.  Can create false positives. */
 
@@ -584,8 +586,6 @@ S_ssc_and(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
                           ? ANYOF_FLAGS(and_with)
                           : 0;
     U8  anded_flags;
-
-    PERL_ARGS_ASSERT_SSC_AND;
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -759,6 +759,8 @@ static void
 S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
                const regnode_charclass *or_with)
 {
+    PERL_ARGS_ASSERT_SSC_OR;
+
     /* Accumulate into SSC 'ssc' its 'OR' with 'or_with', which is either
      * another SSC or a regular ANYOF class.  Can create false positives if
      * 'or_with' is to be inverted. */
@@ -768,8 +770,6 @@ S_ssc_or(pTHX_ const RExC_state_t *pRExC_state, regnode_ssc *ssc,
     U8  or_with_flags = (REGNODE_TYPE(OP(or_with)) == ANYOF)
                          ? ANYOF_FLAGS(or_with)
                          : 0;
-
-    PERL_ARGS_ASSERT_SSC_OR;
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -879,11 +879,11 @@ S_ssc_add_range(pTHX_ regnode_ssc *ssc, const UV start, const UV end)
 static void
 S_ssc_cp_and(pTHX_ regnode_ssc *ssc, const UV cp)
 {
+    PERL_ARGS_ASSERT_SSC_CP_AND;
+
     /* AND just the single code point 'cp' into the SSC 'ssc' */
 
     SV* cp_list = new_invlist_(2);
-
-    PERL_ARGS_ASSERT_SSC_CP_AND;
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -897,8 +897,9 @@ S_ssc_cp_and(pTHX_ regnode_ssc *ssc, const UV cp)
 static void
 S_ssc_clear_locale(regnode_ssc *ssc)
 {
-    /* Set the SSC 'ssc' to not match any locale things */
     PERL_ARGS_ASSERT_SSC_CLEAR_LOCALE;
+
+    /* Set the SSC 'ssc' to not match any locale things */
 
     assert(is_ANYOF_SYNTHETIC(ssc));
 
@@ -1059,6 +1060,8 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
                    UV *min_subtract, bool *unfolded_multi_char,
                    U32 flags, regnode *val, U32 depth)
 {
+    PERL_ARGS_ASSERT_JOIN_EXACT;
+
     /* Merge several consecutive EXACTish nodes into one. */
 
     regnode *n = regnext(scan);
@@ -1073,7 +1076,6 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
     PERL_UNUSED_ARG(depth);
 #endif
 
-    PERL_ARGS_ASSERT_JOIN_EXACT;
 #ifndef EXPERIMENTAL_INPLACESCAN
     PERL_UNUSED_ARG(flags);
     PERL_UNUSED_ARG(val);
@@ -1489,6 +1491,8 @@ Perl_study_chunk(pTHX_
                                a higher caller is holding a ptr to them. */
 )
 {
+    PERL_ARGS_ASSERT_STUDY_CHUNK;
+
     /* vars about the regnodes we are working with */
     regnode *scan = *scanp; /* the current opcode we are inspecting */
     regnode *next = NULL;   /* the next opcode beyond scan, tmp var */
@@ -1526,7 +1530,6 @@ Perl_study_chunk(pTHX_
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_STUDY_CHUNK;
     RExC_study_started = 1;
 
     Zero(&data_fake, 1, scan_data_t);

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -51,13 +51,13 @@ static void
 S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
             AV *revcharmap, U32 depth)
 {
+    PERL_ARGS_ASSERT_DUMP_TRIE;
+
     U32 state;
     SV *sv = sv_newmortal();
     int colwidth = widecharmap ? 6 : 4;
     U16 word;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_DUMP_TRIE;
 
     Perl_re_indentf( aTHX_  "Char : %-6s%-6s%-4s ",
         depth+1, "Match","Base","Ofs" );
@@ -146,12 +146,12 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
                          HV *widecharmap, AV *revcharmap, U32 next_alloc,
                          U32 depth)
 {
+    PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST;
+
     U32 state;
     SV *sv = sv_newmortal();
     int colwidth = widecharmap ? 6 : 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST;
 
     /* print out the table precompression.  */
     Perl_re_indentf( aTHX_  "State :Word | Transition Data\n",
@@ -206,13 +206,13 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
                           HV *widecharmap, AV *revcharmap, U32 next_alloc,
                           U32 depth)
 {
+    PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE;
+
     U32 state;
     U16 charid;
     SV *sv = sv_newmortal();
     int colwidth = widecharmap ? 6 : 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE;
 
     /*
        print out the table precompression so that we can do a visual check
@@ -552,6 +552,8 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                   regnode *first, regnode *last, regnode *tail,
                   U32 word_count, U32 flags, U32 depth)
 {
+    PERL_ARGS_ASSERT_MAKE_TRIE;
+
     /* first pass, loop through and scan words */
     reg_trie_data *trie;
     HV *widecharmap = NULL;
@@ -585,11 +587,9 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
     SV *re_trie_maxbuff;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_MAKE_TRIE;
 #ifndef DEBUGGING
     PERL_UNUSED_ARG(depth);
 #endif
-
     switch (flags) {
         case EXACT: case EXACT_REQ8: case EXACTL: break;
         case EXACTFAA:
@@ -1613,6 +1613,8 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 regnode *
 Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *source, U32 depth)
 {
+    PERL_ARGS_ASSERT_CONSTRUCT_AHOCORASICK_FROM_TRIE;
+
 /* The Trie is constructed and compressed now so we can build a fail array if
  * it's needed
 
@@ -1652,12 +1654,10 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
     regnode *stclass;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_CONSTRUCT_AHOCORASICK_FROM_TRIE;
     PERL_UNUSED_CONTEXT;
 #ifndef DEBUGGING
     PERL_UNUSED_ARG(depth);
 #endif
-
     if ( OP(source) == TRIE ) {
         tregnode_TRIE *op = (tregnode_TRIE *)
             PerlMemShared_calloc(1, sizeof(tregnode_TRIE));

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -895,6 +895,8 @@ Perl_reentrant_free(pTHX) {
 void*
 Perl_reentrant_retry(const char *f, ...)
 {
+    PERL_ARGS_ASSERT_REENTRANT_RETRY;
+
     /* This function is set up to be called if the normal function returns
      * failure with errno ERANGE, which indicates the buffer is too small.
      * This function calls the failing one again with a larger buffer.
@@ -920,7 +922,6 @@ Perl_reentrant_retry(const char *f, ...)
 
     /* Easier to special case this here than in embed.pl. (Look at what it
        generates for proto.h) */
-    PERL_ARGS_ASSERT_REENTRANT_RETRY;
 
 #endif
 

--- a/regexec.c
+++ b/regexec.c
@@ -225,6 +225,8 @@ static regmatch_state * S_push_slab(pTHX);
 static CHECKPOINT
 S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEPTH)
 {
+    PERL_ARGS_ASSERT_REGCPPUSH;
+
     const int retval = PL_savestack_ix;
     /* Number of bytes about to be stored in the stack */
     const SSize_t paren_bytes_to_push = sizeof(*RXp_OFFSp(rex)) * (maxopenparen - parenfloor);
@@ -235,8 +237,6 @@ S_regcppush(pTHX_ const regexp *rex, I32 parenfloor, U32 maxopenparen comma_pDEP
     const UV elems_shifted = total_elems << SAVE_TIGHT_SHIFT;
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGCPPUSH;
 
     if (paren_elems_to_push < 0)
         croak("panic: paren_elems_to_push, %i < 0, maxopenparen: %i parenfloor: %i",
@@ -415,6 +415,8 @@ S_capture_clear(pTHX_ regexp *rex, U16 from_ix, U16 to_ix, const char *str comma
 static void
 S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 {
+    PERL_ARGS_ASSERT_REGCPPOP;
+
     UV i;
     U32 paren;
 #ifdef DEBUGGING
@@ -422,8 +424,6 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 #endif
 
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGCPPOP;
 
 
     DEBUG_BUFFERS_r({
@@ -525,9 +525,10 @@ S_regcppop(pTHX_ regexp *rex, U32 *maxopenparen_p comma_pDEPTH)
 static void
 S_regcp_restore(pTHX_ regexp *rex, I32 ix, U32 *maxopenparen_p comma_pDEPTH)
 {
+    PERL_ARGS_ASSERT_REGCP_RESTORE;
+
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
     I32 tmpix = PL_savestack_ix;
-    PERL_ARGS_ASSERT_REGCP_RESTORE;
 
     DEBUG_STATE_r(
         Perl_re_exec_indentf( aTHX_
@@ -598,6 +599,8 @@ S_isFOO_lc(pTHX_ const U8 classnum, const U8 character)
 PERL_STATIC_INLINE I32
 S_foldEQ_latin1_s2_folded(pTHX_ const char *s1, const char *s2, I32 len)
 {
+    PERL_ARGS_ASSERT_FOLDEQ_LATIN1_S2_FOLDED;
+
     /* Compare non-UTF-8 using Unicode (Latin1) semantics.  s2 must already be
      * folded.  Works on all folds representable without UTF-8, except for
      * LATIN_SMALL_LETTER_SHARP_S, and does not check for this.  Nor does it
@@ -608,8 +611,6 @@ S_foldEQ_latin1_s2_folded(pTHX_ const char *s1, const char *s2, I32 len)
 
     const U8 *a = (const U8 *)s1;
     const U8 *b = (const U8 *)s2;
-
-    PERL_ARGS_ASSERT_FOLDEQ_LATIN1_S2_FOLDED;
 
     assert(len >= 0);
 
@@ -626,6 +627,8 @@ S_foldEQ_latin1_s2_folded(pTHX_ const char *s1, const char *s2, I32 len)
 static bool
 S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8* character, const U8* e)
 {
+    PERL_ARGS_ASSERT_ISFOO_UTF8_LC;
+
     /* Returns a boolean as to whether or not the (well-formed) UTF-8-encoded
      * 'character' is a member of the Posix character class given by 'classnum'
      * that should be equivalent to a value in the typedef
@@ -636,8 +639,6 @@ S_isFOO_utf8_lc(pTHX_ const U8 classnum, const U8* character, const U8* e)
      * rules, ignoring any locale.  So use the Unicode function if this class
      * requires an inversion list, and use the Unicode macro otherwise. */
 
-
-    PERL_ARGS_ASSERT_ISFOO_UTF8_LC;
 
     if (UTF8_IS_INVARIANT(*character)) {
         return isFOO_lc(classnum, *character);
@@ -941,6 +942,8 @@ Perl_re_intuit_start(pTHX_
                     const U32 flags,
                     re_scream_pos_data *data)
 {
+    PERL_ARGS_ASSERT_RE_INTUIT_START;
+
     struct regexp *const prog = ReANY(rx);
     SSize_t start_shift = prog->check_offset_min;
     /* Should be nonnegative! */
@@ -959,10 +962,8 @@ Perl_re_intuit_start(pTHX_
     regmatch_info *const reginfo = &reginfo_buf;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_RE_INTUIT_START;
     PERL_UNUSED_ARG(flags);
     PERL_UNUSED_ARG(data);
-
     DEBUG_EXECUTE_r(Perl_re_printf( aTHX_
                 "Intuit: trying to determine minimum start position...\n"));
 
@@ -2271,6 +2272,7 @@ static char *
 S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
     const char *strend, regmatch_info *reginfo)
 {
+    PERL_ARGS_ASSERT_FIND_BYCLASS;
 
     /* true if x+ need not match at just the 1st pos of run of x's */
     const I32 doevery = (prog->intflags & PREGf_SKIP) == 0;
@@ -2302,8 +2304,6 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
     char_class_number_ classnum;
 
     RXi_GET_DECL(prog,progi);
-
-    PERL_ARGS_ASSERT_FIND_BYCLASS;
 
     /* We know what class it must start with. The case statements below have
      * encoded the OP, and the UTF8ness of the target ('t8' for is UTF-8; 'tb'
@@ -3708,6 +3708,8 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 /* flags:     For optimizations. See REXEC_* in regexp.h */
 
 {
+    PERL_ARGS_ASSERT_REGEXEC_FLAGS;
+
     struct regexp *const prog = ReANY(rx);
     char *s;
     regnode *c;
@@ -3723,9 +3725,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     I32 oldsave;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
-    PERL_ARGS_ASSERT_REGEXEC_FLAGS;
     PERL_UNUSED_ARG(data);
-
     /* Be paranoid... */
     if (prog == NULL) {
         croak("NULL regexp parameter");
@@ -4412,13 +4412,13 @@ S_set_reg_curpm(pTHX_ REGEXP *rx, regmatch_info *reginfo)
 static bool			/* 0 failure, 1 success */
 S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
 {
+    PERL_ARGS_ASSERT_REGTRY;
+
     REGEXP *const rx = reginfo->prog;
     regexp *const prog = ReANY(rx);
     SSize_t result;
     RXi_GET_DECL(prog,progi);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REGTRY;
 
     reginfo->cutpoint = NULL;
 
@@ -4479,10 +4479,11 @@ S_regtry(pTHX_ regmatch_info *reginfo, char **startposp)
 int
 Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 {
+    PERL_ARGS_ASSERT_RE_EXEC_INDENTF;
+
     va_list ap;
     int result;
     PerlIO *f= Perl_debug_log;
-    PERL_ARGS_ASSERT_RE_EXEC_INDENTF;
     va_start(ap, depth);
     PerlIO_printf(f, "%*s|%4" UVuf "| %*s", REPORT_CODE_OFF, "", (UV)depth, INDENT_CHARS(depth), "" );
     result = PerlIO_vprintf(f, fmt, ap);
@@ -4513,9 +4514,9 @@ static void
 S_debug_start_match(pTHX_ const REGEXP *prog, const bool utf8_target,
     const char *start, const char *end, const char *blurb)
 {
-    const bool utf8_pat = RX_UTF8(prog) ? 1 : 0;
-
     PERL_ARGS_ASSERT_DEBUG_START_MATCH;
+
+    const bool utf8_pat = RX_UTF8(prog) ? 1 : 0;
 
     if (!PL_colorset)
             reginitcolors();
@@ -4549,6 +4550,8 @@ S_dump_exec_pos(pTHX_ const char *locinput,
                       const U32 depth
                 )
 {
+    PERL_ARGS_ASSERT_DUMP_EXEC_POS;
+
     const int docolor = *PL_colors[0] || *PL_colors[2] || *PL_colors[4];
     const int taill = (docolor ? 10 : 7); /* 3 chars for "> <" */
     int l = (loc_regeol - locinput) > taill ? taill : (loc_regeol - locinput);
@@ -4561,8 +4564,6 @@ S_dump_exec_pos(pTHX_ const char *locinput,
     int pref_len = (locinput - loc_bostr) > (5 + taill) - l
         ? (5 + taill) - l : locinput - loc_bostr;
     int pref0_len;
-
-    PERL_ARGS_ASSERT_DUMP_EXEC_POS;
 
     if (utf8_target) {
         while (UTF8_IS_CONTINUATION(*(U8*)(locinput - pref_len))) {
@@ -4623,12 +4624,12 @@ S_dump_exec_pos(pTHX_ const char *locinput,
 static I32
 S_reg_check_named_buff_matched(const regexp *rex, const regnode *scan)
 {
+    PERL_ARGS_ASSERT_REG_CHECK_NAMED_BUFF_MATCHED;
+
     I32 n;
     RXi_GET_DECL(rex,rexi);
     SV *sv_dat= MUTABLE_SV(rexi->data->data[ ARG1u( scan ) ]);
     I32 *nums = (I32*)SvPVX(sv_dat);
-
-    PERL_ARGS_ASSERT_REG_CHECK_NAMED_BUFF_MATCHED;
 
     for ( n = 0; n < SvIVX(sv_dat); n++ ) {
         if ((I32)RXp_LASTPAREN(rex) >= nums[n] &&
@@ -5373,9 +5374,9 @@ S_isGCB(pTHX_ const GCB_enum before, const GCB_enum after, const U8 * const strb
 static GCB_enum
 S_backup_one_GCB(pTHX_ const U8 * const strbeg, U8 ** curpos, const bool utf8_target)
 {
-    GCB_enum gcb;
-
     PERL_ARGS_ASSERT_BACKUP_ONE_GCB;
+
+    GCB_enum gcb;
 
     if (*curpos < strbeg) {
         return GCB_EDGE;
@@ -5749,10 +5750,9 @@ S_isLB(pTHX_ LB_enum before,
 static LB_enum
 S_advance_one_LB(pTHX_ U8 ** curpos, const U8 * const strend, const bool utf8_target)
 {
+    PERL_ARGS_ASSERT_ADVANCE_ONE_LB;
 
     LB_enum lb;
-
-    PERL_ARGS_ASSERT_ADVANCE_ONE_LB;
 
     if (*curpos >= strend) {
         return LB_EDGE;
@@ -5852,14 +5852,14 @@ S_isSB(pTHX_ SB_enum before,
              const U8 * const strend,
              const bool utf8_target)
 {
+    PERL_ARGS_ASSERT_ISSB;
+
     /* returns a boolean indicating if there is a Sentence Boundary Break
      * between the inputs.  See https://www.unicode.org/reports/tr29/ */
 
     U8 * lpos = (U8 *) curpos;
     bool has_para_sep = false;
     bool has_sp = false;
-
-    PERL_ARGS_ASSERT_ISSB;
 
     /* Break at the start and end of text.
         SB1.  sot  ÷
@@ -6042,9 +6042,9 @@ S_isSB(pTHX_ SB_enum before,
 static SB_enum
 S_advance_one_SB(pTHX_ U8 ** curpos, const U8 * const strend, const bool utf8_target)
 {
-    SB_enum sb;
-
     PERL_ARGS_ASSERT_ADVANCE_ONE_SB;
+
+    SB_enum sb;
 
     if (*curpos >= strend) {
         return SB_EDGE;
@@ -6075,9 +6075,9 @@ S_advance_one_SB(pTHX_ U8 ** curpos, const U8 * const strend, const bool utf8_ta
 static SB_enum
 S_backup_one_SB(pTHX_ const U8 * const strbeg, U8 ** curpos, const bool utf8_target)
 {
-    SB_enum sb;
-
     PERL_ARGS_ASSERT_BACKUP_ONE_SB;
+
+    SB_enum sb;
 
     if (*curpos < strbeg) {
         return SB_EDGE;
@@ -6641,6 +6641,8 @@ bounds of our window into the string.
 static SSize_t
 S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 {
+    PERL_ARGS_ASSERT_REGMATCH;
+
     const bool utf8_target = reginfo->is_utf8_target;
     const U32 uniflags = UTF8_ALLOW_DEFAULT;
     REGEXP *rex_sv = reginfo->prog;
@@ -6731,8 +6733,6 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
     /* shut up 'may be used uninitialized' compiler warnings for dMULTICALL */
     multicall_oldcatch = 0;
     PERL_UNUSED_VAR(multicall_cop);
-
-    PERL_ARGS_ASSERT_REGMATCH;
 
     st = PL_regmatch_state;
 
@@ -10437,6 +10437,8 @@ static I32
 S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
             char * loceol, regmatch_info *const reginfo, I32 max comma_pDEPTH)
 {
+    PERL_ARGS_ASSERT_REGREPEAT;
+
     char *scan;     /* Pointer to current position in target string */
     I32 c;
     char *this_eol = loceol;   /* potentially adjusted version. */
@@ -10444,8 +10446,6 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
     bool utf8_target = reginfo->is_utf8_target;
     unsigned int to_complement = 0;  /* Invert the result? */
     char_class_number_ classnum;
-
-    PERL_ARGS_ASSERT_REGREPEAT;
 
     /* This routine is structured so that we switch on the input OP.  Each OP
      * case: statement contains a loop to repeatedly apply the OP, advancing
@@ -11115,13 +11115,13 @@ S_regrepeat(pTHX_ regexp *prog, char **startposp, const regnode *p,
 static bool
 S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const p, const U8* const p_end, const bool utf8_target)
 {
+    PERL_ARGS_ASSERT_REGINCLASS;
+
     const char flags = (inRANGE(OP(n), ANYOFH, ANYOFHs))
                         ? 0
                         : ANYOF_FLAGS(n);
     bool match = false;
     UV c = *p;
-
-    PERL_ARGS_ASSERT_REGINCLASS;
 
     /* If c is not already the code point, get it.  Note that
      * UTF8_IS_INVARIANT() works even if not in UTF-8 */
@@ -11331,11 +11331,11 @@ S_reginclass(pTHX_ regexp * const prog, const regnode * const n, const U8* const
 static U8 *
 S_reghop3(U8 *s, SSize_t off, const U8* lim)
 {
+    PERL_ARGS_ASSERT_REGHOP3;
+
     /* return the position 'off' UTF-8 characters away from 's', forward if
      * 'off' >= 0, backwards if negative.  But don't go outside of position
      * 'lim', which better be < s  if off < 0 */
-
-    PERL_ARGS_ASSERT_REGHOP3;
 
     if (off >= 0) {
         while (off-- && s < lim) {
@@ -11583,12 +11583,12 @@ S_cleanup_regmatch_info_aux(pTHX_ void *arg)
 static void
 S_to_utf8_substr(pTHX_ regexp *prog)
 {
+    PERL_ARGS_ASSERT_TO_UTF8_SUBSTR;
+
     /* Converts substr fields in prog from bytes to UTF-8, calling fbm_compile
      * on the converted value */
 
     int i = 1;
-
-    PERL_ARGS_ASSERT_TO_UTF8_SUBSTR;
 
     do {
         if (prog->substrs->data[i].substr
@@ -11617,12 +11617,12 @@ S_to_utf8_substr(pTHX_ regexp *prog)
 static bool
 S_to_byte_substr(pTHX_ regexp *prog)
 {
+    PERL_ARGS_ASSERT_TO_BYTE_SUBSTR;
+
     /* Converts substr fields in prog from UTF-8 to bytes, calling fbm_compile
      * on the converted value; returns false if can't be converted. */
 
     int i = 1;
-
-    PERL_ARGS_ASSERT_TO_BYTE_SUBSTR;
 
     do {
         if (prog->substrs->data[i].utf8_substr
@@ -11655,6 +11655,8 @@ S_to_byte_substr(pTHX_ regexp *prog)
 bool
 Perl_is_grapheme(pTHX_ const U8 * strbeg, const U8 * s, const U8 * strend, const UV cp)
 {
+    PERL_ARGS_ASSERT_IS_GRAPHEME;
+
     /* Temporary helper function for toke.c.  Verify that the code point 'cp'
      * is a stand-alone grapheme.  The UTF-8 for 'cp' begins at position 's' in
      * the larger string bounded by 'strbeg' and 'strend'.
@@ -11667,8 +11669,6 @@ Perl_is_grapheme(pTHX_ const U8 * strbeg, const U8 * s, const U8 * strend, const
 
     GCB_enum cp_gcb_val, prev_cp_gcb_val, next_cp_gcb_val;
     const U8 * prev_cp_start;
-
-    PERL_ARGS_ASSERT_IS_GRAPHEME;
 
     if (   UNLIKELY(UNICODE_IS_SUPER(cp))
         || UNLIKELY(UNICODE_IS_NONCHAR_GIVEN_NOT_SUPER(cp)))
@@ -12235,10 +12235,10 @@ SV*
 Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv,
                           const U32 flags)
 {
+    PERL_ARGS_ASSERT_REG_NAMED_BUFF_FETCH;
+
     SV *ret;
     struct regexp *const rx = ReANY(r);
-
-    PERL_ARGS_ASSERT_REG_NAMED_BUFF_FETCH;
 
     if (rx && RXp_PAREN_NAMES(rx)) {
         HE *he_str = hv_fetch_ent( RXp_PAREN_NAMES(rx), namesv, 0, 0 );
@@ -12273,9 +12273,9 @@ bool
 Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key,
                            const U32 flags)
 {
-    struct regexp *const rx = ReANY(r);
-
     PERL_ARGS_ASSERT_REG_NAMED_BUFF_EXISTS;
+
+    struct regexp *const rx = ReANY(r);
 
     if (rx && RXp_PAREN_NAMES(rx)) {
         if (flags & RXapif_ALL) {
@@ -12297,9 +12297,9 @@ Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key,
 SV*
 Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const r, const U32 flags)
 {
-    struct regexp *const rx = ReANY(r);
-
     PERL_ARGS_ASSERT_REG_NAMED_BUFF_FIRSTKEY;
+
+    struct regexp *const rx = ReANY(r);
 
     if ( rx && RXp_PAREN_NAMES(rx) ) {
         (void)hv_iterinit(RXp_PAREN_NAMES(rx));
@@ -12313,10 +12313,10 @@ Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const r, const U32 flags)
 SV*
 Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const r, const U32 flags)
 {
+    PERL_ARGS_ASSERT_REG_NAMED_BUFF_NEXTKEY;
+
     struct regexp *const rx = ReANY(r);
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
-
-    PERL_ARGS_ASSERT_REG_NAMED_BUFF_NEXTKEY;
 
     if (rx && RXp_PAREN_NAMES(rx)) {
         HV *hv = RXp_PAREN_NAMES(rx);
@@ -12345,12 +12345,12 @@ Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const r, const U32 flags)
 SV*
 Perl_reg_named_buff_scalar(pTHX_ REGEXP * const r, const U32 flags)
 {
+    PERL_ARGS_ASSERT_REG_NAMED_BUFF_SCALAR;
+
     SV *ret;
     AV *av;
     SSize_t length;
     struct regexp *const rx = ReANY(r);
-
-    PERL_ARGS_ASSERT_REG_NAMED_BUFF_SCALAR;
 
     if (rx && RXp_PAREN_NAMES(rx)) {
         if (flags & (RXapif_ALL | RXapif_REGNAMES_COUNT)) {
@@ -12373,10 +12373,10 @@ Perl_reg_named_buff_scalar(pTHX_ REGEXP * const r, const U32 flags)
 SV*
 Perl_reg_named_buff_all(pTHX_ REGEXP * const r, const U32 flags)
 {
+    PERL_ARGS_ASSERT_REG_NAMED_BUFF_ALL;
+
     struct regexp *const rx = ReANY(r);
     AV *av = newAV();
-
-    PERL_ARGS_ASSERT_REG_NAMED_BUFF_ALL;
 
     if (rx && RXp_PAREN_NAMES(rx)) {
         HV *hv= RXp_PAREN_NAMES(rx);
@@ -12418,14 +12418,14 @@ void
 Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren,
                                    SV * const sv, U32 flags)
 {
+    PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH_FLAGS;
+
     struct regexp *const rx = ReANY(re);
     char *s = NULL;
     SSize_t i,t = 0;
     SSize_t s1, t1;
     I32 n = paren;
     I32 logical_nparens = rx->logical_nparens ? rx->logical_nparens : rx->nparens;
-
-    PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH_FLAGS;
 
     if (      n == RX_BUFF_IDX_CARET_PREMATCH
            || n == RX_BUFF_IDX_CARET_FULLMATCH
@@ -12553,12 +12553,12 @@ I32
 Perl_reg_numbered_buff_length(pTHX_ REGEXP * const r, const SV * const sv,
                               const I32 paren)
 {
+    PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_LENGTH;
+
     struct regexp *const rx = ReANY(r);
     I32 i,j;
     I32 s1, t1;
     I32 logical_nparens = rx->logical_nparens ? rx->logical_nparens : rx->nparens;
-
-    PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_LENGTH;
 
     if (   paren == RX_BUFF_IDX_CARET_PREMATCH
         || paren == RX_BUFF_IDX_CARET_FULLMATCH

--- a/scope.c
+++ b/scope.c
@@ -30,10 +30,10 @@
 SV**
 Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
 {
+    PERL_ARGS_ASSERT_STACK_GROW;
+
     SSize_t extra;
     SSize_t current = (p - PL_stack_base);
-
-    PERL_ARGS_ASSERT_STACK_GROW;
 
     if (UNLIKELY(n < 0))
         croak(
@@ -320,10 +320,10 @@ S<C<'local $x = $y'>>), and that will handle the magic.
 static SV *
 S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
 {
+    PERL_ARGS_ASSERT_SAVE_SCALAR_AT;
+
     SV * osv;
     SV *sv;
-
-    PERL_ARGS_ASSERT_SAVE_SCALAR_AT;
 
     osv = *sptr;
     if (flags & SAVEf_KEEPOLDELEM)
@@ -352,9 +352,9 @@ Perl_save_pushptrptr(pTHX_ void *const ptr1, void *const ptr2, const int type)
 SV *
 Perl_save_scalar(pTHX_ GV *gv)
 {
-    SV ** const sptr = &GvSVn(gv);
-
     PERL_ARGS_ASSERT_SAVE_SCALAR;
+
+    SV ** const sptr = &GvSVn(gv);
 
     if (UNLIKELY(SvGMAGICAL(*sptr))) {
         PL_localizing = 1;
@@ -480,9 +480,9 @@ Set the SvFLAGS specified by mask to the values in val
 void
 Perl_save_set_svflags(pTHX_ SV* sv, U32 mask, U32 val)
 {
-    dSS_ADD;
-
     PERL_ARGS_ASSERT_SAVE_SET_SVFLAGS;
+
+    dSS_ADD;
 
     SS_ADD_PTR(sv);
     SS_ADD_INT(mask);
@@ -553,10 +553,10 @@ Perl_save_gp(pTHX_ GV *gv, I32 empty)
 AV *
 Perl_save_ary(pTHX_ GV *gv)
 {
+    PERL_ARGS_ASSERT_SAVE_ARY;
+
     AV * const oav = GvAVn(gv);
     AV *av;
-
-    PERL_ARGS_ASSERT_SAVE_ARY;
 
     if (UNLIKELY(!AvREAL(oav) && AvREIFY(oav)))
         av_reify(oav);
@@ -572,9 +572,9 @@ Perl_save_ary(pTHX_ GV *gv)
 HV *
 Perl_save_hash(pTHX_ GV *gv)
 {
-    HV *ohv, *hv;
-
     PERL_ARGS_ASSERT_SAVE_HASH;
+
+    HV *ohv, *hv;
 
     save_pushptrptr(
         SvREFCNT_inc_simple_NN(gv), (ohv = GvHVn(gv)), SAVEt_HV
@@ -590,9 +590,9 @@ Perl_save_hash(pTHX_ GV *gv)
 void
 Perl_save_item(pTHX_ SV *item)
 {
-    SV * const sv = newSVsv(item);
-
     PERL_ARGS_ASSERT_SAVE_ITEM;
+
+    SV * const sv = newSVsv(item);
 
     save_pushptrptr(item, /* remember the pointer */
                     sv,   /* remember the value */
@@ -602,9 +602,9 @@ Perl_save_item(pTHX_ SV *item)
 void
 Perl_save_bool(pTHX_ bool *boolp)
 {
-    dSS_ADD;
-
     PERL_ARGS_ASSERT_SAVE_BOOL;
+
+    dSS_ADD;
 
     SS_ADD_PTR(boolp);
     SS_ADD_UV(SAVEt_BOOL | (*boolp << 8));
@@ -627,12 +627,12 @@ Perl_save_pushi32ptr(pTHX_ const I32 i, void *const ptr, const int type)
 void
 Perl_save_int(pTHX_ int *intp)
 {
+    PERL_ARGS_ASSERT_SAVE_INT;
+
     const int i = *intp;
     UV type = ((UV)((UV)i << SAVE_TIGHT_SHIFT) | SAVEt_INT_SMALL);
     int size = 2;
     dSS_ADD;
-
-    PERL_ARGS_ASSERT_SAVE_INT;
 
     if (UNLIKELY((int)(type >> SAVE_TIGHT_SHIFT) != i)) {
         SS_ADD_INT(i);
@@ -647,9 +647,9 @@ Perl_save_int(pTHX_ int *intp)
 void
 Perl_save_I8(pTHX_ I8 *bytep)
 {
-    dSS_ADD;
-
     PERL_ARGS_ASSERT_SAVE_I8;
+
+    dSS_ADD;
 
     SS_ADD_PTR(bytep);
     SS_ADD_UV(SAVEt_I8 | ((UV)*bytep << 8));
@@ -659,9 +659,9 @@ Perl_save_I8(pTHX_ I8 *bytep)
 void
 Perl_save_I16(pTHX_ I16 *intp)
 {
-    dSS_ADD;
-
     PERL_ARGS_ASSERT_SAVE_I16;
+
+    dSS_ADD;
 
     SS_ADD_PTR(intp);
     SS_ADD_UV(SAVEt_I16 | ((UV)*intp << 8));
@@ -671,12 +671,12 @@ Perl_save_I16(pTHX_ I16 *intp)
 void
 Perl_save_I32(pTHX_ I32 *intp)
 {
+    PERL_ARGS_ASSERT_SAVE_I32;
+
     const I32 i = *intp;
     UV type = ((I32)((U32)i << SAVE_TIGHT_SHIFT) | SAVEt_I32_SMALL);
     int size = 2;
     dSS_ADD;
-
-    PERL_ARGS_ASSERT_SAVE_I32;
 
     if (UNLIKELY((I32)(type >> SAVE_TIGHT_SHIFT) != i)) {
         SS_ADD_INT(i);
@@ -691,12 +691,12 @@ Perl_save_I32(pTHX_ I32 *intp)
 void
 Perl_save_strlen(pTHX_ STRLEN *ptr)
 {
+    PERL_ARGS_ASSERT_SAVE_STRLEN;
+
     const IV i = *ptr;
     UV type = ((I32)((U32)i << SAVE_TIGHT_SHIFT) | SAVEt_STRLEN_SMALL);
     int size = 2;
     dSS_ADD;
-
-    PERL_ARGS_ASSERT_SAVE_STRLEN;
 
     if (UNLIKELY((I32)(type >> SAVE_TIGHT_SHIFT) != i)) {
         SS_ADD_IV(*ptr);
@@ -824,10 +824,10 @@ Perl_save_pushptr(pTHX_ void *const ptr, const int type)
 void
 Perl_save_clearsv(pTHX_ SV **svp)
 {
+    PERL_ARGS_ASSERT_SAVE_CLEARSV;
+
     const UV offset = svp - PL_curpad;
     const UV offset_shifted = offset << SAVE_TIGHT_SHIFT;
-
-    PERL_ARGS_ASSERT_SAVE_CLEARSV;
 
     ASSERT_CURPAD_ACTIVE("save_clearsv");
     assert(*svp);
@@ -893,11 +893,11 @@ Implements C<SAVEHDELETE>.
 void
 Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
 {
+    PERL_ARGS_ASSERT_SAVE_HDELETE;
+
     STRLEN len;
     I32 klen;
     const char *key;
-
-    PERL_ARGS_ASSERT_SAVE_HDELETE;
 
     key  = SvPV_const(keysv, len);
     klen = SvUTF8(keysv) ? -(I32)len : (I32)len;
@@ -917,9 +917,9 @@ Implements C<SAVEADELETE>.
 void
 Perl_save_adelete(pTHX_ AV *av, SSize_t key)
 {
-    dSS_ADD;
-
     PERL_ARGS_ASSERT_SAVE_ADELETE;
+
+    dSS_ADD;
 
     SvREFCNT_inc_void(av);
     SS_ADD_UV(key);
@@ -931,8 +931,9 @@ Perl_save_adelete(pTHX_ AV *av, SSize_t key)
 void
 Perl_save_destructor(pTHX_ DESTRUCTORFUNC_NOCONTEXT_t f, void* p)
 {
-    dSS_ADD;
     PERL_ARGS_ASSERT_SAVE_DESTRUCTOR;
+
+    dSS_ADD;
 
     SS_ADD_DPTR(f);
     SS_ADD_PTR(p);
@@ -1028,10 +1029,10 @@ void
 Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr,
                             const U32 flags)
 {
+    PERL_ARGS_ASSERT_SAVE_AELEM_FLAGS;
+
     dSS_ADD;
     SV *sv;
-
-    PERL_ARGS_ASSERT_SAVE_AELEM_FLAGS;
 
     SvGETMAGIC(*sptr);
     SS_ADD_PTR(SvREFCNT_inc_simple(av));
@@ -1080,9 +1081,9 @@ is set in in C<flags>.
 void
 Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
 {
-    SV *sv;
-
     PERL_ARGS_ASSERT_SAVE_HELEM_FLAGS;
+
+    SV *sv;
 
     SvGETMAGIC(*sptr);
     {

--- a/sv.c
+++ b/sv.c
@@ -342,11 +342,11 @@ and split it into a list of free SVs.
 static void
 S_sv_add_arena(pTHX_ char *const ptr, const U32 size, const U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_ADD_ARENA;
+
     SV *const sva = MUTABLE_SV(ptr);
     SV* sv;
     SV* svend;
-
-    PERL_ARGS_ASSERT_SV_ADD_ARENA;
 
     /* The first SV in an arena isn't an SV. */
     SvANY(sva) = (void *) PL_sv_arenaroot;		/* ptr to next arena */
@@ -381,10 +381,10 @@ S_sv_add_arena(pTHX_ char *const ptr, const U32 size, const U32 flags)
 static SSize_t
 S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
 {
+    PERL_ARGS_ASSERT_VISIT;
+
     SV* sva;
     I32 visited = 0;
-
-    PERL_ARGS_ASSERT_VISIT;
 
     for (sva = PL_sv_arenaroot; sva; sva = MUTABLE_SV(SvANY(sva))) {
         const SV * const svend = &sva[SvREFCNT(sva)];
@@ -989,6 +989,8 @@ C<L</svtype>>.
 void
 Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
 {
+    PERL_ARGS_ASSERT_SV_UPGRADE;
+
     void*	old_body;
     void*	new_body;
     const svtype old_type = SvTYPE(sv);
@@ -996,8 +998,6 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
     const struct body_details *old_type_details
         = bodies_by_type + old_type;
     SV *referent = NULL;
-
-    PERL_ARGS_ASSERT_SV_UPGRADE;
 
     if (old_type == new_type)
         return;
@@ -1311,11 +1311,12 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
 struct xpvhv_aux*
 Perl_hv_auxalloc(pTHX_ HV *hv)
 {
+    PERL_ARGS_ASSERT_HV_AUXALLOC;
+
     const struct body_details *old_type_details = bodies_by_type + SVt_PVHV;
     void *old_body;
     void *new_body;
 
-    PERL_ARGS_ASSERT_HV_AUXALLOC;
     assert(!HvHasAUX(hv));
 
 #ifdef PURIFY
@@ -1362,10 +1363,10 @@ wrapper instead.
 void
 Perl_sv_backoff(SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_BACKOFF;
+
     STRLEN delta;
     const char * const s = SvPVX_const(sv);
-
-    PERL_ARGS_ASSERT_SV_BACKOFF;
 
     assert(SvOOK(sv));
     assert(SvTYPE(sv) != SVt_PVHV);
@@ -1403,9 +1404,9 @@ Use the C<SvGROW> wrapper instead.
 char *
 Perl_sv_grow(pTHX_ SV *const sv, STRLEN newlen)
 {
-    char *s;
-
     PERL_ARGS_ASSERT_SV_GROW;
+
+    char *s;
 
     if (SvROK(sv))
         sv_unref(sv);
@@ -1498,9 +1499,9 @@ just assigns a char buffer and returns a pointer to it.
 char *
 Perl_sv_grow_fresh(pTHX_ SV *const sv, STRLEN newlen)
 {
-    char *s;
-
     PERL_ARGS_ASSERT_SV_GROW_FRESH;
+
+    char *s;
 
     assert(SvTYPE(sv) >= SVt_PV && SvTYPE(sv) <= SVt_PVMG);
     assert(!SvROK(sv));
@@ -1791,9 +1792,9 @@ Perl_sv_setrv_inc_mg(pTHX_ SV *const sv, SV *const ref)
 static const char *
 S_sv_display(pTHX_ SV *const sv, char *tmpbuf, STRLEN tmpbuf_size)
 {
-    const char *pv;
-
      PERL_ARGS_ASSERT_SV_DISPLAY;
+
+    const char *pv;
 
      if (DO_UTF8(sv)) {
           SV *dsv = newSVpvs_flags("", SVs_TEMP);
@@ -1861,10 +1862,10 @@ S_sv_display(pTHX_ SV *const sv, char *tmpbuf, STRLEN tmpbuf_size)
 static void
 S_not_a_number(pTHX_ SV *const sv)
 {
+     PERL_ARGS_ASSERT_NOT_A_NUMBER;
+
      char tmpbuf[64];
      const char *pv;
-
-     PERL_ARGS_ASSERT_NOT_A_NUMBER;
 
      pv = sv_display(sv, tmpbuf, sizeof(tmpbuf));
 
@@ -1882,10 +1883,10 @@ S_not_a_number(pTHX_ SV *const sv)
 static void
 S_not_incrementable(pTHX_ SV *const sv)
 {
+     PERL_ARGS_ASSERT_NOT_INCREMENTABLE;
+
      char tmpbuf[64];
      const char *pv;
-
-     PERL_ARGS_ASSERT_NOT_INCREMENTABLE;
 
      pv = sv_display(sv, tmpbuf, sizeof(tmpbuf));
 
@@ -1907,11 +1908,11 @@ ignored.
 I32
 Perl_looks_like_number(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_LOOKS_LIKE_NUMBER;
+
     const char *sbegin;
     STRLEN len;
     int numtype;
-
-    PERL_ARGS_ASSERT_LOOKS_LIKE_NUMBER;
 
     if (SvPOK(sv) || SvPOKp(sv)) {
         sbegin = SvPV_nomg_const(sv, len);
@@ -2880,12 +2881,12 @@ It is used internally by sv_2pv_flags() and do_print().
 char *
 Perl_uiv_2buf(char *const buf, const IV iv, UV uv, const int is_uv, char **const peob)
 {
+    PERL_ARGS_ASSERT_UIV_2BUF;
+
     char *ptr = buf + TYPE_CHARS(UV);
     char * const ebuf = ptr;
     U16 *word_ptr;
     U16 const *word_table;
-
-    PERL_ARGS_ASSERT_UIV_2BUF;
 
     /* ptr has to be properly aligned, because we will cast it to U16* */
     assert(PTR2nat(ptr) % 2 == 0);
@@ -2990,10 +2991,10 @@ C<SV_GMAGIC>.
 char *
 Perl_sv_2pv_flags(pTHX_ SV *const sv, STRLEN *const lp, const U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_2PV_FLAGS;
+
     char *s;
     bool done_gmagic = FALSE;
-
-    PERL_ARGS_ASSERT_SV_2PV_FLAGS;
 
     assert (SvTYPE(sv) != SVt_PVAV && SvTYPE(sv) != SVt_PVHV
          && SvTYPE(sv) != SVt_PVFM);
@@ -3320,10 +3321,10 @@ C<flags>) or doesn't (if that bit is cleared).
 void
 Perl_sv_copypv_flags(pTHX_ SV *const dsv, SV *const ssv, const I32 flags)
 {
+    PERL_ARGS_ASSERT_SV_COPYPV_FLAGS;
+
     STRLEN len;
     const char *s;
-
-    PERL_ARGS_ASSERT_SV_COPYPV_FLAGS;
 
     s = SvPV_flags_const(ssv,len,(flags & SV_GMAGIC));
     sv_setpvn(dsv,s,len);
@@ -3856,10 +3857,10 @@ copy-ish functions and macros use it underneath.
 static void
 S_glob_assign_glob(pTHX_ SV *const dsv, SV *const ssv, const int dtype)
 {
+    PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB;
+
     I32 mro_changes = 0; /* 1 = method, 2 = isa, 3 = recursive isa */
     HV *old_stash = NULL;
-
-    PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB;
 
     if (dtype != SVt_PVGV && !isGV_with_GP(dsv)) {
         const char * const name = GvNAME(ssv);
@@ -3995,14 +3996,14 @@ S_glob_assign_glob(pTHX_ SV *const dsv, SV *const ssv, const int dtype)
 void
 Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
 {
+    PERL_ARGS_ASSERT_GV_SETREF;
+
     SV * const sref = SvRV(ssv);
     SV *dref;
     const int intro = GvINTRO(dsv);
     SV **location;
     U8 import_flag = 0;
     const U32 stype = SvTYPE(sref);
-
-    PERL_ARGS_ASSERT_GV_SETREF;
 
     if (intro) {
         GvINTRO_off(dsv);	/* one-shot flag */
@@ -4219,10 +4220,11 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
 void
 Perl_sv_buf_to_ro(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SV_BUF_TO_RO;
+
     struct perl_memory_debug_header * const header =
         (struct perl_memory_debug_header *)(SvPVX(sv)-PERL_MEMORY_DEBUG_HEADER_SIZE);
     const MEM_SIZE len = header->size;
-    PERL_ARGS_ASSERT_SV_BUF_TO_RO;
 # ifdef PERL_TRACK_MEMPOOL
     if (!header->readonly) header->readonly = 1;
 # endif
@@ -4234,10 +4236,11 @@ Perl_sv_buf_to_ro(pTHX_ SV *sv)
 static void
 S_sv_buf_to_rw(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_SV_BUF_TO_RW;
+
     struct perl_memory_debug_header * const header =
         (struct perl_memory_debug_header *)(SvPVX(sv)-PERL_MEMORY_DEBUG_HEADER_SIZE);
     const MEM_SIZE len = header->size;
-    PERL_ARGS_ASSERT_SV_BUF_TO_RW;
     if (mprotect(header, len, PROT_READ|PROT_WRITE))
         warn("mprotect for COW string %p %lu failed with %d",
                          header, len, errno);
@@ -4303,12 +4306,12 @@ Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv)
 void
 Perl_sv_setsv_flags(pTHX_ SV *dsv, SV* ssv, const I32 flags)
 {
+    PERL_ARGS_ASSERT_SV_SETSV_FLAGS;
+
     U32 sflags;
     int dtype;
     svtype stype;
     unsigned int both_type;
-
-    PERL_ARGS_ASSERT_SV_SETSV_FLAGS;
 
     if (UNLIKELY( ssv == dsv ))
         return;
@@ -5310,9 +5313,9 @@ Introduced in perl 5.25.12.
 void
 Perl_sv_set_undef(pTHX_ SV *sv)
 {
-    U32 type = SvTYPE(sv);
-
     PERL_ARGS_ASSERT_SV_SET_UNDEF;
+
+    U32 type = SvTYPE(sv);
 
     /* shortcut, NULL, IV, RV */
 
@@ -5428,6 +5431,8 @@ Perl_sv_setsv_mg(pTHX_ SV *const dsv, SV *const ssv)
 SV *
 Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv)
 {
+    PERL_ARGS_ASSERT_SV_SETSV_COW;
+
     STRLEN cur = SvCUR(ssv);
     STRLEN len = SvLEN(ssv);
     char *new_pv;
@@ -5436,7 +5441,6 @@ Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv)
     const bool already = cBOOL(SvIsCOW(ssv));
 #endif
 
-    PERL_ARGS_ASSERT_SV_SETSV_COW;
 #ifdef DEBUGGING
     if (DEBUG_C_TEST) {
         PerlIO_printf(Perl_debug_log, "Fast copy on write: %p -> %p\n",
@@ -5523,9 +5527,9 @@ formed and ready to use, just like any other SV containing an empty string.
 char *
 Perl_sv_setpv_bufsize(pTHX_ SV *const sv, const STRLEN cur, const STRLEN len)
 {
-    char *pv;
-
     PERL_ARGS_ASSERT_SV_SETPV_BUFSIZE;
+
+    char *pv;
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
     SvUPGRADE(sv, SVt_PV);
@@ -5580,9 +5584,9 @@ SVt_PVNV, or SVt_PVMG.
 void
 Perl_sv_setpvn(pTHX_ SV *const sv, const char *const ptr, const STRLEN len)
 {
-    char *dptr;
-
     PERL_ARGS_ASSERT_SV_SETPVN;
+
+    char *dptr;
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
     if (isGV_with_GP(sv))
@@ -5621,9 +5625,10 @@ Perl_sv_setpvn_mg(pTHX_ SV *const sv, const char *const ptr, const STRLEN len)
 void
 Perl_sv_setpvn_fresh(pTHX_ SV *const sv, const char *const ptr, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_SV_SETPVN_FRESH;
+
     char *dptr;
 
-    PERL_ARGS_ASSERT_SV_SETPVN_FRESH;
     assert(SvTYPE(sv) >= SVt_PV && SvTYPE(sv) <= SVt_PVMG);
     assert(!SvTHINKFIRST(sv));
     assert(!isGV_with_GP(sv));
@@ -5647,9 +5652,9 @@ Perl_sv_setpvn_fresh(pTHX_ SV *const sv, const char *const ptr, const STRLEN len
 void
 Perl_sv_setpv(pTHX_ SV *const sv, const char *const ptr)
 {
-    STRLEN len;
-
     PERL_ARGS_ASSERT_SV_SETPV;
+
+    STRLEN len;
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
     if (!ptr) {
@@ -5762,9 +5767,9 @@ so 'set' magic is performed.
 void
 Perl_sv_usepvn_flags(pTHX_ SV *const sv, char *ptr, const STRLEN len, const U32 flags)
 {
-    STRLEN allocate;
-
     PERL_ARGS_ASSERT_SV_USEPVN_FLAGS;
+
+    STRLEN allocate;
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
     SvUPGRADE(sv, SVt_PV);
@@ -6051,6 +6056,8 @@ C<chop> works from the right.
 void
 Perl_sv_chop(pTHX_ SV *const sv, const char *const ptr)
 {
+    PERL_ARGS_ASSERT_SV_CHOP;
+
     STRLEN delta;
     STRLEN old_delta;
     U8 *p;
@@ -6059,8 +6066,6 @@ Perl_sv_chop(pTHX_ SV *const sv, const char *const ptr)
     STRLEN evacn;
 #endif
     STRLEN max_delta;
-
-    PERL_ARGS_ASSERT_SV_CHOP;
 
     if (!ptr || !SvPOKp(sv))
         return;
@@ -6189,10 +6194,11 @@ if and only if the C<dsv> has the UTF-8 status set.
 void
 Perl_sv_catpvn_flags(pTHX_ SV *const dsv, const char *sstr, const STRLEN slen, const I32 flags)
 {
+    PERL_ARGS_ASSERT_SV_CATPVN_FLAGS;
+
     STRLEN dlen;
     const char * const dstr = SvPV_force_flags(dsv, dlen, flags);
 
-    PERL_ARGS_ASSERT_SV_CATPVN_FLAGS;
     assert((flags & (SV_CATBYTES|SV_CATUTF8)) != (SV_CATBYTES|SV_CATUTF8));
 
     if (!(flags & SV_CATBYTES) || !SvUTF8(dsv)) {
@@ -6280,11 +6286,11 @@ Perl_sv_catsv_flags(pTHX_ SV *const dsv, SV *const sstr, const I32 flags)
 void
 Perl_sv_catpv(pTHX_ SV *const dsv, const char *sstr)
 {
+    PERL_ARGS_ASSERT_SV_CATPV;
+
     STRLEN len;
     STRLEN tlen;
     char *junk;
-
-    PERL_ARGS_ASSERT_SV_CATPV;
 
     if (!sstr)
         return;
@@ -6404,9 +6410,9 @@ MAGIC *
 Perl_sv_magicext(pTHX_ SV *const sv, SV *const obj, const int how,
                 const MGVTBL *const vtable, const char *const name, const I32 namlen)
 {
-    MAGIC* mg;
-
     PERL_ARGS_ASSERT_SV_MAGICEXT;
+
+    MAGIC* mg;
 
     SvUPGRADE(sv, SVt_PVMG);
     Newxz(mg, 1, MAGIC);
@@ -6506,12 +6512,12 @@ void
 Perl_sv_magic(pTHX_ SV *const sv, SV *const obj, const int how,
              const char *const name, const I32 namlen)
 {
+    PERL_ARGS_ASSERT_SV_MAGIC;
+
     const MGVTBL *vtable;
     MAGIC* mg;
     unsigned int flags;
     unsigned int vtable_index;
-
-    PERL_ARGS_ASSERT_SV_MAGIC;
 
     if (how < 0 || (unsigned)how >= C_ARRAY_LENGTH(PL_magic_data)
         || ((flags = PL_magic_data[how]),
@@ -6636,9 +6642,9 @@ on already-weak references.
 SV *
 Perl_sv_rvweaken(pTHX_ SV *const sv)
 {
-    SV *tsv;
-
     PERL_ARGS_ASSERT_SV_RVWEAKEN;
+
+    SV *tsv;
 
     if (!SvOK(sv))  /* let undefs pass */
         return sv;
@@ -6670,9 +6676,9 @@ Silently ignores C<undef> and warns on non-weak references.
 SV *
 Perl_sv_rvunweaken(pTHX_ SV *const sv)
 {
-    SV *tsv;
-
     PERL_ARGS_ASSERT_SV_RVUNWEAKEN;
+
+    SV *tsv;
 
     if (!SvOK(sv)) /* let undefs pass */
         return sv;
@@ -6712,9 +6718,9 @@ C<Perl_sv_kill_backrefs()>
 SV *
 Perl_sv_get_backrefs(SV *const sv)
 {
-    SV *backrefs= NULL;
-
     PERL_ARGS_ASSERT_SV_GET_BACKREFS;
+
+    SV *backrefs= NULL;
 
     /* find slot to store array or singleton backref */
 
@@ -6761,11 +6767,11 @@ Perl_sv_get_backrefs(SV *const sv)
 void
 Perl_sv_add_backref(pTHX_ SV *const tsv, SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_ADD_BACKREF;
+
     SV **svp;
     AV *av = NULL;
     MAGIC *mg = NULL;
-
-    PERL_ARGS_ASSERT_SV_ADD_BACKREF;
 
     /* find slot to store array or singleton backref */
 
@@ -6821,9 +6827,9 @@ Perl_sv_add_backref(pTHX_ SV *const tsv, SV *const sv)
 void
 Perl_sv_del_backref(pTHX_ SV *const tsv, SV *const sv)
 {
-    SV **svp = NULL;
-
     PERL_ARGS_ASSERT_SV_DEL_BACKREF;
+
+    SV **svp = NULL;
 
     if (SvTYPE(tsv) == SVt_PVHV) {
         if (HvHasAUX(tsv))
@@ -6938,11 +6944,11 @@ Perl_sv_del_backref(pTHX_ SV *const tsv, SV *const sv)
 void
 Perl_sv_kill_backrefs(pTHX_ SV *const sv, AV *const av)
 {
+    PERL_ARGS_ASSERT_SV_KILL_BACKREFS;
+
     SV **svp;
     SV **last;
     bool is_array;
-
-    PERL_ARGS_ASSERT_SV_KILL_BACKREFS;
 
     if (!av)
         return;
@@ -7044,14 +7050,14 @@ C<bigstr>.
 void
 Perl_sv_insert_flags(pTHX_ SV *const bigstr, const STRLEN offset, const STRLEN len, const char *little, const STRLEN littlelen, const U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_INSERT_FLAGS;
+
     char *big;
     char *mid;
     char *midend;
     char *bigend;
     SSize_t i;		/* better be sizeof(STRLEN) or bad things happen */
     STRLEN curlen;
-
-    PERL_ARGS_ASSERT_SV_INSERT_FLAGS;
 
     SvPV_force_flags(bigstr, curlen, flags);
     (void)SvPOK_only_UTF8(bigstr);
@@ -7149,9 +7155,9 @@ time you'll want to use C<sv_setsv> or one of its many macro front-ends.
 void
 Perl_sv_replace(pTHX_ SV *const sv, SV *const nsv)
 {
-    const U32 refcnt = SvREFCNT(sv);
-
     PERL_ARGS_ASSERT_SV_REPLACE;
+
+    const U32 refcnt = SvREFCNT(sv);
 
     SV_CHECK_THINKFIRST_COW_DROP(sv);
     if (SvREFCNT(nsv) != 1) {
@@ -7197,10 +7203,10 @@ Perl_sv_replace(pTHX_ SV *const sv, SV *const nsv)
 static void
 S_anonymise_cv_maybe(pTHX_ GV *gv, CV* cv)
 {
+    PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE;
+
     SV *gvname;
     GV *anongv;
-
-    PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE;
 
     /* be assertive! */
     assert(SvREFCNT(gv) == 0);
@@ -7246,13 +7252,13 @@ you'll want to call C<SvREFCNT_dec> instead.
 void
 Perl_sv_clear(pTHX_ SV *const orig_sv)
 {
+    PERL_ARGS_ASSERT_SV_CLEAR;
+
     SV* iter_sv = NULL;
     SV* next_sv = NULL;
     SV *sv = orig_sv;
     STRLEN hash_index = 0; /* initialise to make Coverity et al happy.
                               Not strictly necessary */
-
-    PERL_ARGS_ASSERT_SV_CLEAR;
 
     /* within this loop, sv is the SV currently being freed, and
      * iter_sv is the most recent AV or whatever that's being iterated
@@ -7859,7 +7865,6 @@ Perl_sv_free(pTHX_ SV *const sv)
 void
 Perl_sv_free2(pTHX_ SV *const sv, const U32 rc)
 {
-
     PERL_ARGS_ASSERT_SV_FREE2;
 
     if (LIKELY( rc == 1 )) {
@@ -7988,10 +7993,10 @@ Perl_sv_len_utf8(pTHX_ SV *const sv)
 STRLEN
 Perl_sv_len_utf8_nomg(pTHX_ SV * const sv)
 {
+    PERL_ARGS_ASSERT_SV_LEN_UTF8_NOMG;
+
     STRLEN len;
     const U8 *s = (U8*)SvPV_nomg_const(sv, len);
-
-    PERL_ARGS_ASSERT_SV_LEN_UTF8_NOMG;
 
     if (PL_utf8cache && SvUTF8(sv)) {
             STRLEN ulen;
@@ -8030,10 +8035,10 @@ S_sv_pos_u2b_forwards(const U8 *const start, const U8 *const send,
                       STRLEN *const uoffset_p, bool *const at_end,
                       bool* canonical_position)
 {
+    PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS;
+
     const U8 *s = start;
     STRLEN uoffset = *uoffset_p;
-
-    PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS;
 
     SSize_t overshoot;
     s = utf8_hop_forward_overshoot(s, uoffset, send, &overshoot);
@@ -8055,9 +8060,9 @@ static STRLEN
 S_sv_pos_u2b_midway(const U8 *const start, const U8 *send,
                     STRLEN uoffset, const STRLEN uend)
 {
-    STRLEN backw = uend - uoffset;
-
     PERL_ARGS_ASSERT_SV_POS_U2B_MIDWAY;
+
+    STRLEN backw = uend - uoffset;
 
     if (uoffset < 2 * backw) {
         /* The assumption is that the average size of a character is 2 bytes,
@@ -8090,12 +8095,12 @@ S_sv_pos_u2b_cached(pTHX_ SV *const sv, MAGIC **const mgp, const U8 *const start
                     const U8 *const send, STRLEN uoffset,
                     STRLEN uoffset0, STRLEN boffset0)
 {
+    PERL_ARGS_ASSERT_SV_POS_U2B_CACHED;
+
     STRLEN boffset = 0; /* Actually always set, but let's keep gcc happy.  */
     bool found = FALSE;
     bool at_end = FALSE;
     bool canonical_position = FALSE;
-
-    PERL_ARGS_ASSERT_SV_POS_U2B_CACHED;
 
     assert (uoffset >= uoffset0);
 
@@ -8245,11 +8250,11 @@ STRLEN
 Perl_sv_pos_u2b_flags(pTHX_ SV *const sv, STRLEN uoffset, STRLEN *const lenp,
                       U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_POS_U2B_FLAGS;
+
     const U8 *start;
     STRLEN len;
     STRLEN boffset;
-
-    PERL_ARGS_ASSERT_SV_POS_U2B_FLAGS;
 
     start = (U8*)SvPV_flags(sv, len, flags);
     if (len) {
@@ -8346,9 +8351,9 @@ static void
 S_utf8_mg_pos_cache_update(pTHX_ SV *const sv, MAGIC **const mgp, const STRLEN byte,
                            const STRLEN utf8, const STRLEN blen)
 {
-    STRLEN *cache;
-
     PERL_ARGS_ASSERT_UTF8_MG_POS_CACHE_UPDATE;
+
+    STRLEN *cache;
 
     if (SvREADONLY(sv))
         return;
@@ -8466,10 +8471,10 @@ static STRLEN
 S_sv_pos_b2u_midway(pTHX_ const U8 *const s, const U8 *const target,
                     const U8 *end, STRLEN endu)
 {
+    PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY;
+
     const STRLEN forw = target - s;
     STRLEN backw = end - target;
-
-    PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY;
 
     if (forw < 2 * backw) {
         return utf8_length(s, target);
@@ -8528,14 +8533,14 @@ Both functions use and update C<PERL_MAGIC_utf8>.
 STRLEN
 Perl_sv_pos_b2u_flags(pTHX_ SV *const sv, STRLEN const offset, U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_POS_B2U_FLAGS;
+
     const U8* s;
     STRLEN len = 0; /* Actually always set, but let's keep gcc happy.  */
     STRLEN blen;
     MAGIC* mg = NULL;
     const U8* send;
     bool found = FALSE;
-
-    PERL_ARGS_ASSERT_SV_POS_B2U_FLAGS;
 
     s = (const U8*)SvPV_flags(sv, blen, flags);
 
@@ -9472,9 +9477,9 @@ Otherwise, the two forms behave identically.
 char *
 Perl_sv_collxfrm_flags(pTHX_ SV *const sv, STRLEN *const nxp, const I32 flags)
 {
-    MAGIC *mg;
-
     PERL_ARGS_ASSERT_SV_COLLXFRM_FLAGS;
+
+    MAGIC *mg;
 
     mg = SvMAGICAL(sv) ? mg_find(sv, PERL_MAGIC_collxfrm) : (MAGIC *) NULL;
 
@@ -9664,6 +9669,8 @@ in the SV (typically, C<SvCUR(sv)> is a suitable choice).
 char *
 Perl_sv_gets(pTHX_ SV *const sv, PerlIO *const fp, SSize_t append)
 {
+    PERL_ARGS_ASSERT_SV_GETS;
+
     const char *rsptr;
     STRLEN rslen;
     STDCHAR rslast;
@@ -9671,8 +9678,6 @@ Perl_sv_gets(pTHX_ SV *const sv, PerlIO *const fp, SSize_t append)
     SSize_t cnt;
     int i = 0;
     int rspara = 0;
-
-    PERL_ARGS_ASSERT_SV_GETS;
 
     if (SvTHINKFIRST(sv))
         sv_force_normal_flags(sv, append ? 0 : SV_COW_DROP_PV);
@@ -10806,11 +10811,11 @@ Perl_newSVpv_share(pTHX_ const char *src, U32 hash)
 SV *
 Perl_newSVpvf_nocontext(const char *const pat, ...)
 {
+    PERL_ARGS_ASSERT_NEWSVPVF_NOCONTEXT;
+
     dTHX;
     SV *sv;
     va_list args;
-
-    PERL_ARGS_ASSERT_NEWSVPVF_NOCONTEXT;
 
     va_start(args, pat);
     sv = vnewSVpvf(pat, &args);
@@ -10838,10 +10843,10 @@ the remaining forms are specified as a sprintf-style list of arguments.
 SV *
 Perl_newSVpvf(pTHX_ const char *const pat, ...)
 {
+    PERL_ARGS_ASSERT_NEWSVPVF;
+
     SV *sv;
     va_list args;
-
-    PERL_ARGS_ASSERT_NEWSVPVF;
 
     va_start(args, pat);
     sv = vnewSVpvf(pat, &args);
@@ -11148,10 +11153,10 @@ C<SvRV(sv)> if C<sv> is an RV.
 IO*
 Perl_sv_2io(pTHX_ SV *const sv)
 {
+    PERL_ARGS_ASSERT_SV_2IO;
+
     IO* io;
     GV* gv;
-
-    PERL_ARGS_ASSERT_SV_2IO;
 
     switch (SvTYPE(sv)) {
     case SVt_PVIO:
@@ -11205,10 +11210,10 @@ The flags in C<lref> are passed to C<gv_fetchsv>.
 CV *
 Perl_sv_2cv(pTHX_ SV *sv, HV **const st, GV **const gvp, const I32 lref)
 {
+    PERL_ARGS_ASSERT_SV_2CV;
+
     GV *gv = NULL;
     CV *cv = NULL;
-
-    PERL_ARGS_ASSERT_SV_2CV;
 
     if (!sv) {
         *st = NULL;
@@ -11557,9 +11562,9 @@ directly on the actual object type.
 int
 Perl_sv_isa(pTHX_ SV *sv, const char *const name)
 {
-    const char *hvname;
-
     PERL_ARGS_ASSERT_SV_ISA;
+
+    const char *hvname;
 
     if (!sv)
         return 0;
@@ -11591,9 +11596,9 @@ newRV_inc() and newRV_noinc() for creating a new RV properly.
 SV*
 Perl_newSVrv(pTHX_ SV *const rv, const char *const classname)
 {
-    SV *sv;
-
     PERL_ARGS_ASSERT_NEWSVRV;
+
+    SV *sv;
 
     new_SV(sv);
 
@@ -11628,8 +11633,9 @@ Perl_newSVrv(pTHX_ SV *const rv, const char *const classname)
 SV *
 Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
 {
-    SV * const lv = newSV_type(SVt_PVLV);
     PERL_ARGS_ASSERT_NEWSVAVDEFELEM;
+
+    SV * const lv = newSV_type(SVt_PVLV);
     LvTYPE(lv) = 'y';
     sv_magic(lv, NULL, PERL_MAGIC_defelem, NULL, 0);
     LvTARG(lv) = SvREFCNT_inc_simple_NN(av);
@@ -11779,10 +11785,10 @@ of the SV is unaffected.
 SV*
 Perl_sv_bless(pTHX_ SV *const sv, HV *const stash)
 {
+    PERL_ARGS_ASSERT_SV_BLESS;
+
     SV *tmpRef;
     HV *oldstash = NULL;
-
-    PERL_ARGS_ASSERT_SV_BLESS;
 
     SvGETMAGIC(sv);
     if (!SvROK(sv))
@@ -11821,11 +11827,11 @@ Perl_sv_bless(pTHX_ SV *const sv, HV *const stash)
 PERL_STATIC_INLINE void
 S_sv_unglob(pTHX_ SV *const sv, U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_UNGLOB;
+
     void *xpvmg;
     HV *stash;
     SV * const temp = flags & SV_COW_DROP_PV ? NULL : sv_newmortal();
-
-    PERL_ARGS_ASSERT_SV_UNGLOB;
 
     assert(SvTYPE(sv) == SVt_PVGV || SvTYPE(sv) == SVt_PVLV);
     SvFAKE_off(sv);
@@ -11899,9 +11905,9 @@ See C<L</SvROK_off>>.
 void
 Perl_sv_unref_flags(pTHX_ SV *const ref, const U32 flags)
 {
-    SV* const target = SvRV(ref);
-
     PERL_ARGS_ASSERT_SV_UNREF_FLAGS;
+
+    SV* const target = SvRV(ref);
 
     if (SvWEAKREF(ref)) {
         sv_del_backref(target, ref);
@@ -11972,10 +11978,10 @@ Perl_sv_tainted(pTHX_ SV *const sv)
 void
 Perl_sv_setpvf_nocontext(SV *const sv, const char *const pat, ...)
 {
+    PERL_ARGS_ASSERT_SV_SETPVF_NOCONTEXT;
+
     dTHX;
     va_list args;
-
-    PERL_ARGS_ASSERT_SV_SETPVF_NOCONTEXT;
 
     va_start(args, pat);
     sv_vsetpvf(sv, pat, &args);
@@ -11990,10 +11996,10 @@ Perl_sv_setpvf_nocontext(SV *const sv, const char *const pat, ...)
 void
 Perl_sv_setpvf_mg_nocontext(SV *const sv, const char *const pat, ...)
 {
+    PERL_ARGS_ASSERT_SV_SETPVF_MG_NOCONTEXT;
+
     dTHX;
     va_list args;
-
-    PERL_ARGS_ASSERT_SV_SETPVF_MG_NOCONTEXT;
 
     va_start(args, pat);
     sv_vsetpvf_mg(sv, pat, &args);
@@ -12067,9 +12073,9 @@ There are no other differences between the forms.
 void
 Perl_sv_setpvf(pTHX_ SV *const sv, const char *const pat, ...)
 {
-    va_list args;
-
     PERL_ARGS_ASSERT_SV_SETPVF;
+
+    va_list args;
 
     va_start(args, pat);
     sv_vsetpvf(sv, pat, &args);
@@ -12087,9 +12093,9 @@ Perl_sv_vsetpvf(pTHX_ SV *const sv, const char *const pat, va_list *const args)
 void
 Perl_sv_setpvf_mg(pTHX_ SV *const sv, const char *const pat, ...)
 {
-    va_list args;
-
     PERL_ARGS_ASSERT_SV_SETPVF_MG;
+
+    va_list args;
 
     va_start(args, pat);
     sv_vsetpvf_mg(sv, pat, &args);
@@ -12115,10 +12121,10 @@ Perl_sv_vsetpvf_mg(pTHX_ SV *const sv, const char *const pat, va_list *const arg
 void
 Perl_sv_catpvf_nocontext(SV *const sv, const char *const pat, ...)
 {
+    PERL_ARGS_ASSERT_SV_CATPVF_NOCONTEXT;
+
     dTHX;
     va_list args;
-
-    PERL_ARGS_ASSERT_SV_CATPVF_NOCONTEXT;
 
     va_start(args, pat);
     sv_vcatpvfn_flags(sv, pat, strlen(pat), &args, NULL, 0, NULL, SV_GMAGIC|SV_SMAGIC);
@@ -12133,10 +12139,10 @@ Perl_sv_catpvf_nocontext(SV *const sv, const char *const pat, ...)
 void
 Perl_sv_catpvf_mg_nocontext(SV *const sv, const char *const pat, ...)
 {
+    PERL_ARGS_ASSERT_SV_CATPVF_MG_NOCONTEXT;
+
     dTHX;
     va_list args;
-
-    PERL_ARGS_ASSERT_SV_CATPVF_MG_NOCONTEXT;
 
     va_start(args, pat);
     sv_vcatpvfn_flags(sv, pat, strlen(pat), &args, NULL, 0, NULL, SV_GMAGIC|SV_SMAGIC);
@@ -12226,9 +12232,9 @@ There are no other differences between the forms.
 void
 Perl_sv_catpvf(pTHX_ SV *const sv, const char *const pat, ...)
 {
-    va_list args;
-
     PERL_ARGS_ASSERT_SV_CATPVF;
+
+    va_list args;
 
     va_start(args, pat);
     sv_vcatpvfn_flags(sv, pat, strlen(pat), &args, NULL, 0, NULL, SV_GMAGIC|SV_SMAGIC);
@@ -12246,9 +12252,9 @@ Perl_sv_vcatpvf(pTHX_ SV *const sv, const char *const pat, va_list *const args)
 void
 Perl_sv_catpvf_mg(pTHX_ SV *const sv, const char *const pat, ...)
 {
-    va_list args;
-
     PERL_ARGS_ASSERT_SV_CATPVF_MG;
+
+    va_list args;
 
     va_start(args, pat);
     sv_vcatpvfn_flags(sv, pat, strlen(pat), &args, NULL, 0, NULL, SV_GMAGIC|SV_SMAGIC);
@@ -12380,9 +12386,9 @@ S_sprintf_arg_num_val(pTHX_ va_list *const args, int i, SV *sv, bool *neg)
 static STRLEN
 S_expect_number(pTHX_ const char **const pattern)
 {
-    STRLEN var;
-
     PERL_ARGS_ASSERT_EXPECT_NUMBER;
+
+    STRLEN var;
 
     assert(inRANGE(**pattern, '1', '9'));
 
@@ -12405,10 +12411,10 @@ S_expect_number(pTHX_ const char **const pattern)
 static char *
 S_F0convert(NV nv, char *const endbuf, STRLEN *const len)
 {
+    PERL_ARGS_ASSERT_F0CONVERT;
+
     const int neg = nv < 0;
     UV uv;
-
-    PERL_ARGS_ASSERT_F0CONVERT;
 
     assert(!Perl_isinfnan(nv));
     if (neg)
@@ -13146,6 +13152,8 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                        va_list *const args, SV **const svargs, const Size_t sv_count, bool *const maybe_tainted,
                        const U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_VCATPVFN_FLAGS;
+
     const char *fmtstart; /* character following the current '%' */
     const char *q;        /* current position within format */
     const char *patend;
@@ -13166,9 +13174,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
     bool in_lc_numeric = FALSE;
     SV *tmp_sv = NULL;
 
-    PERL_ARGS_ASSERT_SV_VCATPVFN_FLAGS;
     PERL_UNUSED_ARG(maybe_tainted);
-
     if (flags & SV_GMAGIC)
         SvGETMAGIC(sv);
 
@@ -14817,9 +14823,9 @@ ptr_table_* functions.
 yy_parser *
 Perl_parser_dup(pTHX_ const yy_parser *const proto, CLONE_PARAMS *const param)
 {
-    yy_parser *parser;
-
     PERL_ARGS_ASSERT_PARSER_DUP;
+
+    yy_parser *parser;
 
     if (!proto)
         return NULL;
@@ -14922,9 +14928,10 @@ Duplicate a file handle, returning a pointer to the cloned object.
 PerlIO *
 Perl_fp_dup(pTHX_ PerlIO *const fp, const char type, CLONE_PARAMS *const param)
 {
+    PERL_ARGS_ASSERT_FP_DUP;
+
     PerlIO *ret;
 
-    PERL_ARGS_ASSERT_FP_DUP;
     PERL_UNUSED_ARG(type);
 
     if (!fp)
@@ -14957,10 +14964,10 @@ Duplicate a directory handle, returning a pointer to the cloned object.
 DIR *
 Perl_dirp_dup(pTHX_ DIR *const dp, CLONE_PARAMS *const param)
 {
-    DIR *ret;
-
     PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_DIRP_DUP;
+
+    DIR *ret;
 
     if (!dp)
         return (DIR*)NULL;
@@ -14999,9 +15006,9 @@ Duplicate a typeglob, returning a pointer to the cloned object.
 GP *
 Perl_gp_dup(pTHX_ GP *const gp, CLONE_PARAMS *const param)
 {
-    GP *ret;
-
     PERL_ARGS_ASSERT_GP_DUP;
+
+    GP *ret;
 
     if (!gp)
         return (GP*)NULL;
@@ -15043,10 +15050,10 @@ Duplicate a chain of magic, returning a pointer to the cloned object.
 MAGIC *
 Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS *const param)
 {
+    PERL_ARGS_ASSERT_MG_DUP;
+
     MAGIC *mgret = NULL;
     MAGIC **mgprev_p = &mgret;
-
-    PERL_ARGS_ASSERT_MG_DUP;
 
     for (; mg; mg = mg->mg_moremagic) {
         MAGIC *nmg;
@@ -15149,10 +15156,10 @@ Perl_ptr_table_new(pTHX)
 static PTR_TBL_ENT_t *
 S_ptr_table_find(PTR_TBL_t *const tbl, const void *const sv)
 {
+    PERL_ARGS_ASSERT_PTR_TABLE_FIND;
+
     PTR_TBL_ENT_t *tblent;
     const UV hash = PTR_TABLE_HASH(sv);
-
-    PERL_ARGS_ASSERT_PTR_TABLE_FIND;
 
     tblent = tbl->tbl_ary[hash & tbl->tbl_max];
     for (; tblent; tblent = tblent->next) {
@@ -15174,10 +15181,10 @@ NULL if not found.
 void *
 Perl_ptr_table_fetch(pTHX_ PTR_TBL_t *const tbl, const void *const sv)
 {
-    PTR_TBL_ENT_t const *const tblent = ptr_table_find(tbl, sv);
-
     PERL_ARGS_ASSERT_PTR_TABLE_FETCH;
     PERL_UNUSED_CONTEXT;
+
+    PTR_TBL_ENT_t const *const tblent = ptr_table_find(tbl, sv);
 
     return tblent ? tblent->newval : NULL;
 }
@@ -15197,10 +15204,10 @@ in thread cloning.
 void
 Perl_ptr_table_store(pTHX_ PTR_TBL_t *const tbl, const void *const oldsv, void *const newsv)
 {
-    PTR_TBL_ENT_t *tblent = ptr_table_find(tbl, oldsv);
-
     PERL_ARGS_ASSERT_PTR_TABLE_STORE;
     PERL_UNUSED_CONTEXT;
+
+    PTR_TBL_ENT_t *tblent = ptr_table_find(tbl, oldsv);
 
     if (tblent) {
         tblent->newval = newsv;
@@ -15240,14 +15247,14 @@ Double the hash bucket size of an existing ptr table
 void
 Perl_ptr_table_split(pTHX_ PTR_TBL_t *const tbl)
 {
+    PERL_ARGS_ASSERT_PTR_TABLE_SPLIT;
+
     PTR_TBL_ENT_t **ary = tbl->tbl_ary;
     const UV oldsize = tbl->tbl_max + 1;
     UV newsize = oldsize * 2;
     UV i;
 
-    PERL_ARGS_ASSERT_PTR_TABLE_SPLIT;
     PERL_UNUSED_CONTEXT;
-
     Renew(ary, newsize, PTR_TBL_ENT_t*);
     Zero(&ary[oldsize], newsize-oldsize, PTR_TBL_ENT_t*);
     tbl->tbl_max = --newsize;
@@ -15457,9 +15464,9 @@ S_sv_dup_hvaux(pTHX_ const SV *const ssv, SV *dsv, CLONE_PARAMS *const param)
 static SV *
 S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
 {
-    SV *dsv;
-
     PERL_ARGS_ASSERT_SV_DUP_COMMON;
+
+    SV *dsv;
 
     if (SvIS_FREED(ssv)) {
 #ifdef DEBUG_LEAKING_SCALARS_ABORT
@@ -15875,8 +15882,9 @@ Perl_sv_dup_inc(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
 SV *
 Perl_sv_dup(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
 {
-    SV *dsv = ssv ? sv_dup_common(ssv, param) : NULL;
     PERL_ARGS_ASSERT_SV_DUP;
+
+    SV *dsv = ssv ? sv_dup_common(ssv, param) : NULL;
 
     /* Track every SV that (at least initially) had a reference count of 0.
        We need to do this by holding an actual reference to it in this array.
@@ -15905,9 +15913,9 @@ Perl_sv_dup(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
 PERL_CONTEXT *
 Perl_cx_dup(pTHX_ PERL_CONTEXT *cxs, I32 ix, I32 max, CLONE_PARAMS* param)
 {
-    PERL_CONTEXT *ncxs;
-
     PERL_ARGS_ASSERT_CX_DUP;
+
+    PERL_CONTEXT *ncxs;
 
     if (!cxs)
         return (PERL_CONTEXT*)NULL;
@@ -16025,9 +16033,9 @@ Duplicate a stack info structure, returning a pointer to the cloned object.
 PERL_SI *
 Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS* param)
 {
-    PERL_SI *nsi;
-
     PERL_ARGS_ASSERT_SI_DUP;
+
+    PERL_SI *nsi;
 
     if (!si)
         return (PERL_SI*)NULL;
@@ -16089,9 +16097,9 @@ Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS* param)
 void *
 Perl_any_dup(pTHX_ void *v, const PerlInterpreter *proto_perl)
 {
-    void *ret;
-
     PERL_ARGS_ASSERT_ANY_DUP;
+
+    void *ret;
 
     if (!v)
         return (void*)NULL;
@@ -16122,6 +16130,8 @@ Duplicate the save stack, returning a pointer to the cloned object.
 ANY *
 Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS* param)
 {
+    PERL_ARGS_ASSERT_SS_DUP;
+
     ANY * const ss	= proto_perl->Isavestack;
     const I32 max	= proto_perl->Isavestack_max + SS_MAXPUSH;
     I32 ix		= proto_perl->Isavestack_ix;
@@ -16140,8 +16150,6 @@ Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS* param)
     char *c = NULL;
     void (*dptr) (void*);
     void (*dxptr) (pTHX_ void*);
-
-    PERL_ARGS_ASSERT_SS_DUP;
 
     Newx(nss, max, ANY);
 
@@ -16499,9 +16507,9 @@ perl_clone_host(PerlInterpreter* proto_perl, UV flags);
 PerlInterpreter *
 perl_clone(PerlInterpreter *proto_perl, UV flags)
 {
-#ifdef PERL_IMPLICIT_SYS
-
     PERL_ARGS_ASSERT_PERL_CLONE;
+
+#ifdef PERL_IMPLICIT_SYS
 
    /* perlhost.h so we need to call into it
    to clone the host, CPerlHost should have a c interface, sky */
@@ -16531,6 +16539,8 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
                  const struct IPerlDir** ipD, const struct IPerlSock** ipS,
                  const struct IPerlProc** ipP)
 {
+    PERL_ARGS_ASSERT_PERL_CLONE_USING;
+
     /* XXX many of the string copies here can be optimized if they're
      * constants; they need to be allocated as common memory and just
      * their pointers copied. */
@@ -16541,7 +16551,6 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags,
 
     PerlInterpreter * const my_perl = (PerlInterpreter*)((*ipM)->pMalloc)(ipM, sizeof(PerlInterpreter));
 
-    PERL_ARGS_ASSERT_PERL_CLONE_USING;
 #else		/* !PERL_IMPLICIT_SYS */
     IV i;
     CLONE_PARAMS clone_params;
@@ -17330,11 +17339,11 @@ S_unreferenced_to_tmp_stack(pTHX_ AV *const unreferenced)
 void
 Perl_clone_params_del(CLONE_PARAMS *param)
 {
+    PERL_ARGS_ASSERT_CLONE_PARAMS_DEL;
+
     PerlInterpreter *const was = PERL_GET_THX;
     PerlInterpreter *const to = param->new_perl;
     dTHXa(to);
-
-    PERL_ARGS_ASSERT_CLONE_PARAMS_DEL;
 
     if (was != to) {
         PERL_SET_THX(to);
@@ -17354,14 +17363,14 @@ Perl_clone_params_del(CLONE_PARAMS *param)
 CLONE_PARAMS *
 Perl_clone_params_new(PerlInterpreter *const from, PerlInterpreter *const to)
 {
+    PERL_ARGS_ASSERT_CLONE_PARAMS_NEW;
+
     /* Need to play this game, as newAV() can call safesysmalloc(), and that
        does a dTHX; to get the context from thread local storage.
        FIXME - under PERL_CORE Newx(), Safefree() and friends should expand to
        a version that passes in my_perl.  */
     PerlInterpreter *const was = PERL_GET_THX;
     CLONE_PARAMS *param;
-
-    PERL_ARGS_ASSERT_CLONE_PARAMS_NEW;
 
     if (was != to) {
         PERL_SET_THX(to);
@@ -17551,9 +17560,9 @@ bool
 Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding,
                    SV *ssv, int *offset, char *tstr, int tlen)
 {
-    bool ret = FALSE;
-
     PERL_ARGS_ASSERT_SV_CAT_DECODE;
+
+    bool ret = FALSE;
 
     if (SvPOK(ssv) && SvPOK(dsv) && SvROK(encoding)) {
         SV *offsv;
@@ -17600,10 +17609,10 @@ Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding,
 static SV*
 S_find_hash_subscript(pTHX_ const HV *const hv, const SV *const val)
 {
+    PERL_ARGS_ASSERT_FIND_HASH_SUBSCRIPT;
+
     HE **array;
     I32 i;
-
-    PERL_ARGS_ASSERT_FIND_HASH_SUBSCRIPT;
 
     if (!hv || SvMAGICAL(hv) || !HvTOTALKEYS(hv) ||
                         (HvTOTALKEYS(hv) > FUV_MAX_SEARCH_SIZE))
@@ -17762,11 +17771,11 @@ static SV *
 S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                   bool match, const char **desc_p)
 {
+    PERL_ARGS_ASSERT_FIND_UNINIT_VAR;
+
     SV *sv;
     const GV *gv;
     const OP *o, *o2, *kid;
-
-    PERL_ARGS_ASSERT_FIND_UNINIT_VAR;
 
     if (!obase || (match && (!uninit_sv || uninit_sv == &PL_sv_undef ||
                             uninit_sv == &PL_sv_placeholder)))

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -719,9 +719,9 @@ Perl_SvREFCNT_dec_ret_NULL(pTHX_ SV *sv)
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec_NN(pTHX_ SV *sv)
 {
-    U32 rc = SvREFCNT(sv);
-
     PERL_ARGS_ASSERT_SVREFCNT_DEC_NN;
+
+    U32 rc = SvREFCNT(sv);
 
     if (LIKELY(rc > 1))
         SvREFCNT(sv) = rc - 1;
@@ -901,10 +901,11 @@ S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp)
 PERL_STATIC_INLINE char *
 Perl_sv_pvutf8n_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
 {
+    PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE_WRAPPER;
+
     /* This is just so can be passed to Perl_SvPV_helper() as a function
      * pointer with the same signature as all the other such pointers, and
      * having hence an unused parameter */
-    PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE_WRAPPER;
     PERL_UNUSED_ARG(dummy);
 
     return sv_pvutf8n_force(sv, lp);
@@ -913,10 +914,11 @@ Perl_sv_pvutf8n_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 
 PERL_STATIC_INLINE char *
 Perl_sv_pvbyten_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
 {
+    PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE_WRAPPER;
+
     /* This is just so can be passed to Perl_SvPV_helper() as a function
      * pointer with the same signature as all the other such pointers, and
      * having hence an unused parameter */
-    PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE_WRAPPER;
     PERL_UNUSED_ARG(dummy);
 
     return sv_pvbyten_force(sv, lp);
@@ -991,9 +993,9 @@ SV is B<not> incremented.
 PERL_STATIC_INLINE SV *
 Perl_newRV_noinc(pTHX_ SV *const tmpRef)
 {
-    SV *sv = newSV_type(SVt_IV);
-
     PERL_ARGS_ASSERT_NEWRV_NOINC;
+
+    SV *sv = newSV_type(SVt_IV);
 
     SvTEMP_off(tmpRef);
 

--- a/taint.c
+++ b/taint.c
@@ -34,13 +34,14 @@ Implements the L</TAINT_PROPER> macro, which you should generally use instead.
 void
 Perl_taint_proper(pTHX_ const char *f, const char *const s)
 {
+    PERL_ARGS_ASSERT_TAINT_PROPER;
+
     /* Don't use directly; instead use TAINT_PROPER
      *
      * Output a tainting violation, croaking unless we're just to warn.
      * '_proper' is just to throw you off the scent */
 
 #if defined(HAS_SETEUID) && defined(DEBUGGING)
-    PERL_ARGS_ASSERT_TAINT_PROPER;
 
     {
         const Uid_t  uid = PerlProc_getuid();

--- a/toke.c
+++ b/toke.c
@@ -630,9 +630,9 @@ S_tokereport(pTHX_ I32 rv, const YYSTYPE* lvalp)
 static void
 S_printbuf(pTHX_ const char *const fmt, const char *const s)
 {
-    SV* const tmp = newSVpvs("");
-
     PERL_ARGS_ASSERT_PRINTBUF;
+
+    SV* const tmp = newSVpvs("");
 
     GCC_DIAG_IGNORE_STMT(-Wformat-nonliteral); /* fmt checked by caller */
     PerlIO_printf(Perl_debug_log, fmt, pv_display(tmp, s, strlen(s), 0, 60));
@@ -689,6 +689,8 @@ S_ao(pTHX_ int toketype)
 static void
 S_warn_expect_operator(pTHX_ const char *const what, char *s, I32 pop_oldbufptr)
 {
+    PERL_ARGS_ASSERT_WARN_EXPECT_OPERATOR;
+
     if (PL_expect != XOPERATOR)
         return;
 
@@ -703,8 +705,6 @@ S_warn_expect_operator(pTHX_ const char *const what, char *s, I32 pop_oldbufptr)
                    PERL_DIAG_WARN_SYNTAX("%s found where operator expected"),
                    what
                   ) );
-
-    PERL_ARGS_ASSERT_WARN_EXPECT_OPERATOR;
 
     if (!s)
         s = oldbp;
@@ -1025,8 +1025,9 @@ Perl_parser_free(pTHX_  const yy_parser *parser)
 void
 Perl_parser_free_nexttoke_ops(pTHX_  yy_parser *parser, OPSLAB *slab)
 {
-    I32 nexttoke = parser->nexttoke;
     PERL_ARGS_ASSERT_PARSER_FREE_NEXTTOKE_OPS;
+
+    I32 nexttoke = parser->nexttoke;
     while (nexttoke--) {
         if (S_is_opval_token(parser->nexttype[nexttoke] & 0xffff)
          && parser->nextval[nexttoke].opval
@@ -1241,8 +1242,9 @@ to how the buffer is currently being interpreted (L</lex_bufutf8>).
 void
 Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags)
 {
-    char *bufptr;
     PERL_ARGS_ASSERT_LEX_STUFF_PVN;
+
+    char *bufptr;
     if (flags & ~(LEX_STUFF_UTF8))
         croak("Lexing code internal error (%s)", "lex_stuff_pvn");
     if (UTF) {
@@ -1320,9 +1322,10 @@ Perl_lex_stuff_pv(pTHX_ const char *pv, U32 flags)
 void
 Perl_lex_stuff_sv(pTHX_ SV *sv, U32 flags)
 {
+    PERL_ARGS_ASSERT_LEX_STUFF_SV;
+
     char *pv;
     STRLEN len;
-    PERL_ARGS_ASSERT_LEX_STUFF_SV;
     if (flags)
         croak("Lexing code internal error (%s)", "lex_stuff_sv");
     pv = SvPV(sv, len);
@@ -1346,9 +1349,10 @@ L</lex_read_to>.
 void
 Perl_lex_unstuff(pTHX_ char *ptr)
 {
+    PERL_ARGS_ASSERT_LEX_UNSTUFF;
+
     char *buf, *bufend;
     STRLEN unstuff_len;
-    PERL_ARGS_ASSERT_LEX_UNSTUFF;
     buf = PL_parser->bufptr;
     if (ptr < buf)
         croak("Lexing code internal error (%s)", "lex_unstuff");
@@ -1381,8 +1385,9 @@ L</lex_read_unichar>.
 void
 Perl_lex_read_to(pTHX_ char *ptr)
 {
-    char *s;
     PERL_ARGS_ASSERT_LEX_READ_TO;
+
+    char *s;
     s = PL_parser->bufptr;
     if (ptr < s || ptr > PL_parser->bufend)
         croak("Lexing code internal error (%s)", "lex_read_to");
@@ -1417,9 +1422,10 @@ multi-line tokens growing the buffer without bound.
 void
 Perl_lex_discard_to(pTHX_ char *ptr)
 {
+    PERL_ARGS_ASSERT_LEX_DISCARD_TO;
+
     char *buf;
     STRLEN discard_len;
-    PERL_ARGS_ASSERT_LEX_DISCARD_TO;
     buf = SvPVX(PL_parser->linestr);
     if (ptr < buf)
         croak("Lexing code internal error (%s)", "lex_discard_to");
@@ -1821,6 +1827,8 @@ Note that C<NULL> is a valid C<proto> and will always return C<true>.
 bool
 Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
 {
+    PERL_ARGS_ASSERT_VALIDATE_PROTO;
+
     STRLEN len, origlen;
     char *p;
     bool bad_proto = FALSE;
@@ -1831,8 +1839,6 @@ Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
     bool must_be_last = FALSE;
     bool underscore = FALSE;
     bool bad_proto_after_underscore = FALSE;
-
-    PERL_ARGS_ASSERT_VALIDATE_PROTO;
 
     if (!proto)
         return TRUE;
@@ -2309,12 +2315,12 @@ S_newSV_maybe_utf8(pTHX_ const char *const start, STRLEN len)
 static char *
 S_force_word(pTHX_ char *start, int token, U32 flags)
 {
+    PERL_ARGS_ASSERT_FORCE_WORD;
+
     char *s;
     STRLEN len;
     const bool check_keyword = flags & CHECK_KEYWORD;
     const bool allow_pack    = flags & ALLOW_PACKAGE;
-
-    PERL_ARGS_ASSERT_FORCE_WORD;
 
     start = skipspace(start);
     s = start;
@@ -2399,14 +2405,14 @@ S_force_ident_maybe_lex(pTHX_ char pit)
 NV
 Perl_str_to_version(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_STR_TO_VERSION;
+
     NV retval = 0.0;
     NV nshift = 1.0;
     STRLEN len;
     const U8 *start = (const U8 *) SvPV_const(sv,len);
     const U8 * const end = start + len;
     const bool utf = cBOOL(SvUTF8(sv));
-
-    PERL_ARGS_ASSERT_STR_TO_VERSION;
 
     while (start < end) {
         STRLEN skip;
@@ -2435,10 +2441,10 @@ Perl_str_to_version(pTHX_ SV *sv)
 static char *
 S_force_version(pTHX_ char *s, int guessing)
 {
+    PERL_ARGS_ASSERT_FORCE_VERSION;
+
     OP *version = NULL;
     char *d;
-
-    PERL_ARGS_ASSERT_FORCE_VERSION;
 
     s = skipspace(s);
 
@@ -2479,10 +2485,10 @@ S_force_version(pTHX_ char *s, int guessing)
 static char *
 S_force_strict_version(pTHX_ char *s)
 {
+    PERL_ARGS_ASSERT_FORCE_STRICT_VERSION;
+
     OP *version = NULL;
     const char *errstr = NULL;
-
-    PERL_ARGS_ASSERT_FORCE_STRICT_VERSION;
 
     while (isSPACE(*s)) /* leading whitespace */
         s++;
@@ -2518,12 +2524,12 @@ S_force_strict_version(pTHX_ char *s)
 static SV *
 S_tokeq(pTHX_ SV *sv)
 {
+    PERL_ARGS_ASSERT_TOKEQ;
+
     char *s;
     char *send;
     char *d;
     SV *pv = sv;
-
-    PERL_ARGS_ASSERT_TOKEQ;
 
     assert (SvPOK(sv));
     assert (SvLEN(sv));
@@ -2821,6 +2827,8 @@ HV *
 Perl_load_charnames(pTHX_ SV * char_name, const char * context,
                           const STRLEN context_len, const char ** error_msg)
 {
+    PERL_ARGS_ASSERT_LOAD_CHARNAMES;
+
     /* Load the official _charnames module if not already there.  The
      * parameters are just to give info for any error messages generated:
      *  char_name   a name to look up which is the reason for loading this
@@ -2834,8 +2842,6 @@ Perl_load_charnames(pTHX_ SV * char_name, const char * context,
     HV * table;
     SV **cvp;
     SV * res;
-
-    PERL_ARGS_ASSERT_LOAD_CHARNAMES;
 
     /* This loop is executed 1 1/2 times.  On the first time through, if it
      * isn't already loaded, try loading it, and iterate just once to see if it
@@ -2878,13 +2884,13 @@ Perl_load_charnames(pTHX_ SV * char_name, const char * context,
 static SV*
 S_get_and_check_backslash_N_name_wrapper(pTHX_ const char* s, const char* const e)
 {
+    PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME_WRAPPER;
+
     /* This justs wraps get_and_check_backslash_N_name() to output any error
      * message it returns. */
 
     const char * error_msg = NULL;
     SV * result;
-
-    PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME_WRAPPER;
 
     /* charnames doesn't work well if there have been errors found */
     if (PL_error_count > 0) {
@@ -3210,6 +3216,8 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char* s,
 static char *
 S_scan_const(pTHX_ char *start)
 {
+    PERL_ARGS_ASSERT_SCAN_CONST;
+
     const char * const send = PL_bufend;/* end of the constant */
     SV *sv = newSV(send - start);       /* sv for the constant.  See note below
                                            on sizing. */
@@ -3260,8 +3268,6 @@ S_scan_const(pTHX_ char *start)
     int non_portable_endpoint = 0;  /* ? In a range is an endpoint
                                        platform-specific like \x65 */
 #endif
-
-    PERL_ARGS_ASSERT_SCAN_CONST;
 
     assert(PL_lex_inwhat != OP_TRANSR);
 
@@ -5425,9 +5431,9 @@ Delete most recently added instance of the filter function argument
 void
 Perl_filter_del(pTHX_ filter_t funcp)
 {
-    SV *datasv;
-
     PERL_ARGS_ASSERT_FILTER_DEL;
+
+    SV *datasv;
 
 #ifdef DEBUGGING
     DEBUG_P(PerlIO_printf(Perl_debug_log, "filter_del func %p",
@@ -5452,6 +5458,8 @@ Perl_filter_del(pTHX_ filter_t funcp)
 I32
 Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
 {
+    PERL_ARGS_ASSERT_FILTER_READ;
+
     filter_t funcp;
     I32 ret;
     SV *datasv = NULL;
@@ -5459,8 +5467,6 @@ Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
        Not sure if we want to change the API, but if not we should sanity
        check the value here.  */
     unsigned int correct_length = maxlen < 0 ?  PERL_INT_MAX : maxlen;
-
-    PERL_ARGS_ASSERT_FILTER_READ;
 
     if (!PL_parser || !PL_rsfp_filters)
         return -1;
@@ -5588,9 +5594,9 @@ S_filter_gets(pTHX_ SV *sv, STRLEN append)
 static HV *
 S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
 {
-    GV *gv;
-
     PERL_ARGS_ASSERT_FIND_IN_MY_STASH;
+
+    GV *gv;
 
     if (memEQs(pkgname, len, "__PACKAGE__"))
         return PL_curstash;
@@ -10697,6 +10703,8 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
                SV *sv, SV *pv, const char *type, STRLEN typelen,
                const char ** error_msg)
 {
+    PERL_ARGS_ASSERT_NEW_CONSTANT;
+
     dSP;
     HV * table = GvHV(PL_hintgv);		 /* ^H */
     SV *res;
@@ -10707,7 +10715,6 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen,
     const char * optional_colon = ":";  /* Only some messages have a colon */
     char *msg;
 
-    PERL_ARGS_ASSERT_NEW_CONSTANT;
     /* We assume that this is true: */
     assert(type || s);
 
@@ -11540,14 +11547,14 @@ S_pmflag(pTHX_ const char* const valid_flags, U32 * pmfl, char** s, char* charse
 static char *
 S_scan_pat(pTHX_ char *start, I32 type)
 {
+    PERL_ARGS_ASSERT_SCAN_PAT;
+
     PMOP *pm;
     char *s;
     const char * const valid_flags =
         (const char *)((type == OP_QR) ? QR_PAT_MODS : M_PAT_MODS);
     char charset = '\0';    /* character set modifier */
     unsigned int x_mod_count = 0;
-
-    PERL_ARGS_ASSERT_SCAN_PAT;
 
     s = scan_str(start,TRUE,FALSE, (PL_in_eval & EVAL_RE_REPARSING), NULL);
     if (!s)
@@ -11621,6 +11628,8 @@ S_scan_pat(pTHX_ char *start, I32 type)
 static char *
 S_scan_subst(pTHX_ char *start)
 {
+    PERL_ARGS_ASSERT_SCAN_SUBST;
+
     char *s;
     PMOP *pm;
     I32 first_start;
@@ -11630,8 +11639,6 @@ S_scan_subst(pTHX_ char *start)
     char charset = '\0';    /* character set modifier */
     unsigned int x_mod_count = 0;
     char *t;
-
-    PERL_ARGS_ASSERT_SCAN_SUBST;
 
     pl_yylval.ival = OP_NULL;
 
@@ -11714,6 +11721,8 @@ S_scan_subst(pTHX_ char *start)
 static char *
 S_scan_trans(pTHX_ char *start)
 {
+    PERL_ARGS_ASSERT_SCAN_TRANS;
+
     char* s;
     OP *o;
     U8 squash;
@@ -11721,8 +11730,6 @@ S_scan_trans(pTHX_ char *start)
     U8 complement;
     bool nondestruct = 0;
     char *t;
-
-    PERL_ARGS_ASSERT_SCAN_TRANS;
 
     pl_yylval.ival = OP_NULL;
 
@@ -11799,6 +11806,8 @@ S_scan_trans(pTHX_ char *start)
 static char *
 S_scan_heredoc(pTHX_ char *s)
 {
+    PERL_ARGS_ASSERT_SCAN_HEREDOC;
+
     I32 op_type = OP_SCALAR;
     I32 len;
     SV *tmpstr;
@@ -11812,8 +11821,6 @@ S_scan_heredoc(pTHX_ char *s)
     const bool infile = PL_rsfp || PL_parser->filtered;
     const line_t origline = CopLINE(PL_curcop);
     LEXSHARED *shared = PL_parser->lex_shared;
-
-    PERL_ARGS_ASSERT_SCAN_HEREDOC;
 
     s += 2;
     d = PL_tokenbuf + 1;
@@ -12253,14 +12260,14 @@ S_scan_heredoc(pTHX_ char *s)
 static char *
 S_scan_inputsymbol(pTHX_ char *start)
 {
+    PERL_ARGS_ASSERT_SCAN_INPUTSYMBOL;
+
     char *s = start;		/* current position in buffer */
     char *end;
     I32 len;
     bool nomagicopen = FALSE;
     char *d = PL_tokenbuf;					/* start of temp holding space */
     const char * const e = C_ARRAY_END(PL_tokenbuf);	/* end of temp holding space */
-
-    PERL_ARGS_ASSERT_SCAN_INPUTSYMBOL;
 
     end = (char *) memchr(s, '\n', PL_bufend - s);
     if (!end)
@@ -12457,6 +12464,8 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
                  char **delimp
     )
 {
+    PERL_ARGS_ASSERT_SCAN_STR;
+
     SV *sv;			/* scalar value: string */
     char *s = start;		/* current position in the buffer */
     char *to;			/* current position in the sv's data */
@@ -12473,7 +12482,6 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
     const char * non_grapheme_msg = "Use of unassigned code point or"
                                     " non-standalone grapheme for a delimiter"
                                     " is not allowed";
-    PERL_ARGS_ASSERT_SCAN_STR;
 
     /* skip space before the delimiter */
     if (isSPACE(*s)) {  /* skipspace can change the buffer 's' is in, so
@@ -12784,6 +12792,8 @@ Perl_scan_str(pTHX_ char *start, int keep_bracketed_quoted, int keep_delims, int
 char *
 Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 {
+    PERL_ARGS_ASSERT_SCAN_NUM;
+
     const char *s = start;	/* current position in buffer */
     char *d;			/* destination in temp buffer */
     char *e;			/* end of temp buffer */
@@ -12863,8 +12873,6 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 #endif
     int hexfp_exp = 0;
     bool new_octal = FALSE;     /* octal with "0o" prefix */
-
-    PERL_ARGS_ASSERT_SCAN_NUM;
 
     /* Make sure "int" is wide enough to hold exponent of NV.
        We use "int" (rather than I32 etc.) to be compatible with ldexp() */
@@ -13441,11 +13449,11 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE* lvalp)
 static char *
 S_scan_formline(pTHX_ char *s)
 {
+    PERL_ARGS_ASSERT_SCAN_FORMLINE;
+
     SV * const stuff = newSVpvs("");
     bool needargs = FALSE;
     bool eofmt = FALSE;
-
-    PERL_ARGS_ASSERT_SCAN_FORMLINE;
 
     while (!needargs) {
         char *eol;
@@ -13864,9 +13872,9 @@ Perl_yyerror_pvn(pTHX_ const char *const s, STRLEN len, U32 flags)
 static char*
 S_swallow_bom(pTHX_ U8 *s)
 {
-    const STRLEN slen = SvCUR(PL_linestr);
-
     PERL_ARGS_ASSERT_SWALLOW_BOM;
+
+    const STRLEN slen = SvCUR(PL_linestr);
 
     switch (s[0]) {
     case 0xFF:
@@ -13969,6 +13977,8 @@ S_swallow_bom(pTHX_ U8 *s)
 static I32
 S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
 {
+    PERL_ARGS_ASSERT_UTF16_TEXTFILTER;
+
     SV *const filter = FILTER_DATA(idx);
     /* We re-use this each time round, throwing the contents away before we
        return.  */
@@ -13977,8 +13987,6 @@ S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
     IV status = IoPAGE(filter);
     const bool reverse = cBOOL(IoLINES(filter));
     I32 retval;
-
-    PERL_ARGS_ASSERT_UTF16_TEXTFILTER;
 
     /* As we're automatically added, at the lowest level, and hence only called
        from this file, we can be sure that we're not called in block mode. Hence
@@ -14096,9 +14104,9 @@ S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
 static U8 *
 S_add_utf16_textfilter(pTHX_ U8 *const s, bool reversed)
 {
-    SV *filter = filter_add(S_utf16_textfilter, NULL);
-
     PERL_ARGS_ASSERT_ADD_UTF16_TEXTFILTER;
+
+    SV *filter = filter_add(S_utf16_textfilter, NULL);
 
     IoTOP_GV(filter) = MUTABLE_GV(newSVpvn((char *)s, PL_bufend - (char*)s));
     SvPVCLEAR(filter);
@@ -14144,10 +14152,10 @@ sv_2mortal.
 char *
 Perl_scan_vstring(pTHX_ const char *s, const char *const e, SV *sv)
 {
+    PERL_ARGS_ASSERT_SCAN_VSTRING;
+
     const char *pos = s;
     const char *start = s;
-
-    PERL_ARGS_ASSERT_SCAN_VSTRING;
 
     if (*pos == 'v') pos++;  /* get past 'v' */
     while (pos < e && isDIGIT_or_UNDERSCORE(*pos))

--- a/universal.c
+++ b/universal.c
@@ -81,9 +81,10 @@ S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char * name, STRLEN len, U32 fla
 static bool
 S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char * name, const STRLEN len, U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_DERIVED_FROM_SVPVN;
+
     HV* stash;
 
-    PERL_ARGS_ASSERT_SV_DERIVED_FROM_SVPVN;
     SvGETMAGIC(sv);
 
     if (SvROK(sv)) {
@@ -212,9 +213,9 @@ overloaded C<isa()> method, nor will check subclassing.
 bool
 Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
 {
-    GV *isagv;
-
     PERL_ARGS_ASSERT_SV_ISA_SV;
+
+    GV *isagv;
 
     if(!SvROK(sv) || !SvOBJECT(SvRV(sv)))
         return FALSE;
@@ -296,12 +297,13 @@ XXX extracted in sv_does_sv is more complicated than the hand waving above
 bool
 Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
 {
+    PERL_ARGS_ASSERT_SV_DOES_SV;
+
     SV *classname;
     bool does_it;
     SV *methodname;
     dSP;
 
-    PERL_ARGS_ASSERT_SV_DOES_SV;
     PERL_UNUSED_ARG(flags);
 
     ENTER;
@@ -389,10 +391,10 @@ C<croak()>.  Hence if C<cv> is C<&ouch::awk>, it would call C<croak> as:
 void
 Perl_croak_xs_usage(const CV *const cv, const char *const params)
 {
+    PERL_ARGS_ASSERT_CROAK_XS_USAGE;
+
     /* Avoid CvGV as it requires aTHX.  */
     const GV *gv = CvNAMED(cv) ? NULL : cv->sv_any->xcv_gv_u.xcv_gv;
-
-    PERL_ARGS_ASSERT_CROAK_XS_USAGE;
 
     if (gv) got_gv: {
         const HV *const stash = GvSTASH(gv);

--- a/utf8.c
+++ b/utf8.c
@@ -102,6 +102,8 @@ S_new_msg_hv(pTHX_ const char * const message, /* The message text */
                    U32 categories,  /* Packed warning categories */
                    U32 flag)        /* Flag associated with this message */
 {
+    PERL_ARGS_ASSERT_NEW_MSG_HV;
+
     /* Creates, populates, and returns an HV* that describes an error message
      * for the translators between UTF8 and code point */
 
@@ -110,8 +112,6 @@ S_new_msg_hv(pTHX_ const char * const message, /* The message text */
     SV* flag_bit_sv = newSVuv(flag);
 
     HV* msg_hv = newHV();
-
-    PERL_ARGS_ASSERT_NEW_MSG_HV;
 
     (void) hv_stores(msg_hv, "text", msg_sv);
     (void) hv_stores(msg_hv, "warn_categories",  category_sv);
@@ -209,11 +209,11 @@ The caller, of course, is responsible for freeing any returned HV.
 U8 *
 Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, UV flags, HV** msgs)
 {
+    PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS_MSGS;
+
     U8 *p;
     UV shifted_uv = input_uv;
     STRLEN utf8_skip = OFFUNISKIP(input_uv);
-
-    PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS_MSGS;
 
     if (msgs) {
         *msgs = NULL;
@@ -468,6 +468,8 @@ The new names accurately describe the situation in all cases.
 PERL_STATIC_INLINE SSize_t
 S_is_utf8_overlong(const U8 * const s, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_IS_UTF8_OVERLONG;
+
     /* Returns an int indicating whether or not the UTF-8 sequence from 's' to
      * 's' + 'len' - 1 is an overlong.  It returns a positive number if it is
      * an overlong; 0 if it isn't, and -1 if there isn't enough information to
@@ -485,8 +487,6 @@ S_is_utf8_overlong(const U8 * const s, const STRLEN len)
      * number of leading 1 bits in a start byte increases from the next lower
      * start byte.  That happens for start bytes C0, E0, F0, F8, FC, FE, and
      * FF. */
-
-    PERL_ARGS_ASSERT_IS_UTF8_OVERLONG;
 
     /* Each platform has overlongs after the start bytes given above (expressed
      * in I8 for EBCDIC).  The values below were found by manually inspecting
@@ -532,6 +532,8 @@ S_is_utf8_overlong(const U8 * const s, const STRLEN len)
 PERL_STATIC_INLINE int
 S_isFF_overlong(const U8 * const s, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_ISFF_OVERLONG;
+
     /* Returns an int indicating whether or not the UTF-8 sequence of 'len'
      * bytes starting at 's' is an overlong beginning with \xFF.  It returns a
      * positive number if it is; 0 if it isn't, and -1 if there isn't enough
@@ -542,8 +544,6 @@ S_isFF_overlong(const U8 * const s, const STRLEN len)
      *
      * A positive return gives the number of bytes needed to be examined to
      * make the determination */
-
-    PERL_ARGS_ASSERT_ISFF_OVERLONG;
 
 #ifdef EBCDIC
     /* This works on all three EBCDIC code pages traditionally supported by
@@ -902,6 +902,8 @@ Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e,
 const char *
 Perl_byte_dump_string_(pTHX_ const U8 * const start, const STRLEN len, const bool format)
 {
+    PERL_ARGS_ASSERT_BYTE_DUMP_STRING_;
+
     /* Returns a mortalized C string that is a displayable copy of the 'len'
      * bytes starting at 'start'.  'format' gives how to display each byte.
      * Currently, there are only two formats, so it is currently a bool:
@@ -919,8 +921,6 @@ Perl_byte_dump_string_(pTHX_ const U8 * const start, const STRLEN len, const boo
     const U8 * const e = start + len;
     char * output;
     char * d;
-
-    PERL_ARGS_ASSERT_BYTE_DUMP_STRING_;
 
     Newx(output, output_len, char);
     SAVEFREEPV(output);
@@ -2643,11 +2643,11 @@ and returns the number of valid characters.
 STRLEN
 Perl_utf8_length(pTHX_ const U8 * const s0, const U8 * const e)
 {
+    PERL_ARGS_ASSERT_UTF8_LENGTH;
+
     STRLEN continuations = 0;
     STRLEN len = 0;
     const U8 * s = s0;
-
-    PERL_ARGS_ASSERT_UTF8_LENGTH;
 
     /* For EBCDIC and short strings, we count the characters.  The boundary
      * was determined by eyeballing the output of Porting/bench.pl and
@@ -2781,10 +2781,10 @@ within the strings.
 int
 Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
 {
+    PERL_ARGS_ASSERT_BYTES_CMP_UTF8;
+
     const U8 *const bend = b + blen;
     const U8 *const uend = u + ulen;
-
-    PERL_ARGS_ASSERT_BYTES_CMP_UTF8;
 
     while (b < bend && u < uend) {
         U8 c = *u++;
@@ -3412,10 +3412,10 @@ Perl_utf16_to_utf8_base(pTHX_ U8* p, U8* d, Size_t bytelen, Size_t *newlen,
                                                   high order */
                               const bool low_byte)
 {
+    PERL_ARGS_ASSERT_UTF16_TO_UTF8_BASE;
+
     U8* pend;
     U8* dstart = d;
-
-    PERL_ARGS_ASSERT_UTF16_TO_UTF8_BASE;
 
     if (isODD(bytelen))
         croak("panic: utf16_to_utf8%s: odd bytelen %" UVuf,
@@ -3491,10 +3491,10 @@ Perl_utf8_to_utf16_base(pTHX_ U8* s, U8* d, Size_t bytelen, Size_t *newlen,
                                                        is high order */
                               const bool low_byte)
 {
+    PERL_ARGS_ASSERT_UTF8_TO_UTF16_BASE;
+
     U8* send;
     U8* dstart = d;
-
-    PERL_ARGS_ASSERT_UTF8_TO_UTF16_BASE;
 
     send = s + bytelen;
 
@@ -3683,6 +3683,8 @@ Perl_to_upper_title_latin1_(pTHX_ const U8 c, U8* p, STRLEN *lenp,
 UV
 Perl_to_uni_upper(pTHX_ UV c, U8* p, STRLEN *lenp)
 {
+    PERL_ARGS_ASSERT_TO_UNI_UPPER;
+
     /* Convert the Unicode character whose ordinal is <c> to its uppercase
      * version and store that in UTF-8 in <p> and its length in bytes in <lenp>.
      * Note that the <p> needs to be at least UTF8_MAXBYTES_CASE+1 bytes since
@@ -3690,8 +3692,6 @@ Perl_to_uni_upper(pTHX_ UV c, U8* p, STRLEN *lenp)
      *
      * The ordinal of the first character of the changed version is returned
      * (but note, as explained above, that there may be more.) */
-
-    PERL_ARGS_ASSERT_TO_UNI_UPPER;
 
     if (c < 256) {
         return to_upper_title_latin1_((U8) c, p, lenp, 'S');
@@ -3756,6 +3756,8 @@ Perl_to_uni_lower(pTHX_ UV c, U8* p, STRLEN *lenp)
 UV
 Perl_to_fold_latin1_(const U8 c, U8* p, STRLEN *lenp, const unsigned int flags)
 {
+    PERL_ARGS_ASSERT_TO_FOLD_LATIN1_;
+
     /* Corresponds to to_lower_latin1(); <flags> bits meanings:
      *	    FOLD_FLAGS_NOMIX_ASCII iff non-ASCII to ASCII folds are prohibited
      *	    FOLD_FLAGS_FULL  iff full folding is to be used;
@@ -3764,8 +3766,6 @@ Perl_to_fold_latin1_(const U8 c, U8* p, STRLEN *lenp, const unsigned int flags)
      */
 
     UV converted;
-
-    PERL_ARGS_ASSERT_TO_FOLD_LATIN1_;
 
     assert (! (flags & FOLD_FLAGS_LOCALE));
 
@@ -3816,6 +3816,7 @@ Perl_to_fold_latin1_(const U8 c, U8* p, STRLEN *lenp, const unsigned int flags)
 UV
 Perl_to_uni_fold_flags_(pTHX_ UV c, U8* p, STRLEN *lenp, U8 flags)
 {
+    PERL_ARGS_ASSERT_TO_UNI_FOLD_FLAGS_;
 
     /* Not currently externally documented, and subject to change
      *  <flags> bits meanings:
@@ -3824,8 +3825,6 @@ Perl_to_uni_fold_flags_(pTHX_ UV c, U8* p, STRLEN *lenp, U8 flags)
      *	                      locale are to be used.
      *	    FOLD_FLAGS_NOMIX_ASCII iff non-ASCII to ASCII folds are prohibited
      */
-
-    PERL_ARGS_ASSERT_TO_UNI_FOLD_FLAGS_;
 
     if (flags & FOLD_FLAGS_LOCALE) {
         /* Treat a non-Turkic UTF-8 locale as not being in locale at all,
@@ -3870,9 +3869,9 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category,
                                      const char * const file,
                                      const unsigned line)
 {
-    const char * key;
-
     PERL_ARGS_ASSERT_WARN_ON_FIRST_DEPRECATED_USE;
+
+    const char * key;
 
     if (ckWARN_d(category)) {
 
@@ -3954,6 +3953,8 @@ S_to_case_cp_list(pTHX_
                   const U8 * const aux_table_lengths,
                   const char * const normal)
 {
+    PERL_ARGS_ASSERT_TO_CASE_CP_LIST;
+
     SSize_t index;
     I32 base;
 
@@ -3975,8 +3976,6 @@ S_to_case_cp_list(pTHX_
      * The casing to use is given by the data structures in the remaining
      * arguments.
      */
-
-    PERL_ARGS_ASSERT_TO_CASE_CP_LIST;
 
     /* 'index' is guaranteed to be non-negative, as this is an inversion map
      * that covers all possible inputs.  See [perl #133365] */
@@ -4049,6 +4048,8 @@ S_to_utf8_case_(pTHX_ const UV original, const U8 *p,
                       const U8 * const aux_table_lengths,
                       const char * const normal)
 {
+    PERL_ARGS_ASSERT_TO_UTF8_CASE_;
+
     /* Change the case of code point 'original'.  If 'p' is non-NULL, it points to
      * the beginning of the (assumed to be valid) UTF-8 representation of
      * 'original'.  'normal' is a string to use to name the new case in any
@@ -4070,8 +4071,6 @@ S_to_utf8_case_(pTHX_ const UV original, const U8 *p,
                                invlist, invmap,
                                aux_tables, aux_table_lengths,
                                normal);
-
-    PERL_ARGS_ASSERT_TO_UTF8_CASE_;
 
     /* If the code point maps to itself and we already have its representation,
      * copy it instead of recalculating */
@@ -4103,6 +4102,8 @@ Size_t
 Perl_inverse_folds_(pTHX_ const UV cp, U32 * first_folds_to,
                           const U32 ** remaining_folds_to)
 {
+    PERL_ARGS_ASSERT_INVERSE_FOLDS_;
+
     /* Returns the count of the number of code points that fold to the input
      * 'cp' (besides itself).
      *
@@ -4125,8 +4126,6 @@ Perl_inverse_folds_(pTHX_ const UV cp, U32 * first_folds_to,
      * occupy at most 21 bits, and so a U32 is sufficient, and the lists are
      * constructed with this size (to save space and memory), and we return
      * pointers, so they must be this size */
-
-    PERL_ARGS_ASSERT_INVERSE_FOLDS_;
 
     /* 'index' is guaranteed to be non-negative, as this is an inversion map
      * that covers all possible inputs.  See [GH #16624] */
@@ -4172,6 +4171,8 @@ static UV
 S_check_locale_boundary_crossing(pTHX_ const U8* const p, const UV result,
                                        U8* const ustrp, STRLEN *lenp)
 {
+    PERL_ARGS_ASSERT_CHECK_LOCALE_BOUNDARY_CROSSING;
+
     /* This is called when changing the case of a UTF-8-encoded character above
      * the Latin1 range, and the operation is in a non-UTF-8 locale.  If the
      * result contains a character that crosses the 255/256 boundary, disallow
@@ -4186,8 +4187,6 @@ S_check_locale_boundary_crossing(pTHX_ const U8* const p, const UV result,
      * lenp	points to the length of <ustrp> */
 
     UV original;    /* To store the first code point of <p> */
-
-    PERL_ARGS_ASSERT_CHECK_LOCALE_BOUNDARY_CROSSING;
 
     assert(UTF8_IS_ABOVE_LATIN1(*p));
 
@@ -4671,6 +4670,8 @@ Perl_to_utf8_fold_flags_(pTHX_ const U8 *p,
 bool
 Perl_check_utf8_print(pTHX_ const U8* s, const STRLEN len)
 {
+    PERL_ARGS_ASSERT_CHECK_UTF8_PRINT;
+
     /* May change: warns if surrogates, non-character code points, or
      * non-Unicode code points are in 's' which has length 'len' bytes.
      * Returns TRUE if none found; FALSE otherwise.  The only other validity
@@ -4679,8 +4680,6 @@ Perl_check_utf8_print(pTHX_ const U8* s, const STRLEN len)
 
     const U8* const e = s + len;
     bool ok = TRUE;
-
-    PERL_ARGS_ASSERT_CHECK_UTF8_PRINT;
 
     while (s < e) {
         if (UTF8SKIP(s) > len) {
@@ -4874,10 +4873,10 @@ The pointer to the PV of the C<dsv> is returned.
 char *
 Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
 {
+    PERL_ARGS_ASSERT_SV_UNI_DISPLAY;
+
     const char * const ptr =
         isREGEXP(ssv) ? RX_WRAPPED((REGEXP*)ssv) : SvPVX_const(ssv);
-
-    PERL_ARGS_ASSERT_SV_UNI_DISPLAY;
 
     return Perl_pv_uni_display(aTHX_ dsv, (const U8*)ptr,
                                 SvCUR(ssv), pvlim, flags);
@@ -4966,6 +4965,8 @@ Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1,
                              const char *s2, char **pe2, UV l2, bool u2,
                              U32 flags)
 {
+    PERL_ARGS_ASSERT_FOLDEQ_UTF8_FLAGS;
+
     const U8 *p1  = (const U8*)s1; /* Point to current char */
     const U8 *p2  = (const U8*)s2;
     const U8 *g1 = NULL;       /* goal for s1 */
@@ -4978,8 +4979,6 @@ Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1,
     U8 foldbuf1[UTF8_MAXBYTES_CASE+1];
     U8 foldbuf2[UTF8_MAXBYTES_CASE+1];
     U8 flags_for_folder = FOLD_FLAGS_FULL;
-
-    PERL_ARGS_ASSERT_FOLDEQ_UTF8_FLAGS;
 
     assert( ! (             (flags & (FOLDEQ_UTF8_NOMIX_ASCII | FOLDEQ_LOCALE))
                && ((        (flags &  FOLDEQ_S1_ALREADY_FOLDED)

--- a/util.c
+++ b/util.c
@@ -904,10 +904,10 @@ such occurrence.
 char *
 Perl_rninstr(const char *big, const char *bigend, const char *little, const char *lend)
 {
+    PERL_ARGS_ASSERT_RNINSTR;
+
     const ptrdiff_t little_len = lend - little;
     const ptrdiff_t big_len = bigend - big;
-
-    PERL_ARGS_ASSERT_RNINSTR;
 
     /* A non-existent needle trivially matches the rightmost possible position
      * in the haystack */
@@ -1014,12 +1014,12 @@ Analyzes the string in order to make fast searches on it using C<fbm_instr()>
 void
 Perl_fbm_compile(pTHX_ SV *sv, U32 flags)
 {
+    PERL_ARGS_ASSERT_FBM_COMPILE;
+
     const U8 *s;
     STRLEN i;
     STRLEN len;
     MAGIC *mg;
-
-    PERL_ARGS_ASSERT_FBM_COMPILE;
 
     if (isGV_with_GP(sv) || SvROK(sv))
         return;
@@ -1412,10 +1412,11 @@ S_mess_alloc(pTHX)
 char *
 Perl_form_nocontext(const char* pat, ...)
 {
+    PERL_ARGS_ASSERT_FORM_NOCONTEXT;
+
     dTHX;
     char *retval;
     va_list args;
-    PERL_ARGS_ASSERT_FORM_NOCONTEXT;
     va_start(args, pat);
     retval = vform(pat, &args);
     va_end(args);
@@ -1458,9 +1459,10 @@ automatically when called without the C<Perl_> prefix.
 char *
 Perl_form(pTHX_ const char* pat, ...)
 {
+    PERL_ARGS_ASSERT_FORM;
+
     char *retval;
     va_list args;
-    PERL_ARGS_ASSERT_FORM;
     va_start(args, pat);
     retval = vform(pat, &args);
     va_end(args);
@@ -1470,8 +1472,9 @@ Perl_form(pTHX_ const char* pat, ...)
 char *
 Perl_vform(pTHX_ const char *pat, va_list *args)
 {
-    SV * const sv = mess_alloc();
     PERL_ARGS_ASSERT_VFORM;
+
+    SV * const sv = mess_alloc();
     sv_vsetpvfn(sv, pat, strlen(pat), args, NULL, 0, NULL);
     return SvPVX(sv);
 }
@@ -1503,10 +1506,11 @@ this function.
 SV *
 Perl_mess_nocontext(const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_MESS_NOCONTEXT;
+
     dTHX;
     SV *retval;
     va_list args;
-    PERL_ARGS_ASSERT_MESS_NOCONTEXT;
     va_start(args, pat);
     retval = vmess(pat, &args);
     va_end(args);
@@ -1517,9 +1521,10 @@ Perl_mess_nocontext(const char *pat, ...)
 SV *
 Perl_mess(pTHX_ const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_MESS;
+
     SV *retval;
     va_list args;
-    PERL_ARGS_ASSERT_MESS;
     va_start(args, pat);
     retval = vmess(pat, &args);
     va_end(args);
@@ -1530,11 +1535,11 @@ const COP*
 Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop,
                        bool opnext)
 {
+    PERL_ARGS_ASSERT_CLOSEST_COP;
+
     /* Look for curop starting from o.  cop is the last COP we've seen. */
     /* opnext means that curop is actually the ->op_next of the op we are
        seeking. */
-
-    PERL_ARGS_ASSERT_CLOSEST_COP;
 
     if (!o || !curop || (
         opnext ? o->op_next == curop && o->op_type != OP_SCOPE : o == curop
@@ -1592,6 +1597,8 @@ required) to modify and return C<basemsg> instead of allocating a new SV.
 SV *
 Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
 {
+    PERL_ARGS_ASSERT_MESS_SV;
+
     SV *sv;
 
 #if defined(USE_C_BACKTRACE) && defined(USE_C_BACKTRACE_ON_ERROR)
@@ -1607,8 +1614,6 @@ Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
         }
     }
 #endif
-
-    PERL_ARGS_ASSERT_MESS_SV;
 
     if (SvROK(basemsg)) {
         if (consume) {
@@ -1672,9 +1677,9 @@ Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
 SV *
 Perl_vmess(pTHX_ const char *pat, va_list *args)
 {
-    SV * const sv = mess_alloc();
-
     PERL_ARGS_ASSERT_VMESS;
+
+    SV * const sv = mess_alloc();
 
     sv_vsetpvfn(sv, pat, strlen(pat), args, NULL, 0, NULL);
     return mess_sv(sv, 1);
@@ -1683,10 +1688,10 @@ Perl_vmess(pTHX_ const char *pat, va_list *args)
 void
 Perl_write_to_stderr(pTHX_ SV* msv)
 {
+    PERL_ARGS_ASSERT_WRITE_TO_STDERR;
+
     IO *io;
     MAGIC *mg;
-
-    PERL_ARGS_ASSERT_WRITE_TO_STDERR;
 
     if (PL_stderrgv && SvREFCNT(PL_stderrgv)
         && (io = GvIO(PL_stderrgv))
@@ -1818,8 +1823,9 @@ MSVC_DIAG_RESTORE
 void
 Perl_croak_sv(pTHX_ SV *baseex)
 {
-    SV *ex = with_queued_errors(mess_sv(baseex, 0));
     PERL_ARGS_ASSERT_CROAK_SV;
+
+    SV *ex = with_queued_errors(mess_sv(baseex, 0));
     invoke_exception_hook(ex, FALSE);
     die_unwind(ex);
 }
@@ -1937,9 +1943,9 @@ Perl_croak_no_modify(void)
 void
 Perl_croak_no_mem_ext(const char *context, STRLEN len)
 {
-    dTHX;
-
     PERL_ARGS_ASSERT_CROAK_NO_MEM_EXT;
+
+    dTHX;
 
     int fd = PerlIO_fileno(Perl_error_log);
     if (fd < 0)
@@ -1980,8 +1986,9 @@ Perl_croak_popstack(void)
 void
 Perl_warn_sv(pTHX_ SV *baseex)
 {
-    SV *ex = mess_sv(baseex, 0);
     PERL_ARGS_ASSERT_WARN_SV;
+
+    SV *ex = mess_sv(baseex, 0);
     if (!invoke_exception_hook(ex, TRUE))
         write_to_stderr(ex);
 }
@@ -1989,8 +1996,9 @@ Perl_warn_sv(pTHX_ SV *baseex)
 void
 Perl_vwarn(pTHX_ const char* pat, va_list *args)
 {
-    SV *ex = vmess(pat, args);
     PERL_ARGS_ASSERT_VWARN;
+
+    SV *ex = vmess(pat, args);
     if (!invoke_exception_hook(ex, TRUE))
         write_to_stderr(ex);
 }
@@ -2029,9 +2037,10 @@ See also C<L</warner>>.
 void
 Perl_warn_nocontext(const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_WARN_NOCONTEXT;
+
     dTHX;
     va_list args;
-    PERL_ARGS_ASSERT_WARN_NOCONTEXT;
     va_start(args, pat);
     vwarn(pat, &args);
     va_end(args);
@@ -2041,8 +2050,9 @@ Perl_warn_nocontext(const char *pat, ...)
 void
 Perl_warn(pTHX_ const char *pat, ...)
 {
-    va_list args;
     PERL_ARGS_ASSERT_WARN;
+
+    va_list args;
     va_start(args, pat);
     vwarn(pat, &args);
     va_end(args);
@@ -2113,9 +2123,10 @@ any of the categories are by default enabled.
 void
 Perl_warner_nocontext(U32 err, const char *pat, ...)
 {
+    PERL_ARGS_ASSERT_WARNER_NOCONTEXT;
+
     dTHX;
     va_list args;
-    PERL_ARGS_ASSERT_WARNER_NOCONTEXT;
     va_start(args, pat);
     vwarner(err, pat, &args);
     va_end(args);
@@ -2151,8 +2162,9 @@ Perl_ck_warner(pTHX_ U32 err, const char* pat, ...)
 void
 Perl_warner(pTHX_ U32  err, const char* pat,...)
 {
-    va_list args;
     PERL_ARGS_ASSERT_WARNER;
+
+    va_list args;
     va_start(args, pat);
     vwarner(err, pat, &args);
     va_end(args);
@@ -2266,9 +2278,10 @@ S_ckwarn_common(pTHX_ U32 w)
 char *
 Perl_new_warnings_bitfield(pTHX_ char *buffer, const char *const bits,
                            STRLEN size) {
-    const MEM_SIZE len_wanted = (size > WARNsize ? size : WARNsize);
-    PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_NEW_WARNINGS_BITFIELD;
+    PERL_UNUSED_CONTEXT;
+
+    const MEM_SIZE len_wanted = (size > WARNsize ? size : WARNsize);
 
     /* pass in null as the source string as we will do the
      * copy ourselves. */
@@ -2401,9 +2414,9 @@ Perl_my_setenv(pTHX_ const char *nam, const char *val)
 I32
 Perl_unlnk(pTHX_ const char *f)	/* unlink all versions of a file */
 {
-    I32 retries = 0;
-
     PERL_ARGS_ASSERT_UNLNK;
+
+    I32 retries = 0;
 
     while (PerlLIO_unlink(f) >= 0)
         retries++;
@@ -2438,6 +2451,8 @@ Implementing function on some systems for PerlProc_popen_list()
 PerlIO *
 Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
 {
+    PERL_ARGS_ASSERT_MY_POPEN_LIST;
+
 #if (!defined(DOSISH) || defined(HAS_FORK)) && !defined(OS2) && !defined(VMS) && !defined(__LIBCATAMOUNT__) && !defined(__amigaos4__)
     int p[2];
     I32 This, that;
@@ -2445,8 +2460,6 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
     SV *sv;
     I32 did_pipes = 0;
     int pp[2];
-
-    PERL_ARGS_ASSERT_MY_POPEN_LIST;
 
     PERL_FLUSHALL_FOR_CHILD;
     This = (*mode == 'w');
@@ -2586,6 +2599,8 @@ version knows things that interact with the rest of the perl interpreter.
 PerlIO *
 Perl_my_popen(pTHX_ const char *cmd, const char *mode)
 {
+    PERL_ARGS_ASSERT_MY_POPEN;
+
     int p[2];
     I32 This, that;
     Pid_t pid;
@@ -2593,8 +2608,6 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
     const I32 doexec = !(*cmd == '-' && cmd[1] == '\0');
     I32 did_pipes = 0;
     int pp[2];
-
-    PERL_ARGS_ASSERT_MY_POPEN;
 
     PERL_FLUSHALL_FOR_CHILD;
 #ifdef OS2
@@ -2944,9 +2957,9 @@ Perl_rsignal_state(pTHX_ int signo)
 int
 Perl_rsignal_save(pTHX_ int signo, Sighandler_t handler, Sigsave_t *save)
 {
-    struct sigaction act;
-
     PERL_ARGS_ASSERT_RSIGNAL_SAVE;
+
+    struct sigaction act;
 
 #ifdef USE_ITHREADS
     /* only "parent" interpreter can diddle signals */
@@ -3132,8 +3145,9 @@ Perl_my_pclose(pTHX_ PerlIO *ptr)
 I32
 Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
 {
-    I32 result = 0;
     PERL_ARGS_ASSERT_WAIT4PID;
+
+    I32 result = 0;
 #ifdef PERL_USES_PL_PIDSTATUS
     if (!pid) {
         /* PERL_USES_PL_PIDSTATUS is only defined when neither
@@ -3307,13 +3321,13 @@ Perl_repeatcpy(char *to, const char *from, SSize_t len, IV count)
 I32
 Perl_same_dirent(pTHX_ const char *a, const char *b)
 {
+    PERL_ARGS_ASSERT_SAME_DIRENT;
+
     char *fa = strrchr(a,'/');
     char *fb = strrchr(b,'/');
     Stat_t tmpstatbuf1;
     Stat_t tmpstatbuf2;
     SV * const tmpsv = sv_newmortal();
-
-    PERL_ARGS_ASSERT_SAME_DIRENT;
 
     if (fa)
         fa++;
@@ -3346,6 +3360,8 @@ char*
 Perl_find_script(pTHX_ const char *scriptname, bool dosearch,
                  const char *const *const search_ext, I32 flags)
 {
+    PERL_ARGS_ASSERT_FIND_SCRIPT;
+
     const char *xfound = NULL;
     char *xfailed = NULL;
     char tmpbuf[MAXPATHLEN];
@@ -3375,8 +3391,6 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch,
     PERL_UNUSED_ARG(search_ext);
 #  define MAX_EXT_LEN 0
 #endif
-
-    PERL_ARGS_ASSERT_FIND_SCRIPT;
 
     /*
      * If dosearch is true and if scriptname does not contain path
@@ -3697,9 +3711,10 @@ Perl_get_ppaddr(pTHX)
 char *
 Perl_getenv_len(pTHX_ const char *env_elem, unsigned long *len)
 {
-    char * const env_trans = PerlEnv_getenv(env_elem);
-    PERL_UNUSED_CONTEXT;
     PERL_ARGS_ASSERT_GETENV_LEN;
+    PERL_UNUSED_CONTEXT;
+
+    char * const env_trans = PerlEnv_getenv(env_elem);
     if (env_trans)
         *len = strlen(env_trans);
     return env_trans;
@@ -3886,12 +3901,12 @@ overhead) of mktime().
 void
 Perl_mini_mktime(struct tm *ptm)
 {
+    PERL_ARGS_ASSERT_MINI_MKTIME;
+
     int yearday;
     int secs;
     int month, mday, year, jday;
     int odd_cent, odd_year;
-
-    PERL_ARGS_ASSERT_MINI_MKTIME;
 
 #define DAYS_PER_YEAR   365
 #define DAYS_PER_QYEAR  (4*DAYS_PER_YEAR+1)
@@ -4099,9 +4114,9 @@ Fill C<sv> with current working directory
 int
 Perl_getcwd_sv(pTHX_ SV *sv)
 {
-    SvTAINTED_on(sv);
-
     PERL_ARGS_ASSERT_GETCWD_SV;
+
+    SvTAINTED_on(sv);
 
 #ifdef HAS_GETCWD
     {
@@ -4562,10 +4577,10 @@ Perl_sv_destroyable(pTHX_ SV *sv)
 U32
 Perl_parse_unicode_opts(pTHX_ const char **popt)
 {
+  PERL_ARGS_ASSERT_PARSE_UNICODE_OPTS;
+
   const char *p = *popt;
   U32 opt = 0;
-
-  PERL_ARGS_ASSERT_PARSE_UNICODE_OPTS;
 
   if (*p) {
        if (isDIGIT(*p)) {
@@ -4734,12 +4749,12 @@ Perl_seed(pTHX)
 void
 Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
 {
+    PERL_ARGS_ASSERT_GET_HASH_SEED;
+
 #ifndef NO_PERL_HASH_ENV
     const char *env_pv;
 #endif
     unsigned long i;
-
-    PERL_ARGS_ASSERT_GET_HASH_SEED;
 
     Zero(seed_buffer, PERL_HASH_SEED_BYTES, U8);
     Zero((U8*)PL_hash_state_w, PERL_HASH_STATE_BYTES, U8);
@@ -4921,10 +4936,10 @@ S_mem_log_common(enum mem_log_type mlt, const UV n,
                  const char *filename, const int linenumber,
                  const char *funcname)
 {
+    PERL_ARGS_ASSERT_MEM_LOG_COMMON;
+
     const char *pmlenv;
     dTHX;
-
-    PERL_ARGS_ASSERT_MEM_LOG_COMMON;
 
     PL_mem_log[0] |= 0x2;   /* Flag that the call is from this code */
     pmlenv = PerlEnv_getenv("PERL_MEM_LOG");
@@ -5136,9 +5151,9 @@ See also L</quadmath_format_needed>.
 bool
 Perl_quadmath_format_valid(const char* format)
 {
-    STRLEN len;
-
     PERL_ARGS_ASSERT_QUADMATH_FORMAT_VALID;
+
+    STRLEN len;
 
     if (format[0] != '%' || strchr(format + 1, '%'))
         return FALSE;
@@ -5176,10 +5191,10 @@ In this case, the code should probably fail.
 bool
 Perl_quadmath_format_needed(const char* format)
 {
+  PERL_ARGS_ASSERT_QUADMATH_FORMAT_NEEDED;
+
   const char *p = format;
   const char *q;
-
-  PERL_ARGS_ASSERT_QUADMATH_FORMAT_NEEDED;
 
   while ((q = strchr(p, '%'))) {
     q++;
@@ -5225,11 +5240,12 @@ getting C<vsnprintf>.
 int
 Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
 {
+    PERL_ARGS_ASSERT_MY_SNPRINTF;
+
     int retval = -1;
     va_list ap;
     dTHX;
 
-    PERL_ARGS_ASSERT_MY_SNPRINTF;
 #ifndef HAS_VSNPRINTF
     PERL_UNUSED_VAR(len);
 #endif
@@ -5316,6 +5332,8 @@ C<sv_vcatpvf> instead, or getting C<vsnprintf>.
 int
 Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap)
 {
+    PERL_ARGS_ASSERT_MY_VSNPRINTF;
+
 #ifdef USE_QUADMATH
     PERL_UNUSED_ARG(buffer);
     PERL_UNUSED_ARG(len);
@@ -5331,7 +5349,6 @@ Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap
 #  ifdef NEED_VA_COPY
     va_list apc;
 
-    PERL_ARGS_ASSERT_MY_VSNPRINTF;
     Perl_va_copy(ap, apc);
 #    ifdef HAS_VSNPRINTF
 
@@ -5437,10 +5454,10 @@ off, by allocating or extending the interpreter's C<PL_my_cxt_list> array
 void *
 Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
 {
+    PERL_ARGS_ASSERT_MY_CXT_INIT;
+
     void *p;
     int index;
-
-    PERL_ARGS_ASSERT_MY_CXT_INIT;
 
     index = *indexp;
     /* do initial check without locking.
@@ -5532,6 +5549,8 @@ Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
 Stack_off_t
 Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
 {
+    PERL_ARGS_ASSERT_XS_HANDSHAKE;
+
     va_list args;
     Stack_off_t items;
     Stack_off_t ax;
@@ -5546,7 +5565,6 @@ Perl_xs_handshake(const U32 key, void * v_my_perl, const char * file, ...)
     CV* cv;
     SV *** xs_spp;
 #endif
-    PERL_ARGS_ASSERT_XS_HANDSHAKE;
     va_start(args, file);
 
     got = INT2PTR(void*, (UV)(key & HSm_KEY_MATCH));
@@ -5675,11 +5693,11 @@ static void
 S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p,
                           STRLEN xs_len)
 {
+    PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK;
+
     SV *sv;
     const char *vn = NULL;
     SV *const module = PL_stack_base[ax];
-
-    PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK;
 
     if (items >= 2)	 /* version supplied as bootstrap arg */
         sv = PL_stack_base[ax + 1];
@@ -5734,9 +5752,9 @@ diagnosable than random crashes and mis-behaviour.
 void
 Perl_api_version_assert(size_t interp_size, void *v_my_perl,
                         const char *api_version) {
-    dTHX;
-
     PERL_ARGS_ASSERT_API_VERSION_ASSERT;
+
+    dTHX;
 
     if (interp_size != sizeof(PerlInterpreter)) {
         /* detects various types of configuration mismatches */
@@ -5780,6 +5798,8 @@ S_gv_has_usable_name(pTHX_ GV *gv)
 void
 Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
 {
+    PERL_ARGS_ASSERT_GET_DB_SUB;
+
     SV * const dbsv = GvSVn(PL_DBsub);
     const bool save_taint = TAINT_get;
 
@@ -5787,8 +5807,6 @@ Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
      * we do not care about using dbsv to call CV;
      * it's for informational purposes only.
      */
-
-    PERL_ARGS_ASSERT_GET_DB_SUB;
 
     TAINT_set(FALSE);
     save_item(dbsv);
@@ -6729,9 +6747,9 @@ Returns true if a backtrace could be retrieved, false if not.
 bool
 Perl_dump_c_backtrace(pTHX_ PerlIO* fp, int depth, int skip)
 {
-    SV* sv;
-
     PERL_ARGS_ASSERT_DUMP_C_BACKTRACE;
+
+    SV* sv;
 
     sv = Perl_get_c_backtrace_dump(aTHX_ depth, skip);
     if (sv) {
@@ -6773,13 +6791,13 @@ int perl_tsa_mutex_destroy(perl_mutex* mutex)
 void
 Perl_dtrace_probe_call(pTHX_ CV *cv, bool is_call)
 {
+    PERL_ARGS_ASSERT_DTRACE_PROBE_CALL;
+
     const char *func;
     const char *file;
     const char *stash;
     const COP  *start;
     line_t      line;
-
-    PERL_ARGS_ASSERT_DTRACE_PROBE_CALL;
 
     if (CvNAMED(cv)) {
         HEK *hek = CvNAME_HEK(cv);


### PR DESCRIPTION
Besides being more tidy, this makes sure that the asserts inside them are executed before any attempt to use the parameters.  This will give better error messages when those assertions are violated, instead of the generic SEGFAULT that could occur previously.

* This set of changes does not require a perldelta entry.
