### PR TITLE
Add comprehensive stress tests for class inheritance and field handling

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6042,6 +6042,7 @@ t/class/gh23511.t			Test defining a reader after a strict 'vars' violation
 t/class/inherit.t			See if class inheritance works
 t/class/method.t			See if class method declarations work
 t/class/phasers.t			See if class phaser blocks work
+t/class/stress.t			Stress tests for class inheritance and field handling
 t/class/threads.t			See if classes work across multiple threads
 t/class/utf8.t				See if class syntax works with non-ASCII UTF-8
 t/cmd/elsif.t				See if else-if works

--- a/MANIFEST
+++ b/MANIFEST
@@ -6032,15 +6032,21 @@ t/bigmem/sv_gets.t			Test reading a lot with sv_gets()
 t/bigmem/vec.t				Check vec() handles large offsets
 t/charset_tools.pl			To aid in portable testing across platforms with different character sets
 t/class/accessor.t			See if accessor methods work
+t/class/attribute_combos.t
 t/class/class.t				See if class declarations work
 t/class/construct.t			See if class constructors work
 t/class/destruct.t			See if class destruction works
+t/class/edge_cases.t
 t/class/EndsWithADJUST.pm		Helper module for test for GH#23758 in t/class/phasers.t
+t/class/errors.t
 t/class/field.t				See if class field declarations work
 t/class/gh22169.t			Test defining a class that previously failed to define
 t/class/gh23511.t			Test defining a reader after a strict 'vars' violation
 t/class/inherit.t			See if class inheritance works
+t/class/interop.t
+t/class/lifecycle.t
 t/class/method.t			See if class method declarations work
+t/class/module.t
 t/class/phasers.t			See if class phaser blocks work
 t/class/stress.t			Stress tests for class inheritance and field handling
 t/class/threads.t			See if classes work across multiple threads

--- a/t/class/attribute_combos.t
+++ b/t/class/attribute_combos.t
@@ -1,0 +1,251 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+=pod
+
+Tests for combinations of field attributes (:param, :reader, :writer)
+and their interactions.
+
+=cut
+
+# :param + :reader
+{
+    class AttrCombo1 {
+        field $x :param :reader;
+    }
+
+    my $obj = AttrCombo1->new(x => "hello");
+    is($obj->x, "hello", ':param + :reader works');
+}
+
+# :param + :writer
+{
+    class AttrCombo2 {
+        field $x :param :writer :reader;
+    }
+
+    my $obj = AttrCombo2->new(x => "initial");
+    is($obj->x, "initial", ':param + :writer + :reader initial value');
+    $obj->set_x("modified");
+    is($obj->x, "modified", ':param + :writer + :reader after set');
+}
+
+# :param with custom name + :reader
+{
+    class AttrCombo3 {
+        field $x :param(initial_x) :reader;
+    }
+
+    my $obj = AttrCombo3->new(initial_x => "value");
+    is($obj->x, "value", ':param(custom) + :reader works');
+}
+
+# :param with custom name + :reader with custom name
+{
+    class AttrCombo4 {
+        field $x :param(init_val) :reader(get_val);
+    }
+
+    my $obj = AttrCombo4->new(init_val => "test");
+    is($obj->get_val, "test", ':param(custom) + :reader(custom) works');
+
+    # Original names should not exist
+    ok(!eval { $obj->x }, 'default reader name does not exist');
+}
+
+# :param with custom name + :writer with custom name
+{
+    class AttrCombo5 {
+        field $x :param(init_x) :reader :writer(put_x);
+    }
+
+    my $obj = AttrCombo5->new(init_x => "start");
+    is($obj->x, "start", ':param(custom) + :writer(custom) initial');
+    $obj->put_x("end");
+    is($obj->x, "end", ':param(custom) + :writer(custom) after write');
+
+    # Default writer name should not exist
+    ok(!eval { $obj->set_x("nope") }, 'default writer name does not exist');
+}
+
+# :param + :reader + :writer all together
+{
+    class AttrCombo6 {
+        field $val :param :reader :writer;
+    }
+
+    my $obj = AttrCombo6->new(val => 42);
+    is($obj->val, 42, 'triple combo: read initial param');
+    my $ret = $obj->set_val(99);
+    is($obj->val, 99, 'triple combo: read after write');
+    is($ret, $obj, 'triple combo: writer returns instance');
+}
+
+# :param + :reader + :writer all with custom names
+{
+    class AttrCombo7 {
+        field $internal :param(p) :reader(get_it) :writer(set_it);
+    }
+
+    my $obj = AttrCombo7->new(p => "start");
+    is($obj->get_it, "start", 'all-custom combo: reader');
+    $obj->set_it("end");
+    is($obj->get_it, "end", 'all-custom combo: writer then reader');
+
+    # None of the default names should work
+    ok(!eval { $obj->internal }, 'default reader unavailable');
+    ok(!eval { $obj->set_internal("x") }, 'default writer unavailable');
+}
+
+# :reader with default value (no :param)
+{
+    class AttrCombo8 {
+        field $x :reader = "default";
+    }
+
+    is(AttrCombo8->new->x, "default", ':reader with default value');
+}
+
+# :writer with default value (no :param)
+{
+    class AttrCombo9 {
+        field $x :reader :writer = "default";
+    }
+
+    my $obj = AttrCombo9->new;
+    is($obj->x, "default", ':writer with default value initial');
+    $obj->set_x("changed");
+    is($obj->x, "changed", ':writer with default value after set');
+}
+
+# :param with //= and :reader
+{
+    class AttrCombo10 {
+        field $x :param :reader //= "fallback";
+    }
+
+    is(AttrCombo10->new->x, "fallback",
+        ':param //= with :reader uses fallback when missing');
+    is(AttrCombo10->new(x => undef)->x, "fallback",
+        ':param //= with :reader uses fallback when undef');
+    is(AttrCombo10->new(x => 0)->x, 0,
+        ':param //= with :reader keeps falsy defined value');
+    is(AttrCombo10->new(x => "val")->x, "val",
+        ':param //= with :reader keeps truthy value');
+}
+
+# :param with ||= and :reader
+{
+    class AttrCombo11 {
+        field $x :param :reader ||= "fallback";
+    }
+
+    is(AttrCombo11->new->x, "fallback",
+        ':param ||= with :reader uses fallback when missing');
+    is(AttrCombo11->new(x => 0)->x, "fallback",
+        ':param ||= with :reader uses fallback when false');
+    is(AttrCombo11->new(x => "val")->x, "val",
+        ':param ||= with :reader keeps truthy value');
+}
+
+# Multiple fields with various attribute combos in same class
+{
+    class AttrCombo12 {
+        field $a :param :reader;
+        field $b :param :reader :writer;
+        field $c :reader = "const";
+        field $d :param(d_init) :reader(get_d) :writer(put_d);
+    }
+
+    my $obj = AttrCombo12->new(a => 1, b => 2, d_init => 4);
+    is($obj->a, 1, 'multi-combo: a via :param :reader');
+    is($obj->b, 2, 'multi-combo: b initial');
+    $obj->set_b(22);
+    is($obj->b, 22, 'multi-combo: b after write');
+    is($obj->c, "const", 'multi-combo: c default with :reader');
+    is($obj->get_d, 4, 'multi-combo: d via custom names');
+    $obj->put_d(44);
+    is($obj->get_d, 44, 'multi-combo: d after custom write');
+}
+
+# Attribute combos across inheritance
+{
+    class AttrComboBase1 {
+        field $x :param :reader;
+        field $y :param :reader :writer;
+    }
+    class AttrComboChild1 :isa(AttrComboBase1) {
+        field $z :param(z_val) :reader(get_z) :writer(put_z);
+    }
+
+    my $obj = AttrComboChild1->new(x => "X", y => "Y", z_val => "Z");
+    is($obj->x, "X", 'inherited :param :reader');
+    is($obj->y, "Y", 'inherited :param :reader :writer read');
+    $obj->set_y("YY");
+    is($obj->y, "YY", 'inherited :writer works in child');
+    is($obj->get_z, "Z", 'child custom :reader');
+    $obj->put_z("ZZ");
+    is($obj->get_z, "ZZ", 'child custom :writer');
+}
+
+# :reader on array field
+{
+    class AttrComboArr1 {
+        field @items :reader = (1, 2, 3);
+    }
+
+    my $obj = AttrComboArr1->new;
+    ok(eq_array([$obj->items], [1, 2, 3]), ':reader on array field');
+    is(scalar $obj->items, 3, ':reader on array field in scalar context');
+}
+
+# :reader on hash field
+{
+    class AttrComboHash1 {
+        field %data :reader = (a => 1, b => 2);
+    }
+
+    my $obj = AttrComboHash1->new;
+    ok(eq_hash({$obj->data}, {a => 1, b => 2}), ':reader on hash field');
+    is(scalar $obj->data, 2, ':reader on hash field in scalar context');
+}
+
+# :param only works on scalar fields (array/hash :param tested in t/lib/croak/class)
+
+# Writer returns the invocant for chaining
+{
+    class AttrComboChain1 {
+        field $a :reader :writer = 0;
+        field $b :reader :writer = 0;
+    }
+
+    my $obj = AttrComboChain1->new;
+    my $ret = $obj->set_a(1)->set_b(2);
+    is($obj->a, 1, 'chained writer: a set');
+    is($obj->b, 2, 'chained writer: b set');
+    is($ret, $obj, 'chained writer: returns same instance');
+}
+
+# :reader returns copies not internal references
+{
+    class AttrComboCopy1 {
+        field $s :reader :writer = "original";
+    }
+
+    my $obj = AttrComboCopy1->new;
+    my $copy = $obj->s;
+    $copy = "mutated";
+    is($obj->s, "original", ':reader returns a copy for scalars');
+}
+
+done_testing;

