### PR TITLE
embed.pl Create Perl_foo functions for all mp-flagged macros

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -620,8 +620,10 @@
 :
 :   'm'  The implementation is a macro.  There is no long "S_" name form
 :        created for it.  However, if you also specify the 'p' flag, a long
-:        name Perl_" form is automatically created.  That form will be an
-:        actual function on a threaded build unless the 'T' flag is present.
+:        name Perl_" form is automatically created.  Except when the macro
+:        is visible only to core and extensions, the 'Perl_' form will be an
+:        actual function.  This allows the XS writer to simply #undef the short
+:        name and use the long form if there is a namespace clash.
 :
 :        The implication of this is that we can swap implementations at will,
 :        macro-to-function or function-to-macro, without any source code

--- a/embed.h
+++ b/embed.h
@@ -119,7 +119,6 @@
 # define bytes_to_utf8(a,b)                     Perl_bytes_to_utf8(aTHX_ a,b)
 # define bytes_to_utf8_free_me(a,b,c)           Perl_bytes_to_utf8_free_me(aTHX_ a,b,c)
 # define bytes_to_utf8_temp_pv(a,b)             Perl_bytes_to_utf8_temp_pv(aTHX_ a,b)
-# define Perl_c9strict_utf8_to_uv               c9strict_utf8_to_uv
 # define call_argv(a,b,c)                       Perl_call_argv(aTHX_ a,b,c)
 # define call_atexit(a,b)                       Perl_call_atexit(aTHX_ a,b)
 # define call_list(a,b)                         Perl_call_list(aTHX_ a,b)
@@ -190,8 +189,6 @@
 # define dump_vindent(a,b,c,d)                  Perl_dump_vindent(aTHX_ a,b,c,d)
 # define eval_pv(a,b)                           Perl_eval_pv(aTHX_ a,b)
 # define eval_sv(a,b)                           Perl_eval_sv(aTHX_ a,b)
-# define Perl_expected_size                     expected_size
-# define Perl_extended_utf8_to_uv               extended_utf8_to_uv
 # define fatal_warner(a,...)                    Perl_fatal_warner(aTHX_ a,__VA_ARGS__)
 # define fbm_compile(a,b)                       Perl_fbm_compile(aTHX_ a,b)
 # define fbm_instr(a,b,c,d)                     Perl_fbm_instr(aTHX_ a,b,c,d)
@@ -283,41 +280,29 @@
 # define init_i18nl10n(a)                       Perl_init_i18nl10n(aTHX_ a)
 # define init_stacks()                          Perl_init_stacks(aTHX)
 # define init_tm(a)                             Perl_init_tm(aTHX_ a)
-# define Perl_instr                             instr
 # define intro_my()                             Perl_intro_my(aTHX)
 # define isC9_STRICT_UTF8_CHAR                  Perl_isC9_STRICT_UTF8_CHAR
 # define isSTRICT_UTF8_CHAR                     Perl_isSTRICT_UTF8_CHAR
 # define isUTF8_CHAR                            Perl_isUTF8_CHAR
 # define isUTF8_CHAR_flags                      Perl_isUTF8_CHAR_flags
-# define Perl_is_c9strict_utf8_string           is_c9strict_utf8_string
-# define Perl_is_c9strict_utf8_string_loc       is_c9strict_utf8_string_loc
 # define is_c9strict_utf8_string_loclen         Perl_is_c9strict_utf8_string_loclen
 # define is_in_locale_category_(a,b)            Perl_is_in_locale_category_(aTHX_ a,b)
 # define is_lvalue_sub()                        Perl_is_lvalue_sub(aTHX)
 # define is_safe_syscall(a,b,c,d)               Perl_is_safe_syscall(aTHX_ a,b,c,d)
-# define Perl_is_strict_utf8_string             is_strict_utf8_string
-# define Perl_is_strict_utf8_string_loc         is_strict_utf8_string_loc
 # define is_strict_utf8_string_loclen           Perl_is_strict_utf8_string_loclen
 # define is_uni_FOO_(a,b)                       Perl_is_uni_FOO_(aTHX_ a,b)
 # define is_uni_perl_idcont_(a)                 Perl_is_uni_perl_idcont_(aTHX_ a)
 # define is_uni_perl_idstart_(a)                Perl_is_uni_perl_idstart_(aTHX_ a)
 # define is_utf8_FF_helper_                     Perl_is_utf8_FF_helper_
 # define is_utf8_FOO_(a,b,c)                    Perl_is_utf8_FOO_(aTHX_ a,b,c)
-# define Perl_is_utf8_char_buf                  is_utf8_char_buf
 # define is_utf8_char_helper_                   Perl_is_utf8_char_helper_
-# define Perl_is_utf8_fixed_width_buf_flags     is_utf8_fixed_width_buf_flags
-# define Perl_is_utf8_fixed_width_buf_loc_flags is_utf8_fixed_width_buf_loc_flags
 # define is_utf8_fixed_width_buf_loclen_flags   Perl_is_utf8_fixed_width_buf_loclen_flags
 # define is_utf8_invariant_string_loc           Perl_is_utf8_invariant_string_loc
 # define is_utf8_perl_idcont_(a,b)              Perl_is_utf8_perl_idcont_(aTHX_ a,b)
 # define is_utf8_perl_idstart_(a,b)             Perl_is_utf8_perl_idstart_(aTHX_ a,b)
-# define Perl_is_utf8_string                    is_utf8_string
 # define is_utf8_string_flags                   Perl_is_utf8_string_flags
-# define Perl_is_utf8_string_loc                is_utf8_string_loc
-# define Perl_is_utf8_string_loc_flags          is_utf8_string_loc_flags
 # define is_utf8_string_loclen                  Perl_is_utf8_string_loclen
 # define is_utf8_string_loclen_flags            Perl_is_utf8_string_loclen_flags
-# define Perl_is_utf8_valid_partial_char        is_utf8_valid_partial_char
 # define is_utf8_valid_partial_char_flags       Perl_is_utf8_valid_partial_char_flags
 # define isinfnan                               Perl_isinfnan
 # define leave_adjust_stacks(a,b,c,d)           Perl_leave_adjust_stacks(aTHX_ a,b,c,d)
