### PR TITLE
perlguts: Refer queries directly to P5P list

### DIFF
--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -12,7 +12,7 @@ perlguts - Introduction to the Perl API
 This document attempts to describe how to use the Perl API, as well as
 to provide some info on the basic workings of the Perl core.  It is far
 from complete and probably contains many errors.  Please refer any
-questions or comments to the author below.
+questions or comments to the Perl 5 Porters E<lt>perl5-porters@perl.orgE<gt>.
 
 =head1 Variables
 


### PR DESCRIPTION
Currently, readers of this file who encounter problems have to scroll down over 5000 lines to find the "author" to whom questions should be directed. For nearly 30 years that "author" has been P5P, so let's tell the readers that directly.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