--- a/t/class/edge_cases.t
+++ b/t/class/edge_cases.t
@@ -1,0 +1,396 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+=pod
+
+Edge cases for the class system: unusual but valid constructions,
+boundary conditions, and corner cases.
+
+=cut
+
+# Empty class (no fields, no methods)
+{
+    class EdgeEmpty1 { }
+
+    my $obj = EdgeEmpty1->new;
+    isa_ok($obj, "EdgeEmpty1");
+    is(ref $obj, "EdgeEmpty1", 'ref of empty class instance');
+}
+
+# Class with only fields, no methods
+{
+    class EdgeFieldsOnly1 {
+        field $x = 1;
+        field $y = 2;
+    }
+
+    my $obj = EdgeFieldsOnly1->new;
+    isa_ok($obj, "EdgeFieldsOnly1");
+    # Fields exist but we have no methods to inspect them
+    pass('Class with only fields can be instantiated');
+}
+
+# Class with only methods, no fields
+{
+    class EdgeMethodsOnly1 {
+        method hello { "hello" }
+        method world { "world" }
+    }
+
+    my $obj = EdgeMethodsOnly1->new;
+    is($obj->hello, "hello", 'Method in fieldless class');
+    is($obj->world, "world", 'Second method in fieldless class');
+}
+
+# Class with only ADJUST, no fields or methods
+{
+    my $adjusted = 0;
+    class EdgeAdjustOnly1 {
+        ADJUST { $adjusted = 1 }
+    }
+
+    EdgeAdjustOnly1->new;
+    is($adjusted, 1, 'ADJUST-only class works');
+}
+
+# Deeply nested package name
+{
+    class A::B::C::D::E {
+        field $x :reader = "deep";
+    }
+
+    is(A::B::C::D::E->new->x, "deep", 'Deeply nested package name class');
+}
+
+# Class with single-character name
+{
+    class X {
+        field $v :reader = "x";
+    }
+
+    is(X->new->v, "x", 'Single-character class name');
+}
+
+# Method returning $self
+{
+    class EdgeSelfReturn1 {
+        field $x :reader :writer = 0;
+
+        method chain_inc {
+            $x++;
+            return $self;
+        }
+    }
+
+    my $obj = EdgeSelfReturn1->new;
+    $obj->chain_inc->chain_inc->chain_inc;
+    is($obj->x, 3, 'Method chaining via $self return');
+}
+
+# Method calling another method on $self
+{
+    class EdgeSelfCall1 {
+        field $x = 10;
+        method get_x { $x }
+        method doubled { $self->get_x * 2 }
+        method describe { "val=" . $self->doubled }
+    }
+
+    is(EdgeSelfCall1->new->describe, "val=20",
+        'Method calling other methods on $self');
+}
+
+# wantarray in methods
+{
+    class EdgeWantarray1 {
+        method context {
+            if (wantarray) { return ("list", "context") }
+            elsif (defined wantarray) { return "scalar" }
+            else { return "void" }
+        }
+    }
+
+    my $obj = EdgeWantarray1->new;
+    my @list = $obj->context;
+    ok(eq_array(\@list, ["list", "context"]), 'wantarray list context in method');
+    my $scalar = $obj->context;
+    is($scalar, "scalar", 'wantarray scalar context in method');
+}
+
+# caller() from a method
+{
+    class EdgeCaller1 {
+        method get_caller { return (caller(0))[3] }
+    }
+
+    like(EdgeCaller1->new->get_caller, qr/EdgeCaller1::get_caller/,
+        'caller() inside method reports correct sub name');
+}
+
+# Redefining inherited method with different behavior
+{
+    class EdgeOverride1 {
+        method greet { "base" }
+        method describe { "base:" . $self->greet }
+    }
+    class EdgeOverride2 :isa(EdgeOverride1) {
+        method greet { "child" }
+    }
+
+    is(EdgeOverride2->new->greet, "child", 'Overridden method');
+    is(EdgeOverride2->new->describe, "base:child",
+        'Base method calls overridden method via $self');
+}
+
+# Virtual dispatch (base method calling overridden method)
+{
+    class EdgeVirtual1 {
+        method type { "base" }
+        method label { "I am " . $self->type }
+    }
+    class EdgeVirtual2 :isa(EdgeVirtual1) {
+        method type { "derived" }
+    }
+
+    is(EdgeVirtual1->new->label, "I am base", 'Virtual dispatch: base');
+    is(EdgeVirtual2->new->label, "I am derived", 'Virtual dispatch: derived');
+}
+
+# Multiple instances of same class are independent
+{
+    class EdgeIndep1 {
+        field $n :param :reader :writer;
+    }
+
+    my $a = EdgeIndep1->new(n => 1);
+    my $b = EdgeIndep1->new(n => 2);
+    my $c = EdgeIndep1->new(n => 3);
+
+    $b->set_n(20);
+    is($a->n, 1, 'Instance a unaffected');
+    is($b->n, 20, 'Instance b modified');
+    is($c->n, 3, 'Instance c unaffected');
+}
+
+# Field with undef default, then set in ADJUST
+{
+    class EdgeUndefAdj1 {
+        field $x;
+        ADJUST { $x = "set-in-adjust" }
+        method x { $x }
+    }
+
+    is(EdgeUndefAdj1->new->x, "set-in-adjust",
+        'Field defaults to undef then set in ADJUST');
+}
+
+# ADJUST can access :param fields
+{
+    class EdgeAdjParam1 {
+        field $x :param;
+        field $computed;
+        ADJUST { $computed = "computed:$x" }
+        method computed { $computed }
+    }
+
+    is(EdgeAdjParam1->new(x => "hello")->computed, "computed:hello",
+        'ADJUST can access :param field');
+}
+
+# ADJUST die is catchable and does not corrupt state
+{
+    class EdgeAdjDie1 {
+        field $x :param = "safe";
+        method x { $x }
+        ADJUST { die "boom\n" if $x eq "bad" }
+    }
+
+    my $good = EdgeAdjDie1->new;
+    is($good->x, "safe", 'Normal construction OK');
+
+    eval { EdgeAdjDie1->new(x => "bad") };
+    is($@, "boom\n", 'ADJUST die is catchable');
+
+    my $after = EdgeAdjDie1->new(x => "after");
+    is($after->x, "after", 'Construction works after ADJUST die');
+}
+
+# Multiple ADJUST blocks, one dies
+{
+    my @trace;
+    class EdgeMultiAdj1 {
+        ADJUST { push @trace, "first" }
+        ADJUST { die "second-boom\n" }
+        ADJUST { push @trace, "third" }  # should not run
+    }
+
+    @trace = ();
+    eval { EdgeMultiAdj1->new };
+    is($@, "second-boom\n", 'Die in middle ADJUST');
+    ok(eq_array(\@trace, ["first"]), 'Only ADJUST blocks before die ran');
+}
+
+# eval {} inside a method
+{
+    class EdgeEvalMethod1 {
+        field $x = 42;
+        method safe_div ($y) {
+            my $result = eval { $x / $y };
+            return defined $result ? $result : "error";
+        }
+    }
+
+    my $obj = EdgeEvalMethod1->new;
+    is($obj->safe_div(2), 21, 'eval in method: success');
+    is($obj->safe_div(0), "error", 'eval in method: catches error');
+}
+
+# die inside a method
+{
+    class EdgeDieMethod1 {
+        method fail { die "method-die\n" }
+    }
+
+    eval { EdgeDieMethod1->new->fail };
+    is($@, "method-die\n", 'die in method is catchable');
+}
+
+# Class with many fields (boundary for field index)
+{
+    my $code = "class EdgeManyFields1 {\n";
+    for my $i (0..99) {
+        $code .= "    field \$f$i = $i;\n";
+    }
+    $code .= "    method sum {\n";
+    $code .= "        return " . join(" + ", map { "\$f$_" } 0..99) . ";\n";
+    $code .= "    }\n";
+    $code .= "}\n";
+    $code .= "1;\n";
+    eval $code or die $@;
+
+    is(EdgeManyFields1->new->sum, 4950, '100 fields in one class');
+}
+
+# Field initialized from previous field
+{
+    class EdgeFieldChain1 {
+        field $a = 1;
+        field $b = $a * 10;
+        field $c = $b * 10;
+        field $d = $c * 10;
+        method d { $d }
+    }
+
+    is(EdgeFieldChain1->new->d, 1000, 'Chained field initialization');
+}
+
+# Field init using complex expression
+{
+    my $call_count = 0;
+
+    class EdgeComplexInit1 {
+        my $counter_ref = \$call_count;
+        field $x = do { $$counter_ref++; 21 * 2 };
+        method x { $x }
+    }
+
+    is(EdgeComplexInit1->new->x, 42, 'Field init with complex expression');
+    is($call_count, 1, 'Expression evaluated once per instance');
+
+    EdgeComplexInit1->new;
+    is($call_count, 2, 'Expression evaluated again for second instance');
+}
+
+# $self is available in ADJUST but not in field init
+# ($self in field init is a compile error, tested in t/lib/croak/class)
+{
+    my $self_in_adjust;
+    class EdgeSelfAdjust1 {
+        ADJUST { $self_in_adjust = ref $self }
+    }
+
+    EdgeSelfAdjust1->new;
+    is($self_in_adjust, "EdgeSelfAdjust1", '$self in ADJUST has correct type');
+}
+
+# Nested class definitions (class inside class block)
+{
+    class EdgeOuter1 {
+        field $x :reader = "outer";
+
+        class EdgeInner1 {
+            field $y :reader = "inner";
+        }
+    }
+
+    is(EdgeOuter1->new->x, "outer", 'Outer of nested class');
+    is(EdgeInner1->new->y, "inner", 'Inner of nested class');
+    ok(!EdgeInner1->isa("EdgeOuter1"), 'Nested class does not inherit outer');
+}
+
+# Nested class inheriting from outer
+{
+    class EdgeOuter2 {
+        field $x :reader = "from-outer";
+
+        class EdgeInner2 :isa(EdgeOuter2) {
+            field $y :reader = "from-inner";
+        }
+    }
+
+    my $obj = EdgeInner2->new;
+    is($obj->x, "from-outer", 'Nested child inherits outer parent field');
+    is($obj->y, "from-inner", 'Nested child has own field');
+    ok($obj isa EdgeOuter2, 'Nested child isa outer');
+}
+
+# Constructor with no params on class with no :param fields
+{
+    class EdgeNoParam1 {
+        field $x = "default";
+        method x { $x }
+    }
+
+    my $obj = EdgeNoParam1->new;
+    is($obj->x, "default", 'Constructor with no params on paramless class');
+
+    # Passing params should fail
+    eval { EdgeNoParam1->new(x => 1) };
+    like($@, qr/Unrecognized parameters/,
+        'Passing params to paramless class fails');
+}
+
+# Object identity
+{
+    class EdgeIdent1 { }
+
+    my $a = EdgeIdent1->new;
+    my $b = EdgeIdent1->new;
+    ok($a != $b, 'Different instances are not numerically equal');
+    my $c = $a;
+    ok($a == $c, 'Same instance is numerically equal');
+}
+
+# Object as hash key (stringification)
+{
+    class EdgeHashKey1 {
+        field $name :param :reader;
+    }
+
+    my $obj = EdgeHashKey1->new(name => "test");
+    my %h;
+    $h{$obj} = "found";
+    is($h{$obj}, "found", 'Object usable as hash key via stringify');
+}
+
+done_testing;