@@ -642,7 +627,6 @@
 # define stack_grow(a,b,c)                      Perl_stack_grow(aTHX_ a,b,c)
 # define start_subparse(a,b)                    Perl_start_subparse(aTHX_ a,b)
 # define str_to_version(a)                      Perl_str_to_version(aTHX_ a)
-# define Perl_strict_utf8_to_uv                 strict_utf8_to_uv
 # define suspend_compcv(a)                      Perl_suspend_compcv(aTHX_ a)
 # define sv_2bool_flags(a,b)                    Perl_sv_2bool_flags(aTHX_ a,b)
 # define sv_2cv(a,b,c,d)                        Perl_sv_2cv(aTHX_ a,b,c,d)
@@ -804,26 +788,18 @@
 # define upg_version(a,b)                       Perl_upg_version(aTHX_ a,b)
 # define utf8_distance(a,b)                     Perl_utf8_distance(aTHX_ a,b)
 # define utf8_hop                               Perl_utf8_hop
-# define Perl_utf8_hop_back                     utf8_hop_back
 # define utf8_hop_back_overshoot                Perl_utf8_hop_back_overshoot
-# define Perl_utf8_hop_forward                  utf8_hop_forward
 # define utf8_hop_forward_overshoot             Perl_utf8_hop_forward_overshoot
 # define utf8_hop_overshoot                     Perl_utf8_hop_overshoot
-# define Perl_utf8_hop_safe                     utf8_hop_safe
 # define utf8_length(a,b)                       Perl_utf8_length(aTHX_ a,b)
 # define utf8_to_bytes(a,b)                     Perl_utf8_to_bytes(aTHX_ a,b)
 # define utf8_to_bytes_(a,b,c,d)                Perl_utf8_to_bytes_(aTHX_ a,b,c,d)
 # define utf8_to_bytes_new_pv(a,b,c)            Perl_utf8_to_bytes_new_pv(aTHX_ a,b,c)
 # define utf8_to_bytes_overwrite(a,b)           Perl_utf8_to_bytes_overwrite(aTHX_ a,b)
 # define utf8_to_bytes_temp_pv(a,b)             Perl_utf8_to_bytes_temp_pv(aTHX_ a,b)
-# define Perl_utf8_to_uv                        utf8_to_uv
-# define Perl_utf8_to_uv_errors                 utf8_to_uv_errors
-# define Perl_utf8_to_uv_flags                  utf8_to_uv_flags
 # define utf8_to_uv_msgs                        Perl_utf8_to_uv_msgs
 # define utf8_to_uv_msgs_helper_                Perl_utf8_to_uv_msgs_helper_
 # define utf8_to_uv_or_die                      Perl_utf8_to_uv_or_die
-# define Perl_utf8n_to_uvchr                    utf8n_to_uvchr
-# define Perl_utf8n_to_uvchr_error              utf8n_to_uvchr_error
 # define utf8n_to_uvchr_msgs                    Perl_utf8n_to_uvchr_msgs
 # define uv_to_utf8(a,b)                        Perl_uv_to_utf8(aTHX_ a,b)
 # define uv_to_utf8_flags(a,b,c)                Perl_uv_to_utf8_flags(aTHX_ a,b,c)
@@ -832,7 +808,6 @@
 # define valid_identifier_pvn(a,b,c)            Perl_valid_identifier_pvn(aTHX_ a,b,c)
 # define valid_identifier_sv(a)                 Perl_valid_identifier_sv(aTHX_ a)
 # define valid_utf8_to_uv                       Perl_valid_utf8_to_uv
-# define Perl_valid_utf8_to_uvchr               valid_utf8_to_uvchr
 # define variant_byte_number                    Perl_variant_byte_number
 # define vcmp(a,b)                              Perl_vcmp(aTHX_ a,b)
 # define vcroak(a,b)                            Perl_vcroak(aTHX_ a,b)
@@ -2290,9 +2265,6 @@
          defined(PERL_IN_SV_C) )
 #     define mem_collxfrm_(a,b,c,d)             Perl_mem_collxfrm_(aTHX_ a,b,c,d)
 #   endif
-#   if !defined(USE_THREADS)
-#     define Perl_sv_collxfrm(a,b)              sv_collxfrm(a,b)
-#   endif
 # endif
 # if defined(USE_PERLIO)
 #   define PerlIO_clearerr(a)                   Perl_PerlIO_clearerr(aTHX_ a)
@@ -2321,113 +2293,7 @@
 # if defined(USE_THREADS)
 #   define thread_locale_init()                 Perl_thread_locale_init(aTHX)
 #   define thread_locale_term()                 Perl_thread_locale_term(aTHX)
