### PR TITLE
regcomp: Don't parse ahead in sets recursion

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5876,7 +5876,8 @@ ES	|void	|dump_regex_sets_structures				\
 				|NN RExC_state_t *pRExC_state		\
 				|NN AV *stack				\
 				|const IV fence 			\
-				|NN AV *fence_stack
+				|NN AV *fence_stack			\
+				|line_t line_number
 #   endif
 # endif
 #endif /* defined(PERL_IN_REGCOMP_C) */

--- a/embed.h
+++ b/embed.h
@@ -2326,7 +2326,7 @@
 #       define regnode_guts_debug(a,b,c)        S_regnode_guts_debug(aTHX_ a,b,c)
 #       define regtail_study(a,b,c,d)           S_regtail_study(aTHX_ a,b,c,d)
 #       if defined(ENABLE_REGEX_SETS_DEBUGGING)
-#         define dump_regex_sets_structures(a,b,c,d) S_dump_regex_sets_structures(aTHX_ a,b,c,d)
+#         define dump_regex_sets_structures(a,b,c,d,e) S_dump_regex_sets_structures(aTHX_ a,b,c,d,e)
 #       endif
 #     endif
 #   endif /* defined(PERL_IN_REGCOMP_C) */

--- a/proto.h
+++ b/proto.h
@@ -12731,7 +12731,7 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p, const regnode
         __attribute__warn_unused_result__;
 #     if defined(ENABLE_REGEX_SETS_DEBUGGING)
 static void
-S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const IV fence, AV *fence_stack)
+S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const IV fence, AV *fence_stack, line_t line_number)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2)

--- a/regcomp.c
+++ b/regcomp.c
@@ -9248,6 +9248,7 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
     PERL_ARGS_ASSERT_DUMP_REGEX_SETS_STRUCTURES;
 
     PerlIO_printf(Perl_debug_log, "\nParse position is:%s\n", RExC_parse);
+    PerlIO_printf(Perl_debug_log, "\nDepth is: %zu\n", RExC_sets_depth);
 
     if (stack_top < 0) {
         PerlIO_printf(Perl_debug_log, "Nothing on stack\n");

--- a/regcomp.c
+++ b/regcomp.c
@@ -9224,9 +9224,11 @@ redo_curchar:
             OP(REGNODE_p(node)) = ANYOFL;
             ANYOF_FLAGS(REGNODE_p(node)) |= ANYOFL_UTF8_LOCALE_REQD;
         }
+
+        /* Now able to advance to prepare for the next construct. */
+        nextchar(pRExC_state);
     }
 
-    nextchar(pRExC_state);
     return node;
 
   regclass_failed:

--- a/regcomp.c
+++ b/regcomp.c
@@ -8688,8 +8688,8 @@ redo_curchar:
 
 #ifdef ENABLE_REGEX_SETS_DEBUGGING
                     /* Enable with -Accflags=-DENABLE_REGEX_SETS_DEBUGGING */
-        DEBUG_U(dump_regex_sets_structures(pRExC_state,
-                                           stack, fence, fence_stack));
+        DEBUG_U(dump_regex_sets_structures(pRExC_state, stack, fence,
+                                           fence_stack,__LINE__));
 #endif
 
         top_index = av_tindex_skip_len_mg(stack);
@@ -9238,7 +9238,8 @@ redo_curchar:
 
 static void
 S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
-                             AV * stack, const IV fence, AV * fence_stack)
+                             AV * stack, const IV fence, AV * fence_stack,
+                             line_t line_number)
 {   /* Dumps the stacks in handle_regex_sets() */
 
     const SSize_t stack_top = av_tindex_skip_len_mg(stack);
@@ -9248,6 +9249,8 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state,
     PERL_ARGS_ASSERT_DUMP_REGEX_SETS_STRUCTURES;
 
     PerlIO_printf(Perl_debug_log, "\nParse position is:%s\n", RExC_parse);
+    PerlIO_printf(Perl_debug_log, "    Called from line %" LINE_Tf "\n",
+                                  line_number);
     PerlIO_printf(Perl_debug_log, "\nDepth is: %zu\n", RExC_sets_depth);
 
     if (stack_top < 0) {

--- a/t/re/reg_mesg.t
+++ b/t/re/reg_mesg.t
@@ -344,7 +344,7 @@ my @death =
  '/(?!/' => 'Sequence (?!... not terminated {#} m/(?!{#}/',
  '/(?=/' => 'Sequence (?=... not terminated {#} m/(?={#}/',
  '/\p{vertical  tab}/' => 'Can\'t find Unicode property definition "vertical  tab" {#} m/\\p{vertical  tab}{#}/', # [perl #132055]
- "/$bug133423/" => "Unexpected ']' with no following ')' in (?[... {#} m/(?[(?^:(?[\\ ]))\\]{#} |2[^^]\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80])R.\\670/",
+ "/$bug133423/" => "Operand with no preceding operator {#} m/(?[(?^:(?[\\ ]))\\{#}] |2[^^]\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80])R.\\670/",
  '/[^/' => 'Unmatched [ {#} m/[{#}^/', # [perl #133767]
  '/\p{Is_Other_Alphabetic=F}/ ' => 'Can\'t find Unicode property definition "Is_Other_Alphabetic=F" {#} m/\p{Is_Other_Alphabetic=F}{#}/',
  '/\p{Is_Other_Alphabetic=F}/ ' => 'Can\'t find Unicode property definition "Is_Other_Alphabetic=F" {#} m/\p{Is_Other_Alphabetic=F}{#}/',

--- a/t/re/regex_sets.t
+++ b/t/re/regex_sets.t
@@ -233,6 +233,15 @@ for my $char ("٠", "٥", "٩") {
          "Can use various flags in a nested call");
 }
 
+{   # GH #24238
+    my $RE_CLASS_LOWER = qr/(?[ [a-z] ])/;
+    my $RE_CLASS_UPPER = qr/(?[ [A-Z] ])/;
+    my $RE_CLASS_DIGIT = qr/(?[ [0-9] ])/;
+    like ("y",
+          qr/(?[ $RE_CLASS_LOWER + $RE_CLASS_UPPER + $RE_CLASS_DIGIT ])/x,
+          "/x modifier works with nested sets");
+}
+
 done_testing();
 
 1;


### PR DESCRIPTION
Fixes #24238

This bug was introduced by

commit d8d1dede53afc4f33cf63203b0992459fe964dc3
 Author: Karl Williamson <khw@cpan.org>
 Date:   Mon Feb 17 12:07:07 2020 -0700

     Improve handling of nested qr/(?[...])/

which changed how interpolated ("nested") sets expressions were handled.  The nesting is done by recursive calls then as now, but certain details were changed by that commit

The current bug is due to getting the next character in the input at the end of a nested call, and the layer above is not expecting that.  The solution is just to avoid getting that character when recursed.

However, this causes a different error message to be displayed than prior to this commit in certain cases.  The old message displayed was

    Unexpected ']' with no following ')'

which is accurate.  The new one is

     Operand with no preceding operator

which is no less accurate.  I considered making a special case to try to avoid the diagnostic wording change, and I would have done so if this were just a warning.  But it is a fatal error, so I think it quite unlikely that real code is expecting to not compile and to not compile with this particular message.  And I think the new message is a bit more to the point of what is wrong, so is actually better than before.

* This set of changes does not require a perldelta entry.