--- a/t/class/errors.t
+++ b/t/class/errors.t
@@ -1,0 +1,342 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+=pod
+
+Tests for error messages and warnings produced by the class system.
+Some error cases are also covered in t/lib/croak/class; this file focuses
+on runtime errors that are better tested via eval and fresh_perl_like.
+
+=cut
+
+# Cannot bless into a class
+{
+    class ErrBless1 { }
+
+    eval { bless {}, "ErrBless1" };
+    like($@, qr/Attempt to bless into a class/,
+        'bless {} into a class is an error');
+
+    eval { bless [], "ErrBless1" };
+    like($@, qr/Attempt to bless into a class/,
+        'bless [] into a class is an error');
+
+    # Cannot re-bless an object into something else
+    my $obj = ErrBless1->new;
+    eval { bless $obj, "main" };
+    like($@, qr/Can't bless an object reference/,
+        'Cannot re-bless a class instance');
+}
+
+# Cannot reopen a sealed class
+{
+    class ErrReopen1 { }
+    ok(!eval q{ class ErrReopen1 { } 1; },
+        'Reopening a sealed class is an error');
+    like($@, qr/Cannot reopen existing class/,
+        'Error message for reopening sealed class');
+}
+
+# @ISA of a class is read-only
+{
+    class ErrISA1 { }
+    eval { push @ErrISA1::ISA, "SomeClass" };
+    like($@, qr/Modification of a read-only value/,
+        'push to @ISA of class fails');
+
+    eval { @ErrISA1::ISA = () };
+    like($@, qr/Modification of a read-only value/,
+        'assignment to @ISA of class fails');
+}
+
+# Cross-class method invocation
+{
+    class ErrCross1 {
+        method x { "x" }
+    }
+    class ErrCross2 {
+        method y { "y" }
+    }
+
+    my $obj1 = ErrCross1->new;
+    eval { $obj1->ErrCross2::y() };
+    like($@, qr/Cannot invoke a method of "ErrCross2" on an instance of "ErrCross1"/,
+        'Cross-class method invocation error');
+}
+
+# Method invoked on non-instance values
+{
+    class ErrNonInst1 {
+        method m { "m" }
+    }
+
+    # No args (bare function call)
+    eval { ErrNonInst1::m() };
+    like($@, qr/Cannot invoke method "m" on a non-instance/,
+        'Method called with no args (not as method)');
+
+    # Non-reference
+    eval { ErrNonInst1::m(42) };
+    like($@, qr/Cannot invoke method "m" on a non-instance/,
+        'Method called with non-ref arg');
+
+    # Unblessed reference
+    eval { ErrNonInst1::m([]) };
+    like($@, qr/Cannot invoke method "m" on a non-instance/,
+        'Method called with unblessed ref');
+}
+
+# Unrecognized constructor parameter
+{
+    class ErrParam1 {
+        field $x :param;
+    }
+
+    eval { ErrParam1->new(x => 1, bogus => 2) };
+    like($@, qr/Unrecognized parameters for "ErrParam1" constructor: bogus/,
+        'Unrecognized parameter in constructor');
+
+    eval { ErrParam1->new(x => 1, bogus => 2, other => 3) };
+    like($@, qr/Unrecognized parameters for "ErrParam1" constructor:/,
+        'Multiple unrecognized parameters in constructor');
+}
+
+# Required parameter missing
+{
+    class ErrReq1 {
+        field $a :param;
+        field $b :param;
+    }
+
+    eval { ErrReq1->new(a => 1) };
+    like($@, qr/Required parameter 'b' is missing for "ErrReq1" constructor/,
+        'Missing required parameter error');
+
+    eval { ErrReq1->new() };
+    like($@, qr/Required parameter '\w+' is missing for "ErrReq1" constructor/,
+        'All required parameters missing');
+}
+
+# Odd number of arguments to constructor
+{
+    class ErrOdd1 {
+        field $x :param = undef;
+    }
+
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+    eval { ErrOdd1->new("lonely") };
+    ok(grep(/Odd/, @warnings), 'Odd number of constructor args produces warning');
+}
+
+# Duplicate :param name within same class
+{
+    ok(!eval q{
+        class ErrDupParam1 {
+            field $x :param(same);
+            field $y :param(same);
+        }
+        1;
+    }, 'Duplicate :param name in same class is an error');
+    like($@, qr/already in use/,
+        'Error mentions name conflict for duplicate :param');
+}
+
+# Duplicate :param name across inheritance
+{
+    ok(!eval q{
+        class ErrDupParamBase1 {
+            field $x :param(shared);
+        }
+        class ErrDupParamChild1 :isa(ErrDupParamBase1) {
+            field $y :param(shared);
+        }
+        1;
+    }, 'Duplicate :param across inheritance is an error');
+    like($@, qr/already in use/,
+        'Error mentions name conflict for inherited :param');
+}
+
+# :writer on non-scalar field
+{
+    ok(!eval q{
+        class ErrWriterArr1 {
+            field @x :writer;
+        }
+        1;
+    }, ':writer on array field is an error');
+    like($@, qr/Cannot apply a :writer attribute to a non-scalar field/,
+        'Error for :writer on array field');
+
+    ok(!eval q{
+        class ErrWriterHash1 {
+            field %x :writer;
+        }
+        1;
+    }, ':writer on hash field is an error');
+    like($@, qr/Cannot apply a :writer attribute to a non-scalar field/,
+        'Error for :writer on hash field');
+}
+
+# Invalid method name for :reader
+{
+    ok(!eval q{
+        class ErrReaderName1 {
+            field $x :reader(not-valid);
+        }
+        1;
+    }, 'Invalid :reader name is an error');
+    like($@, qr/is not a valid name for a generated method/,
+        'Error for invalid :reader name');
+}
+
+# Invalid method name for :writer
+{
+    ok(!eval q{
+        class ErrWriterName1 {
+            field $x :writer(not-valid);
+        }
+        1;
+    }, 'Invalid :writer name is an error');
+    like($@, qr/is not a valid name for a generated method/,
+        'Error for invalid :writer name');
+}
+
+# Cannot create incomplete class object
+{
+    eval q{ class ErrIncomplete1 { } 1; };
+
+    # Force an incomplete class via interrupted compilation
+    eval 'class ErrIncomplete2 {';  # parse error, class left incomplete
+    eval { ErrIncomplete2->new };
+    # Should fail - either "Can't locate object method" or "incomplete class"
+    ok($@, 'Cannot create object of class with failed parse');
+}
+
+# __CLASS__ outside of class context
+{
+    ok(!eval q{
+        class ErrClassToken1 {
+            my $x = __CLASS__;
+        }
+        1;
+    }, '__CLASS__ outside method or field init is an error');
+    like($@, qr/Cannot use __CLASS__ outside of a method or field initializer expression/,
+        'Error message for __CLASS__ in wrong context');
+}
+
+# Field access outside method
+{
+    ok(!eval q{
+        class ErrFieldAccess1 {
+            field $secret;
+            $secret = 123;
+        }
+        1;
+    }, 'Field access outside method is an error');
+    like($@, qr/Field \$secret is not accessible outside a method/,
+        'Error message for field access outside method');
+}
+
+# Field access from a regular sub (not a method)
+{
+    ok(!eval q{
+        class ErrFieldSub1 {
+            field $x;
+            sub peek { return $x }
+        }
+        1;
+    }, 'Field access from sub (not method) is an error');
+    like($@, qr/Field \$x is not accessible outside a method/,
+        'Error for field in sub');
+}
+
+# Field access from nested class
+{
+    ok(!eval q{
+        class ErrFieldNested1 {
+            field $x;
+            class ErrFieldNested2 {
+                method peek { return $x }
+            }
+        }
+        1;
+    }, 'Field access from different class method is an error');
+    like($@, qr/Field \$x of "ErrFieldNested1" is not accessible in a method of "ErrFieldNested2"/,
+        'Error for field access from nested class method');
+}
+
+# Superclass that is not a class
+# (:isa auto-requires, so pre-populate stash and %INC in BEGIN)
+{
+    BEGIN {
+        package ErrNotAClass1;
+        sub hello { 1 }
+        $INC{"ErrNotAClass1.pm"} = 1;
+    }
+
+    ok(!eval q{
+        class ErrIsaNotClass1 :isa(ErrNotAClass1) { }
+        1;
+    }, ':isa with non-class package is an error');
+    like($@, qr/requires a class but "ErrNotAClass1" is not one/,
+        'Error for :isa with non-class');
+}
+
+# Class already has a superclass
+{
+    class ErrMultiIsa1 { }
+    class ErrMultiIsa2 { }
+
+    ok(!eval q{
+        class ErrMultiIsaChild1 :isa(ErrMultiIsa1) :isa(ErrMultiIsa2) { }
+        1;
+    }, 'Multiple :isa attributes is an error');
+    like($@, qr/Class already has a superclass/,
+        'Error for multiple :isa');
+}
+
+# Unrecognized class attribute
+{
+    ok(!eval q{
+        class ErrBadAttr1 :bogus { }
+        1;
+    }, 'Unrecognized class attribute is an error');
+    like($@, qr/Unrecognized class attribute/,
+        'Error for unrecognized class attribute');
+}
+
+# Unrecognized field attribute
+{
+    ok(!eval q{
+        class ErrBadFieldAttr1 {
+            field $x :bogus;
+        }
+        1;
+    }, 'Unrecognized field attribute is an error');
+    like($@, qr/Unrecognized field attribute/,
+        'Error for unrecognized field attribute');
+}
+
+# Pre-existing @ISA prevents class creation
+{
+    BEGIN { @ErrPreISA1::ISA = ("Something"); }
+    ok(!eval q{
+        class ErrPreISA1 { }
+        1;
+    }, 'Class with pre-existing @ISA is an error');
+    like($@, qr/already has a non-empty \@ISA/,
+        'Error for pre-existing @ISA');
+}
+
+done_testing;

