### PR TITLE
Release announcement emails close to BLEAD-FINAL note support EOL

### DIFF
--- a/Porting/make-rmg-checklist
+++ b/Porting/make-rmg-checklist
@@ -156,6 +156,10 @@ my ($major, $minor, $point_with_maybe_rc) = split(/\./, $version);
 my ($point) = split(/-/, $point_with_maybe_rc);
 my $last_version = join('.', $major, ($point == 0 ? ($minor - 2, 0) : ($minor, $point-1)));
 
+# Oldest version ("previous stable") that still has full support.
+# This is supposed to match the "Version Support Status" table in perlpolicy.pod
+my $old_support = join('.', $major, ($type eq 'BLEAD-POINT') ? $minor - 3 :
+                                    ($type eq 'MAINT') ? $minor - 2 : $minor - 4 );
 
 foreach my $line (@pod_lines) {
     $line =~ $skip_headers
@@ -193,6 +197,7 @@ foreach my $line (@pod_lines) {
     $line =~ s/\Q5.X.Y\E/$version/g;
     $line =~ s/\Q5.LAST\E/$last_version/g;
     $line =~ s/\Q5.X\E\b/$major.$minor/g;
+    $line =~ s/\Q5.OLDSUPPORT\E/$old_support/g;
 
     $current_element->{'content'} .= "\n" . $line;
 }

--- a/Porting/release_announcement_template.txt
+++ b/Porting/release_announcement_template.txt
@@ -22,6 +22,8 @@ https://metacpan.org/release/[AUTHOR]/perl-5.[VERSION.SUBVERSION]/view/pod/perld
 
 [ACKNOWLEDGEMENTS SECTION FROM PERLDELTA]
 
+[END OF SUPPORT NOTE]
+
 We expect to release version 5.[NEXT BLEAD VERSION.NEXT BLEAD SUBVERSION] on [FUTURE DATE].
 The next major stable release of Perl should appear in the first half of 2026.
 

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -48,6 +48,18 @@ last component is 0, it subtracts 2 from the middle component:
     5.40.0  ->  5.38.0
     5.41.0  ->  5.39.0
 
+=item C<5.OLDSUPPORT>
+
+The oldest release series that is officially eligible for support, as per
+F<pod/perlpolicy.pod>. A lookup isn't actually performed, instead the
+assumption is baked in that only the most recent two series are supported.
+
+The current middle component is taken and a fixed value subtracted:
+
+* 2 if this is a MAINT release
+* 3 if this is a BLEAD-POINT release
+* 4 for all other release types
+
 =back
 
 =head1 SYNOPSIS
@@ -529,20 +541,21 @@ For the first RC release leading up to a BLEAD-FINAL release, update
 F<pod/perlpolicy.pod>: both the version support status table and the
 description of which releases are now "officially" supported.
 
-In the release announcement for RC releases, the C<END OF SUPPORT NOTE>
-placeholder in F<Porting/release_announcement_template.txt> should be
-replaced with:
+That description should match up with these following notes, used to
+fill the C<END OF SUPPORT NOTE> placeholder when preparing the
+release announcement email.
 
-    Support for the 5.[VERSION].x release series will end shortly.
+For a BLEAD-FINAL RC release:
+
+    Support for the 5.OLDSUPPORT.x release series will end shortly.
     Please refer to L<perlpolicy> for version support information.
 
-For a BLEAD-FINAL release, the release announcement placeholder should
-be replaced with:
+For a BLEAD-FINAL release:
 
-    Support for the 5.[VERSION].x release series has now ended.
+    Support for the 5.OLDSUPPORT.x release series has now ended.
     Please refer to L<perlpolicy> for version support information.
 
-MAINT releases should omit the C<END OF SUPPORT NOTE> placeholder.
+MAINT release announcements must not contain C<END OF SUPPORT NOTE> text.
 
 When doing a BLEAD-POINT or BLEAD-FINAL release, also make sure the
 C<PERL_API_*> constants in F<patchlevel.h> are in sync with the version
@@ -584,19 +597,18 @@ When the version number is bumped, you should also update Module::CoreList
 version number.
 
 =for checklist skip RC BLEAD-FINAL MAINT
-
 =head3 Prepare an end of support note (if necessary)
 
 For the I<final> BLEAD-POINT release in a development cycle, the
-C<END OF SUPPORT NOTE> placeholder in
-F<Porting/release_announcement_template.txt> should note the upcoming
-end of support for the oldest of the currently supported release series.
-Check L<perlpolicy> to confirm the affected VERSION.
+release announcement email should note the upcoming end of support
+for the oldest of the currently supported release series.
 
-The format for this note (and subsequent RC releases) should be:
+Replace the C<END OF SUPPORT NOTE> placeholder with this text:
 
-    Support for the 5.[VERSION].x release series will end shortly.
+    Support for the 5.OLDSUPPORT.x release series will end shortly.
     Please refer to L<perlpolicy> for version support information.
+
+Check L<perlpolicy> to confirm the affected VERSION before sending!
 
 For all other BLEAD-POINT releases, there is no need for an
 C<END OF SUPPORT NOTE>.

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -1348,6 +1348,27 @@ Be sure to commit your change:
 
  $ git commit -m 'Disarm RCnnn bump' patchlevel.h
 
+=for checklist skip MAINT
+
+=head3 Prepare an end of support note (if necessary)
+
+As a stable release approaches, the C<END OF SUPPORT NOTE> placeholder in
+F<Porting/release_announcement_template.txt> must mention the upcoming end
+of support for the oldest of the currently supported release series.
+Check L<perlpolicy> to confirm the affected VERSION.
+
+The I<final> BLEAD-POINT and RC releases should state:
+
+ Support for the 5.[VERSION].x release series will end shortly.
+ Please refer to L<perlpolicy> for version support information.
+
+The BLEAD-FINAL release should state:
+
+ Support for the 5.[VERSION].x release series has now ended.
+ Please refer to L<perlpolicy> for version support information.
+
+Non-final BLEAD-POINT and MAINT releases should omit this placeholder.
+
 =head3 Announce to p5p
 
 Mail perl5-porters@perl.org to announce your new release, with a quote you prepared earlier.

--- a/Porting/release_managers_guide.pod
+++ b/Porting/release_managers_guide.pod
@@ -529,6 +529,21 @@ For the first RC release leading up to a BLEAD-FINAL release, update
 F<pod/perlpolicy.pod>: both the version support status table and the
 description of which releases are now "officially" supported.
 
+In the release announcement for RC releases, the C<END OF SUPPORT NOTE>
+placeholder in F<Porting/release_announcement_template.txt> should be
+replaced with:
+
+    Support for the 5.[VERSION].x release series will end shortly.
+    Please refer to L<perlpolicy> for version support information.
+
+For a BLEAD-FINAL release, the release announcement placeholder should
+be replaced with:
+
+    Support for the 5.[VERSION].x release series has now ended.
+    Please refer to L<perlpolicy> for version support information.
+
+MAINT releases should omit the C<END OF SUPPORT NOTE> placeholder.
+
 When doing a BLEAD-POINT or BLEAD-FINAL release, also make sure the
 C<PERL_API_*> constants in F<patchlevel.h> are in sync with the version
 you're releasing, unless you're absolutely sure the release you're about to
@@ -567,6 +582,24 @@ previous version bump.
 When the version number is bumped, you should also update Module::CoreList
 (as described below in L</"Update Module::CoreList">) to reflect the new
 version number.
+
+=for checklist skip RC BLEAD-FINAL MAINT
+
+=head3 Prepare an end of support note (if necessary)
+
+For the I<final> BLEAD-POINT release in a development cycle, the
+C<END OF SUPPORT NOTE> placeholder in
+F<Porting/release_announcement_template.txt> should note the upcoming
+end of support for the oldest of the currently supported release series.
+Check L<perlpolicy> to confirm the affected VERSION.
+
+The format for this note (and subsequent RC releases) should be:
+
+    Support for the 5.[VERSION].x release series will end shortly.
+    Please refer to L<perlpolicy> for version support information.
+
+For all other BLEAD-POINT releases, there is no need for an
+C<END OF SUPPORT NOTE>.
 
 =head3 Update INSTALL
 
@@ -1347,27 +1380,6 @@ Disarm the F<patchlevel.h> change; for example,
 Be sure to commit your change:
 
  $ git commit -m 'Disarm RCnnn bump' patchlevel.h
-
-=for checklist skip MAINT
-
-=head3 Prepare an end of support note (if necessary)
-
-As a stable release approaches, the C<END OF SUPPORT NOTE> placeholder in
-F<Porting/release_announcement_template.txt> must mention the upcoming end
-of support for the oldest of the currently supported release series.
-Check L<perlpolicy> to confirm the affected VERSION.
-
-The I<final> BLEAD-POINT and RC releases should state:
-
- Support for the 5.[VERSION].x release series will end shortly.
- Please refer to L<perlpolicy> for version support information.
-
-The BLEAD-FINAL release should state:
-
- Support for the 5.[VERSION].x release series has now ended.
- Please refer to L<perlpolicy> for version support information.
-
-Non-final BLEAD-POINT and MAINT releases should omit this placeholder.
 
 =head3 Announce to p5p
 


### PR DESCRIPTION
This commit adds:
* a placeholder to the release announcement email
* guidance in the RMG

such that the final BLEAD-POINT, RC, and BLEAD-FINAL announcements mention the end of support for the oldest supported release series, as per _perlpolicy_

Closes #24291

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
