### PR TITLE
embed.pl Generalize handling non-returning, non-void functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2116,6 +2116,9 @@ p	|U32	|magic_regdata_cnt					\
 p	|int	|magic_regdatum_get					\
 				|NN SV *sv				\
 				|NN MAGIC *mg
+pr	|int	|magic_regdatum_set					\
+				|NN SV *sv				\
+				|NN MAGIC *mg
 
 : This is indirectly referenced by globals.c. This is somewhat annoying.
 p	|SV *	|magic_scalarpack					\
@@ -4318,15 +4321,6 @@ Cp	|void	|sys_intern_init
 Cp	|void	|sys_intern_dup |NN struct interp_intern *src		\
 				|NN struct interp_intern *dst
 # endif
-#endif
-#if defined(_MSC_VER)
-p	|int	|magic_regdatum_set					\
-				|NN SV *sv				\
-				|NN MAGIC *mg
-#else
-pr	|int	|magic_regdatum_set					\
-				|NN SV *sv				\
-				|NN MAGIC *mg
 #endif
 #if defined(MULTIPLICITY)
 ATdfpr	|void	|croak_nocontext|NULLOK const char *pat 		\

--- a/embed.h
+++ b/embed.h
@@ -1062,6 +1062,7 @@
 #   define magic_nextpack(a,b,c)                Perl_magic_nextpack(aTHX_ a,b,c)
 #   define magic_regdata_cnt(a,b)               Perl_magic_regdata_cnt(aTHX_ a,b)
 #   define magic_regdatum_get(a,b)              Perl_magic_regdatum_get(aTHX_ a,b)
+#   define magic_regdatum_set(a,b)              Perl_magic_regdatum_set(aTHX_ a,b)
 #   define magic_scalarpack(a,b)                Perl_magic_scalarpack(aTHX_ a,b)
 #   define magic_set(a,b)                       Perl_magic_set(aTHX_ a,b)
 #   define magic_set_all_env(a,b)               Perl_magic_set_all_env(aTHX_ a,b)
@@ -1225,11 +1226,6 @@
        ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) && \
          defined(SOCK_DGRAM) )
 #     define PerlSock_socketpair_cloexec(a,b,c,d) Perl_PerlSock_socketpair_cloexec(aTHX_ a,b,c,d)
-#   endif
-#   if defined(_MSC_VER)
-#     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
-#   else
-#     define magic_regdatum_set(a,b)            Perl_magic_regdatum_set(aTHX_ a,b)
 #   endif
 #   if defined(PERL_DEBUG_READONLY_COW)
 #     define sv_buf_to_ro(a)                    Perl_sv_buf_to_ro(aTHX_ a)

--- a/perl.h
+++ b/perl.h
@@ -4472,6 +4472,13 @@ typedef        struct crypt_data {     /* straight from /usr/include/crypt.h */
 #    define PERL_CALLCONV_NO_RET PERL_CALLCONV
 #endif
 
+/* Some platforms require special handling of functions that don't return, but
+ * are declared as having a return value that isn't 'void'.  Use whatever
+ * they've set, or if nothing, just use the normal handling. */
+#ifndef PERL_CALLCONV_NON_VOID_NO_RET
+#    define PERL_CALLCONV_NON_VOID_NO_RET(ret_type)  PERL_CALLCONV_NO_RET
+#endif
+
 /* PERL_STATIC_NO_RET is supposed to be equivalent to static on builds that
    dont have a noreturn as a declaration specifier
 */

--- a/proto.h
+++ b/proto.h
@@ -1019,14 +1019,14 @@ Perl_despatch_signals(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DESPATCH_SIGNALS
 
-PERL_CALLCONV_NO_RET OP *
+PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_DIE
 
-PERL_CALLCONV_NO_RET OP *
+PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die_sv(pTHX_ SV *baseex)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
@@ -2851,6 +2851,16 @@ Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATUM_GET     \
+        assert(sv); assert(mg)
+
+PERL_CALLCONV_NON_VOID_NO_RET(int) int
+Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        __attribute__noreturn__
+        __attribute__visibility__("hidden");
+#define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET     \
         assert(sv); assert(mg)
 
 PERL_CALLCONV SV *
@@ -7426,28 +7436,6 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst)
 
 # endif /* defined(USE_ITHREADS) */
 #endif /* defined(HAVE_INTERP_INTERN) */
-#if defined(_MSC_VER)
-PERL_CALLCONV int
-Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2)
-        __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET    \
-        assert(sv); assert(mg)
-
-#else /* if !defined(_MSC_VER) */
-PERL_CALLCONV_NO_RET int
-Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2)
-        __attribute__noreturn__
-        __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET    \
-        assert(sv); assert(mg)
-
-#endif /* !defined(_MSC_VER) */
 #if defined(MULTIPLICITY)
 PERL_CALLCONV_NO_RET void
 Perl_croak_nocontext(const char *pat, ...)
