### PR TITLE
Improved handling of HVhek_WASUTF8 with preemptive hekified hash keys

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -535,7 +535,9 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
         key = SvPV_const(keysv, klen);
         is_utf8 = (SvUTF8(keysv) != 0);
         if (SvIsCOW_shared_hash(keysv)) {
-            flags = HVhek_KEYCANONICAL | (is_utf8 ? HVhek_UTF8 : 0);
+            HEK *keysv_hek = SvSHARED_HEK_FROM_PV(SvPVX_const(keysv));
+            unsigned char keysv_flags = HEK_FLAGS(keysv_hek);
+            flags = HVhek_KEYCANONICAL | (keysv_flags & (HVhek_UTF8|HVhek_WASUTF8));
         } else {
             flags = 0;
         }

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -2606,9 +2606,9 @@ my %h;
 (\my %d) = foo();
 \local %_ = \%h;
 (\local %_) = \%h;
-\state %y = {'1',2};
-\our %z = {'1',2};
-(\our %zz) = {'1',2};
+\state %y = {1,2};
+\our %z = {1,2};
+(\our %zz) = {1,2};
 \&a = foo();
 (\&a) = foo();
 \(&a) = foo();
@@ -2684,9 +2684,9 @@ my %h;
 (\my %d) = foo();
 \local %_ = \%h;
 (\local %_) = \%h;
-\state %y = {'1', 2};
-\our %z = {'1', 2};
-(\our %zz) = {'1', 2};
+\state %y = {1, 2};
+\our %z = {1, 2};
+(\our %zz) = {1, 2};
 \&a = foo();
 (\&a) = foo();
 (\&a) = foo();