--- a/t/class/interop.t
+++ b/t/class/interop.t
@@ -1,0 +1,408 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings qw( experimental::class experimental::builtin );
+
+use builtin qw( blessed reftype refaddr );
+use Scalar::Util qw( weaken isvstring looks_like_number );
+
+=pod
+
+Tests for interoperability between the class system and traditional
+Perl OO, builtins, and common idioms.
+
+=cut
+
+# ============================================================
+# blessed(), ref(), reftype(), refaddr() on class instances
+# ============================================================
+
+{
+    class Interop1 {
+        field $x :param :reader;
+    }
+
+    my $obj = Interop1->new(x => 42);
+    is(ref $obj, "Interop1", 'ref() on class instance');
+    is(blessed $obj, "Interop1", 'blessed() on class instance');
+    is(reftype $obj, "OBJECT", 'reftype() is OBJECT');
+    ok(refaddr($obj) > 0, 'refaddr() returns positive integer');
+}
+
+# ============================================================
+# isa() - both method and function forms
+# ============================================================
+
+{
+    class InteropIsaBase1 { }
+    class InteropIsaChild1 :isa(InteropIsaBase1) { }
+    class InteropIsaGC1 :isa(InteropIsaChild1) { }
+
+    my $obj = InteropIsaGC1->new;
+
+    # Method form
+    ok($obj->isa("InteropIsaGC1"), 'isa own class');
+    ok($obj->isa("InteropIsaChild1"), 'isa parent');
+    ok($obj->isa("InteropIsaBase1"), 'isa grandparent');
+    ok(!$obj->isa("Nonexistent"), 'not isa random class');
+
+    # `isa` operator (v5.36)
+    ok($obj isa InteropIsaGC1, 'isa operator: own class');
+    ok($obj isa InteropIsaBase1, 'isa operator: grandparent');
+    ok(!($obj isa Nonexistent::Class), 'isa operator: false for random');
+
+    # UNIVERSAL::isa function form
+    ok(UNIVERSAL::isa($obj, "InteropIsaBase1"),
+        'UNIVERSAL::isa function form');
+}
+
+# ============================================================
+# DOES()
+# ============================================================
+
+{
+    class InteropDoes1 { }
+    class InteropDoes2 :isa(InteropDoes1) { }
+
+    my $obj = InteropDoes2->new;
+    ok($obj->DOES("InteropDoes2"), 'DOES own class');
+    ok($obj->DOES("InteropDoes1"), 'DOES parent class');
+    ok(!$obj->DOES("Something::Else"), 'DOES false for random class');
+}
+
+# ============================================================
+# can()
+# ============================================================
+
+{
+    class InteropCan1 {
+        field $x :reader = 1;
+        method foo { "foo" }
+    }
+    class InteropCan2 :isa(InteropCan1) {
+        method bar { "bar" }
+    }
+
+    my $obj = InteropCan2->new;
+    ok($obj->can("foo"), 'can("foo") inherited method');
+    ok($obj->can("bar"), 'can("bar") own method');
+    ok($obj->can("x"), 'can("x") reader accessor');
+    ok($obj->can("new"), 'can("new") constructor');
+    ok(!$obj->can("nonexistent_xyz"), 'can() false for missing method');
+
+    # can() returns a code ref
+    my $cref = $obj->can("foo");
+    is(ref $cref, "CODE", 'can() returns CODE ref');
+}
+
+# ============================================================
+# Stringification and numification
+# ============================================================
+
+{
+    class InteropStr1 { }
+
+    my $obj = InteropStr1->new;
+
+    # Default stringification
+    like("$obj", qr/^InteropStr1=OBJECT\(0x[0-9a-f]+\)$/i,
+        'Default stringification format');
+
+    # Default numification (refaddr)
+    is($obj + 0, refaddr($obj), 'Default numification is refaddr');
+}
+
+# Custom overloaded stringification
+{
+    class InteropStr2 {
+        field $name :param :reader;
+        use overload
+            '""' => sub { "InteropStr2<" . $_[0]->name . ">" },
+            fallback => 1;
+    }
+
+    my $obj = InteropStr2->new(name => "test");
+    is("$obj", "InteropStr2<test>", 'Overloaded stringify');
+}
+
+# ============================================================
+# Comparison operators
+# ============================================================
+
+{
+    class InteropCmp1 { }
+
+    my $a = InteropCmp1->new;
+    my $b = InteropCmp1->new;
+    my $c = $a;
+
+    ok($a == $c, '== on same instance');
+    ok($a != $b, '!= on different instances');
+    ok(!($a == $b), '== false on different instances');
+}
+
+# ============================================================
+# Class instances passed to traditional Perl code
+# ============================================================
+
+{
+    class InteropPass1 {
+        field $value :param :reader;
+    }
+
+    # Passing to a sub that expects blessed refs
+    sub legacy_handler {
+        my ($obj) = @_;
+        return blessed($obj) . ":" . $obj->value;
+    }
+
+    my $obj = InteropPass1->new(value => "data");
+    is(legacy_handler($obj), "InteropPass1:data",
+        'Class instance works with legacy code expecting blessed refs');
+}
+
+# ============================================================
+# Class instances in data structures
+# ============================================================
+
+{
+    class InteropDS1 {
+        field $id :param :reader;
+    }
+
+    # In arrays
+    my @objs = map { InteropDS1->new(id => $_) } 1..5;
+    is(scalar @objs, 5, 'Objects in array');
+    is($objs[2]->id, 3, 'Array element method call');
+
+    # In hashes
+    my %map = map { ("k$_" => InteropDS1->new(id => $_)) } 1..3;
+    is($map{k2}->id, 2, 'Hash value method call');
+
+    # Sorting
+    my @sorted = sort { $b->id <=> $a->id } @objs;
+    is($sorted[0]->id, 5, 'Sorted objects: first');
+    is($sorted[4]->id, 1, 'Sorted objects: last');
+
+    # grep/map
+    my @even = grep { $_->id % 2 == 0 } @objs;
+    is(scalar @even, 2, 'grep on objects');
+    my @doubled = map { $_->id * 2 } @objs;
+    ok(eq_array(\@doubled, [2, 4, 6, 8, 10]), 'map on objects');
+}
+
+# ============================================================
+# Class instance as argument to builtin functions
+# ============================================================
+
+{
+    class InteropBuiltin1 {
+        field $x :reader = "test";
+    }
+
+    my $obj = InteropBuiltin1->new;
+
+    # defined
+    ok(defined $obj, 'defined on object');
+
+    # ref
+    is(ref $obj, "InteropBuiltin1", 'ref on object');
+
+    # Array/hash of objects with scalar()
+    my @arr = ($obj, $obj);
+    is(scalar @arr, 2, 'scalar on array of objects');
+}
+
+# ============================================================
+# Interaction with eval/die
+# ============================================================
+
+{
+    class InteropEval1 {
+        field $x :param :reader;
+        method fail { die "InteropEval1 error\n" }
+    }
+
+    my $obj = InteropEval1->new(x => "safe");
+    eval { $obj->fail };
+    is($@, "InteropEval1 error\n", 'die from method caught by eval');
+    is($obj->x, "safe", 'Object still usable after caught die');
+
+    # Object as die argument
+    eval { die $obj };
+    is(ref $@, "InteropEval1", 'Object thrown as exception');
+    is($@->x, "safe", 'Thrown object retains fields');
+}
+
+# ============================================================
+# Interaction with local()
+# ============================================================
+
+{
+    class InteropLocal1 {
+        field $x :reader = "default";
+    }
+
+    our $global_obj = InteropLocal1->new;
+    is($global_obj->x, "default", 'Global object before local');
+
+    {
+        local $global_obj = InteropLocal1->new;
+        is($global_obj->x, "default", 'Localized object');
+    }
+    is($global_obj->x, "default", 'Global object restored after local');
+}
+
+# ============================================================
+# Class object with Scalar::Util functions
+# ============================================================
+
+{
+    class InteropSU1 {
+        field $x :reader = 42;
+    }
+
+    my $obj = InteropSU1->new;
+
+    # weaken
+    my $weak = $obj;
+    weaken($weak);
+    ok(defined $weak, 'weaken: ref alive');
+    undef $obj;
+    ok(!defined $weak, 'weaken: ref cleared');
+}
+
+# ============================================================
+# Class with traditional Perl OO in same program
+# ============================================================
+
+{
+    package LegacyOO1 {
+        sub new {
+            my ($class, %args) = @_;
+            return bless \%args, $class;
+        }
+        sub value { return $_[0]->{value} }
+    }
+
+    class ModernOO1 {
+        field $value :param :reader;
+    }
+
+    my $legacy = LegacyOO1->new(value => "old");
+    my $modern = ModernOO1->new(value => "new");
+
+    is($legacy->value, "old", 'Legacy OO works');
+    is($modern->value, "new", 'Modern class works');
+    is(ref $legacy, "LegacyOO1", 'Legacy ref type');
+    is(ref $modern, "ModernOO1", 'Modern ref type');
+    is(reftype $legacy, "HASH", 'Legacy reftype is HASH');
+    is(reftype $modern, "OBJECT", 'Modern reftype is OBJECT');
+}
+
+# ============================================================
+# Class inheriting from traditional OO is NOT supported
+# (traditional packages are not classes)
+# ============================================================
+
+{
+    BEGIN {
+        package LegacyBase1;
+        sub new { bless {}, shift }
+        sub legacy_method { "legacy" }
+        $INC{"LegacyBase1.pm"} = 1;
+    }
+
+    # :isa requires a class, not a regular package
+    ok(!eval q{
+        class HybridChild1 :isa(LegacyBase1) {
+            field $x :reader = "modern";
+        }
+        1;
+    }, 'Cannot :isa from traditional package');
+    like($@, qr/requires a class.*is not one/,
+        'Error: :isa target must be a class');
+}
+
+# ============================================================
+# Multiple dispatch: method resolution order
+# ============================================================
+
+{
+    class InteropMRO1 {
+        method m { "base" }
+    }
+    class InteropMRO2 :isa(InteropMRO1) {
+        method m { "child" }
+    }
+    class InteropMRO3 :isa(InteropMRO2) { }  # inherits m from MRO2
+
+    is(InteropMRO1->new->m, "base", 'MRO: base');
+    is(InteropMRO2->new->m, "child", 'MRO: override');
+    is(InteropMRO3->new->m, "child", 'MRO: grandchild inherits override');
+}
+
+# ============================================================
+# Interaction with for/foreach
+# ============================================================
+
+{
+    class InteropFor1 {
+        field $n :param :reader;
+    }
+
+    my @objs = map { InteropFor1->new(n => $_) } 1..3;
+    my @collected;
+    for my $obj (@objs) {
+        push @collected, $obj->n;
+    }
+    ok(eq_array(\@collected, [1, 2, 3]), 'for loop over objects');
+
+    # C-style for
+    my $sum = 0;
+    for (my $i = 0; $i < @objs; $i++) {
+        $sum += $objs[$i]->n;
+    }
+    is($sum, 6, 'C-style for with objects');
+}
+
+# ============================================================
+# Object in boolean context
+# ============================================================
+
+{
+    class InteropBool1 { }
+
+    my $obj = InteropBool1->new;
+    ok($obj, 'Object is true in boolean context');
+    ok(!!$obj, 'Double-negated object is true');
+
+    if ($obj) {
+        pass('Object in if condition is true');
+    } else {
+        fail('Object in if condition should be true');
+    }
+}
+
+# ============================================================
+# sprintf/printf with objects
+# ============================================================
+
+{
+    class InteropSprintf1 {
+        use overload '""' => sub { "custom-string" }, fallback => 1;
+    }
+
+    my $obj = InteropSprintf1->new;
+    is(sprintf("%s", $obj), "custom-string", 'sprintf %s with overloaded object');
+}
+
+done_testing;

