### PR TITLE
S_intuit_more: Properly handle `\\` in input

### DIFF
--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1298;  # Update this when adding/deleting tests.
+plan tests => 1299;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2669,6 +2669,14 @@ PROG
     {   # GH 16894 Fixed by acababb42be12ff2986b73c1bfa963b70bb5d54e
         "abab" =~ /(?:[^b]*(?=(b)|(a))ab)*/;
         is($1, undef, "GH #16894");
+    }
+
+    {   # GH #24336
+        fresh_perl_is(<<~'PROG', "", {}, "Parses ambiguous array vs subscript correctly");
+            my $foo = "whatever";
+            $foo =~ s{^$foo[/\\]?}{};
+            print $foo, "\n";
+            PROG
     }
 
 } # End of sub run_tests

--- a/toke.c
+++ b/toke.c
@@ -5032,6 +5032,13 @@ S_intuit_more(pTHX_ char *s, char *e,
            */
 
           case '\\':
+
+            if (s[1] == '\\') {
+                /* Escaped backslash is treated as a single literal */
+                s++;
+                break;
+            }
+
             if (s[1] == '\0') {
                 /* \ followed by NUL strongly indicates character class */
                 weight += 100;
@@ -5046,8 +5053,6 @@ S_intuit_more(pTHX_ char *s, char *e,
                  * late in the development cycle that we didn't want to
                  * possibly break anything, so this is commented out to retain
                  * previous (unintended) behavior */
-                seen[(U8) '\\']++;
-                s++;
                 break;
             }
 


### PR DESCRIPTION
Fixes #24336

I apparently got confused between the two characters `\` and `]`.  The commit 7646ce7e591864e549df28dfa7246e8ebba19d14 dealt with both.

What is needed for the sequence `\\` is that it act like a single `\` escaping nothing.

What is needed for the sequence `\]` is that it do nothing beyond what it used to do, despite the intent of the code that that commit partially fixed.  The sequence could never occur before in practice because it was excluded by logic that that commit did fix.  But since it is so late in the development cycle; I decided to comment out what it now would have done, so that there was no difference in behavior for that precise sequence.

But the commit got things wrong, which this should rectify


* This set of changes does not require a perldelta entry.