-# else
-#   define Perl_SvREFCNT_dec_set_NULL(a)        SvREFCNT_dec_set_NULL(a)
-#   define Perl_do_open(a,b,c,d,e,f,g)          do_open(a,b,c,d,e,f,g)
-#   define Perl_foldEQ_utf8(a,b,c,d,e,f,g,h)    foldEQ_utf8(a,b,c,d,e,f,g,h)
-#   define Perl_gv_AVadd(a)                     gv_AVadd(a)
-#   define Perl_gv_HVadd(a)                     gv_HVadd(a)
-#   define Perl_gv_IOadd(a)                     gv_IOadd(a)
-#   define Perl_gv_SVadd(a)                     gv_SVadd(a)
-#   define Perl_gv_efullname3(a,b,c)            gv_efullname3(a,b,c)
-#   define Perl_gv_fetchmeth(a,b,c,d)           gv_fetchmeth(a,b,c,d)
-#   define Perl_gv_fetchmeth_autoload(a,b,c,d)  gv_fetchmeth_autoload(a,b,c,d)
-#   define Perl_gv_fetchmethod(a,b)             gv_fetchmethod(a,b)
-#   define Perl_gv_fullname3(a,b,c)             gv_fullname3(a,b,c)
-#   define Perl_gv_init(a,b,c,d,e)              gv_init(a,b,c,d,e)
-#   define Perl_hv_delete(a,b,c,d)              hv_delete(a,b,c,d)
-#   define Perl_hv_delete_ent(a,b,c,d)          hv_delete_ent(a,b,c,d)
-#   define Perl_hv_exists(a,b,c)                hv_exists(a,b,c)
-#   define Perl_hv_exists_ent(a,b,c)            hv_exists_ent(a,b,c)
-#   define Perl_hv_fetch(a,b,c,d)               hv_fetch(a,b,c,d)
-#   define Perl_hv_fetch_ent(a,b,c,d)           hv_fetch_ent(a,b,c,d)
-#   define Perl_hv_iternext(a)                  hv_iternext(a)
-#   define Perl_hv_magic(a,b,c)                 hv_magic(a,b,c)
-#   define Perl_hv_store(a,b,c,d,e)             hv_store(a,b,c,d,e)
-#   define Perl_hv_store_ent(a,b,c,d)           hv_store_ent(a,b,c,d)
-#   define Perl_hv_store_flags(a,b,c,d,e,f)     hv_store_flags(a,b,c,d,e,f)
-#   define Perl_hv_undef(a)                     hv_undef(a)
-#   define Perl_ibcmp(a,b,c)                    ibcmp(a,b,c)
-#   define Perl_ibcmp_locale(a,b,c)             ibcmp_locale(a,b,c)
-#   define Perl_ibcmp_utf8(a,b,c,d,e,f,g,h)     ibcmp_utf8(a,b,c,d,e,f,g,h)
-#   define Perl_newATTRSUB(a,b,c,d,e)           newATTRSUB(a,b,c,d,e)
-#   define Perl_newAV()                         newAV()
-#   define Perl_newAV_alloc_x(a)                newAV_alloc_x(a)
-#   define Perl_newAV_alloc_xz(a)               newAV_alloc_xz(a)
-#   define Perl_newAV_mortal()                  newAV_mortal()
-#   define Perl_newGVgen(a)                     newGVgen(a)
-#   define Perl_newHV()                         newHV()
-#   define Perl_newIO()                         newIO()
-#   define Perl_newSUB(a,b,c,d)                 newSUB(a,b,c,d)
-#   define Perl_newSVsv(a)                      newSVsv(a)
-#   define Perl_newSVsv_nomg(a)                 newSVsv_nomg(a)
-#   define Perl_op_lvalue(a,b)                  op_lvalue(a,b)
-#   define Perl_phase_name(a)                   phase_name(a)
-#   define Perl_resume_compcv_and_save(a)       resume_compcv_and_save(a)
-#   define Perl_resume_compcv_final(a)          resume_compcv_final(a)
-#   define Perl_save_aelem(a,b,c)               save_aelem(a,b,c)
-#   define Perl_save_freeop(a)                  save_freeop(a)
-#   define Perl_save_freepv(a)                  save_freepv(a)
-#   define Perl_save_freesv(a)                  save_freesv(a)
-#   define Perl_save_helem(a,b,c)               save_helem(a,b,c)
-#   define Perl_save_mortalizesv(a)             save_mortalizesv(a)
-#   define Perl_save_op()                       save_op()
-#   define Perl_sv_2bool(a)                     sv_2bool(a)
-#   define Perl_sv_2iv(a)                       sv_2iv(a)
-#   define Perl_sv_2pv(a,b)                     sv_2pv(a,b)
-#   define Perl_sv_2pv_nolen(a)                 sv_2pv_nolen(a)
-#   define Perl_sv_2pvbyte(a,b)                 sv_2pvbyte(a,b)
-#   define Perl_sv_2pvbyte_nolen(a)             sv_2pvbyte_nolen(a)
-#   define Perl_sv_2pvutf8(a,b)                 sv_2pvutf8(a,b)
-#   define Perl_sv_2pvutf8_nolen(a)             sv_2pvutf8_nolen(a)
-#   define Perl_sv_2uv(a)                       sv_2uv(a)
-#   define Perl_sv_catpvn(a,b,c)                sv_catpvn(a,b,c)
-#   define Perl_sv_catpvn_mg(a,b,c)             sv_catpvn_mg(a,b,c)
-#   define Perl_sv_catsv(a,b)                   sv_catsv(a,b)
-#   define Perl_sv_catsv_mg(a,b)                sv_catsv_mg(a,b)
-#   define Perl_sv_copypv(a,b)                  sv_copypv(a,b)
-#   define Perl_sv_copypv_nomg(a,b)             sv_copypv_nomg(a,b)
-#   define Perl_sv_eq(a,b)                      sv_eq(a,b)
-#   define Perl_sv_force_normal(a)              sv_force_normal(a)
-#   define Perl_sv_insert(a,b,c,d,e)            sv_insert(a,b,c,d,e)
-#   define Perl_sv_mortalcopy(a)                sv_mortalcopy(a)
-#   define Perl_sv_numcmp(a,b)                  sv_numcmp(a,b)
-#   define Perl_sv_numeq(a,b)                   sv_numeq(a,b)
-#   define Perl_sv_numge(a,b)                   sv_numge(a,b)
-#   define Perl_sv_numgt(a,b)                   sv_numgt(a,b)
-#   define Perl_sv_numle(a,b)                   sv_numle(a,b)
-#   define Perl_sv_numlt(a,b)                   sv_numlt(a,b)
-#   define Perl_sv_numne(a,b)                   sv_numne(a,b)
-#   define Perl_sv_pv(a)                        sv_pv(a)
-#   define Perl_sv_pvbyte(a)                    sv_pvbyte(a)
-#   define Perl_sv_pvn_force(a,b)               sv_pvn_force(a,b)
-#   define Perl_sv_pvutf8(a)                    sv_pvutf8(a)
-#   define Perl_sv_setsv(a,b)                   sv_setsv(a,b)
-#   define Perl_sv_streq(a,b)                   sv_streq(a,b)
-#   define Perl_sv_taint(a)                     sv_taint(a)
-#   define Perl_sv_unref(a)                     sv_unref(a)
-#   define Perl_sv_usepvn(a,b,c)                sv_usepvn(a,b,c)
-#   define Perl_sv_usepvn_mg(a,b,c)             sv_usepvn_mg(a,b,c)
-#   define Perl_sv_utf8_downgrade(a,b)          sv_utf8_downgrade(a,b)
-#   define Perl_sv_utf8_downgrade_nomg(a,b)     sv_utf8_downgrade_nomg(a,b)
-#   define Perl_sv_utf8_upgrade(a)              sv_utf8_upgrade(a)
-#   define Perl_sv_utf8_upgrade_flags(a,b)      sv_utf8_upgrade_flags(a,b)
-#   define Perl_sv_utf8_upgrade_nomg(a)         sv_utf8_upgrade_nomg(a)
-#   define Perl_to_uni_fold(a,b,c)              to_uni_fold(a,b,c)
-#   define Perl_uv_to_utf8_msgs(a,b,c,d)        uv_to_utf8_msgs(a,b,c,d)
-#   define Perl_uvchr_to_utf8(a,b)              uvchr_to_utf8(a,b)
-#   define Perl_uvchr_to_utf8_flags(a,b,c)      uvchr_to_utf8_flags(a,b,c)
-#   define Perl_uvchr_to_utf8_flags_msgs(a,b,c,d) uvchr_to_utf8_flags_msgs(a,b,c,d)
-#   define Perl_uvoffuni_to_utf8_flags(a,b,c)   uvoffuni_to_utf8_flags(a,b,c)
-#   define Perl_whichsig(a)                     whichsig(a)
-#   if defined(PERL_CORE) || defined(PERL_EXT)
-#     define Perl_utf16_to_utf8(a,b,c,d)        utf16_to_utf8(a,b,c,d)
-#     define Perl_utf16_to_utf8_reversed(a,b,c,d) utf16_to_utf8_reversed(a,b,c,d)
-#   endif
-#   if !defined(USE_ITHREADS)
-#     define Perl_CopFILEGV_set(a,b)            CopFILEGV_set(a,b)
-#   endif
-# endif /* !defined(USE_THREADS) */
+# endif
 # if defined(VMS) || defined(WIN32)
 #   define do_aspawn(a,b,c)                     Perl_do_aspawn(aTHX_ a,b,c)
 #   define do_spawn(a)                          Perl_do_spawn(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -2141,6 +2141,10 @@
 #       define re_exec_indentf(a,...)           Perl_re_exec_indentf(aTHX_ a,__VA_ARGS__)
 #     endif
 #   endif /* defined(PERL_IN_REGEXEC_C) */