@@ -7462,7 +7450,7 @@ Perl_deb_nocontext(const char *pat, ...)
 # define PERL_ARGS_ASSERT_DEB_NOCONTEXT         \
         assert(pat)
 
-PERL_CALLCONV_NO_RET OP *
+PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die_nocontext(const char *pat, ...)
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,1,2);

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3980,7 +3980,7 @@ sub generate_proto_h {
         $ind .= "  " x ($level-1) if $level>1;
         my $inner_ind= $ind ? "  " : " ";
 
-        my ($flags, $retval, $plain_func, $args, $assertions ) =
+        my ($flags, $ret_type, $plain_func, $args, $assertions ) =
                         @{$embed}{qw(flags return_type name args assertions)};
         if ($flags =~
              m/([^ aA b C dD eE fF h iI mM nN oO pP Rr sS T uU v W xX ; ])/xx)
@@ -4049,7 +4049,7 @@ sub generate_proto_h {
             $need_longs{$plain_func} = $args_assert_line = 1;
         }
 
-        if (! $can_ignore && $retval eq 'void') {
+        if (! $can_ignore && $ret_type eq 'void') {
             warn "It is nonsensical to require the return value of a void"
                . " function ($plain_func) to be checked";
         }
@@ -4087,6 +4087,7 @@ sub generate_proto_h {
                      "$plain_func: flags $flags_str are mutually exclusive\n";
         }
 
+        my $retval = $ret_type;
         my $static_inline = 0;
         if ($static_flag) {
             my $type;
@@ -4121,7 +4122,12 @@ sub generate_proto_h {
                                     && $plain_func !~ /[Pp]erl/;
 
             if ($never_returns) {
-                $retval = "PERL_CALLCONV_NO_RET $retval";
+                if ($ret_type eq 'void') {
+                    $retval = "PERL_CALLCONV_NO_RET $retval";
+                }
+                else {
+                    $retval = "PERL_CALLCONV_NON_VOID_NO_RET($ret_type) $retval";
+                }
             }
             else {
                 $retval = "PERL_CALLCONV $retval";

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -99,6 +99,10 @@
 #  else /* MSVC noreturn support inside the interp */
 #    ifdef _MSC_VER
 #      define PERL_CALLCONV_NO_RET __declspec(noreturn)
+
+        /* Windows can't cope with a function that isn't supposed to return
+         * declared as having a non-void return value */
+#      define PERL_CALLCONV_NON_VOID_NO_RET(ret_type)
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
embed.fnc contained a special #if case for Windows for a function that is declared as not returning, and also is declared as returning 'int'.

This commit generalizes that so that any platform that needs it can create a macro for that case, and the code not specific to that platform doesn't have to know about which platforms have which constraints.

This commit showed several other instances of similar circumstances to the one that was special cased.  Apparently they didn't cause problems. They all returned a pointer instead of an int.  This commit treats them as the special case; I don't see a problem with that


* This set of changes does not require a perldelta entry.