--- a/t/class/lifecycle.t
+++ b/t/class/lifecycle.t
@@ -1,0 +1,412 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+use Scalar::Util 'weaken';
+
+=pod
+
+Tests for object lifecycle: construction ordering, ADJUST and field init
+ordering across inheritance, DESTROY ordering, weak references, and
+cleanup behavior.
+
+=cut
+
+# A legacy-perl class helper to track destruction
+package LifeDestructNotify {
+    sub new { my $pkg = shift; bless [ @_ ], $pkg }
+    sub DESTROY { my $self = shift; ${ $self->[0] } .= $self->[1] }
+}
+
+# ============================================================
+# Construction order: field inits then ADJUST, base before child
+# ============================================================
+
+{
+    my @trace;
+
+    class LifeOrderBase1 {
+        field $x = do { push @trace, "base-field-init"; "bx" };
+        ADJUST { push @trace, "base-adjust" }
+    }
+    class LifeOrderChild1 :isa(LifeOrderBase1) {
+        field $y = do { push @trace, "child-field-init"; "cy" };
+        ADJUST { push @trace, "child-adjust" }
+    }
+
+    @trace = ();
+    LifeOrderChild1->new;
+    ok(eq_array(\@trace, [
+        "base-field-init",
+        "child-field-init",
+        "base-adjust",
+        "child-adjust",
+    ]), 'Construction order: all field inits (base then child), then all ADJUSTs (base then child)');
+}
+
+# 3-level construction order
+{
+    my @trace;
+
+    class LifeOrder3Base {
+        field $x = do { push @trace, "L1-field"; 1 };
+        ADJUST { push @trace, "L1-adjust" }
+    }
+    class LifeOrder3Mid :isa(LifeOrder3Base) {
+        field $y = do { push @trace, "L2-field"; 2 };
+        ADJUST { push @trace, "L2-adjust" }
+    }
+    class LifeOrder3Leaf :isa(LifeOrder3Mid) {
+        field $z = do { push @trace, "L3-field"; 3 };
+        ADJUST { push @trace, "L3-adjust" }
+    }
+
+    @trace = ();
+    LifeOrder3Leaf->new;
+    ok(eq_array(\@trace, [
+        "L1-field",
+        "L2-field",
+        "L3-field",
+        "L1-adjust",
+        "L2-adjust",
+        "L3-adjust",
+    ]), '3-level construction order: all fields then all ADJUSTs');
+}
+
+# Multiple ADJUST blocks per level
+{
+    my @trace;
+
+    class LifeMultiAdjBase {
+        ADJUST { push @trace, "b1" }
+        ADJUST { push @trace, "b2" }
+    }
+    class LifeMultiAdjChild :isa(LifeMultiAdjBase) {
+        ADJUST { push @trace, "c1" }
+        ADJUST { push @trace, "c2" }
+        ADJUST { push @trace, "c3" }
+    }
+
+    @trace = ();
+    LifeMultiAdjChild->new;
+    ok(eq_array(\@trace, ["b1", "b2", "c1", "c2", "c3"]),
+        'Multiple ADJUST blocks per level fire in order');
+}
+
+# ============================================================
+# DESTROY ordering across inheritance
+# ============================================================
+
+{
+    my @destroyed;
+
+    class LifeDestrBase1 {
+        field $name :param;
+        method DESTROY { push @destroyed, "base:$name" }
+    }
+    class LifeDestrChild1 :isa(LifeDestrBase1) {
+        field $tag :param;
+        method DESTROY {
+            push @destroyed, "child:$tag";
+            $self->SUPER::DESTROY();
+        }
+    }
+    class LifeDestrGC1 :isa(LifeDestrChild1) {
+        field $label :param;
+        method DESTROY {
+            push @destroyed, "gc:$label";
+            $self->SUPER::DESTROY();
+        }
+    }
+
+    @destroyed = ();
+    {
+        my $obj = LifeDestrGC1->new(name => "n", tag => "t", label => "l");
+    }
+    ok(eq_array(\@destroyed, ["gc:l", "child:t", "base:n"]),
+        'DESTROY chain fires gc -> child -> base');
+}
+
+# DESTROY can access fields
+{
+    my $field_in_destroy;
+
+    class LifeDestrField1 {
+        field $x :param;
+        method DESTROY { $field_in_destroy = $x }
+    }
+
+    {
+        my $obj = LifeDestrField1->new(x => "still-here");
+    }
+    is($field_in_destroy, "still-here", 'DESTROY can read field values');
+}
+
+# Field destruction order (fields destroyed in reverse order)
+{
+    my $order = "";
+
+    class LifeFieldDestr1 {
+        field $a;
+        field $b;
+        field $c;
+        ADJUST {
+            $a = LifeDestructNotify->new(\$order, "a");
+            $b = LifeDestructNotify->new(\$order, "b");
+            $c = LifeDestructNotify->new(\$order, "c");
+        }
+    }
+
+    {
+        my $obj = LifeFieldDestr1->new;
+    }
+    is($order, "cba", 'Fields destroyed in reverse declaration order');
+}
+
+# Field destruction order across inheritance
+{
+    my $order = "";
+
+    class LifeFieldDestrBase2 {
+        field $bx;
+        field $by;
+        ADJUST {
+            $bx = LifeDestructNotify->new(\$order, "bx");
+            $by = LifeDestructNotify->new(\$order, "by");
+        }
+    }
+    class LifeFieldDestrChild2 :isa(LifeFieldDestrBase2) {
+        field $cx;
+        field $cy;
+        ADJUST {
+            $cx = LifeDestructNotify->new(\$order, "cx");
+            $cy = LifeDestructNotify->new(\$order, "cy");
+        }
+    }
+
+    {
+        my $obj = LifeFieldDestrChild2->new;
+    }
+    is($order, "cycxbybx",
+        'Fields destroyed: child reverse, then base reverse');
+}
+
+# ============================================================
+# Weak references
+# ============================================================
+
+{
+    class LifeWeak1 {
+        field $x :param :reader;
+    }
+
+    my $strong = LifeWeak1->new(x => "alive");
+    my $weak = $strong;
+    weaken($weak);
+
+    ok(defined $weak, 'Weakref alive with strong ref');
+    is($weak->x, "alive", 'Weakref can call methods');
+
+    undef $strong;
+    ok(!defined $weak, 'Weakref cleared after strong ref gone');
+}
+
+# Weak ref in field (preventing circular leak)
+{
+    class LifeWeakField1 {
+        field $partner;
+        field $name :param :reader;
+
+        method set_partner { $partner = $_[0] }
+        method partner_name {
+            defined $partner ? $partner->name : "none"
+        }
+    }
+
+    my $a = LifeWeakField1->new(name => "A");
+    my $b = LifeWeakField1->new(name => "B");
+
+    $a->set_partner($b);
+    $b->set_partner($a);
+
+    is($a->partner_name, "B", 'Circular ref: A sees B');
+    is($b->partner_name, "A", 'Circular ref: B sees A');
+
+    # Use weak ref to break cycle
+    weaken($a->{partner}) if 0;  # can't access fields directly; use ADJUST approach
+
+    # Just verify cleanup does not segfault
+    $a->set_partner(undef);
+    $b->set_partner(undef);
+    pass('Circular reference cleanup OK');
+}
+
+# Weak ref across inheritance
+{
+    class LifeWeakBase2 {
+        field $v :param :reader;
+    }
+    class LifeWeakChild2 :isa(LifeWeakBase2) {
+        field $extra :param :reader;
+    }
+
+    my $obj = LifeWeakChild2->new(v => "base-val", extra => "child-val");
+    my $weak = $obj;
+    weaken($weak);
+
+    is($weak->v, "base-val", 'Weakref to child: base field');
+    is($weak->extra, "child-val", 'Weakref to child: child field');
+
+    undef $obj;
+    ok(!defined $weak, 'Weakref to child cleared');
+}
+
+# ============================================================
+# Destruction during error (constructor failure)
+# ============================================================
+
+{
+    my $destroyed_field;
+
+    class LifeErrDestr1 {
+        field $f1 :param :reader;
+        field $f2 :param;
+
+        method DESTROY { $destroyed_field = $f1 }
+    }
+
+    # f2 is required but missing -> constructor dies after f1 is set
+    eval { LifeErrDestr1->new(f1 => "was-set") };
+    like($@, qr/Required parameter 'f2' is missing/,
+        'Constructor dies for missing param');
+    is($destroyed_field, "was-set",
+        'DESTROY fires on partial object, earlier field accessible');
+}
+
+# ADJUST die triggers DESTROY
+{
+    my @trace;
+
+    class LifeAdjDestr1 {
+        field $name :param;
+        ADJUST { die "adj-fail\n" if $name eq "fail" }
+        method DESTROY { push @trace, "destroyed:$name" }
+    }
+
+    @trace = ();
+    eval { LifeAdjDestr1->new(name => "fail") };
+    is($@, "adj-fail\n", 'ADJUST die is caught');
+    ok(grep(/destroyed:fail/, @trace), 'DESTROY fires after ADJUST die');
+}
+
+# ============================================================
+# Refcount verification
+# ============================================================
+
+{
+    class LifeRefcount1 {
+        field $x :param;
+    }
+
+    my $obj = LifeRefcount1->new(x => 1);
+    refcount_is $obj, 1, 'Fresh object has refcount 1';
+
+    my $ref2 = $obj;
+    refcount_is $obj, 2, 'Object with two refs has refcount 2';
+
+    undef $ref2;
+    refcount_is $obj, 1, 'Back to refcount 1 after undef';
+}
+
+# ============================================================
+# Objects in arrays and hashes
+# ============================================================
+
+{
+    class LifeContainer1 {
+        field $id :param :reader;
+    }
+
+    my @arr;
+    for my $i (1..5) {
+        push @arr, LifeContainer1->new(id => $i);
+    }
+    is(scalar @arr, 5, '5 objects in array');
+    is($arr[0]->id, 1, 'First object');
+    is($arr[4]->id, 5, 'Last object');
+
+    my %hash;
+    for my $i (1..3) {
+        $hash{"obj$i"} = LifeContainer1->new(id => $i * 10);
+    }
+    is($hash{obj2}->id, 20, 'Object in hash');
+}
+
+# Objects destroyed when container is cleared
+{
+    my $destroyed = 0;
+
+    class LifeContainerDestr1 {
+        method DESTROY { $destroyed++ }
+    }
+
+    my @arr = map { LifeContainerDestr1->new } 1..5;
+    is($destroyed, 0, 'No destruction yet');
+    @arr = ();
+    is($destroyed, 5, 'All 5 objects destroyed when array cleared');
+}
+
+# ============================================================
+# Rapid lifecycle stress
+# ============================================================
+
+{
+    class LifeStress1 {
+        field $id :param;
+        field $data = "x" x 100;
+        method id { $id }
+    }
+
+    my $ok = 1;
+    for my $i (1..2000) {
+        my $obj = LifeStress1->new(id => $i);
+        if ($obj->id != $i) {
+            $ok = 0;
+            last;
+        }
+    }
+    ok($ok, '2000 rapid create/destroy cycles');
+}
+
+# Rapid lifecycle with inheritance
+{
+    class LifeStressBase2 {
+        field $x :param;
+        method x { $x }
+    }
+    class LifeStressChild2 :isa(LifeStressBase2) {
+        field $y :param;
+        method y { $y }
+    }
+
+    my $ok = 1;
+    for my $i (1..1000) {
+        my $obj = LifeStressChild2->new(x => $i, y => $i * 2);
+        if ($obj->x != $i || $obj->y != $i * 2) {
+            $ok = 0;
+            last;
+        }
+    }
+    ok($ok, '1000 rapid create/destroy cycles with inheritance');
+}
+
+done_testing;