+#   if !defined(USE_THREADS)
+#     define Perl_utf16_to_utf8(a,b,c,d)        utf16_to_utf8(a,b,c,d)
+#     define Perl_utf16_to_utf8_reversed(a,b,c,d) utf16_to_utf8_reversed(a,b,c,d)
+#   endif
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API)
 #   define finalize_optree(a)                   Perl_finalize_optree(aTHX_ a)
@@ -2293,6 +2297,10 @@
 # if defined(USE_THREADS)
 #   define thread_locale_init()                 Perl_thread_locale_init(aTHX)
 #   define thread_locale_term()                 Perl_thread_locale_term(aTHX)
+#   if defined(PERL_CORE) || defined(PERL_EXT)
+#     define Perl_utf16_to_utf8(mTHX,a,b,c,d)   utf16_to_utf8(a,b,c,d)
+#     define Perl_utf16_to_utf8_reversed(mTHX,a,b,c,d) utf16_to_utf8_reversed(a,b,c,d)
+#   endif
 # endif
 # if defined(VMS) || defined(WIN32)
 #   define do_aspawn(a,b,c)                     Perl_do_aspawn(aTHX_ a,b,c)

--- a/long_names.c
+++ b/long_names.c
@@ -921,26 +921,6 @@ Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
     return to_uni_fold(c, p, lenp);
 }
 
-#if defined(PERL_CORE) || defined(PERL_EXT)
-U8 *
-Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
-{
-    PERL_ARGS_ASSERT_UTF16_TO_UTF8;
-
-    return utf16_to_utf8(p, d, bytelen, newlen);
-}
-#endif
-
-#if defined(PERL_CORE) || defined(PERL_EXT)
-U8 *
-Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
-{
-    PERL_ARGS_ASSERT_UTF16_TO_UTF8_REVERSED;
-
-    return utf16_to_utf8_reversed(p, d, bytelen, newlen);
-}
-#endif
-
 U8 *
 Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
 {

--- a/long_names.c
+++ b/long_names.c
@@ -56,11 +56,35 @@ Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv)
 }
 
 bool
+Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+{
+    PERL_ARGS_ASSERT_C9STRICT_UTF8_TO_UV;
+
+    return c9strict_utf8_to_uv(s, e, cp_p, advance_p);
+}
+
+bool
 Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp)
 {
     PERL_ARGS_ASSERT_DO_OPEN;
 
     return do_open(gv, name, len, as_raw, rawmode, rawperm, supplied_fp);
+}
+
+Size_t
+Perl_expected_size(UV size)
+{
+    PERL_ARGS_ASSERT_EXPECTED_SIZE;
+
+    return expected_size(size);
+}
+
+bool
+Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+{
+    PERL_ARGS_ASSERT_EXTENDED_UTF8_TO_UV;
+
+    return extended_utf8_to_uv(s, e, cp_p, advance_p);
 }
 
 I32
@@ -271,6 +295,102 @@ Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2
     return ibcmp_utf8(s1, pe1, l1, u1, s2, pe2, l2, u2);
 }
 
