### PR TITLE
perlpod.pod: remove empty paragraph in bullet

### DIFF
--- a/pod/perlpod.pod
+++ b/pod/perlpod.pod
@@ -713,11 +713,11 @@ Without that empty line before the "=head1", many translators wouldn't
 have recognized the "=head1" as starting a Pod block.
 
 =head2 Hints for Writing Pod
+X<podchecker> X<POD, validating>
 
 =over
 
 =item *
-X<podchecker> X<POD, validating>
 
 The B<podchecker> command is provided for checking Pod syntax for errors
 and warnings.  For example, it checks for completely blank lines in


### PR DESCRIPTION
There had been a strange line with only a bullet in `man perlpod`. It was caused by index entries like `X<podchecker>` being placed after a bullet. Normally they succeed list items. `perldoc` and `pod2text` were unaffected. I fixed this problem for `pod2html` and `pod2man` by moving the index entries to after the paragraph.

# Before

```console
$ pod2html /usr/share/perl/5.40.1/pod/perlpod.pod
[...]
<h2 id="Hints-for-Writing-Pod">Hints for Writing Pod</h2>

<ul>

<li><p> </p>

<p>The <b>podchecker</b> command is provided for checking Pod syntax [...]
[...]
$ pod2man /usr/share/perl/5.40.1/pod/perlpod.pod
[...]
.SS "Hints for Writing Pod"
.IX Subsection "Hints for Writing Pod"
.IP \(bu 4

.IX Xref "podchecker POD, validating"
.Sp
The \fBpodchecker\fR command is provided for checking Pod syntax for errors
and warnings.  For example, it checks for completely blank lines in
Pod blocks and for unknown commands and formatting codes.  You should
still also pass your document through one or more translators and proofread
the result, or print out the result and proofread that.  Some of the
problems found may be bugs in the translators, which you may or may not
wish to work around.
.IP \(bu 4
[...]
```

https://linux.die.net/man/1/perlpod :
<img width="756" height="407" alt="perlpod html blank paragraph" src="https://github.com/user-attachments/assets/e712d844-a97b-472a-8c8d-83a47a5eeb03" />

# After

```console
$ pod2html ./perlpod.pod
[...]
<h2 id="Hints-for-Writing-Pod">Hints for Writing Pod</h2>

<ul>

<li><p>The <b>podchecker</b> command is provided for checking Pod syntax [...]
[...]
$ pod2man ./perlpod.pod
[...]
.SS "Hints for Writing Pod"
.IX Subsection "Hints for Writing Pod"
.IP \(bu 4
The \fBpodchecker\fR command is provided for checking Pod syntax for errors
and warnings.  For example, it checks for completely blank lines in
Pod blocks and for unknown commands and formatting codes.  You should
still also pass your document through one or more translators and proofread
the result, or print out the result and proofread that.  Some of the
problems found may be bugs in the translators, which you may or may not
wish to work around.
.IX Xref "podchecker POD, validating"
.IP \(bu 4
[...]
```

<img width="680" height="313" alt="perlpod html correctly formatted list" src="https://github.com/user-attachments/assets/ce4e28dd-11c5-4353-aa63-dae1a8fae421" />

`perldoc ./perlpod.pod` and `pod2text ./perlpod.pod` are unchanged.

# Alternatives

* Changing Pod::HTML and Pod::Man would require too much testing
* Removing the pre-paragraph blank line or moving the index entry down one line would require reflowing the text to prevent an extra indent in `pod2text`, yet `pod2man`'s `.IX Xref` still ends up after the paragraph like my solution

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
