### PR TITLE
op/magic.t: skip non-UTF-8 on Ubuntu 25.10

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -868,10 +868,18 @@ SKIP: {
 	utf8::upgrade($chars = $bytes);
 	$forced = $ENV{foo} = $chars;
 	ok(!utf8::is_utf8($forced) && $forced eq $bytes, 'ENV store downgrades utf8 in SV');
-	env_is(foo => $bytes, 'ENV store downgrades utf8 in setenv');
+	SKIP: {
+		skip("Non-UTF-8 env is broken on Ubuntu 25.10", 1)
+			if `env --version` eq "uu_env (uutils coreutils) 0.2.2\n";
+		env_is(foo => $bytes, 'ENV store downgrades utf8 in setenv');
+	}
 	fail 'chars should still be wide!' if !utf8::is_utf8($chars);
 	$ENV{$chars} = 'widekey';
-	env_is("eh zero \x{A0}" => 'widekey', 'ENV store downgrades utf8 key in setenv');
+	SKIP: {
+		skip("Non-UTF-8 env is broken on Ubuntu 25.10", 1)
+			if `env --version` eq "uu_env (uutils coreutils) 0.2.2\n";
+		env_is("eh zero \x{A0}" => 'widekey', 'ENV store downgrades utf8 key in setenv');
+	}
 	fail 'chars should still be wide!' if !utf8::is_utf8($chars);
 	is( delete($ENV{$chars}), 'widekey', 'delete(%ENV) downgrades utf8 key' );
 


### PR DESCRIPTION
`env` from uutils 0.2.0 has a crash bug, as it relies on Rust's standard library to iterate envvars, but Rust likes to check that everything is UTF-8. This is fixed in uutils 0.6.0 with Ubuntu 26.04, which is unreleased however. Ubuntu 25.10's EOL won't be until 3 months: July 2026.

This commit allows `./perl t/harness` to show "Result: PASS" on Ubuntu 25.10.

# Before

```console
$ ./perl t/harness t/op/magic.t
op/magic.t .. 66/208 
thread 'main' panicked at library/std/src/env.rs:163:83:
called `Result::unwrap()` on an `Err` value: "eh zero \xA0"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
# Failed test 186 - ENV store downgrades utf8 in setenv at op/magic.t line 88
#      got ""
# expected "eh zero �"

thread 'main' panicked at library/std/src/env.rs:163:83:
called `Result::unwrap()` on an `Err` value: "eh zero \xA0"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
# Failed test 187 - ENV store downgrades utf8 key in setenv at op/magic.t line 88
#      got ""
# expected "widekey"
op/magic.t .. Failed 2/208 subtests 
        (less 4 skipped subtests: 202 okay)

Test Summary Report
-------------------
op/magic.t (Wstat: 0 Tests: 208 Failed: 2)
  Failed tests:  186-187
Files=1, Tests=208,  3 wallclock secs ( 0.01 usr  0.00 sys +  0.05 cusr  0.13 csys =  0.19 CPU)
Result: FAIL
Finished test run at Sun Mar 22 18:57:34 2026.
```

# After

```console
$ ./perl t/harness t/op/magic.t
op/magic.t .. ok       
All tests successful.
Files=1, Tests=208,  3 wallclock secs ( 0.01 usr  0.00 sys +  0.05 cusr  0.12 csys =  0.18 CPU)
Result: PASS
Finished test run at Sun Mar 22 19:03:10 2026.
```

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