+char *
+Perl_instr(const char *big, const char *little)
+{
+    PERL_ARGS_ASSERT_INSTR;
+
+    return instr(big, little);
+}
+
+bool
+Perl_is_c9strict_utf8_string(const U8 *s, STRLEN len)
+{
+    PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING;
+
+    return is_c9strict_utf8_string(s, len);
+}
+
+bool
+Perl_is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
+{
+    PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOC;
+
+    return is_c9strict_utf8_string_loc(s, len, ep);
+}
+
+bool
+Perl_is_strict_utf8_string(const U8 *s, STRLEN len)
+{
+    PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING;
+
+    return is_strict_utf8_string(s, len);
+}
+
+bool
+Perl_is_strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
+{
+    PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOC;
+
+    return is_strict_utf8_string_loc(s, len, ep);
+}
+
+STRLEN
+Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end)
+{
+    PERL_ARGS_ASSERT_IS_UTF8_CHAR_BUF;
+
+    return is_utf8_char_buf(buf, buf_end);
+}
+
+bool
+Perl_is_utf8_fixed_width_buf_flags(const U8 * const s, STRLEN len, const U32 flags)
+{
+    PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_FLAGS;
+
+    return is_utf8_fixed_width_buf_flags(s, len, flags);
+}
+
+bool
+Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 **ep, const U32 flags)
+{
+    PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOC_FLAGS;
+
+    return is_utf8_fixed_width_buf_loc_flags(s, len, ep, flags);
+}
+
+bool
+Perl_is_utf8_string(const U8 *s, STRLEN len)
+{
+    PERL_ARGS_ASSERT_IS_UTF8_STRING;
+
+    return is_utf8_string(s, len);
+}
+
+bool
+Perl_is_utf8_string_loc(const U8 *s, const STRLEN len, const U8 **ep)
+{
+    PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC;
+
+    return is_utf8_string_loc(s, len, ep);
+}
+
+bool
+Perl_is_utf8_string_loc_flags(const U8 *s, STRLEN len, const U8 **ep, const U32 flags)
+{
+    PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC_FLAGS;
+
+    return is_utf8_string_loc_flags(s, len, ep, flags);
+}
+
+bool
+Perl_is_utf8_valid_partial_char(const U8 * const s0, const U8 * const e)
+{
+    PERL_ARGS_ASSERT_IS_UTF8_VALID_PARTIAL_CHAR;
+
+    return is_utf8_valid_partial_char(s0, e);
+}
+
 CV *
 Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
 {
@@ -445,6 +565,14 @@ Perl_save_op(pTHX)
     PERL_ARGS_ASSERT_SAVE_OP;
 
     save_op();
+}
+
+bool
+Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+{
+    PERL_ARGS_ASSERT_STRICT_UTF8_TO_UV;
+
+    return strict_utf8_to_uv(s, e, cp_p, advance_p);
 }
 
 bool
@@ -814,6 +942,70 @@ Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
 #endif
 
 U8 *
+Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
+{
+    PERL_ARGS_ASSERT_UTF8_HOP_BACK;
+
+    return utf8_hop_back(s, off, start);
+}
+
+U8 *
+Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
+{
+    PERL_ARGS_ASSERT_UTF8_HOP_FORWARD;
+
+    return utf8_hop_forward(s, off, end);
+}
+
+U8 *
+Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end)
+{
+    PERL_ARGS_ASSERT_UTF8_HOP_SAFE;
+
+    return utf8_hop_safe(s, off, start, end);
+}
+
+bool
+Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+{
+    PERL_ARGS_ASSERT_UTF8_TO_UV;
+
+    return utf8_to_uv(s, e, cp_p, advance_p);
+}
+
+bool
+Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors)
+{
+    PERL_ARGS_ASSERT_UTF8_TO_UV_ERRORS;
+
+    return utf8_to_uv_errors(s, e, cp_p, advance_p, flags, errors);
+}
+
+bool
+Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags)
+{
+    PERL_ARGS_ASSERT_UTF8_TO_UV_FLAGS;
+
+    return utf8_to_uv_flags(s, e, cp_p, advance_p, flags);
+}
+
+UV
+Perl_utf8n_to_uvchr(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags)
+{
+    PERL_ARGS_ASSERT_UTF8N_TO_UVCHR;
+
+    return utf8n_to_uvchr(s, curlen, retlen, flags);
+}
+
+UV
+Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors)
+{
+    PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_ERROR;
+
+    return utf8n_to_uvchr_error(s, curlen, retlen, flags, errors);
+}
+
+U8 *
 Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
 {
     PERL_ARGS_ASSERT_UV_TO_UTF8_MSGS;
@@ -851,6 +1043,14 @@ Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
     PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS;
 
     return uvoffuni_to_utf8_flags(d, uv, flags);
+}
+
+UV
+Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
+{
+    PERL_ARGS_ASSERT_VALID_UTF8_TO_UVCHR;
+
+    return valid_utf8_to_uvchr(s, retlen);
 }
 
 I32

--- a/proto.h
+++ b/proto.h
@@ -15466,12 +15466,6 @@ Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
 # define PERL_ARGS_ASSERT_TO_UNI_FOLD           \
         assert(p); assert(lenp)
 
-# define PERL_ARGS_ASSERT_UTF16_TO_UTF8         \
-        assert(p); assert(d); assert(newlen)
-
-# define PERL_ARGS_ASSERT_UTF16_TO_UTF8_REVERSED \
-        assert(p); assert(d); assert(newlen)
-
 PERL_CALLCONV U8 *
 Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
         Perl_attribute_nonnull(1)
@@ -15594,18 +15588,12 @@ Perl_thread_locale_term(pTHX)
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
-PERL_CALLCONV U8 *
+/* PERL_CALLCONV U8 *
 Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2)
-        Perl_attribute_nonnull(pTHX_4);
-PERL_CALLCONV U8 *
+        Perl_attribute_nonnull_aTHX; */
+/* PERL_CALLCONV U8 *
 Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2)
-        Perl_attribute_nonnull(pTHX_4);
+        Perl_attribute_nonnull_aTHX; */
 #   if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 /* PERL_CALLCONV void
@@ -15618,7 +15606,7 @@ invlist_subtract_(pTHX_ SV * const a, SV * const b, SV **result)
 invlist_union_(pTHX_ SV * const a, SV * const b, SV **output)
         Perl_attribute_nonnull_aTHX; */
 #   endif
-# endif /* defined(PERL_CORE) || defined(PERL_EXT) */
+# endif
 # if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 

--- a/proto.h
+++ b/proto.h
@@ -14739,8 +14739,13 @@ Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC_SET_NULL
 