--- a/t/class/module.t
+++ b/t/class/module.t
@@ -1,0 +1,250 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+=pod
+
+Tests for class interaction with the module/require system.
+
+=cut
+
+# Class in a require'd file (already tested for :isa auto-loading in inherit.t,
+# but here we test broader module integration)
+{
+    use lib 'lib/class';
+    ok(eval { require A::B; 1 }, 'can require a class module')
+        or diag("Error: $@");
+    my $obj = A::B->new;
+    isa_ok($obj, "A::B", 'required class module creates objects');
+}
+
+# Multiple classes defined in a single eval (simulating one file)
+{
+    eval q{
+        class ModMulti1 {
+            field $x :reader = "one";
+        }
+        class ModMulti2 {
+            field $y :reader = "two";
+        }
+        1;
+    } or die $@;
+
+    is(ModMulti1->new->x, "one", 'First class from multi-class eval');
+    is(ModMulti2->new->y, "two", 'Second class from multi-class eval');
+}
+
+# Class with regular subs alongside methods
+{
+    class ModMixed1 {
+        my $counter = 0;
+
+        sub class_method { return "class_method" }
+        sub increment { $counter++ }
+        sub get_count { $counter }
+
+        field $x :param :reader;
+
+        method describe { "ModMixed1($x)" }
+    }
+
+    is(ModMixed1::class_method(), "class_method",
+        'Regular sub in class is callable');
+    ModMixed1::increment();
+    ModMixed1::increment();
+    is(ModMixed1::get_count(), 2, 'Regular sub shares class lexicals');
+
+    my $obj = ModMixed1->new(x => "test");
+    is($obj->describe, "ModMixed1(test)", 'Method works alongside subs');
+}
+
+# Class with use constant
+{
+    class ModConst1 {
+        use constant PI => 3.14159;
+        use constant NAME => "ModConst1";
+
+        field $radius :param :reader;
+        method area { PI * $radius * $radius }
+    }
+
+    is(ModConst1::PI, 3.14159, 'use constant in class');
+    is(ModConst1::NAME, "ModConst1", 'use constant for name in class');
+    my $obj = ModConst1->new(radius => 10);
+    # Just check it computes without dying
+    ok($obj->area > 314 && $obj->area < 315, 'method using constant works');
+}
+
+# Class with use overload
+{
+    class ModOverload1 {
+        field $value :param :reader;
+
+        use overload
+            '""' => sub { "ModOverload1(" . $_[0]->value . ")" },
+            '0+' => sub { $_[0]->value },
+            '==' => sub { $_[0]->value == (ref $_[1] ? $_[1]->value : $_[1]) },
+            fallback => 1;
+    }
+
+    my $obj = ModOverload1->new(value => 42);
+    is("$obj", "ModOverload1(42)", 'overloaded stringify');
+    is($obj + 0, 42, 'overloaded numify');
+    ok($obj == 42, 'overloaded == with scalar');
+
+    my $obj2 = ModOverload1->new(value => 42);
+    ok($obj == $obj2, 'overloaded == with another object');
+}
+
+# Class package variables coexist with fields
+{
+    class ModPkgVar1 {
+        our $CLASS_VAR = "shared";
+        our @CLASS_LIST = (1, 2, 3);
+        our %CLASS_MAP = (a => 1);
+
+        field $instance :param :reader;
+
+        method combined { "$CLASS_VAR:$instance" }
+    }
+
+    is($ModPkgVar1::CLASS_VAR, "shared", 'our variable in class');
+    ok(eq_array(\@ModPkgVar1::CLASS_LIST, [1, 2, 3]), 'our array in class');
+    ok(eq_hash(\%ModPkgVar1::CLASS_MAP, {a => 1}), 'our hash in class');
+
+    my $obj = ModPkgVar1->new(instance => "inst");
+    is($obj->combined, "shared:inst", 'method accesses both our and field');
+}
+
+# Class in eval across separate compilation units with use
+fresh_perl_is(<<'CODE', "hello 42\n", {}, 'Class defined in eval, used in another eval');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+eval q{
+    class EvalMod1 {
+        field $msg :param;
+        field $num :param;
+        method describe { "$msg $num" }
+    }
+    1;
+} or die $@;
+eval q{
+    print EvalMod1->new(msg => "hello", num => 42)->describe, "\n";
+    1;
+} or die $@;
+CODE
+
+# Class in BEGIN block is available at runtime
+fresh_perl_is(<<'CODE', "works\n", {}, 'Class in BEGIN is available at runtime');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+BEGIN {
+    eval q{
+        class BeginMod1 {
+            field $x :reader = "works";
+        }
+        1;
+    } or die $@;
+}
+print BeginMod1->new->x, "\n";
+CODE
+
+# Nested classes in same package hierarchy
+{
+    class ModNest1 {
+        field $x :reader = "outer";
+    }
+    class ModNest1::Inner {
+        field $y :reader = "inner";
+    }
+    class ModNest1::Inner::Deep {
+        field $z :reader = "deep";
+    }
+
+    is(ModNest1->new->x, "outer", 'Outer class of nested hierarchy');
+    is(ModNest1::Inner->new->y, "inner", 'Inner class of nested hierarchy');
+    is(ModNest1::Inner::Deep->new->z, "deep", 'Deeply nested class');
+}
+
+# Class with Exporter-like functionality via regular subs
+{
+    class ModExportLike1 {
+        my @exports;
+
+        sub import {
+            my ($class, @syms) = @_;
+            # Just verify import is called
+            push @exports, @syms;
+        }
+
+        sub exported { return \@exports }
+
+        field $x :reader = "instance";
+    }
+
+    # Simulate what 'use' would do
+    ModExportLike1->import("foo", "bar");
+    ok(eq_array(ModExportLike1::exported(), ["foo", "bar"]),
+        'import sub in class works');
+
+    my $obj = ModExportLike1->new;
+    is($obj->x, "instance", 'class still works as a class after import');
+}
+
+# AUTOLOAD does not interfere with class methods
+{
+    class ModAutoload1 {
+        field $x :reader = "real";
+
+        sub AUTOLOAD {
+            our $AUTOLOAD;
+            return "auto:$AUTOLOAD";
+        }
+    }
+
+    my $obj = ModAutoload1->new;
+    is($obj->x, "real", 'Real method called, not AUTOLOAD');
+    is($obj->nonexistent, "auto:ModAutoload1::nonexistent",
+        'AUTOLOAD works for missing methods');
+}
+
+# isa() and DOES() on class instances
+{
+    class ModIsa1 { }
+    class ModIsa2 :isa(ModIsa1) { }
+
+    my $obj = ModIsa2->new;
+    ok($obj->isa("ModIsa2"), '$obj->isa own class');
+    ok($obj->isa("ModIsa1"), '$obj->isa parent class');
+    ok($obj->isa("UNIVERSAL"), '$obj->isa UNIVERSAL (all objects do)');
+
+    ok($obj->DOES("ModIsa2"), '$obj->DOES own class');
+    ok($obj->DOES("ModIsa1"), '$obj->DOES parent class');
+
+    ok($obj->can("new"), '$obj->can("new")');
+    ok(!$obj->can("nonexistent_method_xyz"), '$obj->can returns false for missing');
+}
+
+# Class interacting with regular Perl BEGIN/END blocks
+fresh_perl_is(<<'CODE', "begin adjust\n", {}, 'BEGIN and ADJUST blocks coexist in class');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+my @order;
+class ModPhase1 {
+    BEGIN { push @order, "begin" }
+    ADJUST { push @order, "adjust" }
+}
+ModPhase1->new;
+print join(" ", @order), "\n";
+CODE
+
+done_testing;

