### PR TITLE
Defer seal of subclass until superclass is done

### DIFF
--- a/class.c
+++ b/class.c
@@ -398,12 +398,14 @@ Perl_class_setup_stash(pTHX_ HV *stash)
      */
 
     struct xpvhv_aux *aux = HvAUX(stash);
+    aux->xhv_class_flags         = 0;
     aux->xhv_class_superclass    = NULL;
     aux->xhv_class_initfields_cv = NULL;
     aux->xhv_class_adjust_blocks = NULL;
     aux->xhv_class_fields        = NULL;
     aux->xhv_class_next_fieldix  = 0;
     aux->xhv_class_param_map     = NULL;
+    aux->xhv_class_subclasses_pending_seal = NULL;
 
     aux->xhv_aux_flags |= HvAUXf_IS_CLASS;
 
@@ -683,6 +685,9 @@ S_class_cleanup_definition(pTHX_ HV *stash)
     SvREFCNT_dec(aux->xhv_class_param_map);
     aux->xhv_class_param_map = NULL;
 
+    SvREFCNT_dec(aux->xhv_class_subclasses_pending_seal);
+    aux->xhv_class_subclasses_pending_seal = NULL;
+
     /* clean up the ops for defaults for fields, if any, since
        padname_free() doesn't.
     */
@@ -760,7 +765,29 @@ Perl_class_seal_stash(pTHX_ HV *stash)
         return;
     }
 
+    if(HvCLASS_IS_SEALED(stash))
+        /* idempotent */
+        return;
+
     struct xpvhv_aux *aux = HvAUX(stash);
+    struct xpvhv_aux *superaux = NULL;
+
+    if(aux->xhv_class_superclass) {
+        HV *superstash = aux->xhv_class_superclass;
+        assert(HvSTASH_IS_CLASS(superstash));
+        superaux = HvAUX(superstash);
+
+        if(!HvCLASS_IS_SEALED(superstash)) {
+            if(!superaux->xhv_class_subclasses_pending_seal)
+                superaux->xhv_class_subclasses_pending_seal = newAV();
+            /* tut tut this will be an AV whose elements are HV *s directly.
+             * That's fine. perl code won't ever see this array so there's no
+             * point us wrapping them in newRV_inc()s
+             */
+            av_push(superaux->xhv_class_subclasses_pending_seal, SvREFCNT_inc((SV *)stash));
+            return;
+        }
+    }
 
     /* generate initfields CV */
     I32 floor_ix = PL_savestack_ix;
@@ -793,11 +820,8 @@ Perl_class_seal_stash(pTHX_ HV *stash)
     ops = op_append_list(OP_LINESEQ, ops,
          newUNOP_AUX(OP_METHSTART, OPpINITFIELDS << 8, NULL, NULL));
 