-/* PERL_CALLCONV bool
-Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
+PERL_CALLCONV bool
+Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_C9STRICT_UTF8_TO_UV   \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
 
 PERL_CALLCONV bool
 Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp)
@@ -14750,11 +14755,17 @@ Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, i
 # define PERL_ARGS_ASSERT_DO_OPEN               \
         assert(gv); assert(name)
 
-/* PERL_CALLCONV Size_t
-Perl_expected_size(UV size); */
+PERL_CALLCONV Size_t
+Perl_expected_size(UV size);
+# define PERL_ARGS_ASSERT_EXPECTED_SIZE
 
-/* PERL_CALLCONV bool
-Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
+PERL_CALLCONV bool
+Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_EXTENDED_UTF8_TO_UV   \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
 
 PERL_CALLCONV I32
 Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
@@ -14941,48 +14952,91 @@ Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2
 # define PERL_ARGS_ASSERT_IBCMP_UTF8            \
         assert(s1); assert(s2)
 
-/* PERL_CALLCONV char *
+PERL_CALLCONV char *
 Perl_instr(const char *big, const char *little)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__
-        __attribute__pure__; */
+        __attribute__pure__;
+# define PERL_ARGS_ASSERT_INSTR                 \
+        assert(big); assert(little)
 
-/* PERL_CALLCONV bool
+PERL_CALLCONV bool
 Perl_is_c9strict_utf8_string(const U8 *s, STRLEN len)
-        __attribute__warn_unused_result__; */
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING \
+        assert(s)
 
-/* PERL_CALLCONV bool
-Perl_is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep); */
+PERL_CALLCONV bool
+Perl_is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOC \
+        assert(s); assert(ep)
 
-/* PERL_CALLCONV bool
+PERL_CALLCONV bool
 Perl_is_strict_utf8_string(const U8 *s, STRLEN len)
-        __attribute__warn_unused_result__; */
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING \
+        assert(s)
 
-/* PERL_CALLCONV bool
-Perl_is_strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep); */
+PERL_CALLCONV bool
+Perl_is_strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOC \
+        assert(s); assert(ep)
 
-/* PERL_CALLCONV STRLEN
-Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end); */
+PERL_CALLCONV STRLEN
+Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2);
+# define PERL_ARGS_ASSERT_IS_UTF8_CHAR_BUF      \
+        assert(buf); assert(buf_end); assert(buf <= buf_end)
 
-/* PERL_CALLCONV bool
-Perl_is_utf8_fixed_width_buf_flags(const U8 * const s, STRLEN len, const U32 flags); */
+PERL_CALLCONV bool
+Perl_is_utf8_fixed_width_buf_flags(const U8 * const s, STRLEN len, const U32 flags)
+        Perl_attribute_nonnull(1);
+# define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_FLAGS \
+        assert(s)
 
-/* PERL_CALLCONV bool
-Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 **ep, const U32 flags); */
+PERL_CALLCONV bool
+Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 **ep, const U32 flags)
+        Perl_attribute_nonnull(1);
+# define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOC_FLAGS \
+        assert(s)
 
-/* PERL_CALLCONV bool
+PERL_CALLCONV bool
 Perl_is_utf8_string(const U8 *s, STRLEN len)
-        __attribute__warn_unused_result__; */
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_IS_UTF8_STRING        \
+        assert(s)
 
-/* PERL_CALLCONV bool
-Perl_is_utf8_string_loc(const U8 *s, const STRLEN len, const U8 **ep); */
+PERL_CALLCONV bool
+Perl_is_utf8_string_loc(const U8 *s, const STRLEN len, const U8 **ep)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC    \
+        assert(s); assert(ep)
 
-/* PERL_CALLCONV bool
-Perl_is_utf8_string_loc_flags(const U8 *s, STRLEN len, const U8 **ep, const U32 flags); */
+PERL_CALLCONV bool
+Perl_is_utf8_string_loc_flags(const U8 *s, STRLEN len, const U8 **ep, const U32 flags)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC_FLAGS \
+        assert(s); assert(ep)
 
-/* PERL_CALLCONV bool
+PERL_CALLCONV bool
 Perl_is_utf8_valid_partial_char(const U8 * const s0, const U8 * const e)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__
-        __attribute__pure__; */
+        __attribute__pure__;
+# define PERL_ARGS_ASSERT_IS_UTF8_VALID_PARTIAL_CHAR \
+        assert(s0); assert(e); assert(s0 < e)
 
 PERL_CALLCONV CV *
 Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
@@ -15117,8 +15171,13 @@ Perl_save_op(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SAVE_OP
 
-/* PERL_CALLCONV bool
-Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
+PERL_CALLCONV bool
+Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_STRICT_UTF8_TO_UV     \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
 
 PERL_CALLCONV bool
 Perl_sv_2bool(pTHX_ SV * const sv)
@@ -15413,32 +15472,67 @@ Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
 # define PERL_ARGS_ASSERT_UTF16_TO_UTF8_REVERSED \
         assert(p); assert(d); assert(newlen)
 
-/* PERL_CALLCONV U8 *
+PERL_CALLCONV U8 *
 Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
-        __attribute__warn_unused_result__; */
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_UTF8_HOP_BACK         \
+        assert(s); assert(start); assert(start <= s)
 
-/* PERL_CALLCONV U8 *
+PERL_CALLCONV U8 *
 Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
-        __attribute__warn_unused_result__; */
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD      \
+        assert(s); assert(end); assert(s <= end)
 
-/* PERL_CALLCONV U8 *
+PERL_CALLCONV U8 *
 Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end)
-        __attribute__warn_unused_result__; */
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3)
+        Perl_attribute_nonnull(4)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_UTF8_HOP_SAFE         \
+        assert(s); assert(start); assert(end); assert(start <= s); \
+        assert(s <= end)
 
-/* PERL_CALLCONV bool
-Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
+PERL_CALLCONV bool
+Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_UTF8_TO_UV            \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
 
-/* PERL_CALLCONV bool
-Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors); */
+PERL_CALLCONV bool
+Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_UTF8_TO_UV_ERRORS     \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
 
