### PR TITLE
Remove extraneous line breaking POD  for POSIX::fclose

### DIFF
--- a/ext/POSIX/lib/POSIX.pod
+++ b/ext/POSIX/lib/POSIX.pod
@@ -442,7 +442,6 @@ be provided with an explicit value (rather than relying on an implicit C<$_>):
 
 See L<perlfunc/abs>.
 
-This is identical to Perl's builtin C<cos()> function for returning the cosine
 =item C<fclose>
 
 Not implemented.  Use method C<IO::Handle::close()> instead, or see L<perlfunc/close>.


### PR DESCRIPTION
The POD for the `POSIX` module's `fclose` is slightly broken. This fixes it. See https://metacpan.org/pod/POSIX#fabs

* This set of changes does not require a perldelta entry.
