### PR TITLE
regcomp_study: Don't create a trie that would overflow

### DIFF
--- a/embed.h
+++ b/embed.h
@@ -48,6 +48,7 @@
 #     undef OPpPARAM_IF_FALSE
 #     undef OPpPARAM_IF_UNDEF
 #     undef OPpSELF_IN_PAD
+#     undef PREVENT_LVALUE
 #     undef utf16_to_utf8
 #     undef utf16_to_utf8_reversed
 #   endif /* !defined(PERL_EXT) */

--- a/handy.h
+++ b/handy.h
@@ -1439,6 +1439,23 @@ or casts
  */
 #define ASSERT_IS_PTR(x) (assert(sizeof(*(x))), (x))
 
+/*
+=for apidoc_section $directives_scn
+=for apidoc Em|bool|PREVENT_LVALUE|x
+
+This returns its input C<x>, but forces a compilation error if called from an
+lvalue context.  Its main use is to be placed in a macro that otherwise could 
+be used to change the value of C<x>, but doing so is undesirable.
+
+A common example is when there are getter and setter macros for C<x>, and the
+setter has error checking that shouldn't be short circuited.  Wrapping C<x>
+with this macro in the getter call forces the setter one to be used to change
+C<x>.
+
+=cut
+*/
+#define PREVENT_LVALUE(x)  ((x) | 0)
+
 /* FITS_IN_8_BITS(c) returns true if c doesn't have  a bit set other than in
  * the lower 8.  It is designed to be hopefully bomb-proof, making sure that no
  * bits of information are lost even on a 64-bit machine, but to get the

--- a/regcomp.c
+++ b/regcomp.c
@@ -4469,13 +4469,13 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                 });
                 OP(br)= NOTHING;
                 if (OP(REGNODE_p(ender)) == TAIL) {
-                    NEXT_OFF(br)= 0;
+                    NEXT_OFF_set(br, 0);
                     RExC_emit = REGNODE_OFFSET(br) + NODE_STEP_REGNODE;
                 } else {
                     regnode *opt;
                     for ( opt = br + 1; opt < REGNODE_p(ender) ; opt++ )
                         OP(opt)= OPTIMIZED;
-                    NEXT_OFF(br)= REGNODE_p(ender) - br;
+                    NEXT_OFF_set(br, REGNODE_p(ender) - br);
                 }
             }
         }
@@ -4877,8 +4877,8 @@ S_regpiece(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
                                    unconditionally */
                 reginsert(pRExC_state, OPFAIL, orig_emit, depth+1);
                 ckWARNreg(RExC_parse, "Quantifier {n,m} with n > m can't match");
-                NEXT_OFF(REGNODE_p(orig_emit)) =
-                                    REGNODE_ARG_LEN(OPFAIL) + NODE_STEP_REGNODE;
+                NEXT_OFF_set(REGNODE_p(orig_emit),
+                             REGNODE_ARG_LEN(OPFAIL) + NODE_STEP_REGNODE);
                 return ret;
             }
             else if (min == max && *RExC_parse == '?') {
@@ -13118,7 +13118,8 @@ S_reg2node(pTHX_ RExC_state_t *pRExC_state, const U8 op, const U32 arg1, const I
 * set up NEXT_OFF() of the inserted node if needed. Something like this:
 *
 *   reginsert(pRExC, OPFAIL, orig_emit, depth+1);
-*   NEXT_OFF(REGNODE_p(orig_emit)) = REGNODE_ARG_LEN(OPFAIL) + NODE_STEP_REGNODE;
+*   NEXT_OFF_set(REGNODE_p(orig_emit),
+*                REGNODE_ARG_LEN(OPFAIL) + NODE_STEP_REGNODE);
 *
 * ALSO NOTE - FLAGS(newly-inserted-operator) will be set to 0 as well.
 */
@@ -13240,10 +13241,10 @@ S_regtail(pTHX_ RExC_state_t * pRExC_state,
             /* Populate this with something that won't loop and will likely
              * lead to a crash if the caller ignores the failure return, and
              * execution continues */
-            NEXT_OFF(REGNODE_p(scan)) = U16_MAX;
+            NEXT_OFF_set(REGNODE_p(scan), U16_MAX);
             return false;
         }
-        NEXT_OFF(REGNODE_p(scan)) = val - scan;
+        NEXT_OFF_set(REGNODE_p(scan), val - scan);
     }
 
     return true;
@@ -13339,10 +13340,10 @@ S_regtail_study(pTHX_ RExC_state_t *pRExC_state, regnode_offset p,
             /* Populate this with something that won't loop and will likely
              * lead to a crash if the caller ignores the failure return, and
              * execution continues */
-            NEXT_OFF(REGNODE_p(scan)) = U16_MAX;
+            NEXT_OFF_set(REGNODE_p(scan), U16_MAX);
             return false;
         }
-        NEXT_OFF(REGNODE_p(scan)) = val - scan;
+        NEXT_OFF_set(REGNODE_p(scan), val - scan);
     }
 
     return true; /* Was 'return exact' */

