### PR TITLE
Mark svpv_buf as uninitialized to avoid performance regression

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -423,6 +423,7 @@ DH                             <crazyinsomniac@yahoo.com>
 Diab Jerius                    <dj@head-cfa.harvard.edu>
 dLux                           <dlux@spam.sch.bme.hu>
 Dmitri Tikhonov                <dmitri@cpan.org>
+Dmitrii Kuvaiskii              <dimakuv@amazon.de>
 Dmitry Karasik                 <dk@tetsuo.karasik.eu.org>
 Dmitry Ulanov                  <zprogd@gmail.com>
 Dominic Dunlop                 <domo@computer.org>

--- a/embed.h
+++ b/embed.h
@@ -28,6 +28,7 @@
 #   undef CC_MAGICAL_
 #   undef CC_UNDERSCORE_
 #   undef do_aexec
+#   undef HASATTRIBUTE_UNINITIALIZED
 #   undef is_WORD_BUT_NONCONT_safe
 #   undef isFOO_or_UNDERSCORE_
 #   undef isIDCONT_lazy_if_safe

--- a/perl.h
+++ b/perl.h
@@ -425,6 +425,9 @@ Now a no-op.
 #  if PERL_GCC_VERSION_GE(3,3,0)
 #    define HASATTRIBUTE_VISIBILITY
 #  endif
+#  if PERL_GCC_VERSION_GE(12,0,0)
+#    define HASATTRIBUTE_UNINITIALIZED
+#  endif
 #endif
 
 #ifdef HASATTRIBUTE_DEPRECATED
@@ -465,6 +468,9 @@ Now a no-op.
  */
 #  define __attribute__visibility__(x) __attribute__((visibility(x)))
 #endif
+#ifdef HASATTRIBUTE_UNINITIALIZED
+#  define __attribute__uninitialized__ __attribute__((uninitialized))
+#endif
 
 /* If we haven't defined the attributes yet, define them to blank. */
 #ifndef __attribute__deprecated__
@@ -496,6 +502,9 @@ Now a no-op.
 #endif
 #ifndef __attribute__visibility__
 #  define __attribute__visibility__(x)
+#endif
+#ifndef __attribute__uninitialized__
+#  define __attribute__uninitialized__
 #endif
 
 /* Some OS warn on NULL format to printf */

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -707,7 +707,8 @@ PP(pp_multiconcat)
         *svpv_p,             /* ptr for looping through svpv_buf */
         *svpv_base,          /* first slot (may be greater than svpv_buf), */
         *svpv_end,           /* and slot after highest result so far, of: */
-        svpv_buf[PERL_MULTICONCAT_MAXARG]; /* buf for storing SvPV() results */
+        /* buf for storing SvPV() results */
+        svpv_buf[PERL_MULTICONCAT_MAXARG] __attribute__uninitialized__;
 
     aux   = cUNOP_AUXx(PL_op)->op_aux;
     stack_adj = nargs = aux[PERL_MULTICONCAT_IX_NARGS].ssize;


### PR DESCRIPTION
Fixes #24317. See details in that issue.

---

Previously, when compiling Perl with `-ftrivial-auto-var-init=zero` (on GCC14+), there was a performance regression in pp_multiconcat(). This happened because of the `svpv_buf` local array with a rather-large size, which was auto initialized to zero.

Since `svpv_buf` is used in a performance-critical path, and is used safely in the current codebase, this commit marks this array as `__attribute__((uninitialized))`. This way, even when compiled with `-ftrivial-auto-var-init=zero`, Perl still exhibits good performance.

-------------------------------------------------------------------------------

With this PR, the reproducer from #24317 doesn't have any performance overhead:

```
$ PERL5LIB="$(pwd)" ./perlbench-run -t ipol ../vanilla-perl/bin/perl5.43.10 ../slow-perl/bin/perl5.43.10

A) perl-5
        version     = 5.04301
        git-version = v5.43.9-12-gef53bc6892
        path        = ../vanilla-perl/bin/perl5.43.10
        ccflags     = -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2

B) perl-5
        version     = 5.04301
        git-version = v5.43.9-12-gef53bc6892*
        path        = ../slow-perl/bin/perl5.43.10
        ccflags     = -ftrivial-auto-var-init=zero -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2

                           A       B
                         ---     ---
string/ipol              100     103
```