### PR TITLE
embed.pl: Add some constraints

### DIFF
--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3399,7 +3399,6 @@ $cpp_ifdef_constraints{PERL_FOR_X2P} = 0;
 $cpp_ifdef_constraints{WIN32_USE_FAKE_OLD_MINGW_LOCALES} = 0;
 
 $cpp_ifdef_constraints{PERL_EXT} = 0;
-$cpp_ifdef_constraints{PERL_EXT_RE_BUILD} = 0;
 
 # This program evaluates the conditionals surrounding every #define in every
 # examined header.  It turns out that in many cases, using the constraints in

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3358,6 +3358,8 @@ my @regex_conditions = qw(
 
                            PERL_IN_REGCOMP_ANY
                            PERL_EXT_RE_BUILD
+                           PERL_EXT_RE_DEBUG
+                           PERL_EXT_RE_STATIC
                            PERL_IN_REGEX_ENGINE
                            PLUGGABLE_RE_EXTENSION
                          );
@@ -3388,6 +3390,9 @@ $cpp_ifdef_constraints{PERL_IN_XS_APITEST} = 0;
 $cpp_ifdef_constraints{PERL_DEBUG_READONLY_OPS} = 0;
 $cpp_ifdef_constraints{PERL_DEBUG_DUMPUNTIL} = 0;
 $cpp_ifdef_constraints{PERL_ENABLE_EXPERIMENTAL_REGEX_OPTIMISATIONS} = 0;
+$cpp_ifdef_constraints{PERL_ENABLE_EXTENDED_TRIE_OPTIMISATION} = 0;
+$cpp_ifdef_constraints{PERL_ENABLE_POSITIVE_ASSERTION_STUDY} = 0;
+$cpp_ifdef_constraints{PERL_ENABLE_TRIE_OPTIMISATION} = 0;
 $cpp_ifdef_constraints{EXPERIMENTAL_INPLACESCAN} = 0;
 
 # Appears to be obsolete; App:s2p, etc were created to handle this
@@ -3399,6 +3404,9 @@ $cpp_ifdef_constraints{PERL_FOR_X2P} = 0;
 $cpp_ifdef_constraints{WIN32_USE_FAKE_OLD_MINGW_LOCALES} = 0;
 
 $cpp_ifdef_constraints{PERL_EXT} = 0;
+$cpp_ifdef_constraints{PERL_EXT_IO} = 0;
+$cpp_ifdef_constraints{PERL_EXT_LANGINFO} = 0;
+$cpp_ifdef_constraints{PERL_EXT_POSIX} = 0;
 
 # This program evaluates the conditionals surrounding every #define in every
 # examined header.  It turns out that in many cases, using the constraints in


### PR DESCRIPTION
I did some more grepping of the source to look for symbols that we can assume are undefined for general usage, cpan and darkpan.  An example is PERL_EXT_POSIX (seeing that in the source prompted this endeavour).  That symbol should only be defined when compiling the POSIX module, so any symbols created only while it is #defined, won't be visible to the outside world.

I looked for "/ \b PERL_ \w+ /x" and scanned through the list.  The result are the symbols added here, which showed that 5 symbols this previously thought were visible everywhere actually aren't.  So they are removed from the list.

* This set of changes does not require a perldelta entry.
