### PR TITLE
perlfunc: Document auto source::encoding 'ascii'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -633,6 +633,7 @@ James                          <james@rf.net>
 James A. Duncan                <jduncan@fotango.com>
 James Bence
 James Clarke                   <jrtc27@jrtc27.com>
+James Cook                     <falsifian@falsifian.org>
 James E Keenan                 <jkeenan@cpan.org>
 James FitzGibbon               <james@ican.net>
 James Jurach                   <muaddib@erf.net>

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -10414,6 +10414,9 @@ If the specified Perl version is 5.39.0 or higher, builtin functions are
 imported lexically as with L<C<use builtin>|builtin> with a corresponding
 version bundle.
 
+If the specified Perl version is v5.41.0 or higher,
+L<S<C<use source::encoding 'ascii'>>|source::encoding> is enabled lexically.
+
 Use of C<use VERSION> while another is in effect is not allowed with a
 C<use v5.39;> or greater version.  For lower versions, C<use VERSION> will
 override most behavior of a previous C<use VERSION>, possibly removing


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
`perldoc -f use` was not showing this effect of using v5.41+. The behaviour is documented in `source::encoding`, but that doesn't help someone who doesn't already know about it. 

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