--- a/t/class/stress.t
+++ b/t/class/stress.t
@@ -1,0 +1,942 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+    require Config;
+}
+
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+
+=pod
+
+Stress tests for the Perl class system, focusing on:
+- Seal ordering with unit-syntax and block-syntax classes
+- Field index correctness across inheritance chains
+- Pathological combinations of fields, :param, :reader, :writer, ADJUST
+- Edge cases that have historically caused segfaults (GH#20890, GH#21221)
+
+These tests use fresh_perl_is/fresh_perl_like where a segfault is plausible,
+so a crash doesn't take down the test harness.
+
+=cut
+
+# ============================================================
+# GH#20890 / GH#21221: seal ordering with unit-syntax classes
+# ============================================================
+
+# GH#21221: empty base class, both unit syntax
+fresh_perl_is(<<'CODE', "ok\n", {}, 'Empty unit-syntax base and child (GH#21221)');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{ class Animal; class Dog :isa(Animal); }
+print "ok\n";
+CODE
+
+# GH#20890: unit-syntax base with fields, unit-syntax child
+fresh_perl_is(<<'CODE', "42\n", {}, 'Unit-syntax base with field, unit-syntax child inherits');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class UBase;
+    field $x = 42;
+    method x { return $x }
+    class UChild :isa(UBase);
+}
+print UChild->new->x, "\n";
+CODE
+
+# Block-scoped subclass defined inside base class body
+fresh_perl_is(<<'CODE', "10 20\n", {}, 'Block-scoped child inside base class body');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+class Outer {
+    field $x = 10;
+    method x { $x }
+    class Inner :isa(Outer) {
+        field $y = 20;
+        method y { $y }
+    }
+}
+my $obj = Inner->new;
+print $obj->x, " ", $obj->y, "\n";
+CODE
+
+# Multiple subclasses of the same unsealed base
+fresh_perl_is(<<'CODE', "b b b\n", {}, 'Multiple subclasses of same unit-syntax base');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class MBase;
+    field $v = "b";
+    method v { $v }
+    class MSub1 :isa(MBase);
+    class MSub2 :isa(MBase);
+    class MSub3 :isa(MBase);
+}
+print MSub1->new->v, " ", MSub2->new->v, " ", MSub3->new->v, "\n";
+CODE
+
+# Mixed unit/block syntax with shared base
+fresh_perl_is(<<'CODE', "a b a c\n", {}, 'Mixed unit/block siblings sharing unit-syntax base');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class MixBase;
+    field $a = "a";
+    method a { $a }
+
+    class MixBlock :isa(MixBase) {
+        field $b = "b";
+        method b { $b }
+    }
+
+    class MixUnit :isa(MixBase);
+    field $c = "c";
+    method c { $c }
+}
+print MixBlock->new->a, " ", MixBlock->new->b, " ",
+      MixUnit->new->a, " ", MixUnit->new->c, "\n";
+CODE
+
+# Alternating unit/block syntax in a chain
+fresh_perl_is(<<'CODE', "u b u\n", {}, 'Alternating unit/block/unit inheritance chain');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class AltBase;
+    field $u1 = "u";
+    method u1 { $u1 }
+
+    class AltBlock :isa(AltBase) {
+        field $b = "b";
+        method b { $b }
+    }
+
+    class AltUnit :isa(AltBlock);
+    field $u2 = "u";
+    method u2 { $u2 }
+}
+my $obj = AltUnit->new;
+print $obj->u1, " ", $obj->b, " ", $obj->u2, "\n";
+CODE
+
+# ============================================================
+# Deep inheritance chains (stress field index computation)
+# ============================================================
+
+# 5-level deep unit-syntax chain
+fresh_perl_is(<<'CODE', "12345\n", {}, '5-level deep unit-syntax inheritance chain');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class D1; field $f1 = 1; method f1 { $f1 }
+    class D2 :isa(D1); field $f2 = 2; method f2 { $f2 }
+    class D3 :isa(D2); field $f3 = 3; method f3 { $f3 }
+    class D4 :isa(D3); field $f4 = 4; method f4 { $f4 }
+    class D5 :isa(D4); field $f5 = 5; method f5 { $f5 }
+}
+my $obj = D5->new;
+print $obj->f1, $obj->f2, $obj->f3, $obj->f4, $obj->f5, "\n";
+CODE
+
+# 4-level nested block classes, each inheriting from parent
+fresh_perl_is(<<'CODE', "1234\n", {}, 'Deeply nested block classes inheriting from outer');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+class N1 {
+    field $n1 = 1; method n1 { $n1 }
+    class N2 :isa(N1) {
+        field $n2 = 2; method n2 { $n2 }
+        class N3 :isa(N2) {
+            field $n3 = 3; method n3 { $n3 }
+            class N4 :isa(N3) {
+                field $n4 = 4; method n4 { $n4 }
+            }
+        }
+    }
+}
+my $obj = N4->new;
+print $obj->n1, $obj->n2, $obj->n3, $obj->n4, "\n";
+CODE
+
+# Tree-shaped inheritance (not just linear chain)
+fresh_perl_is(<<'CODE', "abd ace\n", {}, 'Tree-shaped inheritance with unit syntax');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class TA; field $a = "a"; method a { $a }
+    class TB :isa(TA); field $b = "b"; method b { $b }
+    class TC :isa(TA); field $c = "c"; method c { $c }
+    class TD :isa(TB); field $d = "d"; method d { $d }
+    class TE :isa(TC); field $e = "e"; method e { $e }
+}
+my $d = TD->new;
+my $e = TE->new;
+print $d->a, $d->b, $d->d, " ", $e->a, $e->c, $e->e, "\n";
+CODE
+
+# Chain of empty (field-less) classes
+fresh_perl_is(<<'CODE', "EmptyC yes\n", {}, 'Chain of empty unit-syntax classes');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class EmptyA;
+    class EmptyB :isa(EmptyA);
+    class EmptyC :isa(EmptyB);
+}
+my $obj = EmptyC->new;
+print ref($obj), " ", ($obj isa EmptyA ? "yes" : "no"), "\n";
+CODE
+
+# Interleaved empty/non-empty classes
+fresh_perl_is(<<'CODE', "hello world\n", {}, 'Interleaved empty and field-bearing classes in chain');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class IE_NoField;
+    class IE_HasField :isa(IE_NoField);
+    field $x :param;
+    method x { $x }
+    class IE_NoField2 :isa(IE_HasField);
+    class IE_HasField2 :isa(IE_NoField2);
+    field $y :param;
+    method y { $y }
+}
+my $obj = IE_HasField2->new(x => "hello", y => "world");
+print $obj->x, " ", $obj->y, "\n";
+CODE
+
+# ============================================================
+# Field index correctness
+# ============================================================
+
+# Many fields in base, few in child
+{
+    class BigBase {
+        field $f0 = 0; field $f1 = 1; field $f2 = 2; field $f3 = 3;
+        field $f4 = 4; field $f5 = 5; field $f6 = 6; field $f7 = 7;
+        field $f8 = 8; field $f9 = 9;
+        method sum { $f0+$f1+$f2+$f3+$f4+$f5+$f6+$f7+$f8+$f9 }
+        method last_base { $f9 }
+    }
+    class BigChild :isa(BigBase) {
+        field $g0 = 10; field $g1 = 11;
+        method child_sum { $g0 + $g1 }
+        method last_base { $g1 }  # override
+    }
+
+    my $obj = BigChild->new;
+    is($obj->sum, 45, 'Field sum from base with 10 fields');
+    is($obj->child_sum, 21, 'Field sum from child with 2 fields');
+    is($obj->last_base, 11, 'Method override returns child field');
+}
+
+# Same-named fields in parent and child (field shadowing)
+{
+    class ShadowBase {
+        field $x = "base-x";
+        field $y = "base-y";
+        method base_x { $x }
+        method base_y { $y }
+    }
+    class ShadowChild :isa(ShadowBase) {
+        field $x = "child-x";
+        field $y = "child-y";
+        method child_x { $x }
+        method child_y { $y }
+    }
+
+    my $obj = ShadowChild->new;
+    is($obj->base_x, "base-x", 'Parent method sees parent field $x');
+    is($obj->base_y, "base-y", 'Parent method sees parent field $y');
+    is($obj->child_x, "child-x", 'Child method sees child field $x');
+    is($obj->child_y, "child-y", 'Child method sees child field $y');
+}
+
+# Fieldless children of field-heavy base
+{
+    class FieldyBase {
+        field $a :param = "da";
+        field $b :param = "db";
+        field $c :param = "dc";
+        method abc { "$a-$b-$c" }
+    }
+    class EmptyChild1 :isa(FieldyBase) {}
+    class EmptyGC1 :isa(EmptyChild1) {}
+
+    my $obj = EmptyGC1->new(a => "A", b => "B", c => "C");
+    is($obj->abc, "A-B-C", 'Fieldless children pass params through to base');
+}
+
+# Large field count via eval (50 fields)
+fresh_perl_is(<<'CODE', "1225 999\n", {}, '50 fields in base, child adds one more');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+my $fields = join "\n", map { "field \$f$_ = $_;" } 0..49;
+my $sum = join " + ", map { "\$f$_" } 0..49;
+eval qq{
+    class Big50 { $fields method sum { $sum } }
+    class Big50Child :isa(Big50) {
+        field \$extra = 999;
+        method extra { \$extra }
+    }
+    1;
+} or die $@;
+my $obj = Big50Child->new;
+print $obj->sum, " ", $obj->extra, "\n";
+CODE
+
+# ============================================================
+# :param, :reader, :writer across inheritance
+# ============================================================
+
+# :param across unit-syntax inheritance chain
+{
+    class ParamChainBase {
+        field $name :param;
+        method name { $name }
+    }
+    class ParamChainMid :isa(ParamChainBase) {
+        field $age :param;
+        method age { $age }
+    }
+    class ParamChainLeaf :isa(ParamChainMid) {
+        field $color :param;
+        method color { $color }
+    }
+
+    my $obj = ParamChainLeaf->new(name => "A", age => 1, color => "red");
+    is($obj->name, "A", ':param works through 3-level chain (base)');
+    is($obj->age, 1, ':param works through 3-level chain (mid)');
+    is($obj->color, "red", ':param works through 3-level chain (leaf)');
+}
+
+# :reader across inheritance
+{
+    class ReaderBase {
+        field $rb :reader = "base-read";
+    }
+    class ReaderChild :isa(ReaderBase) {
+        field $rc :reader = "child-read";
+    }
+
+    my $obj = ReaderChild->new;
+    is($obj->rb, "base-read", ':reader on base field works in child');
+    is($obj->rc, "child-read", ':reader on child field works');
+}
+
+# :writer across inheritance
+{
+    class WriterBase {
+        field $wb :reader :writer = "wb-init";
+    }
+    class WriterChild :isa(WriterBase) {
+        field $wc :reader :writer = "wc-init";
+    }
+
+    my $obj = WriterChild->new;
+    $obj->set_wb("wb-new");
+    $obj->set_wc("wc-new");
+    is($obj->wb, "wb-new", ':writer on base field works in child');
+    is($obj->wc, "wc-new", ':writer on child field works');
+}
+
+# Duplicate :param name across inheritance is an error
+{
+    ok(!eval q{
+        class DupParamBase2 {
+            field $x :param;
+        }
+        class DupParamChild2 :isa(DupParamBase2) {
+            field $x :param;
+        }
+        1;
+    }, 'Duplicate :param name across inheritance is an error');
+    like($@, qr/already in use/, 'Error message mentions name conflict');
+}
+
+# ============================================================
+# ADJUST blocks across inheritance
+# ============================================================
+
+{
+    my @trace;
+    class AdjustChainBase {
+        field $x;
+        ADJUST { $x = 1; push @trace, "b1" }
+        ADJUST { push @trace, "b2" }
+        method x { $x }
+    }
+    class AdjustChainChild :isa(AdjustChainBase) {
+        field $y;
+        ADJUST { $y = 2; push @trace, "c1" }
+        ADJUST { push @trace, "c2" }
+        method y { $y }
+    }
+    class AdjustChainGC :isa(AdjustChainChild) {
+        ADJUST { push @trace, "gc1" }
+    }
+
+    my $obj = AdjustChainGC->new;
+    is($obj->x, 1, 'ADJUST sets field in base');
+    is($obj->y, 2, 'ADJUST sets field in child');
+    is(join(",", @trace), "b1,b2,c1,c2,gc1",
+        'ADJUST blocks fire in correct order through chain');
+}
+
+# ADJUST-only subclass (no fields)
+{
+    my @log;
+    class AdjOnlyBase2 {
+        field $v = "adj-base";
+        ADJUST { push @log, "base" }
+        method v { $v }
+    }
+    class AdjOnlyChild2 :isa(AdjOnlyBase2) {
+        ADJUST { push @log, "child" }
+    }
+
+    my $obj = AdjOnlyChild2->new;
+    is($obj->v, "adj-base", 'ADJUST-only child inherits base fields');
+    is(join(",", @log), "base,child", 'ADJUST-only child fires ADJUSTs in order');
+}
+
+# ============================================================
+# __CLASS__ across inheritance
+# ============================================================
+
+{
+    class ClassTokenBase2 {
+        field $class_at_init = __CLASS__;
+        method class_at_init { $class_at_init }
+    }
+    class ClassTokenChild2 :isa(ClassTokenBase2) {
+        field $child_class = __CLASS__;
+        method child_class { $child_class }
+    }
+
+    my $obj = ClassTokenChild2->new;
+    is($obj->class_at_init, "ClassTokenChild2",
+        '__CLASS__ in base field init yields runtime class');
+    is($obj->child_class, "ClassTokenChild2",
+        '__CLASS__ in child field init yields runtime class');
+}
+
+# ============================================================
+# SUPER::method with fields
+# ============================================================
+
+{
+    class SuperBase2 {
+        field $x = "base";
+        method describe { "base:$x" }
+    }
+    class SuperChild2 :isa(SuperBase2) {
+        field $y = "child";
+        method describe { $self->SUPER::describe() . "/child:$y" }
+    }
+    class SuperGC2 :isa(SuperChild2) {
+        field $z = "gc";
+        method describe { $self->SUPER::describe() . "/gc:$z" }
+    }
+
+    is(SuperGC2->new->describe, "base:base/child:child/gc:gc",
+        'SUPER::method chain with fields at each level');
+}
+
+# ============================================================
+# Forward-declared methods with fields in inheritance
+# ============================================================
+
+{
+    class FwdBase {
+        field $x = "fwd-base";
+        method x;
+        method x { $x }
+    }
+    class FwdChild :isa(FwdBase) {
+        field $y = "fwd-child";
+        method y;
+        method y { $y }
+    }
+
+    my $obj = FwdChild->new;
+    is($obj->x, "fwd-base", 'Forward-declared method in base works');
+    is($obj->y, "fwd-child", 'Forward-declared method in child works');
+}
+
+# ============================================================
+# Anonymous method closures over fields in inheritance
+# ============================================================
+
+{
+    class AnonBase2 {
+        field $x = 10;
+        method get_x_closure {
+            return method { $x }
+        }
+    }
+    class AnonChild2 :isa(AnonBase2) {
+        field $y = 20;
+        method get_y_closure {
+            return method { $y }
+        }
+    }
+
+    my $obj = AnonChild2->new;
+    my $xc = $obj->get_x_closure;
+    my $yc = $obj->get_y_closure;
+    is($obj->$xc, 10, 'Anonymous method closure over base field works');
+    is($obj->$yc, 20, 'Anonymous method closure over child field works');
+}
+
+# ============================================================
+# Closures capturing fields across inheritance
+# ============================================================
+
+{
+    class ClosureBase2 {
+        field $counter = 0;
+        method make_callbacks {
+            my @callbacks;
+            for my $i (1..3) {
+                push @callbacks, sub { $counter += $i; return $counter };
+            }
+            return @callbacks;
+        }
+        method counter { $counter }
+    }
+    class ClosureChild2 :isa(ClosureBase2) {
+        field $extra = 100;
+        method extra { $extra }
+    }
+
+    my $obj = ClosureChild2->new;
+    my @cbs = $obj->make_callbacks;
+    $cbs[0]->();
+    $cbs[1]->();
+    $cbs[2]->();
+    is($obj->counter, 6, 'Closures capturing base field work in child instance');
+    is($obj->extra, 100, 'Child field unaffected by base closures');
+}
+
+# ============================================================
+# Lexical methods with fields in inheritance
+# ============================================================
+
+{
+    class LexBase2 {
+        field $x = "lex-base";
+        my method secret { $x }
+        method reveal { $self->&secret }
+    }
+    class LexChild2 :isa(LexBase2) {
+        field $y = "lex-child";
+        my method child_secret { $y }
+        method child_reveal { $self->&child_secret }
+    }
+
+    my $obj = LexChild2->new;
+    is($obj->reveal, "lex-base", 'Lexical method accessing base field via ->&');
+    is($obj->child_reveal, "lex-child", 'Lexical method accessing child field via ->&');
+}
+
+# ============================================================
+# DESTROY with fields across inheritance
+# ============================================================
+
+{
+    my @destroyed;
+    class DestrBase2 {
+        field $name :param;
+        method DESTROY { push @destroyed, "base:$name" }
+    }
+    class DestrChild2 :isa(DestrBase2) {
+        field $extra :param;
+        method DESTROY { push @destroyed, "child:$extra"; $self->SUPER::DESTROY() }
+    }
+
+    {
+        my $obj = DestrChild2->new(name => "obj1", extra => "x1");
+    }
+    is(join(",", @destroyed), "child:x1,base:obj1",
+        'DESTROY chain fires correctly with fields from both classes');
+}
+
+# ============================================================
+# Cross-class method safety
+# ============================================================
+
+{
+    class SafetyA {
+        field $x = "A";
+        method x { $x }
+    }
+    class SafetyB {
+        field $y = "B";
+        method y { $y }
+    }
+
+    my $a = SafetyA->new;
+    eval { $a->SafetyB::y() };
+    like($@, qr/Cannot invoke a method of "SafetyB" on an instance of "SafetyA"/,
+        'Cross-class method invocation gives clear error, not segfault');
+}
+
+# ============================================================
+# Kitchen sink: all features combined with unit syntax
+# ============================================================
+
+fresh_perl_is(<<'CODE', "b-default A-adj e-default 42 KSLeaf-adjusted\nnew-e\n", {}, 'Kitchen sink: all features in unit-syntax chain');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class KSBase;
+    field $a :param;
+    field $b :reader = "b-default";
+    field $c;
+    ADJUST { $c = $a . "-adj" }
+    method c { $c }
+
+    class KSMid :isa(KSBase);
+    field $d :param;
+    field $e :reader :writer = "e-default";
+    field $f = 42;
+    method f { $f }
+
+    class KSLeaf :isa(KSMid);
+    field $g :param(gee);
+    field $h = __CLASS__;
+    ADJUST { $h .= "-adjusted" }
+    method h { $h }
+}
+my $obj = KSLeaf->new(a => "A", d => "D", gee => "G");
+print join(" ", $obj->b, $obj->c, $obj->e, $obj->f, $obj->h), "\n";
+$obj->set_e("new-e");
+print $obj->e, "\n";
+CODE
+
+# ============================================================
+# Eval-based inheritance (separate compilation units)
+# ============================================================
+
+fresh_perl_is(<<'CODE', "1 2 3\n", {}, 'Multi-level inheritance across separate eval compilation units');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+eval q{
+    class EvalBase { field $eb :param; method eb { $eb } } 1;
+} or die $@;
+eval q{
+    class EvalMid :isa(EvalBase) { field $em :param; method em { $em } } 1;
+} or die $@;
+eval q{
+    class EvalLeaf :isa(EvalMid) { field $el :param; method el { $el } } 1;
+} or die $@;
+my $obj = EvalLeaf->new(eb => 1, em => 2, el => 3);
+print $obj->eb, " ", $obj->em, " ", $obj->el, "\n";
+CODE
+
+# ============================================================
+# BEGIN block class definition + runtime subclass
+# ============================================================
+
+fresh_perl_is(<<'CODE', "begin runtime\n", {}, 'Class defined in BEGIN block, subclassed at runtime');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+BEGIN {
+    eval q{
+        class BeginBase2 { field $x = "begin"; method x { $x } } 1;
+    } or die $@;
+}
+class BeginChild2 :isa(BeginBase2) {
+    field $y = "runtime";
+    method y { $y }
+}
+my $obj = BeginChild2->new;
+print $obj->x, " ", $obj->y, "\n";
+CODE
+
+# ============================================================
+# Field init order with unit-syntax inheritance
+# ============================================================
+
+{
+    class InitOrderBase2 {
+        field $x = 10;
+        field $y = $x * 2;
+        method vals { "$x:$y" }
+    }
+    class InitOrderChild2 :isa(InitOrderBase2) {
+        field $z = 30;
+        field $w = $z + 1;
+        method child_vals { "$z:$w" }
+    }
+
+    my $obj = InitOrderChild2->new;
+    is($obj->vals, "10:20", 'Base field init order preserved');
+    is($obj->child_vals, "30:31", 'Child field init order preserved');
+}
+
+# ============================================================
+# Rapid object creation/destruction stress test
+# ============================================================
+
+{
+    class StressBase2 {
+        field $x :param;
+        field $y = "default";
+        method x { $x }
+    }
+    class StressChild2 :isa(StressBase2) {
+        field $z :param = 0;
+        method z { $z }
+    }
+
+    my $ok = 1;
+    for (1..1000) {
+        my $obj = StressChild2->new(x => $_, z => $_ * 2);
+        if ($obj->x != $_ || $obj->z != $_ * 2) {
+            $ok = 0;
+            last;
+        }
+    }
+    ok($ok, '1000 rapid object create/destroy cycles with inheritance');
+}
+
+# ============================================================
+# Class defined inside method (eval at runtime)
+# ============================================================
+
+fresh_perl_is(<<'CODE', "10 20\n", {}, 'Class defined inside method via eval');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+class EvalNestBase {
+    field $x :param;
+    method x { $x }
+    method make_child_class {
+        eval q{
+            class EvalNestChild :isa(EvalNestBase) {
+                field $y :param;
+                method y { $y }
+            }
+            1;
+        } or die $@;
+    }
+}
+EvalNestBase->new(x => 1)->make_child_class;
+my $child = EvalNestChild->new(x => 10, y => 20);
+print $child->x, " ", $child->y, "\n";
+CODE
+
+# ============================================================
+# Method override with field access (no SUPER)
+# ============================================================
+
+{
+    class OverrideBase {
+        field $x = "base";
+        method x { $x }
+    }
+    class OverrideChild :isa(OverrideBase) {
+        field $y = "child";
+        method x { $y }  # override, using own field
+    }
+
+    is(OverrideChild->new->x, "child",
+        'Method override accessing own field (not base field)');
+}
+
+# ============================================================
+# SUPER with no own fields
+# ============================================================
+
+{
+    class SUPERNoFieldBase {
+        field $a = 1; field $b = 2; field $c = 3;
+        method all { "$a-$b-$c" }
+    }
+    class SUPERNoFieldChild :isa(SUPERNoFieldBase) {
+        method all { "child:" . $self->SUPER::all() }
+    }
+
+    is(SUPERNoFieldChild->new->all, "child:1-2-3",
+        'SUPER works in fieldless child accessing field-heavy base');
+}
+
+# ============================================================
+# Safety: cross-class method dispatch, unblessed refs, bless-into-class
+# ============================================================
+
+{
+    class SafetyC {
+        field $x = "C";
+        method x { $x }
+    }
+
+    # Unblessed ref
+    eval { SafetyC::x({}) };
+    like($@, qr/Cannot invoke method/, 'Method on unblessed ref gives error, not segfault');
+
+    # Bless into class is forbidden
+    eval { bless {}, "SafetyC" };
+    like($@, qr/Attempt to bless into a class/,
+        'Cannot bless into a class');
+
+    # @ISA is read-only
+    eval { push @SafetyC::ISA, "SomeOther" };
+    like($@, qr/Modification of a read-only value/,
+        '@ISA of class is read-only');
+}
+
+# ============================================================
+# Weakrefs to class instances with fields
+# ============================================================
+
+{
+    use Scalar::Util 'weaken';
+    class WeakRefTest2 {
+        field $x :param;
+        method x { $x }
+    }
+    class WeakRefChild2 :isa(WeakRefTest2) {
+        field $y :param;
+        method y { $y }
+    }
+
+    my $obj = WeakRefChild2->new(x => "hello", y => "world");
+    my $weak = $obj;
+    weaken($weak);
+    ok(defined($weak), 'Weakref alive while strong ref exists');
+    is($weak->x, "hello", 'Weakref can access base field');
+    is($weak->y, "world", 'Weakref can access child field');
+    undef $obj;
+    ok(!defined($weak), 'Weakref cleared after strong ref undef');
+}
+
+# ============================================================
+# Class objects as field values
+# ============================================================
+
+{
+    class ValueInner {
+        field $val :param;
+        method val { $val }
+    }
+    class ValueOuter {
+        field $inner;
+        ADJUST { $inner = ValueInner->new(val => 42) }
+        method inner_val { $inner->val }
+    }
+    class ValueOuterChild :isa(ValueOuter) {
+        field $extra = "extra";
+        method extra { $extra }
+    }
+
+    my $obj = ValueOuterChild->new;
+    is($obj->inner_val, 42, 'Class object stored in field works through inheritance');
+    is($obj->extra, "extra", 'Child field works alongside object-valued base field');
+}
+
+# ============================================================
+# Exception in ADJUST during construction
+# ============================================================
+
+{
+    class AdjDieBase {
+        field $x :param = "ok";
+        method x { $x }
+    }
+    class AdjDieChild :isa(AdjDieBase) {
+        field $y = "child-ok";
+        ADJUST { die "boom\n" if $self->x eq "trigger" }
+        method y { $y }
+    }
+
+    my $ok = AdjDieChild->new;
+    is($ok->x, "ok", 'Normal construction works');
+    is($ok->y, "child-ok", 'Normal construction sets child field');
+
+    eval { AdjDieChild->new(x => "trigger") };
+    is($@, "boom\n", 'ADJUST die is catchable');
+
+    my $ok2 = AdjDieChild->new;
+    is($ok2->x, "ok", 'Construction works after prior ADJUST failure');
+}
+
+# ============================================================
+# Circular references in fields
+# ============================================================
+
+{
+    class CircNode {
+        field $partner;
+        field $name :param;
+        method set_partner { $partner = $_[0] }
+        method partner { $partner }
+        method name { $name }
+    }
+    class CircNodeChild :isa(CircNode) {
+        field $tag :param = "child";
+        method tag { $tag }
+    }
+
+    my $a = CircNodeChild->new(name => "A");
+    my $b = CircNodeChild->new(name => "B");
+    $a->set_partner($b);
+    $b->set_partner($a);
+    is($a->partner->name, "B", 'Circular ref A->B works');
+    is($b->partner->name, "A", 'Circular ref B->A works');
+    # Cleanup (will leak, but should not segfault)
+    $a->set_partner(undef);
+    $b->set_partner(undef);
+    pass('Circular reference cleanup did not segfault');
+}
+
+# ============================================================
+# Two independent inheritance chains in same scope (unit syntax)
+# ============================================================
+
+fresh_perl_is(<<'CODE', "ab cd\n", {}, 'Two independent unit-syntax chains in same scope');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class ChainABase;
+    field $a = "a"; method a { $a }
+    class ChainAChild :isa(ChainABase);
+    field $b = "b"; method b { $b }
+
+    class ChainBBase;
+    field $c = "c"; method c { $c }
+    class ChainBChild :isa(ChainBBase);
+    field $d = "d"; method d { $d }
+}
+my $ac = ChainAChild->new;
+my $bc = ChainBChild->new;
+print $ac->a, $ac->b, " ", $bc->c, $bc->d, "\n";
+CODE
+
+# ============================================================
+# Block class inside unit class scope, inheriting from it
+# ============================================================
+
+fresh_perl_is(<<'CODE', "outer inner\n", {}, 'Block class inside unit class scope');
+use v5.36;
+use feature 'class'; no warnings 'experimental::class';
+{
+    class UnitOuter;
+    field $x = "outer"; method x { $x }
+    {
+        class BlockInner :isa(UnitOuter) {
+            field $y = "inner"; method y { $y }
+        }
+    }
+}
+my $obj = BlockInner->new;
+print $obj->x, " ", $obj->y, "\n";
+CODE
+
+done_testing;


