### PR TITLE
B::Concise: Fix one-liner `print` examples in docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -351,6 +351,7 @@ Daniel Muiño                   <dmuino@afip.gov.ar>
 Daniel P. Berrange             <dan@berrange.com>
 Daniel Perrett                 <perrettdl@googlemail.com>
 Daniel S. Lewart               <lewart@uiuc.edu>
+Daniel Tang                    <danielzgtg.opensource@gmail.com>
 Daniel Yacob                   <perl@geez.org>
 danielnachun                   <daniel.nachun@gmail.com>
 Danny R. Faught                <faught@mailhost.rsn.hp.com>

--- a/ext/B/B/Concise.pm
+++ b/ext/B/B/Concise.pm
@@ -1,4 +1,4 @@
-package B::Concise 1.011;
+package B::Concise 1.012;
 # Copyright (C) 2000-2003 Stephen McCamant. All rights reserved.
 # This program is free software; you can redistribute and/or modify it
 # under the same terms as Perl itself.
@@ -1766,13 +1766,13 @@ Identifies _POSIX_ARG_MAX as a constant sub, optimized to an IV.
 Although POSIX isn't entirely consistent across platforms, this is
 likely to be present in virtually all of them.
 
-=item perl -MPOSIX -MO=Concise,a -e 'print _POSIX_SAVED_IDS'
+=item perl -MPOSIX -MO=Concise -e 'print _POSIX_SAVED_IDS'
 
 This renders a print statement, which includes a call to the function.
 It's identical to rendering a file with a use call and that single
 statement, except for the filename which appears in the nextstate ops.
 
-=item perl -MPOSIX -MO=Concise,a -e 'sub a{_POSIX_SAVED_IDS}'
+=item perl -MPOSIX -MO=Concise,a -e 'sub a{print _POSIX_SAVED_IDS}'
 
 This is B<very> similar to previous, only the first two ops differ.  This
 subroutine rendering is more representative, insofar as a single main


### PR DESCRIPTION
The first example had printed `err: unknown function (main::a)`. The second example was adjusted to ensure "only the first two ops differ."

# Before

```console
$ perl -MPOSIX -MO=Concise,a -e 'print _POSIX_SAVED_IDS'
main::a:
err: unknown function (main::a)
-e syntax OK
$ perl -MPOSIX -MO=Concise,a -e 'sub a{_POSIX_SAVED_IDS}'
main::a:
3  <1> leavesub[1 ref] K/REFC,1 ->(end)
-     <@> lineseq KP ->3
1        <;> nextstate(main 2 -e:1) v ->2
2        <$> const[SPECIAL sv_yes] s*/FOLD ->3
-e syntax OK
```

# After

```console
$ perl -MPOSIX -MO=Concise -e 'print _POSIX_SAVED_IDS'
6  <@> leave[1 ref] vKP/REFC ->(end)
1     <0> enter v ->2
2     <;> nextstate(main 1 -e:1) v:{ ->3
5     <@> print vK ->6
3        <0> pushmark s ->4
4        <$> const[SPECIAL sv_yes] s*/FOLD ->5
-e syntax OK
$ perl -MPOSIX -MO=Concise,a -e 'sub a{print _POSIX_SAVED_IDS}'
main::a:
5  <1> leavesub[1 ref] K/REFC,1 ->(end)
-     <@> lineseq KP ->5
1        <;> nextstate(main 2 -e:1) v ->2
4        <@> print sK ->5
2           <0> pushmark s ->3
3           <$> const[SPECIAL sv_yes] s*/FOLD ->4
-e syntax OK
```

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
