### PR TITLE
Reschedule 'use VERSION' switch fatalisation to 5.46

### DIFF
--- a/op.c
+++ b/op.c
@@ -8587,7 +8587,7 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
             }
             else {
                 /* OK let's at least warn */
-                deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.44",
+                deprecate_fatal_in(WARN_DEPRECATED__SUBSEQUENT_USE_VERSION, "5.46",
                     "Changing use VERSION while another use VERSION is in scope");
             }
         }

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -43,6 +43,8 @@ in deprecation warnings.
 
 Category: "deprecated::unicode_property_name"
 
+=head2 Perl 5.46
+
 =head3 Changing C<use VERSION> while another C<use VERSION> is in scope
 
 A C<use VERSION> declaration has many implicit effects on the surrounding

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -74,7 +74,7 @@ evalbytes "say 'yes'";
 use 5.014;
 evalbytes;
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.44 at - line 8.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 8.
 say sub
 yes
 evalbytes sub
@@ -86,7 +86,7 @@ print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 use v5.14;
 print 'ss' =~ /$sharp_s/i ? "ok\n" : "nok\n";
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.44 at - line 5.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 5.
 nok
 ok
 ########
@@ -98,6 +98,6 @@ print eval "use utf8; q|$long_s|" eq "\x{17f}" ? "ok\n" : "nok\n";
 use v5.15;
 print eval "use utf8; q|$long_s|" eq $long_s ? "ok\n" : "nok\n";
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.44 at - line 6.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 6.
 ok
 ok

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -2261,7 +2261,7 @@ use warnings;
 use v5.12;
 use v5.20;
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.44 at - line 3.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
 ########
 use warnings;
 use v5.8;
@@ -2272,7 +2272,7 @@ use warnings;
 use v5.10;
 use v5.8;
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.44 at - line 3.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at - line 3.
 ########
 use warnings;
 use v5.12;

--- a/t/lib/warnings/pp_ctl
+++ b/t/lib/warnings/pp_ctl
@@ -251,7 +251,7 @@ EXPECT
 use warnings;
 eval 'use 5.012; use 5.14.0';
 EXPECT
-Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.44 at (eval 1) line 1.
+Changing use VERSION while another use VERSION is in scope is deprecated, and will become fatal in Perl 5.46 at (eval 1) line 1.
 ########
 # SKIP ? !$Config{default_inc_includes_dot}
 # NAME check warning for do with no . in @INC


### PR DESCRIPTION
We did say we'd do this for 5.44 but we forgot to make the change until now, and it's a bit late in the cycle. We'll reschedule it for 5.46.

* This set of changes might require a perldelta entry - do we write about reschedules?
