### PR TITLE
expected_size() needs to be visible everywhere

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1355,7 +1355,7 @@ AOdp	|SV *	|eval_pv	|NN const char *p			\
 				|I32 croak_on_error
 AOdp	|SSize_t|eval_sv	|NN SV *sv				\
 				|I32 flags
-ETmpx	|Size_t |expected_size	|UV size
+CTmpx	|Size_t |expected_size	|UV size
 ATdmp	|bool	|extended_utf8_to_uv					\
 				|SPTR const U8 * const s		\
 				|EPTRge const U8 * const e		\

--- a/embed.h
+++ b/embed.h
@@ -40,7 +40,6 @@
 #   undef SvRVx
 #   undef UNI_DISPLAY_TR_
 #   if !defined(PERL_EXT)
-#     undef expected_size
 #     undef GV_CACHE_ONLY
 #     undef invlist_intersection_
 #     undef invlist_subtract_
@@ -191,6 +190,7 @@
 # define dump_vindent(a,b,c,d)                  Perl_dump_vindent(aTHX_ a,b,c,d)
 # define eval_pv(a,b)                           Perl_eval_pv(aTHX_ a,b)
 # define eval_sv(a,b)                           Perl_eval_sv(aTHX_ a,b)
+# define Perl_expected_size                     expected_size
 # define Perl_extended_utf8_to_uv               extended_utf8_to_uv
 # define fatal_warner(a,...)                    Perl_fatal_warner(aTHX_ a,__VA_ARGS__)
 # define fbm_compile(a,b)                       Perl_fbm_compile(aTHX_ a,b)
@@ -1897,7 +1897,6 @@
 #   define cv_ckproto_len_flags(a,b,c,d,e)      Perl_cv_ckproto_len_flags(aTHX_ a,b,c,d,e)
 #   define delimcpy_no_escape                   Perl_delimcpy_no_escape
 #   define do_uniprop_match                     Perl_do_uniprop_match
-#   define Perl_expected_size                   expected_size
 #   define get_and_check_backslash_N_name(a,b,c,d) Perl_get_and_check_backslash_N_name(aTHX_ a,b,c,d)
 #   define get_deprecated_property_msg          Perl_get_deprecated_property_msg
 #   define get_prop_definition(a)               Perl_get_prop_definition(aTHX_ a)

--- a/proto.h
+++ b/proto.h
@@ -14750,6 +14750,9 @@ Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, i
 # define PERL_ARGS_ASSERT_DO_OPEN               \
         assert(gv); assert(name)
 
+/* PERL_CALLCONV Size_t
+Perl_expected_size(UV size); */
+
 /* PERL_CALLCONV bool
 Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p); */
 
@@ -15494,8 +15497,6 @@ Perl_thread_locale_term(pTHX)
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
-/* PERL_CALLCONV Size_t
-Perl_expected_size(UV size); */
 PERL_CALLCONV U8 *
 Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
         Perl_attribute_nonnull_aTHX_


### PR DESCRIPTION
It was marked as being visible only to perl extensions, but it is called from the macro SvPV_shrink_to_cur, which is visible everywhere. When an element needs to be visible everywhere, but we don't want people to be using it directly, the 'C' flag is what is needed.

Thanks to Tony Cook for diagnosing the problem

Fixes #24295
Fixes #24296


* This set of changes does not require a perldelta entry.
