### PR TITLE
perlsyn: remove reference to "do SUB" syntax

### DIFF
--- a/pod/perlsyn.pod
+++ b/pod/perlsyn.pod
@@ -162,9 +162,8 @@ condition is true (or while the condition is false):
 
 The C<while> and C<until> modifiers have the usual "C<while> loop"
 semantics (conditional evaluated first), except when applied to a
-C<do>-BLOCK (or to the Perl4 C<do>-SUBROUTINE statement), in
-which case the block executes once before the conditional is
-evaluated.
+C<do>-BLOCK, in which case the block executes once before the
+conditional is evaluated.
 
 This is so that you can write loops like:
 


### PR DESCRIPTION
This (long deprecated) syntax was removed in v5.20 (commit 8c74b4142557).

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
