### PR TITLE
Mark reginfo_buf as uninitialized to avoid performance regression

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -958,7 +958,8 @@ Perl_re_intuit_start(pTHX_
     char *check_at = NULL;		/* check substr found at this pos */
     const I32 multiline = prog->extflags & RXf_PMf_MULTILINE;
     RXi_GET_DECL(prog,progi);
-    regmatch_info reginfo_buf;  /* create some info to pass to find_byclass */
+    /* create some info to pass to find_byclass */
+    regmatch_info reginfo_buf __attribute__uninitialized__;
     regmatch_info *const reginfo = &reginfo_buf;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
@@ -1009,6 +1010,9 @@ Perl_re_intuit_start(pTHX_
     reginfo->intuit = 1;
     /* not actually used within intuit, but zero for safety anyway */
     reginfo->poscache_maxiter = 0;
+    reginfo->prog = NULL;
+    reginfo->sv = NULL;
+    reginfo->warned = false;
 
     if (utf8_target) {
         if ((!prog->anchored_utf8 && prog->anchored_substr)
@@ -3719,7 +3723,8 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     const bool utf8_target = cBOOL(DO_UTF8(sv));
     I32 multiline;
     RXi_GET_DECL(prog,progi);
-    regmatch_info reginfo_buf;  /* create some info to pass to regtry etc */
+    /* create some info to pass to regtry etc */
+    regmatch_info reginfo_buf __attribute__uninitialized__;
     regmatch_info *const reginfo = &reginfo_buf;
     regexp_paren_pair *swap = NULL;
     I32 oldsave;
@@ -3876,6 +3881,9 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     reginfo->poscache_maxiter = 0; /* not yet started a countdown */
     /* see how far we have to get to not match where we matched before */
     reginfo->till = stringarg + minend;
+
+    /* zero for safety */
+    reginfo->info_aux = NULL;
 
     if (prog->extflags & RXf_EVAL_SEEN && SvPADTMP(sv)) {
         /* SAVEFREESV, not sv_mortalcopy, as this SV must last until after


### PR DESCRIPTION
This PR must be applied on top of https://github.com/Perl/perl5/pull/24318. This is a logical continuation of that PR.

---

Previously, when compiling Perl with `-ftrivial-auto-var-init=zero` (on GCC14+), there was a performance regression in Perl_regexec_flags() and Perl_re_intuit_start(). This happened because of the `reginfo_buf` local array with a rather-large size, which was auto initialized to zero.

Since `reginfo_buf` is used in a performance-critical path, and is used safely in the current codebase, this commit marks this array as `__attribute__((uninitialized))`. This way, even when compiled with `-ftrivial-auto-var-init=zero`, Perl still exhibits good performance. Note that this commit adds explicit initialization-to-zero to a couple fields -- I deemed those fields the most important (after quick inspection of the code, but I may be totally wrong).

-------------------------------------------------------------------------------

The reproducer is similar to https://github.com/Perl/perl5/issues/24317, but with the replacement:
- `./perlbench-run -t ipol` -> `./perlbench-run -t re/const`

With this PR, the reproducer has minimal performance overhead:
```bash
$ PERL5LIB="$(pwd)" ./perlbench-run -t re/const ../vanilla-perl/bin/perl5.43.10 ../slow-perl/bin/perl5.43.10 ../fixed-perl/bin/perl5.43.10

A) perl-5   # vanilla perl
        version     = 5.04301
        git-version = v5.43.9-29-g042eaf57f6
        path        = ../vanilla-perl/bin/perl5.43.10
        ccflags     = -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2

B) perl-5   # with -ftrivial-auto-var-init=zero and without this PR
        version     = 5.04301
        git-version = v5.43.9-29-g042eaf57f6
        path        = ../slow-perl/bin/perl5.43.10
        ccflags     = -ftrivial-auto-var-init=zero -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2

C) perl-5   # with -ftrivial-auto-var-init=zero and with this PR
        version     = 5.04301
        git-version = v5.43.9-42-gc8718ed586*
        path        = ../fixed-perl/bin/perl5.43.10
        ccflags     = -ftrivial-auto-var-init=zero -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2

                           A       B       C
                         ---     ---     ---
re/const                 100      89      97
```

---

The nitty-gritty details of profiling:
```
$ PERL5LIB="$(pwd)" perf record -g --call-graph dwarf -- ../vanilla-perl/bin/perl5.43.10 benchmarks/re/const.t 2800984 37817066

-  100.00%     0.00%  perl5.43.10  perl5.43.10           [.] _start
   - main
      - 99.99% perl_run
         - Perl_runops_standard
            - 70.49% Perl_pp_match
               - 52.44% Perl_regexec_flags
                  + 40.71% Perl_re_intuit_start
              15.68% Perl_pp_gvsv
              5.56% Perl_pp_nextstate

$ PERL5LIB="$(pwd)" perf record -g --call-graph dwarf -- ../slow-perl/bin/perl5.43.10 benchmarks/re/const.t 2800984 37817066

-   99.99%     0.00%  perl5.43.10  perl5.43.10           [.] _start
   - main
      - 99.99% perl_run
         - Perl_runops_standard
            - 80.12% Perl_pp_match
               - 67.62% Perl_regexec_flags
                  - 59.36% Perl_re_intuit_start
                     + 13.36% Perl_fbm_instr			  
```