@@ -2773,16 +2773,16 @@ foreach \our @a ([1, 2], [3, 4]) {
 foreach \@_ ([1, 2], [3, 4]) {
     die;
 }
-foreach \my %a ({'5', 6}, {'7', 8}) {
+foreach \my %a ({5, 6}, {7, 8}) {
     die;
 }
-foreach \our %a ({'5', 6}, {'7', 8}) {
+foreach \our %a ({5, 6}, {7, 8}) {
     die;
 }
-foreach \state %a ({'5', 6}, {'7', 8}) {
+foreach \state %a ({5, 6}, {7, 8}) {
     die;
 }
-foreach \%_ ({'5', 6}, {'7', 8}) {
+foreach \%_ ({5, 6}, {7, 8}) {
     die;
 }
 {

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -699,6 +699,24 @@ EOS
     is(f(123), 123, "check TARG.IOK is reset properly");
 }
 
+# github #24302
+{
+    use builtin qw( created_as_number );
+    package HekifiedConstantKeys {
+        sub TIEHASH {  bless {}, shift; }
+        sub STORE {
+            my ($hash, $key, $value) = @_;
+            $hash->{$key} = ($key == 123 && created_as_number($key))
+                             ? $value : undef;
+        }
+        sub CLEAR {}
+        sub FETCH { return $_[0]{$_[1]} }
+    }
+    tie my %h, 'HekifiedConstantKeys';
+    %h = (123 => 456);
+    is($h{123}, 456, "Numerical OP_CONST SVs in hash init are created_as_number() when hekified");
+}
+
 # vim: tabstop=4 shiftwidth=4 expandtab autoindent softtabstop=4
 
 done_testing();

--- a/op.c
+++ b/op.c
@@ -14325,20 +14325,34 @@ S_check_alt_hash_fields_hekify(pTHX_ OP *o)
             SV **svp = cSVOPx_svp(sib);
             SV *sv = *svp;
 
-            /* Make the CONST have a shared SV */
-            if (!SvIsCOW_shared_hash(sv) && SvTYPE(sv) < SVt_PVMG
-                && SvOK(sv) && !SvROK(sv)
-                && !(SvNOK(sv) && IN_LC_RUNTIME(LC_NUMERIC))
+            if (SvTYPE(sv) < SVt_PVMG && (
+                (SvPOK(sv) && !SvIsCOW_shared_hash(sv)) || SvIOK(sv)
+                 || (SvNOK(sv) && !IN_LC_RUNTIME(LC_NUMERIC)) )
             ) {
+                bool was_POK = (SvFLAGS(sv) & SVf_POK);
                 STRLEN keylen;
+                /* SvPV_const will upgrade any SVt_IV or SVt_NV */
                 const char * const key = SvPV_const(sv, keylen);
+
                 if (UNLIKELY(keylen > I32_MAX)) {
                     croak("Sorry, hash keys must be smaller than 2**31 bytes");
                 }
 
                 SV *nsv = newSVpvn_share(key, SvUTF8(sv) ? -(I32)keylen : (I32)keylen, 0);
-                SvREFCNT_dec_NN(sv);
                 *svp = nsv;
+
+                if (SvTYPE(sv) != SVt_PV) {
+                    sv_upgrade(nsv, SvTYPE(sv));
+                    if (!was_POK)
+                        SvFLAGS(nsv) &= ~SVf_POK;
+                    SvFLAGS(nsv) |= SvFLAGS(sv) & (SVf_IOK|SVp_IOK|SVf_IVisUV|SVf_NOK|SVp_NOK);
+
+                    if (SvIOK(sv))
+                        SvIV_set(nsv, SvIVX(sv));
+                    if (SvNOK(sv))
+                        SvNV_set(nsv, SvNVX(sv));
+                }
+                SvREFCNT_dec_NN(sv);
             }
         } else if (!(PL_opargs[sib->op_type] & OA_RETSCALAR))
             break;

--- a/op.c
+++ b/op.c
@@ -2851,18 +2851,11 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
             if (keylen > I32_MAX) {
                 croak("Sorry, hash keys must be smaller than 2**31 bytes");
             }
-            if (SvUTF8(sv) && utf8_to_bytes_temp_pv((const U8**)&key, &keylen)) {
-                /* See GH#24266. This is (hopefully) a temporary constraint
-                 * that can be removed when HVhek_WASUTF8 propagation/
-                 * checking has been fully examined. */
-                goto HVhek_WASUTF8_bugs;
-            }
 
             SV *nsv = newSVpvn_share(key, SvUTF8(sv) ? -(I32)keylen : (I32)keylen, 0);
             SvREFCNT_dec_NN(sv);
             *svp = nsv;
         }
-  HVhek_WASUTF8_bugs:
 
         if (   check_fields
             && !hv_fetch_ent(GvHV(*fields), *svp, FALSE, 0))
@@ -14342,12 +14335,6 @@ S_check_alt_hash_fields_hekify(pTHX_ OP *o)
                 if (UNLIKELY(keylen > I32_MAX)) {
                     croak("Sorry, hash keys must be smaller than 2**31 bytes");
                 }
-                if (SvUTF8(sv) && utf8_to_bytes_temp_pv((const U8**)&key, &keylen)) {
-                    /* See GH#24266. This is (hopefully) a temporary constraint
-                     * that can be removed when HVhek_WASUTF8 propagation/
-                     * checking has been fully examined. */
-                    goto HVhek_WASUTF8_bugs;
-                }
 
                 SV *nsv = newSVpvn_share(key, SvUTF8(sv) ? -(I32)keylen : (I32)keylen, 0);
                 SvREFCNT_dec_NN(sv);
@@ -14355,8 +14342,6 @@ S_check_alt_hash_fields_hekify(pTHX_ OP *o)
             }
         } else if (!(PL_opargs[sib->op_type] & OA_RETSCALAR))
             break;
-
-  HVhek_WASUTF8_bugs:
 
         /* Looking for a corresponding value OP */
         sib = OpSIBLING(sib);

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -348,6 +348,34 @@ well.
 
 =item *
 
+When a UTF-8 constant string was used as the hash key in an insert
+operation, such as C<$hash{'über maus'} = 1;>, and the string could
+be converted into a single byte representation, the flag noting the
+original encoding (C<HVhek_WASUTF8>) was not always retained.
+
+When this occurred, the relevant scalars returned by C<keys %hash>
+would not be in the original, expected UTF-8 encoding.
+
+The original encoding is now captured and propagated.
+[GH #24266]
+
+=item *
+
+When a constant IV or NV was used as a hash key, such as in
+C<my %hash = ( 42 => 0 );>, and was preemptively stringified
+into a hash key, the fact that the numerical value came first
+was lost. This unintentionally modified deparse output for
+such keys.
+
+The numerical values are now carried across, and flags on the
+key variable reflect the original data type.
+
+Note: This now preserves the form of constant keys supplied
+to tied hashes in list assignments.
+[GH #24302]
+
+=item *
+
 XXX
 
 =back

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -4777,7 +4777,6 @@ PP(pp_multideref)
                        || !SvOK(keysv)
                        || SvROK(keysv)
                        || SvNOK(keysv)
-                       || SvUTF8(keysv) /* See GH#24266 */
                        || SvIsCOW_shared_hash(keysv));
 
                 /* this is basically a copy of pp_helem with OPpDEREF skipped */

--- a/sv.c
+++ b/sv.c
@@ -10756,31 +10756,20 @@ Perl_newSVpvn_share(pTHX_ const char *src, I32 len, U32 hash)
 {
     PERL_ARGS_ASSERT_NEWSVPVN_SHARE;
 
-    SV *sv;
-    bool is_utf8 = FALSE;
-
-    if (len < 0) {
-        len = -len;
-        Size_t size_t_len = len;
-        /* See the note in hv.c:hv_fetch() --jhi */
-        if (! utf8_to_bytes_temp_pv((const U8**)&src, &size_t_len)) {
-            is_utf8 = true;
-        }
-        else {
-            hash = 0;
-            len = size_t_len;
-        }
+    if (!hash) {
+        PERL_HASH(hash, src, abs(len));
     }
-    if (!hash)
-        PERL_HASH(hash, src, len);
-    sv = newSV_type(SVt_PV);
+
+    HEK *hek = share_hek(src, len, hash);
+    SV *sv = newSV_type(SVt_PV);
+
     /* The logic for this is inlined in S_mro_get_linear_isa_dfs(), so if it
        changes here, update it there too.  */
     SvFLAGS(sv) |= SVf_POK | SVp_POK | SVf_IsCOW |
-                   (is_utf8 ? SVf_UTF8 : 0);
-    SvCUR_set(sv, len);
+                   (HEK_UTF8(hek) ? SVf_UTF8 : 0);
+    SvCUR_set(sv, HEK_LEN(hek));
     assert(SvLEN(sv) ==0);
-    SvPV_set(sv, sharepvn(src, is_utf8?-len:len, hash));
+    SvPV_set(sv, HEK_KEY(hek));
     return sv;
 }
 


### PR DESCRIPTION
As described in #24287, the preemptive hekification of hash keys did not handle the `HVhek_WASUTF8` flag correctly, meaning that the downgraded UTF-8 keys did not get converted back to UTF-8 when extracted by `keys %hash` or `each %hash`.

As it wasn't clear how deep the remediation rabbithole would go, #24287 added the workaround of doing an additional string scan and only hekifying keys that would not be downgraded.

It appears that the rabbithole may actually be shallow. This PR:
* Reverts the workaround, leaving the two added tests.
* Modifies `Perl_newSVpvn_flags()` such that `Perl_share_kek()` does the string scan, with needed values then read from the resulting HEK.
* Modifies `Perl_hv_common()` to check for `HVhek_WASUTF8` at the same time as checking the UTF-8 status of the `keysv` HEK.
* Rewrites the _perldelta_ entry to reflect these changes.

-------------------------------------------------------------------------------
* This set of changes modifies the perldelta entry added in #24287