-    if(aux->xhv_class_superclass) {
-        HV *superstash = aux->xhv_class_superclass;
-        assert(HvSTASH_IS_CLASS(superstash));
-        struct xpvhv_aux *superaux = HvAUX(superstash);
-
+    if(superaux) {
+        assert(superaux->xhv_class_initfields_cv);
         /* Build an OP_ENTERSUB */
         OP *o = newLISTOPn(OP_ENTERSUB, OPf_WANT_VOID|OPf_STACKED,
             newPADxVOP(OP_PADSV, 0, PADIX_SELF),
@@ -920,6 +944,17 @@ Perl_class_seal_stash(pTHX_ HV *stash)
     CvIsMETHOD_on(initfields);
 
     aux->xhv_class_initfields_cv = initfields;
+
+    aux->xhv_class_flags |= HvCLASSf_SEALED;
+
+    if(aux->xhv_class_subclasses_pending_seal) {
+        AV *subclasses = aux->xhv_class_subclasses_pending_seal;
+        for (UV idx = 0; idx < av_count(subclasses); idx++)
+            class_seal_stash((HV *)AvARRAY(subclasses)[idx]);
+
+        SvREFCNT_dec(subclasses);
+        aux->xhv_class_subclasses_pending_seal = NULL;
+    }
 }
 
 void

--- a/hv.h
+++ b/hv.h
@@ -137,12 +137,15 @@ struct xpvhv_aux {
     U32         xhv_aux_flags;      /* assorted extra flags */
 
     /* The following fields are only valid if we have the flag HvAUXf_IS_CLASS */
+    U32         xhv_class_flags;
     HV          *xhv_class_superclass;         /* STASH of the :isa() base class */
     CV          *xhv_class_initfields_cv;      /* CV for running initfields */
     AV          *xhv_class_adjust_blocks;      /* CVs containing the ADJUST blocks */
     PADNAMELIST *xhv_class_fields;             /* PADNAMEs with PadnameIsFIELD() */
     PADOFFSET    xhv_class_next_fieldix;
     HV          *xhv_class_param_map;          /* Maps param names to field index stored in UV */
+    AV          *xhv_class_subclasses_pending_seal;
+                                               /* STASHes of subclasses that are awaiting seal after this */
 
     struct suspended_compcv
                 *xhv_class_suspended_initfields_compcv;
@@ -154,6 +157,11 @@ struct xpvhv_aux {
 
 #define HvSTASH_IS_CLASS(hv) \
     (HvHasAUX(hv) && HvAUX(hv)->xhv_aux_flags & HvAUXf_IS_CLASS)
+
+#define HvCLASSf_SEALED     0x1   /* class seal operation has been invoked */
+
+#define HvCLASS_IS_SEALED(hv) \
+    (HvSTASH_IS_CLASS(hv) && HvAUX(hv)->xhv_class_flags & HvCLASSf_SEALED)
 
 /* hash structure: */
 /* This structure must match the beginning of struct xpvmg in sv.h. */

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1061,6 +1061,8 @@ my @unresolved_visibility_overrides = qw(
     HvAUXf_IS_CLASS
     HvAUXf_NO_DEREF
     HvAUXf_SCAN_STASH
+    HvCLASS_IS_SEALED
+    HvCLASSf_SEALED
     HV_DELETE
     HV_DISABLE_UVAR_XKEY
     HvEITER

--- a/t/class/inherit.t
+++ b/t/class/inherit.t
@@ -114,4 +114,27 @@ EOS
     is(Testcase6B->VERSION, 1.23, 'Testcase6B sets VERSION');
 }
 
+# GH#20890
+{
+    {
+        class Testcase7A; # unit syntax, not block
+        method m { return "the method"; }
+
+        class Testcase7B :isa(Testcase7A);
+    }
+
+    my $obj1 = Testcase7B->new;
+    is($obj1->m, "the method", 'Testcase7B can inherit from unit-syntax base class');
+
+    # Not in the original bug report but inspired by Object::Pad's equivalent test
+    class Testcase7C {
+        method m { return "also the method"; }
+
+        class Testcase7D :isa(Testcase7C) { }
+    }
+
+    my $obj2 = Testcase7D->new;
+    is($obj2->m, "also the method", 'Testcase7D can inherit from inside block-syntax base class');
+}
+
 done_testing;


### PR DESCRIPTION
Fixes https://github.com/Perl/perl5/issues/20890

The bug is that when you seal class that is a subclass of an existing one, if that existing one was not yet sealed then a pointer access hasn't yet been filled in, and a NULL deref occurs.

This is fixed by a reïmplementation of the same deferral logic that [`Object::Pad`](https://metacpan.org/pod/Object::Pad) has found to be good and stable. Namely, that each class needs a flag that tracks whether it has been sealed. When attempting to seal a class whose superclass isn't yet sealed, we defer the operation until the superclass is sealed, instead just making a note within the superclass that it should come back and seal this one later.

This deferral mechanism allows a variety of subclassing cases to work which previously did not. As well as the original case described in #20890, this also permits block-scoped sub-classes defined inside the base class's scope. Such syntax may be useful for a new ability in future.

* I don't feel that this set of changes requires a perldelta entry as it's a small bugfix to an experimental feature, but I could be talked into it