### PR DESCRIPTION
Add t/class/stress.t with 74 tests exercising pathological combinations of the class system, with a focus on verifying that the seal-ordering fixes for GH#20890 and GH#21221 cover a wide range of edge cases.

Tests use fresh_perl_is for scenarios where a segfault is plausible (seal ordering, deep chains, eval-based class definitions) so that a crash is detected cleanly rather than taking down the test harness.

Categories and coverage:

  Seal ordering (GH#20890/GH#21221)    11 tests
    - unit-syntax base with unit/block children
    - multiple subclasses of the same unsealed base
    - mixed unit/block siblings, alternating syntax in chains
    - block-scoped child defined inside base class body

  Deep inheritance chains                4 tests
    - 5-level unit-syntax chain
    - 4-level nested block classes
    - tree-shaped (non-linear) inheritance
    - chain of empty (fieldless) classes

  Field index correctness                5 tests
    - 10+ fields in base with child additions
    - same-named fields in parent and child (shadowing)
    - fieldless children of field-heavy base
    - 50 fields in base with child field

  :param, :reader, :writer               5 tests
    - :param through 3-level chain
    - :reader and :writer across inheritance
    - duplicate :param name detection

  ADJUST blocks                          4 tests
    - multiple ADJUST blocks, ordering across chain
    - ADJUST-only subclass (no own fields)
    - exception in ADJUST during construction

  __CLASS__, SUPER, forward-declared      5 tests
    - __CLASS__ in field initializers across inheritance
    - SUPER::method chain with fields at each level
    - forward-declared methods with fields

  Closures and lexical methods            5 tests
    - anonymous method closures over fields
    - sub closures capturing fields in child instances
    - lexical methods with ->& syntax

  Safety checks                          3 tests
    - cross-class method dispatch (clean error)
    - bless into class (forbidden)
    - @ISA mutation (read-only)

  Object lifecycle                       8 tests
    - weakrefs to class instances
    - class objects as field values
    - circular references between instances
    - DESTROY with SUPER chain

  Compilation boundaries                 5 tests
    - multi-level inheritance across eval blocks
    - class defined in BEGIN, subclassed at runtime
    - class defined inside method via eval
    - two independent chains in same scope
    - block class inside unit class scope

  Stress                                 1 test
    - 1000 rapid object create/destroy cycles

  Other                                  4 tests
    - method override with own field access
    - SUPER in fieldless child of field-heavy base
    - field init order preserved across inheritance
    - method override returning child field