--- a/regcomp.h
+++ b/regcomp.h
@@ -386,7 +386,7 @@ struct regnode_ssc {
 #define set_ANYOF_SYNTHETIC(n)  \
     STMT_START{                 \
         OP(n) = ANYOF;          \
-        NEXT_OFF(n) = 1;        \
+        NEXT_OFF_set(n, 1);     \
     } STMT_END
 
 #define is_ANYOF_SYNTHETIC(n) (REGNODE_TYPE(OP(n)) == ANYOF && NEXT_OFF(n) == 1)
@@ -481,7 +481,7 @@ struct regnode_ssc {
 #undef NEXT_OFF
 #undef NODE_ALIGN
 
-#define NEXT_OFF(p)     ((p)->head.data.next_off)
+#define NEXT_OFF_base(p)((p)->head.data.next_off)
 #define OP(p)           ((p)->head.data.type)
 #define STR_LEN_U8(p)   ((p)->head.data.u_8.str_len_u8)
 #define FIRST_BYTE(p)   ((p)->head.data.u_8.first_byte)
@@ -491,7 +491,9 @@ struct regnode_ssc {
 #define FLAGS(p)        ((p)->head.data.u_8.flags)
 
 #define NEXT_OFF_set(p, v)                                                  \
-                    (assert(inRANGE((v), 0, U16_MAX)), NEXT_OFF(p) = (v))
+                (assert(inRANGE((v), 0, U16_MAX)), NEXT_OFF_base(p) = (v))
+#define NEXT_OFF(p)  PREVENT_LVALUE(NEXT_OFF_base(p))
+
 #define STR_LENs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \
                                     STR_LEN_U8((struct regnode_string *)p))
 #define STRINGs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \

--- a/regcomp.h
+++ b/regcomp.h
@@ -490,6 +490,8 @@ struct regnode_ssc {
  * set of the regnode */
 #define FLAGS(p)        ((p)->head.data.u_8.flags)
 
+#define NEXT_OFF_set(p, v)                                                  \
+                    (assert(inRANGE((v), 0, U16_MAX)), NEXT_OFF(p) = (v))
 #define STR_LENs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \
                                     STR_LEN_U8((struct regnode_string *)p))
 #define STRINGs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \
@@ -668,7 +670,7 @@ struct regnode_ssc {
 #define FILL_NODE(offset, op)                                           \
     STMT_START {                                                        \
                     OP(REGNODE_p(offset)) = op;                         \
-                    NEXT_OFF(REGNODE_p(offset)) = 0;                    \
+                    NEXT_OFF_set(REGNODE_p(offset), 0);                 \
     } STMT_END
 #define FILL_ADVANCE_NODE(offset, op)                                   \
     STMT_START {                                                        \

--- a/regcomp.h
+++ b/regcomp.h
@@ -485,9 +485,11 @@ struct regnode_ssc {
 #define OP(p)           ((p)->head.data.type)
 #define STR_LEN_U8(p)   ((p)->head.data.u_8.str_len_u8)
 #define FIRST_BYTE(p)   ((p)->head.data.u_8.first_byte)
-#define FLAGS(p)        ((p)->head.data.u_8.flags) /* Caution: Doesn't apply to all      \
-                                           regnode types.  For some, it's the \
-                                           character set of the regnode */
+
+/* Caution: Doesn't apply to all regnode types.  For some, it's the character
+ * set of the regnode */
+#define FLAGS(p)        ((p)->head.data.u_8.flags)
+
 #define STR_LENs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \
                                     STR_LEN_U8((struct regnode_string *)p))
 #define STRINGs(p)	(assert(OP(p) != LEXACT && OP(p) != LEXACT_REQ8),   \

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -1211,6 +1211,6 @@ static const scan_data_t zero_scan_data = {
     node = dumpuntil(r,start,(b),(e),last,sv,indent+1,depth+1);
 
 #define REGNODE_STEP_OVER(ret,t1,t2) \
-    NEXT_OFF(REGNODE_p(ret)) = ((sizeof(t1)+sizeof(t2))/sizeof(regnode))
+    NEXT_OFF_set(REGNODE_p(ret), ((sizeof(t1)+sizeof(t2))/sizeof(regnode)));
 
 #endif /* PERL_REGCOMP_INTERNAL_H */

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -67,7 +67,7 @@ S_rck_elide_nothing(pTHX_ regnode *node)
         if (REGNODE_OFF_BY_ARG(OP(node)))
             ARG1u(node) = off;
         else
-            NEXT_OFF(node) = off;
+            NEXT_OFF_set(node, off);
     }
     return;
 }
@@ -1097,7 +1097,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
             stringok = 0;
         if (REGNODE_TYPE(OP(n)) == NOTHING) {
             DEBUG_PEEP("skip:", n, depth, 0);
-            NEXT_OFF(scan) += NEXT_OFF(n);
+            NEXT_OFF_set(scan, NEXT_OFF(scan) + NEXT_OFF(n));
             next = n + NODE_STEP_REGNODE;
 #ifdef DEBUGGING
             if (stringok)
@@ -1221,7 +1221,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
 #endif
 
             next = REGNODE_AFTER_varies(n);
-            NEXT_OFF(scan) += NEXT_OFF(n);
+            NEXT_OFF_set(scan, NEXT_OFF(scan) + NEXT_OFF(n));
             assert( ( STR_LEN(scan) + STR_LEN(n) ) < 256 );
             setSTR_LEN(scan, (U8)(STR_LEN(scan) + STR_LEN(n)));
             /* Now we can overwrite *n : */
@@ -1240,7 +1240,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
                 ARG1u_SET(n, val - n);
             }
             else {
-                NEXT_OFF(n) = val - n;
+                NEXT_OFF_set(n, val - n);
             }
             stopnow = 1;
         }
@@ -1456,7 +1456,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan,
     while (n <= stop) {
         OP(n) = OPTIMIZED;
         FLAGS(n) = 0;
-        NEXT_OFF(n) = 0;
+        NEXT_OFF_set(n, 0);
         n++;
     }
 #endif
@@ -2100,7 +2100,8 @@ Perl_study_chunk(pTHX_
 
                                     });
                                     OP(startbranch)= NOTHING;
-                                    NEXT_OFF(startbranch)= tail - startbranch;
+                                    NEXT_OFF_set(startbranch,
+                                                 tail - startbranch);
                                     for ( opt = startbranch + 1; opt < tail ; opt++ )
                                         OP(opt)= OPTIMIZED;
                                 }