-/* PERL_CALLCONV bool
-Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags); */
+PERL_CALLCONV bool
+Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+# define PERL_ARGS_ASSERT_UTF8_TO_UV_FLAGS      \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
 
-/* PERL_CALLCONV UV
-Perl_utf8n_to_uvchr(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags); */
+PERL_CALLCONV UV
+Perl_utf8n_to_uvchr(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags)
+        Perl_attribute_nonnull(1);
+# define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR        \
+        assert(s)
 
-/* PERL_CALLCONV UV
-Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors); */
+PERL_CALLCONV UV
+Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors)
+        Perl_attribute_nonnull(1);
+# define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_ERROR  \
+        assert(s)
 
 PERL_CALLCONV U8 *
 Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
@@ -15475,9 +15569,12 @@ Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
 # define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS \
         assert(d)
 
-/* PERL_CALLCONV UV
+PERL_CALLCONV UV
 Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
-        __attribute__warn_unused_result__; */
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+# define PERL_ARGS_ASSERT_VALID_UTF8_TO_UVCHR   \
+        assert(s)
 
 PERL_CALLCONV I32
 Perl_whichsig(pTHX_ const char *sig)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4045,13 +4045,13 @@ sub generate_proto_h {
         if (! $has_mflag) {
             $args_assert_line = 1;
         }
-        elsif ($has_mpflags && $has_context && $flags =~ /[ACE]/) {
+        elsif ($has_mpflags && $flags =~ $visible_outside_core_flags_re) {
 
             # And assertions are created for the automatically generated
             # functions from macros.  No function is needed unless one has
-            # been requested (p flag), and is needed.  None is needed if there
-            # is no implicit thread context parameter, nor if the macro
-            # doesn't have visibility outside core.
+            # been requested (p flag), and is needed.  None is needed if the
+            # macro doesn't have visibility outside core, as no function
+            # gets generated.
             $need_longs{$plain_func} = $args_assert_line = 1;
         }
 
@@ -4692,9 +4692,27 @@ sub embed_h {
 
             # Here is the case where the code implements the functionality
             # with a macro, and we're supposed to create a long name synonym
-            # for it.  If there's no thread context, we can just #define the
-            # long name to be equivalent to the short.
-            if ($flags =~ /[T]/) {
+            # for it.  The long name should work even if the XS code
+            # #undefines the short name (this would happen because it
+            # conflicts with their name).  If there's no thread context, the
+            # naive implementation would be to just copy the macro expansion.
+            # But what if that expansion uses a short name that has also been
+            # #undefined?  The only thing that works in all cases is to create
+            # a function named with the long name, and have it call the short
+            # name macro.  XXX The naive approach could still work for
+            # "simple" enough expansions.
+            #
+            # Another thing to consider is that we can't discard the thread
+            # context for elements visible outside core is because of the
+            # possibility of embedding.  Suppose a program contains two
+            # embedded perl instances.  It calls the various long form
+            # functions with whatever thread context it wants.  We can't just
+            # ignore that context, so an actual function needs to be created
+            # to pass the context to.
+            #
+            # But we don't have to worry about collisions for functions that
+            # are visible only to core
+            if ($flags =~ /[T]/ && $flags !~ $visible_outside_core_flags_re) {
                 # Yields
                 #   #define Perl_func  func
                 # which works when there is no thread context.
@@ -4702,31 +4720,19 @@ sub embed_h {
             }
             else {
 
-                # Here, there is thread context.  The macro doesn't have an
-                # explicit thread context argument, but the long name will
-                # which is empty on unthreaded builds.  We need to have two
-                # scenarios, one for threaded, and one for not.
-                #
-                # First, create the base argument list by converting the input
-                # argument list to 'a', 'b' ....  This keeps us from having to
-                # worry about all the extra stuff in the input list; stuff
-                # like the type declarations, things like NULLOK, and pointers
-                # '*'.
+                # Here, there is thread context and/or the function is visible
+                # outside the perl coccoon.  We will have to deal with the
+                # arguments.  Create the base argument list by converting the
+                # input argument list to 'a', 'b' ....  This keeps us from
+                # having to worry about all the extra stuff in the input list;
+                # stuff like the type declarations, things like NULLOK, and
+                # pointers '*'.
                 my $argname = 'a';
                 my @stripped_args;
                 push @stripped_args, $argname++ for $args->@*;
                 my $arglist = join ",", @stripped_args;
 
-                # For the unthreaded case, there is no actual thread context
-                # parameter, so the short and long versions are identical.
-                $ret = "#${ind}ifndef USE_THREADS\n"
-                     . indent_define("$full_name($arglist)",
-                                     "$func($arglist)", $ind);
-                # Code below may add an #else, so defer adding the #endif
-
-                # Now handle the threaded case.  We can shortcut for elements
-                # not visible outside core, so split the possibilities.
-                if ($flags =~ /[ACE]/) {
+                if ($flags =~ $visible_outside_core_flags_re) {
 
                     # For elements visible outside core, we need to generate a
                     # function to implement the macro.  This is done elsehwere
@@ -4736,33 +4742,31 @@ sub embed_h {
                     $need_longs{$full_name} = $object;
                 }
                 else {
-                    
-                    # But a macro suffices for core-only elements.  We just
-                    # discard the thread context passed to the long form and
-                    # call the short form macro whose expansion adds it back
-                    # in.
+
+                    # Here, the visibility is restricted so that we don't have
+                    # to worry about the short name getting undefined.  We
+                    # already took care of the case where there isn't a thread
+                    # context.  But here, we have different code handling
+                    # threaded/unthreaded.  For unthreaded, there is no actual
+                    # thread context parameter, so the short and long versions
+                    # are identical.
+                    $ret = "#${ind}ifndef USE_THREADS\n"
+                         . indent_define("$full_name($arglist)",
+                                         "$func($arglist)", $ind)
+                         . "#${ind}else\n";
+
+                    # But for threaded builds, the macro doesn't have an
+                    # explicit thread context argument, but the long name
+                    # does.  We just discard the thread context passed to the
+                    # long form and call the short form macro whose expansion
+                    # adds it back in.
                     my $mTHX_ = "mTHX";
                     $mTHX_ .= ',' if $arglist ne "";
 
-                    # And append this opposite branch
-                    $ret .= "#${ind}else\n"
-                         . indent_define("$full_name($mTHX_$arglist)",
+                    $ret .= indent_define("$full_name($mTHX_$arglist)",
                                          "$func($arglist)", $ind)
-
-                    # The reason we can't discard the thread context for
-                    # elements visible outside core is because of the
-                    # possibility of embedding.  Suppose a program contains
-                    # two embedded perl instances.  It calls the various long
-                    # form functions with whatever thread context it wants.
-                    # We can't just ignore that context, so an actual function
-                    # needs to be created to pass the context to.  However, if
-                    # the function isn't visible outside core, it can't be
-                    # called directly by the embedding code, so the thread
-                    # context is always going to be aTHX, and so can be
-                    # omitted, and the called-macro will add aTHX back in.
-                } 
-
-                $ret .= "#${ind}endif\n";
+                         . "#${ind}endif\n";
+                }
             }
         }
         elsif ($flags !~ /[omM]/) {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3888,7 +3888,13 @@ my @az = ('a'..'z');
 my $never_visible_flags= "eX";
 my $never_visible_flags_re = qr/[$never_visible_flags]/;
 
-my $visibility_flags = "ACE$never_visible_flags";
+my $visible_everywhere_flags = "AC";
+my $visible_everywhere_flags_re = qr/[$visible_everywhere_flags]/;
+
+my $visible_outside_core_flags = "E$visible_everywhere_flags";
+my $visible_outside_core_flags_re = qr/[$visible_outside_core_flags]/;
+
+my $visibility_flags = "$visible_outside_core_flags$never_visible_flags";
 my $visibility_flags_re = qr/[$visibility_flags]/;
 
 my $discard_non_visibility_flags_re = qr/[^$visibility_flags]/;
@@ -4054,7 +4060,7 @@ sub generate_proto_h {
                . " function ($plain_func) to be checked";
         }
 
-        if ($flags =~ /[AC]/ && $flags =~ /([EX])/) {
+        if ($flags =~ $visible_everywhere_flags_re && $flags =~ /([EX])/) {
             die_at_end "$plain_func: $1 flag is incompatible with either A"
                      . " or C flags";
         }
@@ -4069,7 +4075,7 @@ sub generate_proto_h {
 
             # Don't generate a prototype for a macro that is not usable by the
             # outside world.
-            next unless $flags =~ /[ACE]/;
+            next unless $flags =~ $visible_outside_core_flags_re;
 
             # Nor one that is weird, which would likely be a syntax error.
             next if $flags =~ /u/;
@@ -4117,7 +4123,7 @@ sub generate_proto_h {
             # prefix available to call it with (in case of name conflicts).
             die_at_end "$plain_func: requires p flag because has A or C flag"
                                     if $flags !~ /p/
-                                    && $flags =~ /[AC]/
+                                    && $flags =~ $visible_everywhere_flags_re
                                     && $plain_func !~ /[Pp]erl/;
 
             if ($never_returns) {
@@ -4663,7 +4669,7 @@ sub embed_h {
         # Macros with [oO] don't appear without a [Pp]erl_ prefix, so nothing
         # to undef
         if ($flags =~ /m/ && $flags !~ /[oO]/) {
-            if ($flags !~ /[ACE]/) {    # No external visibility
+            if ($flags !~ $visible_outside_core_flags_re) {
                 $always_undefs{$func} = 1
                   unless defined $unresolved_visibility_overrides{$func};
             }

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4045,12 +4045,12 @@ sub generate_proto_h {
         if (! $has_mflag) {
             $args_assert_line = 1;
         }
-        elsif ($has_mpflags && $flags =~ $visible_outside_core_flags_re) {
+        elsif ($has_mpflags && $flags =~ $visible_everywhere_flags_re) {
 
             # And assertions are created for the automatically generated
             # functions from macros.  No function is needed unless one has
             # been requested (p flag), and is needed.  None is needed if the
-            # macro doesn't have visibility outside core, as no function
+            # macro is only visible to core and extensions, as no function
             # gets generated.
             $need_longs{$plain_func} = $args_assert_line = 1;
         }
@@ -4711,8 +4711,8 @@ sub embed_h {
             # to pass the context to.
             #
             # But we don't have to worry about collisions for functions that
-            # are visible only to core
-            if ($flags =~ /[T]/ && $flags !~ $visible_outside_core_flags_re) {
+            # are visible only to core or its extensions
+            if ($flags =~ /[T]/ && $flags !~ $visible_everywhere_flags_re) {
                 # Yields
                 #   #define Perl_func  func
                 # which works when there is no thread context.
@@ -4732,7 +4732,7 @@ sub embed_h {
                 push @stripped_args, $argname++ for $args->@*;
                 my $arglist = join ",", @stripped_args;
 
-                if ($flags =~ $visible_outside_core_flags_re) {
+                if ($flags =~ $visible_everywhere_flags_re) {
 
                     # For elements visible outside core, we need to generate a
                     # function to implement the macro.  This is done elsehwere

--- a/util.h
+++ b/util.h
@@ -251,8 +251,11 @@ returning NULL if not found.  The terminating NUL bytes are not compared.
 =cut
 */
 
-
-#define instr(haystack, needle) strstr(haystack, needle)
+/* The casting away const is because some implementations of strstr() have
+ * haystack not declared const, even though POSIX requires it to be const.
+ * This allows them to compile; we've never had a problem with the function
+ * zapping the 'haystack' */
+#define instr(haystack, needle) strstr( (char *) haystack, needle)
 
 #ifdef HAS_MEMMEM
 #   define ninstr(big, bigend, little, lend)                                \


### PR DESCRIPTION
This extends the existing mechanism to macros that don't have an aTHX parameter.  This allows a module to #undef a macro whose name collides with its version, and still have access to the functionality via the long name.

This is a step towards avoiding name space pollution.

The previous mechanism which didn't create a function is retained for macros not visible outside the core or its extensions, as we don't have to worry about name collisions.

* This set of changes does not require a perldelta entry.
