### PR TITLE
Disable -Wc++-keyword because of false positives

### DIFF
--- a/cflags.SH
+++ b/cflags.SH
@@ -198,7 +198,7 @@ Intel*) ;; # # Is that you, Intel C++?
 	-Wextra \
 	-Wno-long-long -Wno-declaration-after-statement \
         -Wno-nonnull-compare \
-	-Wc++-compat -Wwrite-strings"
+	-Wc++-compat -Wno-c++-keyword -Wwrite-strings"
    case " $ccflags " in
    *" -std="*) ;; # Already have -std=...
    *) warns="-std=c99 $warns" ;;


### PR DESCRIPTION
This warning, a child category of -Wc++-compat, was causing a lot of false positives of the following variety because of a [clang 21 issue](https://github.com/llvm/llvm-project/issues/155988), as reported in #24164:

```
In file included from op.c:163:
In file included from ./perl.h:6228:
./proto.h:6124:26: warning: identifier 'wchar_t' conflicts with a C++ keyword [-Wc++-keyword]
 6124 | Perl_mbtowc_(pTHX_ const wchar_t *pwc, const char *s, const Size_t len);
      |                          ^
1 warning generated.
```

* This set of changes does not require a perldelta entry.