@@ -2646,11 +2647,11 @@ Perl_study_chunk(pTHX_
 
 #ifdef DEBUGGING
                     OP(nxt1 + 1) = OPTIMIZED; /* was count. */
-                    NEXT_OFF(nxt1+ 1) = 0; /* just for consistency. */
-                    NEXT_OFF(nxt2) = 0; /* just for consistency with CURLY. */
+                    NEXT_OFF_set(nxt1 + 1, 0); /* just for consistency. */
+                    NEXT_OFF_set(nxt2, 0); /* just for consistency with CURLY. */
                     OP(nxt) = OPTIMIZED;        /* was CLOSE. */
                     OP(nxt + 1) = OPTIMIZED; /* was count. */
-                    NEXT_OFF(nxt+ 1) = 0; /* just for consistency. */
+                    NEXT_OFF_set(nxt + 1, 0); /* just for consistency. */
 #endif
                 }
               nogo:
@@ -2704,8 +2705,8 @@ Perl_study_chunk(pTHX_
 #ifdef DEBUGGING
                         OP(nxt1 + 1) = OPTIMIZED; /* was count. */
                         OP(nxt + 1) = OPTIMIZED; /* was count. */
-                        NEXT_OFF(nxt1 + 1) = 0; /* just for consistency. */
-                        NEXT_OFF(nxt + 1) = 0; /* just for consistency. */
+                        NEXT_OFF_set(nxt1 + 1, 0); /* just for consistency. */
+                        NEXT_OFF_set(nxt + 1, 0);  /* just for consistency. */
 #endif
 #if 0
                         while ( nxt1 && (OP(nxt1) != WHILEM)) {
@@ -2714,7 +2715,7 @@ Perl_study_chunk(pTHX_
                                 if (REGNODE_OFF_BY_ARG(OP(nxt1)))
                                     ARG1u_SET(nxt1, nxt2 - nxt1);
                                 else if (nxt2 - nxt1 < U16_MAX)
-                                    NEXT_OFF(nxt1) = nxt2 - nxt1;
+                                    NEXT_OFF_set(nxt1, nxt2 - nxt1);
                                 else
                                     OP(nxt) = NOTHING;  /* Cannot beautify */
                             }
@@ -3204,7 +3205,7 @@ Perl_study_chunk(pTHX_
                      * matches to avoid breakage for those not using this
                      * extension) */
                     if (deltanext)  {
-                        NEXT_OFF(scan) = deltanext;
+                        NEXT_OFF_set(scan, deltanext);
                         if (
                             /* See a CLOSE op inside this lookbehind? */
                             cur_last_close_op != *(data_fake.last_close_opp)
@@ -3320,7 +3321,7 @@ Perl_study_chunk(pTHX_
                     }
 
                     if (deltanext) {
-                        NEXT_OFF(scan) = deltanext;
+                        NEXT_OFF_set(scan, deltanext);
                     }
                     FLAGS(scan) = (U8)*minnextp + deltanext;
                 }

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1844,6 +1844,16 @@ Perl_study_chunk(pTHX_
                             tail = regnext( tail );
                         }
 
+                        /* The code below currently saves the difference from
+                         * start to finish in a 16-bit field, causing
+                         * GH #23388.  This defeats the design of batching
+                         * tries into chunks that each fit.  khw thinks it is
+                         * too late in the 5.44 cycle to relook at the design,
+                         * so for now anyway, don't make a trie that would
+                         * overflow */
+                        if (tail - startbranch >= U16_MAX) {
+                            continue;
+                        }
 
                         DEBUG_TRIE_COMPILE_r({
                             regprop(RExC_rx, RExC_mysv, tail, NULL, pRExC_state);

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -479,7 +479,8 @@ is the recommended Unicode-aware way of saying
             trie->j_after_paren = (U16 *) PerlMemShared_calloc( word_count + 1, \
                                                  sizeof(U16) ); \
         }                                                       \
-        trie->jump[curword] = (U16)(noper_next - convert);      \
+        assert(inRANGE(noper_next - convert, 0, U16_MAX));      \
+        trie->jump[curword] = noper_next - convert;             \
         U16 set_before_paren;                                   \
         U16 set_after_paren;                                    \
         if (OP(cur) == BRANCH) {                                \
@@ -1517,8 +1518,10 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             /* Store the offset to the first unabsorbed branch in
                jump[0], which is otherwise unused by the jump logic.
                We use this when dumping a trie and during optimisation. */
-            if (trie->jump)
+            if (trie->jump) {
+                assert(inRANGE(nextbranch - convert, 0, U16_MAX));
                 trie->jump[0] = (U16)(nextbranch - convert);
+            }
 
             /* If the start state is not accepting (meaning there is no empty string/NOTHING)
              *   and there is a bitmap

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -1370,7 +1370,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         /* Find the node we are going to overwrite */
         if ( first != startbranch || OP( last ) == BRANCH ) {
             /* branch sub-chain */
-            NEXT_OFF( first ) = (U16)(last - first);
+            NEXT_OFF_set(first, last - first);
             /* whole branch chain */
         }
         /* But first we check to see if there is a common prefix we can
@@ -1474,8 +1474,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             trie->prefixlen = (state-1);
             if (str) {
                 regnode *n = REGNODE_AFTER(convert);
-                assert( n - convert <= U16_MAX );
-                NEXT_OFF(convert) = n - convert;
+                NEXT_OFF_set(convert, n - convert);
                 trie->startstate = state;
                 trie->minlen -= (state - 1);
                 trie->maxlen -= (state - 1);
@@ -1505,7 +1504,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 if (trie->maxlen) {
                     convert = n;
                 } else {
-                    NEXT_OFF(convert) = (U16)(tail - convert);
+                    NEXT_OFF_set(convert, tail - convert);
                     DEBUG_r(optimize= n);
                 }
             }
@@ -1513,7 +1512,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         if (!jumper)
             jumper = last;
         if ( trie->maxlen ) {
-            NEXT_OFF( convert ) = (U16)(tail - convert);
+            NEXT_OFF_set( convert, tail - convert);
             ARG1u_SET( convert, data_slot );
             /* Store the offset to the first unabsorbed branch in
                jump[0], which is otherwise unused by the jump logic.

--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -2723,6 +2723,15 @@ EOF_DEBUG_OUT
         is($?, 0, "No segfault; [GH 16627]");
     }
 
+    { # GH #23388
+        fresh_perl_is(<<~'PROG', , "", {}, "Avoid trie overflow");
+            my $x = join "|", "aaa".."mzz";
+            my $y = join "|", "naa".."zzz";
+            use re 'Debug';
+            "fnord" =~ m/(?:$x)|(?:$y)/;
+            PROG
+    }
+
 
     # !!! NOTE that tests that aren't at all likely to crash perl should go
     # a ways above, above these last ones.  There's a comment there that, like


### PR DESCRIPTION
This addresses GH #23388

The design of the trie compiling code is to batch extra long tries into smaller chunks that fit into whatever limitations there are.  However, this ticket shows that that isn't always being done.

In this case, a bunch of branches that have TAIL operands can be combined together, and the final TAIL is used.  And the code requires that the delta between the first branch and this final TAIL fit into a 16-bit field.  That is the root cause of this bug.

I'm not familiar enough with the trie construction code to easily understand why the final tail needs to be used here.  So this patch simply doesn't optimize a sequence of branches into a trie that would overflow.

This could be revisited by someone who knows more about this than I, or earlier in the development cycle.  I 'm not closing #23388.

This set of changes does not require a perldelta entry.
