### PR TITLE
Fix intuit_more missing context bug

### DIFF
--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1298;  # Update this when adding/deleting tests.
+plan tests => 1299;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2669,6 +2669,14 @@ PROG
     {   # GH 16894 Fixed by acababb42be12ff2986b73c1bfa963b70bb5d54e
         "abab" =~ /(?:[^b]*(?=(b)|(a))ab)*/;
         is($1, undef, "GH #16894");
+    }
+
+    {   # GH 24339
+        fresh_perl_is(<<~'PROG', "", {}, "intuit_more bug compiles");
+        use strict;
+        my ($prevDecade, $decade, $year) = (0, 1, 2);
+        qr/\A(?:1[0-9][0-9]{2}|20[0-$prevDecade][0-9]|20$decade[0-$year])\Z/o;
+        PROG
     }
 
 } # End of sub run_tests

--- a/toke.c
+++ b/toke.c
@@ -4657,7 +4657,9 @@ S_intuit_more(pTHX_ char *s, char *e,
      * variables, so in that case it MUST be a character class.)  If the
      * situation is reversed, it is more likely to be (or must be) a
      * subscript.  */
-    if (caller_context == FROM_DOLLAR) {
+    if (   caller_context == FROM_DOLLAR
+        || (caller_context == FROM_INTERDEPENDMAYBE && caller_s[0] == '$'))
+    {
         assert (caller_s);
 
         /* See if there is a known scalar for the input identifier */
@@ -10317,7 +10319,8 @@ Perl_yylex(pTHX)
         return yylex();
 
     case LEX_INTERPENDMAYBE:
-        if (intuit_more(PL_bufptr, PL_bufend, FROM_INTERDEPENDMAYBE, NULL, 0))
+        if (intuit_more(PL_bufptr, PL_bufend, FROM_INTERDEPENDMAYBE,
+                        PL_oldbufptr, PL_bufptr - PL_oldbufptr))
         {
             PL_lex_state = LEX_INTERPNORMAL;	/* false alarm, more expr */
             break;

--- a/toke.c
+++ b/toke.c
@@ -4537,7 +4537,7 @@ S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8)
 
     char save_sigil = s[0];
     s[0] = sigil;
-    PADOFFSET slot = pad_findmy_pv(s, 0);
+    PADOFFSET slot = pad_findmy_pvn(s, len, 0);
     s[0] = save_sigil;
 
     return   slot != NOT_IN_PAD


### PR DESCRIPTION
Fixes #24339

This bug stemmed from two things:

1. Not using the known length to limit parsing to the substring of interest
2. The code correctly determining that a [...] was a character class and not a subscript, but then forgetting about it.

The solution is to use the length, and to pass the context to intuit_more() from a place where I hadn't realized it was available, and then check that context.  That gives intuit_more the information it needs to quickly realize that yes, this was a character class.

* This set of changes does not require a perldelta entry.
