### PR TITLE
Configure, perlbug: Fall back to git user.email

### DIFF
--- a/Configure
+++ b/Configure
@@ -9360,9 +9360,16 @@ while test "$cont"; do
 		;;
 	*)  maildomain="$MAILDOMAIN";;
 	esac
+	dflt=''
+	case "$mydomain" in
+		'.(none)'|.nonet) dflt=`git config user.email 2>/dev/null`;;
+	esac
+	case "$dflt" in
+		'') dflt="$cf_by@$maildomain";;
+	esac
 	case "$cf_email" in
-	'') dflt="$cf_by@$maildomain";;
-	*)  dflt="$cf_email";;
+		'') :;;
+		*) dflt="$cf_email";;
 	esac
 	rp='What is your e-mail address?'
 	. ./myread

--- a/utils/perlbug.PL
+++ b/utils/perlbug.PL
@@ -343,6 +343,7 @@ EOF
     $from = $::Config{'cf_email'}
        if !$from && $::Config{'cf_email'} && $::Config{'cf_by'} && $me &&
                ($me eq $::Config{'cf_by'});
+    chomp($from = `git config user.email`) if !$from;
 } # sub Init
 
 sub Query {


### PR DESCRIPTION
Modern Linux installations, especially those at home, do not set `domainname`. I have "(none)". But most programmers use Git, so will have their email set there. Improving these defaults is convenient, as I have already mistyped my email in `perlbug` once.

# Before

```text
What is your e-mail address? [home@daniel-desktop3.(none)] 
```

# After

```text
What is your e-mail address? [danielzgtg.opensource@gmail.com] 
```

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
