### PR TITLE
Downgradable OP_CONST UTF-8 strings will not be preemptively hekified

### DIFF
--- a/op.c
+++ b/op.c
@@ -2846,16 +2846,23 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
             && !(SvNOK(sv) && IN_LC_RUNTIME(LC_NUMERIC)) /* Decimal separator depends on runtime locale */
             && real)
         {
-            SSize_t keylen;
+            STRLEN keylen;
             const char * const key = SvPV_const(sv, *(STRLEN*)&keylen);
             if (keylen > I32_MAX) {
                 croak("Sorry, hash keys must be smaller than 2**31 bytes");
+            }
+            if (SvUTF8(sv) && utf8_to_bytes_temp_pv((const U8**)&key, &keylen)) {
+                /* See GH#24266. This is (hopefully) a temporary constraint
+                 * that can be removed when HVhek_WASUTF8 propagation/
+                 * checking has been fully examined. */
+                goto HVhek_WASUTF8_bugs;
             }
 
             SV *nsv = newSVpvn_share(key, SvUTF8(sv) ? -(I32)keylen : (I32)keylen, 0);
             SvREFCNT_dec_NN(sv);
             *svp = nsv;
         }
+  HVhek_WASUTF8_bugs:
 
         if (   check_fields
             && !hv_fetch_ent(GvHV(*fields), *svp, FALSE, 0))
@@ -14335,6 +14342,12 @@ S_check_alt_hash_fields_hekify(pTHX_ OP *o)
                 if (UNLIKELY(keylen > I32_MAX)) {
                     croak("Sorry, hash keys must be smaller than 2**31 bytes");
                 }
+                if (SvUTF8(sv) && utf8_to_bytes_temp_pv((const U8**)&key, &keylen)) {
+                    /* See GH#24266. This is (hopefully) a temporary constraint
+                     * that can be removed when HVhek_WASUTF8 propagation/
+                     * checking has been fully examined. */
+                    goto HVhek_WASUTF8_bugs;
+                }
 
                 SV *nsv = newSVpvn_share(key, SvUTF8(sv) ? -(I32)keylen : (I32)keylen, 0);
                 SvREFCNT_dec_NN(sv);
@@ -14342,6 +14355,8 @@ S_check_alt_hash_fields_hekify(pTHX_ OP *o)
             }
         } else if (!(PL_opargs[sib->op_type] & OA_RETSCALAR))
             break;
+
+  HVhek_WASUTF8_bugs:
 
         /* Looking for a corresponding value OP */
         sib = OpSIBLING(sib);

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -375,6 +375,22 @@ compile time and run time locales could differ.
 
 =item *
 
+C<Perl_check_hash_fields_and_hekify>, partly called as a compile-time
+optimization, no longer preemptively converts a UTF-8 string to a HEK
+when this will downgrade the string to a single byte representation.
+
+At present, multiple functions inadequately handle the flag used to
+denote when a key originally had UTF-8 encoding, making it impossible to
+restore the encoding when keys are extracted from a hash (using C<keys>
+for example).
+
+Tracking of UTF-8 origins can hopefully be improved in the next development
+cycle, allowing for preemptive conversion of all UTF-8 strings once again.
+[GH #24266]
+[GH #24287]
+
+=item *
+
 XXX
 
 =back

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4777,6 +4777,7 @@ PP(pp_multideref)
                        || !SvOK(keysv)
                        || SvROK(keysv)
                        || SvNOK(keysv)
+                       || SvUTF8(keysv) /* See GH#24266 */
                        || SvIsCOW_shared_hash(keysv));
 
                 /* this is basically a copy of pp_helem with OPpDEREF skipped */

--- a/t/comp/parser.t
+++ b/t/comp/parser.t
@@ -8,7 +8,7 @@ BEGIN {
     chdir 't' if -d 't';
 }
 
-print "1..193\n";
+print "1..195\n";
 
 sub failed {
     my ($got, $expected, $name) = @_;
@@ -682,6 +682,42 @@ is $@, "", 'substr keys assignment';
     }
     else {
         is ($result, $expected, "Parser can handle a continuation as 2nd char");
+    }
+}
+
+{
+    # GH#24266 - when a UTF-8 string is used as a hash key, it will
+    # be downgraded to a single-byte encoding if possible. However,
+    # when `keys %hash` returns a list of keys, any keys that started
+    # out as UTF-8 strings must come back out as UTF-8 strings, not
+    # the downgraded representation. The HVhek_WASUTF8 flag on the
+    # relevant HEK is what makes that possible.
+    #
+    # However, this flag was not always included when converting
+    # strings to HEKs ahead of time as an optimization, and when
+    # that did happen, other functions failed to check for the
+    # flag or propagate it correctly.
+
+    # Note: "de" should _not_ get uppercased in real life. It's only
+    #       shown like that below to keep the test case simple.
+    my %lower_to_upper = eval q[use utf8;
+        my %lower_to_upper = ( 'über maus' => 'Über Maus' );
+        $lower_to_upper{'Explicación dél significado de los términos utilizados en "Don Quijote", por capítulo.'}
+                =   'Explicación Dél Significado De Los Términos Utilizados En "Don Quijote", Por Capítulo.';
+        return %lower_to_upper;
+    ];
+
+    my %messages = (
+       'über maus'
+           => 'HVhek_WASUTF8 set on downgraded UTF8 key in hash initialization',
+       'Explicación dél significado de los términos utilizados en "Don Quijote", por capítulo.'
+           => 'HVhek_WASUTF8 set on downgraded UTF8 key in helelm store',
+    );
+
+    foreach (sort keys %lower_to_upper) {
+        my $key = $_;
+        s/\b(.*?)\b/$1 eq uc $1 ? $1 : "\u\L$1"/ge;
+        is($_, $lower_to_upper{$key}, $messages{$key});
     }
 }
 


### PR DESCRIPTION
OP_CONST SVs containing valid strings that will be used directly as
hash keys can be converted at compile time to use shared HEKs.
Doing so improves the performance of hash operations.

Two main functions control this:
* `Perl_check_hash_fields_and_hekify()` - used for OP_MULTIDEREF
* `S_check_alt_hash_fields_hekify()` - used in hash initializers

GH #24266 revealed that the UTF-8 origins of strings downgraded
to single byte representations are lost during the conversion
and any subsequent use in hash _store_ operations. This breaks
the expectation that when keys come back out of the hash, such as
through the `keys` keyword, the encodings in the resulting SVs
are identical to the originally specified encodings.

Comprehensive tracking of UTF-8 origins, via the `HVhek_WASUTF8`
HEK flag, will require changes to `Perl_newSVpvn_share` and
`Perl_hv_common`, as well as additional functions TBD.

Considering the closeness to the v5.44.0 stable release date,
this commit takes the crude approach of pre-scanning UTF8
strings ahead of hekifying, rejecting those strings that can
be downgraded.

This will likely incur a performance decrease in `OP_MULTIDEREF`
when the `OP_CONST` SVs it subsumes contain downgradable UTF8.

Hopefully, all changes required to track the UTF-8 origins of
downgraded HEKs can be identified and implemented soon,
allowing this limitation to be reversed.

-------------------------------------------------------------------------------

* This set of changes requires a perldelta entry, and it is included.