### PR TITLE
Add asserts for aTHX

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -112,9 +112,9 @@
 : In practice, every element here will have at least one flag.  But without any
 : flags, the default would be to create an entry in proto.h declaring 'name' as
 : a function returning 'return_type' with arguments aTHX, 'arg1', ..., 'argN',
-: with 'aTHX' omitted on builds that don't need it.  The function would be
-: visible to only other files in the perl core, unless the system doesn't allow
-: visibility restrictions.
+: with 'aTHX' omitted on builds that don't need it.  When present, it is
+: asserted to be non-NULL.  The function would be visible to only other files
+: in the perl core, unless the system doesn't allow visibility restrictions.
 :
 : A common pattern is to use defines like 'PERL_IN_FILE_C' (with FILE_C being
 : appropriately replaced with the real filename).  Most, if not all, of the

--- a/embed.fnc
+++ b/embed.fnc
@@ -6,32 +6,62 @@
 : makedef.pl, Devel::PPPort, and porting/diag.t.
 :
 : This file contains entries for various functions, macros, typedefs, and
-: other values defined by perl.  Each entry includes the name, parameters, and
-: various attributes about it.  In most functions listed here, the name is a
-: short name, and the function's real name is the short one, prefixed by either
-: 'Perl_' (for publicly visible functions) or 'S_' (for internal-to-a-file
-: static ones).  In many instances a macro is defined that is the name in this
-: file, and which expands to call the real (full) name, with any appropriate
-: thread context parameters, thus hiding that detail from the typical code.
+: other values defined by perl.  Each entry includes the name, any parameters,
+: and various attributes about it.
+:
+: In almost all functions listed here, the specified name is a shortened
+: version of the function's real name.  The actual name for publicly visible
+: functions needs to be different from any other name that the loader could
+: need to combine with it.  We accomplish this by reserving for our use any
+: name begininng with /^[pP]erl_/, and add those prefixes to the actual names
+: of the publicly visible functions.
+:
+: Using the long names is unwieldly and harder to read; so most code will call
+: the function using the short name, never needing to even know that a long
+: name exists.  embed.h contains macros that map the short name to the actual
+: name.  But the long name may be needed in special circumstances.  See
+: perlembed for one such; another is when the short name collides with a name
+: that XS code uses.  Our short name can be #undef'ed, and the function will
+: still be accessible via its long name.  Using intermediary macros to access
+: functions also allows flexibility.  For example, parameters may be added,
+: subtracted, or rearranged.
+:
+: In contrast, macros do not usually have long versus short names, and, until
+: v5.44, there was not much effort to avoid polluting the XS namespace.  But,
+: symbols newly created in that release and going forward, are by default not
+: visible to XS code, so that new pollutants will not be inadvertently added.
+:
+: WARNING: The default hiding of symbols from XS code applies only to functions
+: and macros.  Other types of values that are created in a header file, such as
+: typedefs and enum names, will be visible to XS code, unless care is taken to
+: wrap them within C preprocessor guards like the following
+:
+:    #if defined(PERL_CORE)
+:    ...
+:    #endif
 :
 : embed.pl uses the entries here to construct:
 :   1) proto.h to declare to the compiler the function interfaces; and
-:   2) embed.h to create short name macros, and to control the visibility of
-:      other macros
+:   2) embed.h to create the short name macros, and to control the visibility
+:      of other macros
 :   3) long_names.c holds long-named function definitions that implement
 :      short-named macros listed here, when a function is necessary.
 :
 : Static functions internal to a file need not appear here, but there is
-: benefit to declaring them here:
+: significant benefit to declaring them here:
 :   1)  It generally handles the thread context parameter invisibly making it
 :       trivial to add or remove needing thread context passed;
-:   2)  It defines a PERL_ARGS_ASSERT_foo macro, which can save you debugging
-:       time;
-:   3)  It is is automatically known to Devel::PPPort, making it quicker to
+:   2)  The function may appear anywhere in the file; otherwise it has to be
+:       placed before the first call to it;
+:   3)  It defines a PERL_ARGS_ASSERT_foo macro, which can save you debugging
+:       time.  These ASSERT macros have been enhanced over time; your code will
+:       get the benefits of future enhancements without any changes to the
+:       source needed.
+:   4)  It is is automatically known to Devel::PPPort, making it quicker to
 :       later find out when it came into existence.  For example
 :           perl ppport.h --api-info=/edit_distance/
 :       yields
-:               Supported at least since perl-5.23.8, with or without ppport.h.
+:           Supported at least since perl-5.23.8, with or without ppport.h.
 :
 : Lines in this file are of the form:
 :    flags|return_type|name|arg1|arg2|...|argN ( assert(...) )*
@@ -47,59 +77,44 @@
 : comments here mostly don't include how Devel::PPPort or diag.t use them:
 : All the possible flags and their meanings are given in comments below.
 :
-: A function taking no parameters will have no 'arg' elements.  Currently
-: arguments that are function pointers are unlikely to be parsed properly here
-: (patches welcome!); you can work around this by creating a typedef for the
-: function pointer in an appropriate header file and use that here.
+: The 'argN' components denote the arguments, in order, that the macro or
+: function requires to be passed to it when calling it.  These do not appear on
+: entries for other types of elements, such as typedefs, nor when the function
+: or macro doesn't have any argumentes.  Each is usually of the form
 :
-: The optional list of asserts is used to customize the generated
-: PERL_ARGS_ASSERT macro.  See AUTOMATIC PARAMETER SANITY CHECKING below
+:   arg-type arg-name
+:
+: but with lots of possible added attributes and special cases, as described
+: below.  The attributes may come anywhere in the component.  But they function
+: as reserved keywords.  For example 'NZ' is an attribute, and hence no
+: argument may be named 'NZ.
+:
+: In threaded and embedded uses of perl, operations need to know which thread
+: or which embedded instance to operate on.  This is often invisible to the
+: operation, made possible by passing the context information to it in a
+: parameter named 'aTHX', which transparently is passed on through potentially
+: multiple layers to lower level code that does know about it.  When the perl
+: interpreter is built to not need context, it would be wasteful to have to
+: call functions with an extra meaningless parameter, so it is omitted for
+: those builds.  The entries in this file do not show it; it is automagically
+: added when needed.
+:
+: An element taking no parameters or just an implicit 'aTHX' parameter will
+: contain no 'arg' components.  Currently arguments that are function pointers
+: are unlikely to be parsed properly here (patches welcome!); you can work
+: around this by creating a typedef for the function pointer in an appropriate
+: header file and use that here.
+:
+: The final component in an entry is an optional list of asserts.  It is used
+: to customize the generated PERL_ARGS_ASSERT macro.  See AUTOMATIC PARAMETER
+: SANITY CHECKING below
 :
 : In practice, every element here will have at least one flag.  But without any
 : flags, the default would be to create an entry in proto.h declaring 'name' as
-: a function returning 'return_type' with arguments aTHX, 'arg1', ..., 'argN'.
-: The function would be visible to only other files in the perl core, unless
-: the system doesn't allow visibility restrictions.
-:
-: But, in practice, every function listed here will have a flag to indicate
-: that the function's name isn't precisely 'name', but is a perturbation of
-: that so that the actual name declared in proto.h is either 'S_name' (for
-: static (file-scoped) functions) or 'Perl_name' (for functions visible outside
-: a single file).  (A very few cases have a different backwards-compatibility
-: name instead.)  A macro is then added to embed.h which maps 'name' to the
-: actual name.  If the Perl interpreter is embedded in a larger application, or
-: on platforms where all non-static functions are externally visible, there
-: could be two functions with the same name; making ours 'Perl_foo' instead of
-: 'foo' prevents that.  This is done by using the 'p' flag.  Hence, just about
-: every function element here that is non-static should have that flag
-: specified.
-:
-: Most calls wanting to invoke 'name' will use that precise spelling, which
-: embed.h maps to the actual function.  This allows the macro to do some
-: hanky-panky behind the scenes to hide various details from the caller.
-: Notably, this includes whether or not to call the function with a
-: thread-context parameter.  This parameter is only needed for threaded or
-: embedded uses of perl, and it would be wasteful to have to call functions
-: with an extra meaningless parameter, so it is omitted unless needed.  The
-: macro in embed.h knows whether there is one or not, expanding appropriately
-: without exposing it to the code calling it.  Hence the same source code works
-: in both cases.  The macro can hide other things as well.  Devel::PPPort, for
-: example, can redefine the macro to backport fixes to bugs.
-:
-: For elements in place here in 5.42 and earlier, the visibility of the macros
-: in embed.h (and other header files) is everywhere.  This presents the
-: possibility of name space collisions in XS code, generally resolved by the XS
-: writer changing their name to not conflict.  For elements created later than
-: that, the default visibility is core-only.
-:
-: WARNING: The default hiding of symbols from XS code applies only to functions
-: and macros.  Other types of values that are created in a header file, such as
-: typedefs and enum names, will be visible to XS code, unless care is taken to
-: wrap them within C preprocessor guards like the following
-:
-:    #if defined(PERL_CORE)
-:    ...
-:    #endif
+: a function returning 'return_type' with arguments aTHX, 'arg1', ..., 'argN',
+: with 'aTHX' omitted on builds that don't need it.  The function would be
+: visible to only other files in the perl core, unless the system doesn't allow
+: visibility restrictions.
 :
 : A common pattern is to use defines like 'PERL_IN_FILE_C' (with FILE_C being
 : appropriately replaced with the real filename).  Most, if not all, of the
@@ -174,11 +189,11 @@
 :   'foo()', the generated macro will be named 'PERL_ARGS_ASSERT_FOO'.  You
 :   should place a call to that macro in foo() before any other code.  It will
 :   automatically expand to whatever checking is currently generated for 'foo'
-:   (often none).  These are mostly in the form of assert() calls, so they are
-:   only activated for DEBUGGING builds.  But for non-DEBUGGING builds, pointer
-:   parameters that must not point to NULL have a compiler directive that means
-:   the same as GCC and Clang's '__attribute__nonnull__' generated for them for
-:   compilers that we know understand it.
+:   (often none).  These are mostly in the form of assert() calls, so they
+:   are only activated for DEBUGGING builds.  But for non-DEBUGGING builds,
+:   pointer parameters that must not point to NULL have a compiler directive
+:   that means the same as GCC and Clang's '__attribute__nonnull__' generated
+:   for them for compilers that we know understand it.
 :
 :   A porting test enforces that an ARGS_ASSERT macro has been included in all
 :   new functions added to this file.  Each call should be at the top of your
@@ -627,12 +642,15 @@
 :
 :        The implication of this is that we can swap implementations at will,
 :        macro-to-function or function-to-macro, without any source code
-:        changes needed.  That doesn't work for fancy macros that use the C
-:        preprocessor language for things, like the '#' and '##' commands to
-:        it, or expanding a single argument to a list, such as 'STR_WITH_LEN'
-:        does.  And the behavior isn't precisely synonymous if the macro
-:        evaluates an argument more than once, and is called with that argument
-:        being an expression with side effects.
+:        changes needed.  That isn't advisable for changing an externally
+:        visible function into a macro because someone might be taking a
+:        function pointer of it, that will suddenly break.  It also doesn't
+:        work for fancy macros that use the C preprocessor language for things,
+:        like the '#' and '##' commands to it, or expanding a single argument
+:        to a list, such as 'STR_WITH_LEN' does.  And the behavior isn't
+:        precisely synonymous if the macro evaluates an argument more than
+:        once, and is called with that argument being an expression with side
+:        effects.
 :
 :        The default visibility of macros created before 5.43 is visible
 :        everywhere, so the visibility flags are ignored.  Starting in that

--- a/proto.h
+++ b/proto.h
@@ -15583,22 +15583,17 @@ Perl_thread_locale_term(pTHX)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 /* PERL_CALLCONV U8 *
-Perl_utf16_to_utf8(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
-        Perl_attribute_nonnull_aTHX; */
+Perl_utf16_to_utf8(U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 /* PERL_CALLCONV U8 *
-Perl_utf16_to_utf8_reversed(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen)
-        Perl_attribute_nonnull_aTHX; */
+Perl_utf16_to_utf8_reversed(U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 #   if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
        defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
 /* PERL_CALLCONV void
-invlist_intersection_(pTHX_ SV * const a, SV * const b, SV **i)
-        Perl_attribute_nonnull_aTHX; */
+invlist_intersection_(SV * const a, SV * const b, SV **i); */
 /* PERL_CALLCONV void
-invlist_subtract_(pTHX_ SV * const a, SV * const b, SV **result)
-        Perl_attribute_nonnull_aTHX; */
+invlist_subtract_(SV * const a, SV * const b, SV **result); */
 /* PERL_CALLCONV void
-invlist_union_(pTHX_ SV * const a, SV * const b, SV **output)
-        Perl_attribute_nonnull_aTHX; */
+invlist_union_(SV * const a, SV * const b, SV **output); */
 #   endif
 # endif
 # if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \

--- a/proto.h
+++ b/proto.h
@@ -26,9 +26,11 @@
 #endif
 
 #if defined(MULTIPLICITY)
-#  define Perl_attribute_nonnull_aTHX  __attribute__nonnull__(1)
+  #  define Perl_assert_aTHX             assert(aTHX)
+  #  define Perl_attribute_nonnull_aTHX  __attribute__nonnull__(1)
 #else
-#  define Perl_attribute_nonnull_aTHX
+  #  define Perl_assert_aTHX
+  #  define Perl_attribute_nonnull_aTHX
 #endif
 
 START_EXTERN_C
@@ -38,25 +40,28 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_AMUPDATE            \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV const char *
 Perl_PerlIO_context_layers(pTHX_ const char *mode)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PERLIO_CONTEXT_LAYERS
+#define PERL_ARGS_ASSERT_PERLIO_CONTEXT_LAYERS  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlLIO_dup2_cloexec(pTHX_ int oldfd, int newfd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_PERLLIO_DUP2_CLOEXEC
+#define PERL_ARGS_ASSERT_PERLLIO_DUP2_CLOEXEC   \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlLIO_dup_cloexec(pTHX_ int oldfd)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_PERLLIO_DUP_CLOEXEC
+#define PERL_ARGS_ASSERT_PERLLIO_DUP_CLOEXEC    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
@@ -65,7 +70,7 @@ Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_OPEN3_CLOEXEC  \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV int
 Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
@@ -74,7 +79,7 @@ Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_OPEN_CLOEXEC   \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV const char *
 Perl_langinfo(const nl_item item);
@@ -89,7 +94,8 @@ Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness)
 PERL_CALLCONV HV *
 Perl_localeconv(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PERL_LOCALECONV
+#define PERL_ARGS_ASSERT_PERL_LOCALECONV        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV const char *
 Perl_setlocale(const int category, const char *locale);
@@ -99,14 +105,15 @@ PERL_CALLCONV void *
 Perl_Slab_Alloc(pTHX_ size_t sz)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_SLAB_ALLOC
+#define PERL_ARGS_ASSERT_SLAB_ALLOC             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_Slab_Free(pTHX_ void *op)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SLAB_FREE              \
-        assert(op)
+        Perl_assert_aTHX; assert(op)
 
 PERL_CALLCONV_NO_RET void
 Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
@@ -115,13 +122,14 @@ Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ABORT_EXECUTION        \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV LOGOP *
 Perl_alloc_LOGOP(pTHX_ I32 type, OP *first, OP *other)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_ALLOC_LOGOP
+#define PERL_ARGS_ASSERT_ALLOC_LOGOP            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PADOFFSET
 Perl_allocmy(pTHX_ const char * const name, const STRLEN len, const U32 flags)
@@ -129,14 +137,14 @@ Perl_allocmy(pTHX_ const char * const name, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ALLOCMY                \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV bool
 Perl_amagic_applies(pTHX_ SV *sv, int method, int flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_APPLIES         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SV *
 Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir)
@@ -144,20 +152,21 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AMAGIC_CALL            \
-        assert(left); assert(right)
+        Perl_assert_aTHX; assert(left); assert(right)
 
 PERL_CALLCONV SV *
 Perl_amagic_deref_call(pTHX_ SV *ref, int method)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL      \
-        assert(ref)
+        Perl_assert_aTHX; assert(ref)
 
 PERL_CALLCONV bool
 Perl_amagic_is_enabled(pTHX_ int method)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED
+#define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_api_version_assert(size_t interp_size, void *v_my_perl, const char *api_version)
@@ -172,7 +181,7 @@ Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_APPLY                  \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV void
 Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, STRLEN len)
@@ -181,7 +190,7 @@ Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_APPLY_ATTRS_STRING     \
-        assert(stashpv); assert(cv); \
+        Perl_assert_aTHX; assert(stashpv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(attrstr)
 
@@ -190,7 +199,8 @@ Perl_apply_builtin_cv_attributes(pTHX_ CV *cv, OP *attrlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_APPLY_BUILTIN_CV_ATTRIBUTES \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_atfork_child(void);
@@ -209,14 +219,14 @@ Perl_av_arylen_p(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ARYLEN_P            \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_clear(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_CLEAR               \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val)
@@ -224,7 +234,7 @@ Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_PUSH     \
-        assert(avp); assert(val)
+        Perl_assert_aTHX; assert(avp); assert(val)
 
 PERL_CALLCONV SV **
 Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val)
@@ -232,20 +242,20 @@ Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_UNSHIFT_ONE \
-        assert(avp); assert(val)
+        Perl_assert_aTHX; assert(avp); assert(val)
 
 PERL_CALLCONV SV *
 Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_DELETE              \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_dump(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_AV_DUMP                \
-        assert(!av || SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV bool
 Perl_av_exists(pTHX_ AV *av, SSize_t key)
@@ -253,14 +263,14 @@ Perl_av_exists(pTHX_ AV *av, SSize_t key)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_EXISTS              \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_extend(pTHX_ AV *av, SSize_t key)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_EXTEND              \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV ***arrayp)
@@ -270,8 +280,8 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV *
         Perl_attribute_nonnull(pTHX_5)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_EXTEND_GUTS         \
-        assert(!av || SvTYPE(av) == SVt_PVAV); assert(maxp); assert(allocp); \
-        assert(arrayp)
+        Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV); assert(maxp); \
+        assert(allocp); assert(arrayp)
 
 PERL_CALLCONV SV **
 Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
@@ -279,21 +289,21 @@ Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_FETCH               \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_fill(pTHX_ AV *av, SSize_t fill)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_FILL                \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV IV *
 Perl_av_iter_p(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ITER_P              \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SSize_t
 Perl_av_len(pTHX_ AV *av)
@@ -301,7 +311,7 @@ Perl_av_len(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_LEN                 \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV AV *
 Perl_av_make(pTHX_ SSize_t size, SV **strp)
@@ -309,7 +319,7 @@ Perl_av_make(pTHX_ SSize_t size, SV **strp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_MAKE                \
-        assert(strp)
+        Perl_assert_aTHX; assert(strp)
 
 PERL_CALLCONV SV *
 Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
@@ -317,14 +327,14 @@ Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_NONELEM             \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SV *
 Perl_av_pop(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_POP                 \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_push(pTHX_ AV *av, SV *val)
@@ -332,10 +342,11 @@ Perl_av_push(pTHX_ AV *av, SV *val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_PUSH                \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(val)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        assert(val)
 
 #define PERL_ARGS_ASSERT_AV_REIFY               \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SV *
 Perl_av_shift(pTHX_ AV *av)
@@ -343,28 +354,28 @@ Perl_av_shift(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_SHIFT               \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SV **
 Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_STORE               \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_undef(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNDEF               \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_av_unshift(pTHX_ AV *av, SSize_t num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNSHIFT             \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV OP *
 Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
@@ -374,56 +385,63 @@ Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BIND_MATCH             \
-        assert(left); assert(right)
+        Perl_assert_aTHX; assert(left); assert(right)
 
 PERL_CALLCONV OP *
 Perl_block_end(pTHX_ I32 floor, OP *seq)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_BLOCK_END
+#define PERL_ARGS_ASSERT_BLOCK_END              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV U8
 Perl_block_gimme(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_BLOCK_GIMME
+#define PERL_ARGS_ASSERT_BLOCK_GIMME            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_block_start(pTHX_ int full)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_BLOCK_START
+#define PERL_ARGS_ASSERT_BLOCK_START            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_blockhook_register(pTHX_ BHK *hk)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_BLOCKHOOK_REGISTER     \
-        assert(hk)
+        Perl_assert_aTHX; assert(hk)
 
 PERL_CALLCONV void
 Perl_boot_core_PerlIO(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_BOOT_CORE_PERLIO
+#define PERL_ARGS_ASSERT_BOOT_CORE_PERLIO       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_boot_core_UNIVERSAL(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_BOOT_CORE_UNIVERSAL
+#define PERL_ARGS_ASSERT_BOOT_CORE_UNIVERSAL    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_boot_core_builtin(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_BOOT_CORE_BUILTIN
+#define PERL_ARGS_ASSERT_BOOT_CORE_BUILTIN      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_boot_core_mro(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_BOOT_CORE_MRO
+#define PERL_ARGS_ASSERT_BOOT_CORE_MRO          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
@@ -433,9 +451,10 @@ Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BUILD_INFIX_PLUGIN     \
-        assert(lhs); assert(rhs); assert(tokendata)
+        Perl_assert_aTHX; assert(lhs); assert(rhs); assert(tokendata)
 
-#define PERL_ARGS_ASSERT_BYTE_DUMP_STRING_
+#define PERL_ARGS_ASSERT_BYTE_DUMP_STRING_      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
@@ -443,7 +462,7 @@ Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_BYTES_CMP_UTF8         \
-        assert(b); assert(u)
+        Perl_assert_aTHX; assert(b); assert(u)
 
 PERL_CALLCONV U8 *
 Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p)
@@ -452,7 +471,7 @@ Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_BYTES_FROM_UTF8        \
-        assert(s); assert(lenp); assert(is_utf8p)
+        Perl_assert_aTHX; assert(s); assert(lenp); assert(is_utf8p)
 
 PERL_CALLCONV U8 *
 Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me)
@@ -460,7 +479,7 @@ Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_BYTES_TO_UTF8_FREE_ME  \
-        assert(s); assert(lenp)
+        Perl_assert_aTHX; assert(s); assert(lenp)
 
 PERL_CALLCONV SSize_t
 Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
@@ -468,45 +487,48 @@ Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CALL_ARGV              \
-        assert(sub_name); assert(argv)
+        Perl_assert_aTHX; assert(sub_name); assert(argv)
 
 PERL_CALLCONV void
 Perl_call_atexit(pTHX_ ATEXIT_t fn, void *ptr)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_CALL_ATEXIT
+#define PERL_ARGS_ASSERT_CALL_ATEXIT            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_CALL_LIST              \
-        assert(paramList); assert(SvTYPE(paramList) == SVt_PVAV)
+        Perl_assert_aTHX; assert(paramList); \
+        assert(SvTYPE(paramList) == SVt_PVAV)
 
 PERL_CALLCONV SSize_t
 Perl_call_method(pTHX_ const char *methname, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_METHOD            \
-        assert(methname)
+        Perl_assert_aTHX; assert(methname)
 
 PERL_CALLCONV SSize_t
 Perl_call_pv(pTHX_ const char *sub_name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_PV                \
-        assert(sub_name)
+        Perl_assert_aTHX; assert(sub_name)
 
 PERL_CALLCONV SSize_t
 Perl_call_sv(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_SV                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV const PERL_CONTEXT *
 Perl_caller_cx(pTHX_ I32 level, const PERL_CONTEXT **dbcxp)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_CALLER_CX
+#define PERL_ARGS_ASSERT_CALLER_CX              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV Malloc_t
 Perl_calloc(MEM_SIZE elements, MEM_SIZE size)
@@ -521,7 +543,7 @@ Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CANDO                  \
-        assert(statbufp)
+        Perl_assert_aTHX; assert(statbufp)
 
 PERL_CALLCONV I32
 Perl_cast_i32(NV f)
@@ -549,7 +571,7 @@ Perl_check_utf8_print(pTHX_ const U8 *s, const STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CHECK_UTF8_PRINT       \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
@@ -559,14 +581,14 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_CORE  \
-        assert(entersubop); assert(namegv); assert(protosv)
+        Perl_assert_aTHX; assert(entersubop); assert(namegv); assert(protosv)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_list(pTHX_ OP *entersubop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_LIST  \
-        assert(entersubop)
+        Perl_assert_aTHX; assert(entersubop)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
@@ -575,7 +597,7 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO \
-        assert(entersubop); assert(namegv); assert(protosv)
+        Perl_assert_aTHX; assert(entersubop); assert(namegv); assert(protosv)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
@@ -584,7 +606,7 @@ Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protos
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO_OR_LIST \
-        assert(entersubop); assert(namegv); assert(protosv)
+        Perl_assert_aTHX; assert(entersubop); assert(namegv); assert(protosv)
 
 PERL_CALLCONV void
 Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
@@ -592,7 +614,7 @@ Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER              \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV void
 Perl_ck_warner_d(pTHX_ U32 err, const char *pat, ...)
@@ -600,28 +622,30 @@ Perl_ck_warner_d(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER_D            \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV bool
 Perl_ckwarn(pTHX_ U32 w)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__pure__;
-#define PERL_ARGS_ASSERT_CKWARN
+#define PERL_ARGS_ASSERT_CKWARN                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_ckwarn_d(pTHX_ U32 w)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__pure__;
-#define PERL_ARGS_ASSERT_CKWARN_D
+#define PERL_ARGS_ASSERT_CKWARN_D               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_clear_defarray(pTHX_ AV *av, bool abandon)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CLEAR_DEFARRAY         \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV const COP *
 Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop, bool opnext)
@@ -629,7 +653,7 @@ Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop, bool opnext
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CLOSEST_COP            \
-        assert(cop)
+        Perl_assert_aTHX; assert(cop)
 
 PERL_CALLCONV OP *
 Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
@@ -638,7 +662,7 @@ Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_EXTEND        \
-        assert(ch)
+        Perl_assert_aTHX; assert(ch)
 
 PERL_CALLCONV OP *
 Perl_cmpchain_finish(pTHX_ OP *ch)
@@ -647,14 +671,15 @@ Perl_cmpchain_finish(pTHX_ OP *ch)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_FINISH        \
-        assert(ch)
+        Perl_assert_aTHX; assert(ch)
 
 PERL_CALLCONV OP *
 Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_CMPCHAIN_START
+#define PERL_ARGS_ASSERT_CMPCHAIN_START         \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_CNTRL_TO_MNEMONIC
 
@@ -663,28 +688,28 @@ Perl_cop_disable_warning(pTHX_ COP *cop, int warn_bit)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_DISABLE_WARNING    \
-        assert(cop)
+        Perl_assert_aTHX; assert(cop)
 
 PERL_CALLCONV void
 Perl_cop_enable_warning(pTHX_ COP *cop, int warn_bit)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_ENABLE_WARNING     \
-        assert(cop)
+        Perl_assert_aTHX; assert(cop)
 
 PERL_CALLCONV const char *
 Perl_cop_fetch_label(pTHX_ COP * const cop, STRLEN *len, U32 *flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_FETCH_LABEL        \
-        assert(cop)
+        Perl_assert_aTHX; assert(cop)
 
 PERL_CALLCONV bool
 Perl_cop_has_warning(pTHX_ const COP *cop, int warn_bit)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_HAS_WARNING        \
-        assert(cop)
+        Perl_assert_aTHX; assert(cop)
 
 PERL_CALLCONV void
 Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 flags)
@@ -692,7 +717,7 @@ Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 f
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_COP_STORE_LABEL        \
-        assert(cop); assert(label)
+        Perl_assert_aTHX; assert(cop); assert(label)
 
 PERL_CALLCONV SV *
 Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code, int * const opnum)
@@ -700,7 +725,7 @@ Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code, int * const 
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORE_PROTOTYPE         \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV OP *
 Perl_coresub_op(pTHX_ SV * const coreargssv, const int code, const int opnum)
@@ -708,7 +733,7 @@ Perl_coresub_op(pTHX_ SV * const coreargssv, const int code, const int opnum)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORESUB_OP             \
-        assert(coreargssv)
+        Perl_assert_aTHX; assert(coreargssv)
 
 PERL_CALLCONV void
 Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
@@ -716,14 +741,15 @@ Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CREATE_EVAL_SCOPE      \
-        assert(sp)
+        Perl_assert_aTHX; assert(sp)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,pTHX_1,pTHX_2);
-#define PERL_ARGS_ASSERT_CROAK
+#define PERL_ARGS_ASSERT_CROAK                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_caller(const char *pat, ...)
@@ -767,7 +793,7 @@ Perl_croak_sv(pTHX_ SV *baseex)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_CROAK_SV               \
-        assert(baseex)
+        Perl_assert_aTHX; assert(baseex)
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_xs_usage(const CV * const cv, const char * const params)
@@ -785,7 +811,8 @@ PERL_CALLCONV Signal_t
 Perl_csighandler3(int sig, Siginfo_t *info, void *uap);
 #define PERL_ARGS_ASSERT_CSIGHANDLER3
 
-#define PERL_ARGS_ASSERT_CURRENT_RE_ENGINE
+#define PERL_ARGS_ASSERT_CURRENT_RE_ENGINE      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV XOPRETANY
 Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
@@ -793,7 +820,7 @@ Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_CUSTOM_OP_GET_FIELD    \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
@@ -801,17 +828,17 @@ Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_CUSTOM_OP_REGISTER     \
-        assert(ppaddr); assert(xop)
+        Perl_assert_aTHX; assert(ppaddr); assert(xop)
 
 #define PERL_ARGS_ASSERT_CV_CKPROTO_LEN_FLAGS   \
-        assert(cv)
+        Perl_assert_aTHX; assert(cv)
 
 PERL_CALLCONV CV *
 Perl_cv_clone(pTHX_ CV *proto)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_CLONE               \
-        assert(proto); \
+        Perl_assert_aTHX; assert(proto); \
         assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM)
 
 PERL_CALLCONV CV *
@@ -821,7 +848,7 @@ Perl_cv_clone_into(pTHX_ CV *proto, CV *target)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_CLONE_INTO          \
-        assert(proto); \
+        Perl_assert_aTHX; assert(proto); \
         assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM); \
         assert(target); \
         assert(SvTYPE(target) == SVt_PVCV || SvTYPE(target) == SVt_PVFM)
@@ -842,6 +869,7 @@ Perl_cv_forget_slab(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_FORGET_SLAB         \
+        Perl_assert_aTHX; \
         assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -851,7 +879,8 @@ Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER    \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(ckfun_p); assert(ckobj_p)
 
 PERL_CALLCONV void
@@ -862,7 +891,8 @@ Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfu
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER_FLAGS \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(ckfun_p); assert(ckobj_p); assert(ckflags_p)
 
 PERL_CALLCONV SV *
@@ -870,7 +900,7 @@ Perl_cv_name(pTHX_ CV *cv, SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_NAME                \
-        assert(cv)
+        Perl_assert_aTHX; assert(cv)
 
 PERL_CALLCONV void
 Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
@@ -879,8 +909,9 @@ Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER    \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
-        assert(ckfun); assert(ckobj)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(ckfun); \
+        assert(ckobj)
 
 PERL_CALLCONV void
 Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj, U32 ckflags)
@@ -889,15 +920,17 @@ Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj,
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER_FLAGS \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
-        assert(ckfun); assert(ckobj)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(ckfun); \
+        assert(ckobj)
 
 PERL_CALLCONV void
 Perl_cv_undef(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_UNDEF               \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
@@ -905,28 +938,32 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_UNDEF_FLAGS         \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV GV *
 Perl_cvgv_from_hek(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_FROM_HEK          \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cvgv_set(pTHX_ CV *cv, GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_SET               \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVSTASH_SET            \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
@@ -934,13 +971,14 @@ Perl_cx_dump(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CX_DUMP                \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_CALLCONV I32
 Perl_cxinc(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_CXINC
+#define PERL_ARGS_ASSERT_CXINC                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_deb(pTHX_ const char *pat, ...)
@@ -948,41 +986,46 @@ Perl_deb(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_DEB                    \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV void
 Perl_deb_stack_all(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_DEB_STACK_ALL
+#define PERL_ARGS_ASSERT_DEB_STACK_ALL          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_debop(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DEBOP                  \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_debprofdump(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DEBPROFDUMP
+#define PERL_ARGS_ASSERT_DEBPROFDUMP            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_debstack(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DEBSTACK
+#define PERL_ARGS_ASSERT_DEBSTACK               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_debstackptrs(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DEBSTACKPTRS
+#define PERL_ARGS_ASSERT_DEBSTACKPTRS           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_debug_hash_seed(pTHX_ bool via_debug_h)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_DEBUG_HASH_SEED
+#define PERL_ARGS_ASSERT_DEBUG_HASH_SEED        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
@@ -991,18 +1034,20 @@ Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DEFELEM_TARGET         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_defer_error(pTHX_ SV *err)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DEFER_ERROR
+#define PERL_ARGS_ASSERT_DEFER_ERROR            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_delete_eval_scope(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_DELETE_EVAL_SCOPE
+#define PERL_ARGS_ASSERT_DELETE_EVAL_SCOPE      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen)
@@ -1022,14 +1067,16 @@ Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_e
 PERL_CALLCONV void
 Perl_despatch_signals(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DESPATCH_SIGNALS
+#define PERL_ARGS_ASSERT_DESPATCH_SIGNALS       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__
         __attribute__format__null_ok__(__printf__,pTHX_1,pTHX_2);
-#define PERL_ARGS_ASSERT_DIE
+#define PERL_ARGS_ASSERT_DIE                    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die_sv(pTHX_ SV *baseex)
@@ -1037,7 +1084,7 @@ Perl_die_sv(pTHX_ SV *baseex)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_DIE_SV                 \
-        assert(baseex)
+        Perl_assert_aTHX; assert(baseex)
 
 PERL_CALLCONV_NO_RET void
 Perl_die_unwind(pTHX_ SV *msv)
@@ -1046,7 +1093,7 @@ Perl_die_unwind(pTHX_ SV *msv)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DIE_UNWIND             \
-        assert(msv)
+        Perl_assert_aTHX; assert(msv)
 
 PERL_CALLCONV bool
 Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp, int fd, int do_report)
@@ -1055,12 +1102,13 @@ Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp, int fd, int do_report)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_AEXEC5              \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV bool
 Perl_do_close(pTHX_ GV *gv, bool is_explicit)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DO_CLOSE
+#define PERL_ARGS_ASSERT_DO_CLOSE               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
@@ -1068,7 +1116,7 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_DUMP_PAD            \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV bool
 Perl_do_eof(pTHX_ GV *gv)
@@ -1076,7 +1124,7 @@ Perl_do_eof(pTHX_ GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_EOF                 \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
@@ -1084,7 +1132,7 @@ Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GV_DUMP             \
-        assert(file); assert(name)
+        Perl_assert_aTHX; assert(file); assert(name)
 
 PERL_CALLCONV void
 Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
@@ -1092,7 +1140,7 @@ Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GVGV_DUMP           \
-        assert(file); assert(name)
+        Perl_assert_aTHX; assert(file); assert(name)
 
 PERL_CALLCONV void
 Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
@@ -1100,7 +1148,8 @@ Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_HV_DUMP             \
-        assert(file); assert(name); assert(!sv || SvTYPE(sv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(file); assert(name); \
+        assert(!sv || SvTYPE(sv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
@@ -1110,14 +1159,14 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_DO_JOIN                \
-        assert(sv); assert(delim); assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(sv); assert(delim); assert(mark); assert(sp)
 
 PERL_CALLCONV void
 Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_MAGIC_DUMP          \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV I32
 Perl_do_ncmp(pTHX_ SV * const left, SV * const right)
@@ -1127,14 +1176,14 @@ Perl_do_ncmp(pTHX_ SV * const left, SV * const right)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_NCMP                \
-        assert(left); assert(right)
+        Perl_assert_aTHX; assert(left); assert(right)
 
 PERL_CALLCONV void
 Perl_do_op_dump(pTHX_ I32 level, PerlIO *file, const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OP_DUMP             \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV bool
 Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, SV **svp, U32 num)
@@ -1143,7 +1192,7 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, 
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_OPEN6               \
-        assert(gv); assert(oname)
+        Perl_assert_aTHX; assert(gv); assert(oname)
 
 PERL_CALLCONV bool
 Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int rawperm, Stat_t *statbufp)
@@ -1152,7 +1201,7 @@ Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int r
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_OPEN_RAW            \
-        assert(gv); assert(oname)
+        Perl_assert_aTHX; assert(gv); assert(oname)
 
 PERL_CALLCONV bool
 Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp, SV **svp, I32 num)
@@ -1160,14 +1209,14 @@ Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode,
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OPENN               \
-        assert(gv); assert(oname)
+        Perl_assert_aTHX; assert(gv); assert(oname)
 
 PERL_CALLCONV void
 Perl_do_pmop_dump(pTHX_ I32 level, PerlIO *file, const PMOP *pm)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_PMOP_DUMP           \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV bool
 Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
@@ -1175,20 +1224,22 @@ Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_PRINT               \
-        assert(fp)
+        Perl_assert_aTHX; assert(fp)
 
 PERL_CALLCONV OP *
 Perl_do_readline(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_DO_READLINE
+#define PERL_ARGS_ASSERT_DO_READLINE            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_do_seek(pTHX_ GV *gv, Off_t pos, int whence)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_DO_SEEK
+#define PERL_ARGS_ASSERT_DO_SEEK                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
@@ -1196,14 +1247,14 @@ Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_SPRINTF             \
-        assert(sv); assert(sarg)
+        Perl_assert_aTHX; assert(sv); assert(sarg)
 
 PERL_CALLCONV void
 Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_SV_DUMP             \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV Off_t
 Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
@@ -1211,7 +1262,7 @@ Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_SYSSEEK             \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV Off_t
 Perl_do_tell(pTHX_ GV *gv)
@@ -1220,7 +1271,7 @@ Perl_do_tell(pTHX_ GV *gv)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_TELL                \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV Size_t
 Perl_do_trans(pTHX_ SV *sv)
@@ -1228,7 +1279,7 @@ Perl_do_trans(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_TRANS               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #define PERL_ARGS_ASSERT_DO_UNIPROP_MATCH       \
         assert(key)
@@ -1239,7 +1290,7 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECGET              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_do_vecset(pTHX_ SV *sv)
@@ -1247,7 +1298,7 @@ Perl_do_vecset(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECSET              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
@@ -1257,7 +1308,7 @@ Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VOP                 \
-        assert(sv); assert(left); assert(right)
+        Perl_assert_aTHX; assert(sv); assert(left); assert(right)
 
 PERL_CALLCONV OP *
 Perl_dofile(pTHX_ OP *term, I32 force_builtin)
@@ -1265,7 +1316,7 @@ Perl_dofile(pTHX_ OP *term, I32 force_builtin)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DOFILE                 \
-        assert(term)
+        Perl_assert_aTHX; assert(term)
 
 PERL_CALLCONV bool
 Perl_doing_taint(int argc, char **argv, char **env)
@@ -1277,19 +1328,21 @@ Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DOREF                  \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_dounwind(pTHX_ I32 cxix)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DOUNWIND
+#define PERL_ARGS_ASSERT_DOUNWIND               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV U8
 Perl_dowantarray(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__deprecated__
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_DOWANTARRAY
+#define PERL_ARGS_ASSERT_DOWANTARRAY            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_drand48_init_r(perl_drand48_t *random_state, U32 seed)
@@ -1306,25 +1359,28 @@ Perl_drand48_r(perl_drand48_t *random_state)
 PERL_CALLCONV void
 Perl_dump_all(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DUMP_ALL
+#define PERL_ARGS_ASSERT_DUMP_ALL               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_dump_all_perl(pTHX_ bool justperl)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_DUMP_ALL_PERL
+#define PERL_ARGS_ASSERT_DUMP_ALL_PERL          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_dump_eval(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_DUMP_EVAL
+#define PERL_ARGS_ASSERT_DUMP_EVAL              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_dump_form(pTHX_ const GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_FORM              \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char *pat, ...)
@@ -1333,14 +1389,14 @@ Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__format__(__printf__,pTHX_3,pTHX_4);
 #define PERL_ARGS_ASSERT_DUMP_INDENT            \
-        assert(file); assert(pat)
+        Perl_assert_aTHX; assert(file); assert(pat)
 
 PERL_CALLCONV void
 Perl_dump_packsubs(pTHX_ const HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS          \
-        assert(stash)
+        Perl_assert_aTHX; assert(stash)
 
 PERL_CALLCONV void
 Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
@@ -1348,14 +1404,14 @@ Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS_PERL     \
-        assert(stash)
+        Perl_assert_aTHX; assert(stash)
 
 PERL_CALLCONV void
 Perl_dump_sub(pTHX_ const GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_SUB               \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
@@ -1363,7 +1419,7 @@ Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_SUB_PERL          \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
@@ -1371,26 +1427,27 @@ Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DUMP_VINDENT           \
-        assert(file); assert(pat)
+        Perl_assert_aTHX; assert(file); assert(pat)
 
-#define PERL_ARGS_ASSERT_DUP_WARNINGS
+#define PERL_ARGS_ASSERT_DUP_WARNINGS           \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_EMULATE_COP_IO         \
-        assert(c); assert(sv)
+        Perl_assert_aTHX; assert(c); assert(sv)
 
 PERL_CALLCONV SV *
 Perl_eval_pv(pTHX_ const char *p, I32 croak_on_error)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_PV                \
-        assert(p)
+        Perl_assert_aTHX; assert(p)
 
 PERL_CALLCONV SSize_t
 Perl_eval_sv(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_SV                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
@@ -1398,14 +1455,14 @@ Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_FATAL_WARNER           \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV void
 Perl_fbm_compile(pTHX_ SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_FBM_COMPILE            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U32 flags)
@@ -1415,19 +1472,21 @@ Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FBM_INSTR              \
-        assert(big); assert(bigend); assert(littlestr); assert(big <= bigend)
+        Perl_assert_aTHX; assert(big); assert(bigend); assert(littlestr); \
+        assert(big <= bigend)
 
 PERL_CALLCONV SV *
 Perl_filter_add(pTHX_ filter_t funcp, SV *datasv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_FILTER_ADD
+#define PERL_ARGS_ASSERT_FILTER_ADD             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_filter_del(pTHX_ filter_t funcp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_FILTER_DEL             \
-        assert(funcp)
+        Perl_assert_aTHX; assert(funcp)
 
 PERL_CALLCONV I32
 Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
@@ -1435,31 +1494,35 @@ Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FILTER_READ            \
-        assert(buf_sv)
+        Perl_assert_aTHX; assert(buf_sv)
 
 PERL_CALLCONV CV *
 Perl_find_lexical_cv(pTHX_ PADOFFSET off)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_FIND_LEXICAL_CV
+#define PERL_ARGS_ASSERT_FIND_LEXICAL_CV        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV CV *
 Perl_find_runcv(pTHX_ U32 *db_seqp)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_FIND_RUNCV
+#define PERL_ARGS_ASSERT_FIND_RUNCV             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV CV *
 Perl_find_runcv_where(pTHX_ U8 cond, IV arg, U32 *db_seqp)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_FIND_RUNCV_WHERE
+#define PERL_ARGS_ASSERT_FIND_RUNCV_WHERE       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_find_rundefsv(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_FIND_RUNDEFSV
+#define PERL_ARGS_ASSERT_FIND_RUNDEFSV          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const * const search_ext, I32 flags)
@@ -1467,7 +1530,7 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_SCRIPT            \
-        assert(scriptname)
+        Perl_assert_aTHX; assert(scriptname)
 
 PERL_CALLCONV I32
 Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2, U32 flags)
@@ -1475,7 +1538,7 @@ Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const c
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_FOLDEQ_UTF8_FLAGS      \
-        assert(s1); assert(s2)
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_CALLCONV void
 Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname)
@@ -1483,13 +1546,14 @@ Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_FORBID_OUTOFBLOCK_OPS  \
-        assert(o); assert(blockname)
+        Perl_assert_aTHX; assert(o); assert(blockname)
 
 PERL_CALLCONV void
 Perl_force_locale_unlock(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK
+#define PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * const e, U32 flags, const bool die_here)
@@ -1497,7 +1561,7 @@ Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * cons
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_FORCE_OUT_MALFORMED_UTF8_MESSAGE_ \
-        assert(p); assert(e); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
 
 PERL_CALLCONV char *
 Perl_form(pTHX_ const char *pat, ...)
@@ -1505,49 +1569,53 @@ Perl_form(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_FORM                   \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV void
 Perl_free_tied_hv_pool(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_FREE_TIED_HV_POOL
+#define PERL_ARGS_ASSERT_FREE_TIED_HV_POOL      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_free_tmps(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_FREE_TMPS
+#define PERL_ARGS_ASSERT_FREE_TMPS              \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME \
-        assert(s); assert(e); assert(error_msg); assert(s <= e)
+        Perl_assert_aTHX; assert(s); assert(e); assert(error_msg); \
+        assert(s <= e)
 
 PERL_CALLCONV AV *
 Perl_get_av(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_AV                 \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV CV *
 Perl_get_cv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CV                 \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV CV *
 Perl_get_cvn_flags(pTHX_ const char *name, STRLEN len, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CVN_FLAGS          \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV void
 Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GET_DB_SUB             \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 #define PERL_ARGS_ASSERT_GET_DEPRECATED_PROPERTY_MSG
 
@@ -1562,14 +1630,14 @@ Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GET_HASH_SEED          \
-        assert(seed_buffer)
+        Perl_assert_aTHX; assert(seed_buffer)
 
 PERL_CALLCONV HV *
 Perl_get_hv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_HV                 \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV const char *
 Perl_get_no_modify(pTHX)
@@ -1578,7 +1646,8 @@ Perl_get_no_modify(pTHX)
         __attribute__warn_unused_result__
         __attribute__pure__
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_GET_NO_MODIFY
+#define PERL_ARGS_ASSERT_GET_NO_MODIFY          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char **
 Perl_get_op_descs(pTHX)
@@ -1586,7 +1655,8 @@ Perl_get_op_descs(pTHX)
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__;
-#define PERL_ARGS_ASSERT_GET_OP_DESCS
+#define PERL_ARGS_ASSERT_GET_OP_DESCS           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char **
 Perl_get_op_names(pTHX)
@@ -1594,7 +1664,8 @@ Perl_get_op_names(pTHX)
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__;
-#define PERL_ARGS_ASSERT_GET_OP_NAMES
+#define PERL_ARGS_ASSERT_GET_OP_NAMES           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV U32 *
 Perl_get_opargs(pTHX)
@@ -1603,7 +1674,8 @@ Perl_get_opargs(pTHX)
         __attribute__warn_unused_result__
         __attribute__pure__
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_GET_OPARGS
+#define PERL_ARGS_ASSERT_GET_OPARGS             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PPADDR_t *
 Perl_get_ppaddr(pTHX)
@@ -1611,40 +1683,45 @@ Perl_get_ppaddr(pTHX)
         __attribute__deprecated__
         __attribute__warn_unused_result__
         __attribute__pure__;
-#define PERL_ARGS_ASSERT_GET_PPADDR
+#define PERL_ARGS_ASSERT_GET_PPADDR             \
+        Perl_assert_aTHX
 
-#define PERL_ARGS_ASSERT_GET_PROP_DEFINITION
+#define PERL_ARGS_ASSERT_GET_PROP_DEFINITION    \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_GET_PROP_VALUES
 
 PERL_CALLCONV REGEXP *
 Perl_get_re_arg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_GET_RE_ARG
+#define PERL_ARGS_ASSERT_GET_RE_ARG             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_get_sv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_SV                 \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV int
 Perl_getcwd_sv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GETCWD_SV              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_gp_free(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_GP_FREE
+#define PERL_ARGS_ASSERT_GP_FREE                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV GP *
 Perl_gp_ref(pTHX_ GP *gp)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_GP_REF
+#define PERL_ARGS_ASSERT_GP_REF                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_grok_atoUV(const char *pv, UV *valptr, const char **endptr)
@@ -1660,7 +1737,7 @@ Perl_grok_bin_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GROK_BIN_HEX           \
-        assert(start); assert(len_p); assert(flags)
+        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
 
 PERL_CALLCONV int
 Perl_grok_infnan(pTHX_ const char **sp, const char *send)
@@ -1668,21 +1745,22 @@ Perl_grok_infnan(pTHX_ const char **sp, const char *send)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GROK_INFNAN            \
-        assert(sp); assert(*sp); assert(send); assert(*sp <= send)
+        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send); \
+        assert(*sp <= send)
 
 PERL_CALLCONV int
 Perl_grok_number(pTHX_ const char *pv, STRLEN len, UV *valuep)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER            \
-        assert(pv)
+        Perl_assert_aTHX; assert(pv)
 
 PERL_CALLCONV int
 Perl_grok_number_flags(pTHX_ const char *pv, STRLEN len, UV *valuep, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER_FLAGS      \
-        assert(pv)
+        Perl_assert_aTHX; assert(pv)
 
 PERL_CALLCONV bool
 Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
@@ -1691,7 +1769,8 @@ Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GROK_NUMERIC_RADIX     \
-        assert(sp); assert(*sp); assert(send); assert(*sp <= send)
+        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send); \
+        assert(*sp <= send)
 
 PERL_CALLCONV UV
 Perl_grok_uint_by_base(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *approximation, uint_fast8_t base, const U32 lookup_bit, uint_fast8_t offset)
@@ -1700,12 +1779,13 @@ Perl_grok_uint_by_base(pTHX_ const char * const start, STRLEN *len_p, I32 *flags
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GROK_UINT_BY_BASE      \
-        assert(start); assert(len_p); assert(flags)
+        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
 
 PERL_CALLCONV GV *
 Perl_gv_add_by_type(pTHX_ GV *gv, svtype type)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_GV_ADD_BY_TYPE
+#define PERL_ARGS_ASSERT_GV_ADD_BY_TYPE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
@@ -1713,7 +1793,7 @@ Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PV         \
-        assert(namepv)
+        Perl_assert_aTHX; assert(namepv)
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
@@ -1721,7 +1801,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PVN        \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_sv(pTHX_ HV *stash, SV *namesv, U32 flags)
@@ -1729,14 +1809,14 @@ Perl_gv_autoload_sv(pTHX_ HV *stash, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_SV         \
-        assert(namesv)
+        Perl_assert_aTHX; assert(namesv)
 
 PERL_CALLCONV void
 Perl_gv_check(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_CHECK               \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_gv_const_sv(pTHX_ GV *gv)
@@ -1744,12 +1824,13 @@ Perl_gv_const_sv(pTHX_ GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_CONST_SV            \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_gv_dump(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_GV_DUMP
+#define PERL_ARGS_ASSERT_GV_DUMP                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
@@ -1757,63 +1838,63 @@ Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_EFULLNAME4          \
-        assert(sv); assert(gv)
+        Perl_assert_aTHX; assert(sv); assert(gv)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchfile(pTHX_ const char *name)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE           \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchfile_flags(pTHX_ const char * const name, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE_FLAGS     \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pv(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV        \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pv_autoload(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV_AUTOLOAD \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pvn(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN       \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pvn_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN_AUTOLOAD \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_sv(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV        \
-        assert(namesv)
+        Perl_assert_aTHX; assert(namesv)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV_AUTOLOAD \
-        assert(namesv)
+        Perl_assert_aTHX; assert(namesv)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
@@ -1821,7 +1902,7 @@ Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_AUTOLOAD \
-        assert(stash); assert(name)
+        Perl_assert_aTHX; assert(stash); assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
@@ -1829,7 +1910,7 @@ Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PV_FLAGS \
-        assert(stash); assert(name)
+        Perl_assert_aTHX; assert(stash); assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN len, U32 flags)
@@ -1837,7 +1918,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PVN_FLAGS \
-        assert(stash); assert(name)
+        Perl_assert_aTHX; assert(stash); assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
@@ -1845,28 +1926,28 @@ Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_SV_FLAGS \
-        assert(stash); assert(namesv)
+        Perl_assert_aTHX; assert(stash); assert(namesv)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPV             \
-        assert(nambeg)
+        Perl_assert_aTHX; assert(nambeg)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchpvn_flags(pTHX_ const char *nambeg, STRLEN len, I32 flags, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPVN_FLAGS      \
-        assert(nambeg)
+        Perl_assert_aTHX; assert(nambeg)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHSV             \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV void
 Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
@@ -1874,14 +1955,14 @@ Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FULLNAME4           \
-        assert(sv); assert(gv)
+        Perl_assert_aTHX; assert(sv); assert(gv)
 
 PERL_CALLCONV CV *
 Perl_gv_handler(pTHX_ HV *stash, I32 id)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_HANDLER             \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
@@ -1889,7 +1970,8 @@ Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PV             \
-        assert(gv); assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
+        Perl_assert_aTHX; assert(gv); \
+        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
 Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flags)
@@ -1897,7 +1979,8 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PVN            \
-        assert(gv); assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
+        Perl_assert_aTHX; assert(gv); \
+        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
 Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
@@ -1905,7 +1988,8 @@ Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_SV             \
-        assert(gv); assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(namesv)
+        Perl_assert_aTHX; assert(gv); \
+        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(namesv)
 
 PERL_CALLCONV void
 Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
@@ -1913,14 +1997,14 @@ Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_NAME_SET            \
-        assert(gv); assert(name)
+        Perl_assert_aTHX; assert(gv); assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_override(pTHX_ const char * const name, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_OVERRIDE            \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV void
 Perl_gv_setref(pTHX_ SV * const dsv, SV * const ssv)
@@ -1929,35 +2013,35 @@ Perl_gv_setref(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GV_SETREF              \
-        assert(dsv); assert(ssv)
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 PERL_CALLCONV HV *
 Perl_gv_stashpv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPV             \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV HV *
 Perl_gv_stashpvn(pTHX_ const char *name, U32 namelen, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPVN            \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV HV *
 Perl_gv_stashsv(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHSV             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_gv_try_downgrade(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_TRY_DOWNGRADE       \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV struct xpvhv_aux *
 Perl_hv_auxalloc(pTHX_ HV *hv)
@@ -1965,7 +2049,7 @@ Perl_hv_auxalloc(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_AUXALLOC            \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV AV **
 Perl_hv_backreferences_p(pTHX_ HV *hv)
@@ -1973,7 +2057,7 @@ Perl_hv_backreferences_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_BACKREFERENCES_P    \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_hv_bucket_ratio(pTHX_ HV *hv)
@@ -1981,44 +2065,45 @@ Perl_hv_bucket_ratio(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_BUCKET_RATIO        \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_clear(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_CLEAR               \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_clear_placeholders(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_CLEAR_PLACEHOLDERS  \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void *
 Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int flags, int action, SV *val, U32 hash)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_HV_COMMON
+#define PERL_ARGS_ASSERT_HV_COMMON              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV HV *
 Perl_hv_copy_hints_hv(pTHX_ HV * const ohv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_COPY_HINTS_HV       \
-        assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_delayfree_ent(pTHX_ HV *notused, HE *entry)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_DELAYFREE_ENT       \
-        assert(!notused || SvTYPE(notused) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!notused || SvTYPE(notused) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_dump(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_DUMP                \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV HE **
 Perl_hv_eiter_p(pTHX_ HV *hv)
@@ -2026,14 +2111,14 @@ Perl_hv_eiter_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_EITER_P             \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_EITER_SET           \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
@@ -2042,7 +2127,8 @@ Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_ADD           \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(name)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(name)
 
 PERL_CALLCONV void
 Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
@@ -2051,27 +2137,28 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_DELETE        \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(name)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(name)
 
 PERL_CALLCONV STRLEN
 Perl_hv_fill(pTHX_ HV * const hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_FILL                \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_free_ent(pTHX_ HV *notused, HE *entry)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_FREE_ENT            \
-        assert(!notused || SvTYPE(notused) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!notused || SvTYPE(notused) == SVt_PVHV)
 
 PERL_CALLCONV I32
 Perl_hv_iterinit(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_ITERINIT            \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV char *
 Perl_hv_iterkey(pTHX_ HE *entry, I32 *retlen)
@@ -2080,7 +2167,7 @@ Perl_hv_iterkey(pTHX_ HE *entry, I32 *retlen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERKEY             \
-        assert(entry); assert(retlen)
+        Perl_assert_aTHX; assert(entry); assert(retlen)
 
 PERL_CALLCONV SV *
 Perl_hv_iterkeysv(pTHX_ HE *entry)
@@ -2088,7 +2175,7 @@ Perl_hv_iterkeysv(pTHX_ HE *entry)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERKEYSV           \
-        assert(entry)
+        Perl_assert_aTHX; assert(entry)
 
 PERL_CALLCONV HE *
 Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
@@ -2096,7 +2183,7 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXT_FLAGS      \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
@@ -2106,7 +2193,8 @@ Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXTSV          \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(retlen)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(key); assert(retlen)
 
 PERL_CALLCONV SV *
 Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
@@ -2115,21 +2203,22 @@ Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERVAL             \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(entry)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(entry)
 
 PERL_CALLCONV void
 Perl_hv_ksplit(pTHX_ HV *hv, IV newmax)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_KSPLIT              \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_NAME_SET            \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV I32
 Perl_hv_placeholders_get(pTHX_ const HV *hv)
@@ -2137,7 +2226,7 @@ Perl_hv_placeholders_get(pTHX_ const HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_GET    \
-        assert(hv)
+        Perl_assert_aTHX; assert(hv)
 
 PERL_CALLCONV SSize_t *
 Perl_hv_placeholders_p(pTHX_ HV *hv)
@@ -2145,14 +2234,14 @@ Perl_hv_placeholders_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_P      \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_SET    \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
@@ -2160,14 +2249,14 @@ Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_PUSHKV              \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RAND_SET            \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV I32 *
 Perl_hv_riter_p(pTHX_ HV *hv)
@@ -2175,14 +2264,14 @@ Perl_hv_riter_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_RITER_P             \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_riter_set(pTHX_ HV *hv, I32 riter)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RITER_SET           \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_hv_scalar(pTHX_ HV *hv)
@@ -2190,13 +2279,13 @@ Perl_hv_scalar(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_SCALAR              \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_UNDEF_FLAGS         \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV STRLEN
 Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct Perl_custom_infix **def)
@@ -2204,7 +2293,7 @@ Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_INFIX_PLUGIN_STANDARD  \
-        assert(operator_ptr); assert(def)
+        Perl_assert_aTHX; assert(operator_ptr); assert(def)
 
 PERL_CALLCONV void
 Perl_init_argv_symbols(pTHX_ int argc, char **argv)
@@ -2212,30 +2301,34 @@ Perl_init_argv_symbols(pTHX_ int argc, char **argv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_ARGV_SYMBOLS      \
-        assert(argv)
+        Perl_assert_aTHX; assert(argv)
 
 PERL_CALLCONV void
 Perl_init_constants(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_INIT_CONSTANTS
+#define PERL_ARGS_ASSERT_INIT_CONSTANTS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_init_dbargs(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_INIT_DBARGS
+#define PERL_ARGS_ASSERT_INIT_DBARGS            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_init_debugger(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_INIT_DEBUGGER
+#define PERL_ARGS_ASSERT_INIT_DEBUGGER          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_init_i18nl10n(pTHX_ int printwarn)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_INIT_I18NL10N
+#define PERL_ARGS_ASSERT_INIT_I18NL10N          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
@@ -2243,41 +2336,45 @@ Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_INIT_NAMED_CV          \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
-        assert(nameop)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(nameop)
 
 PERL_CALLCONV void
 Perl_init_stacks(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_INIT_STACKS
+#define PERL_ARGS_ASSERT_INIT_STACKS            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_init_tm(pTHX_ struct tm *ptm)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_INIT_TM                \
-        assert(ptm)
+        Perl_assert_aTHX; assert(ptm)
 
 PERL_CALLCONV void
 Perl_init_uniprops(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_INIT_UNIPROPS
+#define PERL_ARGS_ASSERT_INIT_UNIPROPS          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV U32
 Perl_intro_my(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_INTRO_MY
+#define PERL_ARGS_ASSERT_INTRO_MY               \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_INVERSE_FOLDS_         \
-        assert(first_folds_to); assert(remaining_folds_to)
+        Perl_assert_aTHX; assert(first_folds_to); assert(remaining_folds_to)
 
 PERL_CALLCONV OP *
 Perl_invert(pTHX_ OP *cmd)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_INVERT
+#define PERL_ARGS_ASSERT_INVERT                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_invmap_dump(pTHX_ SV *invlist, UV *map)
@@ -2286,7 +2383,7 @@ Perl_invmap_dump(pTHX_ SV *invlist, UV *map)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INVMAP_DUMP            \
-        assert(invlist); assert(map)
+        Perl_assert_aTHX; assert(invlist); assert(map)
 
 PERL_CALLCONV bool
 Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
@@ -2294,36 +2391,41 @@ Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_IO_CLOSE               \
-        assert(io)
+        Perl_assert_aTHX; assert(io)
 
 PERL_CALLCONV bool
 Perl_is_in_locale_category_(pTHX_ const bool compiling, const int category)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_IS_IN_LOCALE_CATEGORY_
+#define PERL_ARGS_ASSERT_IS_IN_LOCALE_CATEGORY_ \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_is_lvalue_sub(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_IS_LVALUE_SUB
+#define PERL_ARGS_ASSERT_IS_LVALUE_SUB          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_is_uni_FOO_(pTHX_ const U8 classnum, const UV c)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_IS_UNI_FOO_
+#define PERL_ARGS_ASSERT_IS_UNI_FOO_            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_is_uni_perl_idcont_(pTHX_ UV c)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_IS_UNI_PERL_IDCONT_
+#define PERL_ARGS_ASSERT_IS_UNI_PERL_IDCONT_    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_is_uni_perl_idstart_(pTHX_ UV c)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_IS_UNI_PERL_IDSTART_
+#define PERL_ARGS_ASSERT_IS_UNI_PERL_IDSTART_   \
+        Perl_assert_aTHX
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e, const bool require_partial)
@@ -2341,7 +2443,7 @@ Perl_is_utf8_FOO_(pTHX_ const U8 classnum, const U8 *p, const U8 * const e)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_FOO_           \
-        assert(p); assert(e); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
 
 PERL_CALLCONV STRLEN
 Perl_is_utf8_char_helper_(const U8 * const s, const U8 *e, const U32 flags)
@@ -2359,7 +2461,7 @@ Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_PERL_IDCONT_   \
-        assert(p); assert(e); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idstart_(pTHX_ const U8 *p, const U8 * const e)
@@ -2368,7 +2470,7 @@ Perl_is_utf8_perl_idstart_(pTHX_ const U8 *p, const U8 * const e)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_PERL_IDSTART_  \
-        assert(p); assert(e); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
 
 PERL_CALLCONV bool
 Perl_isinfnan(NV nv)
@@ -2382,7 +2484,7 @@ Perl_isinfnansv(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ISINFNANSV             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV OP *
 Perl_jmaybe(pTHX_ OP *o)
@@ -2390,7 +2492,7 @@ Perl_jmaybe(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_JMAYBE                 \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV I32
 Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
@@ -2400,7 +2502,7 @@ Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
         __attribute__pure__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_KEYWORD                \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV int
 Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **op_ptr)
@@ -2408,7 +2510,7 @@ Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **o
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_KEYWORD_PLUGIN_STANDARD \
-        assert(keyword_ptr); assert(op_ptr)
+        Perl_assert_aTHX; assert(keyword_ptr); assert(op_ptr)
 
 PERL_CALLCONV void
 Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int filter)
@@ -2416,105 +2518,114 @@ Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int filter)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_LEAVE_ADJUST_STACKS    \
-        assert(from_sp); assert(to_sp)
+        Perl_assert_aTHX; assert(from_sp); assert(to_sp)
 
 PERL_CALLCONV void
 Perl_leave_scope(pTHX_ I32 base)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEAVE_SCOPE
+#define PERL_ARGS_ASSERT_LEAVE_SCOPE            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_lex_bufutf8(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEX_BUFUTF8
+#define PERL_ARGS_ASSERT_LEX_BUFUTF8            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_lex_discard_to(pTHX_ char *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_DISCARD_TO         \
-        assert(ptr)
+        Perl_assert_aTHX; assert(ptr)
 
 PERL_CALLCONV char *
 Perl_lex_grow_linestr(pTHX_ STRLEN len)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEX_GROW_LINESTR
+#define PERL_ARGS_ASSERT_LEX_GROW_LINESTR       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_lex_next_chunk(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEX_NEXT_CHUNK
+#define PERL_ARGS_ASSERT_LEX_NEXT_CHUNK         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_lex_peek_unichar(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEX_PEEK_UNICHAR
+#define PERL_ARGS_ASSERT_LEX_PEEK_UNICHAR       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_lex_read_space(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEX_READ_SPACE
+#define PERL_ARGS_ASSERT_LEX_READ_SPACE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_lex_read_to(pTHX_ char *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_READ_TO            \
-        assert(ptr)
+        Perl_assert_aTHX; assert(ptr)
 
 PERL_CALLCONV I32
 Perl_lex_read_unichar(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEX_READ_UNICHAR
+#define PERL_ARGS_ASSERT_LEX_READ_UNICHAR       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_lex_start(pTHX_ SV *line, PerlIO *rsfp, U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_LEX_START
+#define PERL_ARGS_ASSERT_LEX_START              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_lex_stuff_pv(pTHX_ const char *pv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PV           \
-        assert(pv)
+        Perl_assert_aTHX; assert(pv)
 
 PERL_CALLCONV void
 Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PVN          \
-        assert(pv)
+        Perl_assert_aTHX; assert(pv)
 
 PERL_CALLCONV void
 Perl_lex_stuff_sv(pTHX_ SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_SV           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_lex_unstuff(pTHX_ char *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_UNSTUFF            \
-        assert(ptr)
+        Perl_assert_aTHX; assert(ptr)
 
 PERL_CALLCONV OP *
 Perl_list(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_LIST
+#define PERL_ARGS_ASSERT_LIST                   \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_LOAD_CHARNAMES         \
-        assert(char_name); assert(context); assert(error_msg)
+        Perl_assert_aTHX; assert(char_name); assert(context); assert(error_msg)
 
 PERL_CALLCONV void
 Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_LOAD_MODULE            \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV_NO_RET void
 Perl_locale_panic(const char *msg, const line_t immediate_caller_line, const char * const higher_caller_file, const line_t higher_caller_line)
@@ -2530,7 +2641,7 @@ Perl_localize(pTHX_ OP *o, I32 lex)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_LOCALIZE               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV UV
 Perl_long_valid_utf8_to_uv(const U8 * const s, const U8 * const e)
@@ -2545,7 +2656,7 @@ Perl_looks_like_number(pTHX_ SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_LOOKS_LIKE_NUMBER      \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV int
 Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
@@ -2554,7 +2665,7 @@ Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEAR_ALL_ENV    \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_cleararylen_p(pTHX_ SV *sv, MAGIC *mg)
@@ -2563,7 +2674,7 @@ Perl_magic_cleararylen_p(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARARYLEN_P    \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearenv(pTHX_ SV *sv, MAGIC *mg)
@@ -2572,7 +2683,7 @@ Perl_magic_clearenv(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARENV         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhint(pTHX_ SV *sv, MAGIC *mg)
@@ -2581,7 +2692,7 @@ Perl_magic_clearhint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHINT        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhints(pTHX_ SV *sv, MAGIC *mg)
@@ -2590,7 +2701,7 @@ Perl_magic_clearhints(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHINTS       \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
@@ -2598,7 +2709,7 @@ Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOK        \
-        assert(mg)
+        Perl_assert_aTHX; assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearhookall(pTHX_ SV *sv, MAGIC *mg)
@@ -2606,7 +2717,7 @@ Perl_magic_clearhookall(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOKALL     \
-        assert(mg)
+        Perl_assert_aTHX; assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
@@ -2614,7 +2725,7 @@ Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARISA         \
-        assert(mg)
+        Perl_assert_aTHX; assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
@@ -2623,7 +2734,7 @@ Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARPACK        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_clearsig(pTHX_ SV *sv, MAGIC *mg)
@@ -2632,7 +2743,7 @@ Perl_magic_clearsig(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARSIG         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv, const char *name, I32 namlen)
@@ -2642,12 +2753,13 @@ Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv, const char *name, I
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_COPYCALLCHECKER  \
-        assert(sv); assert(mg); assert(nsv)
+        Perl_assert_aTHX; assert(sv); assert(mg); assert(nsv)
 
 PERL_CALLCONV void
 Perl_magic_dump(pTHX_ const MAGIC *mg)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MAGIC_DUMP
+#define PERL_ARGS_ASSERT_MAGIC_DUMP             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
@@ -2656,7 +2768,7 @@ Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_EXISTSPACK       \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
@@ -2665,7 +2777,7 @@ Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEARYLEN_P     \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freedestruct(pTHX_ SV *sv, MAGIC *mg)
@@ -2674,7 +2786,7 @@ Perl_magic_freedestruct(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEDESTRUCT     \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
@@ -2683,7 +2795,7 @@ Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEMGLOB        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
@@ -2692,7 +2804,7 @@ Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEOVRLD        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
@@ -2701,7 +2813,7 @@ Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEUTF8         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
@@ -2710,7 +2822,7 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GET              \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
@@ -2719,7 +2831,7 @@ Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETARYLEN        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
@@ -2728,7 +2840,7 @@ Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETDEBUGVAR      \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getdefelem(pTHX_ SV *sv, MAGIC *mg)
@@ -2737,7 +2849,7 @@ Perl_magic_getdefelem(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETDEFELEM       \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
@@ -2746,7 +2858,7 @@ Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETNKEYS         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
@@ -2755,7 +2867,7 @@ Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETPACK          \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
@@ -2764,7 +2876,7 @@ Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETPOS           \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
@@ -2773,7 +2885,7 @@ Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETSIG           \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
@@ -2782,7 +2894,7 @@ Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETSUBSTR        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_gettaint(pTHX_ SV *sv, MAGIC *mg)
@@ -2791,7 +2903,7 @@ Perl_magic_gettaint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETTAINT         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
@@ -2800,7 +2912,7 @@ Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETUVAR          \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
@@ -2809,7 +2921,7 @@ Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETVEC           \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_killbackrefs(pTHX_ SV *sv, MAGIC *mg)
@@ -2818,7 +2930,7 @@ Perl_magic_killbackrefs(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_KILLBACKREFS     \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV SV *
 Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, U32 argc, ...)
@@ -2828,7 +2940,7 @@ Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, U32 argc
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_METHCALL         \
-        assert(sv); assert(mg); assert(meth)
+        Perl_assert_aTHX; assert(sv); assert(mg); assert(meth)
 
 PERL_CALLCONV int
 Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
@@ -2838,7 +2950,7 @@ Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_NEXTPACK         \
-        assert(sv); assert(mg); assert(key)
+        Perl_assert_aTHX; assert(sv); assert(mg); assert(key)
 
 PERL_CALLCONV U32
 Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
@@ -2847,7 +2959,7 @@ Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATA_CNT      \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
@@ -2856,7 +2968,7 @@ Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATUM_GET     \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV_NON_VOID_NO_RET(int) int
 Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
@@ -2866,7 +2978,7 @@ Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET     \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV SV *
 Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
@@ -2875,7 +2987,7 @@ Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SCALARPACK       \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(mg)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
@@ -2884,7 +2996,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SET              \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
@@ -2893,7 +3005,7 @@ Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SET_ALL_ENV      \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
@@ -2902,7 +3014,7 @@ Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETARYLEN        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
@@ -2911,7 +3023,7 @@ Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDBLINE        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
@@ -2920,7 +3032,7 @@ Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDEBUGVAR      \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
@@ -2929,7 +3041,7 @@ Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDEFELEM       \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
@@ -2938,7 +3050,7 @@ Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETENV           \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
@@ -2947,7 +3059,7 @@ Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHINT          \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
@@ -2955,7 +3067,7 @@ Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHOOK          \
-        assert(mg)
+        Perl_assert_aTHX; assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_sethookall(pTHX_ SV *sv, MAGIC *mg)
@@ -2964,7 +3076,7 @@ Perl_magic_sethookall(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHOOKALL       \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
@@ -2973,7 +3085,7 @@ Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETISA           \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
@@ -2982,7 +3094,7 @@ Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETLVREF         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setmglob(pTHX_ SV *sv, MAGIC *mg)
@@ -2991,7 +3103,7 @@ Perl_magic_setmglob(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETMGLOB         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setnkeys(pTHX_ SV *sv, MAGIC *mg)
@@ -3000,7 +3112,7 @@ Perl_magic_setnkeys(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETNKEYS         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setnonelem(pTHX_ SV *sv, MAGIC *mg)
@@ -3009,7 +3121,7 @@ Perl_magic_setnonelem(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETNONELEM       \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
@@ -3018,7 +3130,7 @@ Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETPACK          \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
@@ -3027,7 +3139,7 @@ Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETPOS           \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
@@ -3036,7 +3148,7 @@ Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETREGEXP        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
@@ -3044,7 +3156,7 @@ Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSIG           \
-        assert(mg)
+        Perl_assert_aTHX; assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setsigall(pTHX_ SV *sv, MAGIC *mg)
@@ -3053,7 +3165,7 @@ Perl_magic_setsigall(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSIGALL        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
@@ -3062,7 +3174,7 @@ Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSUBSTR        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
@@ -3071,7 +3183,7 @@ Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETTAINT         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setutf8(pTHX_ SV *sv, MAGIC *mg)
@@ -3080,7 +3192,7 @@ Perl_magic_setutf8(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETUTF8          \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
@@ -3089,7 +3201,7 @@ Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETUVAR          \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
@@ -3098,7 +3210,7 @@ Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETVEC           \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV U32
 Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
@@ -3107,7 +3219,7 @@ Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SIZEPACK         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
@@ -3116,7 +3228,7 @@ Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_WIPEPACK         \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV Malloc_t
 Perl_malloc(MEM_SIZE nbytes)
@@ -3127,9 +3239,11 @@ Perl_malloc(MEM_SIZE nbytes)
 PERL_CALLCONV Stack_off_t *
 Perl_markstack_grow(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MARKSTACK_GROW
+#define PERL_ARGS_ASSERT_MARKSTACK_GROW         \
+        Perl_assert_aTHX
 
-#define PERL_ARGS_ASSERT_MBTOWC_
+#define PERL_ARGS_ASSERT_MBTOWC_                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_mess(pTHX_ const char *pat, ...)
@@ -3137,14 +3251,14 @@ Perl_mess(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_MESS                   \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV SV *
 Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MESS_SV                \
-        assert(basemsg)
+        Perl_assert_aTHX; assert(basemsg)
 
 PERL_CALLCONV Free_t
 Perl_mfree(Malloc_t where);
@@ -3155,7 +3269,7 @@ Perl_mg_clear(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_CLEAR               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV int
 Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen)
@@ -3163,7 +3277,7 @@ Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MG_COPY                \
-        assert(sv); assert(nsv)
+        Perl_assert_aTHX; assert(sv); assert(nsv)
 
 PERL_CALLCONV MAGIC *
 Perl_mg_find(const SV *sv, int type)
@@ -3171,7 +3285,7 @@ Perl_mg_find(const SV *sv, int type)
 #define PERL_ARGS_ASSERT_MG_FIND
 
 #define PERL_ARGS_ASSERT_MG_FIND_MGLOB          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV MAGIC *
 Perl_mg_findext(const SV *sv, int type, const MGVTBL *vtbl)
@@ -3183,28 +3297,28 @@ Perl_mg_free(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_mg_free_type(pTHX_ SV *sv, int how)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE_TYPE           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_mg_freeext(pTHX_ SV *sv, int how, const MGVTBL *vtbl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREEEXT             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV int
 Perl_mg_get(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_GET                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
@@ -3213,7 +3327,7 @@ Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MG_LOCALIZE            \
-        assert(sv); assert(nsv)
+        Perl_assert_aTHX; assert(sv); assert(nsv)
 
 PERL_CALLCONV void
 Perl_mg_magical(SV *sv)
@@ -3226,14 +3340,14 @@ Perl_mg_set(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SET                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV I32
 Perl_mg_size(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SIZE                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_mini_mktime(struct tm *ptm)
@@ -3245,50 +3359,54 @@ PERL_CALLCONV int
 Perl_mode_from_discipline(pTHX_ const char *s, STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_MODE_FROM_DISCIPLINE
+#define PERL_ARGS_ASSERT_MODE_FROM_DISCIPLINE   \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void *
 Perl_more_bodies(pTHX_ const svtype sv_type)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MORE_BODIES
+#define PERL_ARGS_ASSERT_MORE_BODIES            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_more_sv(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MORE_SV
+#define PERL_ARGS_ASSERT_MORE_SV                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV const char *
 Perl_moreswitches(pTHX_ const char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MORESWITCHES           \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV void
 Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MORTAL_DESTRUCTOR_SV   \
-        assert(coderef)
+        Perl_assert_aTHX; assert(coderef)
 
 PERL_CALLCONV void
 Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *p)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MORTAL_SVFUNC_X
+#define PERL_ARGS_ASSERT_MORTAL_SVFUNC_X        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV const struct mro_alg *
 Perl_mro_get_from_name(pTHX_ SV *name)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_FROM_NAME      \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV AV *
 Perl_mro_get_linear_isa(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA     \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV SV *
 Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which)
@@ -3296,7 +3414,7 @@ Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_GET_PRIVATE_DATA   \
-        assert(smeta); assert(which)
+        Perl_assert_aTHX; assert(smeta); assert(which)
 
 PERL_CALLCONV void
 Perl_mro_isa_changed_in(pTHX_ HV *stash)
@@ -3304,28 +3422,28 @@ Perl_mro_isa_changed_in(pTHX_ HV *stash)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MRO_ISA_CHANGED_IN     \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV struct mro_meta *
 Perl_mro_meta_init(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_META_INIT          \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_mro_method_changed_in(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_METHOD_CHANGED_IN  \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash, const GV * const gv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_PACKAGE_MOVED      \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV); \
         assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(gv)
 
 PERL_CALLCONV void
@@ -3333,7 +3451,7 @@ Perl_mro_register(pTHX_ const struct mro_alg *mro)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_REGISTER           \
-        assert(mro)
+        Perl_assert_aTHX; assert(mro)
 
 PERL_CALLCONV void
 Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name)
@@ -3341,7 +3459,7 @@ Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_SET_MRO            \
-        assert(meta); assert(name)
+        Perl_assert_aTHX; assert(meta); assert(name)
 
 PERL_CALLCONV SV *
 Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which, SV * const data)
@@ -3350,13 +3468,13 @@ Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_SET_PRIVATE_DATA   \
-        assert(smeta); assert(which); assert(data)
+        Perl_assert_aTHX; assert(smeta); assert(which); assert(data)
 
 #define PERL_ARGS_ASSERT_MULTICONCAT_STRINGIFY  \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 #define PERL_ARGS_ASSERT_MULTIDEREF_STRINGIFY   \
-        assert(o); \
+        Perl_assert_aTHX; assert(o); \
         assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV NV
@@ -3364,7 +3482,7 @@ Perl_my_atof(pTHX_ const char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MY_ATOF                \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV char *
 Perl_my_atof2(pTHX_ const char *orig, NV *value)
@@ -3372,7 +3490,7 @@ Perl_my_atof2(pTHX_ const char *orig, NV *value)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF2               \
-        assert(orig); assert(value)
+        Perl_assert_aTHX; assert(orig); assert(value)
 
 PERL_CALLCONV char *
 Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len)
@@ -3380,7 +3498,7 @@ Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF3               \
-        assert(orig); assert(value)
+        Perl_assert_aTHX; assert(orig); assert(value)
 
 PERL_CALLCONV OP *
 Perl_my_attrs(pTHX_ OP *o, OP *attrs)
@@ -3388,12 +3506,13 @@ Perl_my_attrs(pTHX_ OP *o, OP *attrs)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_ATTRS               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_my_clearenv(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MY_CLEARENV
+#define PERL_ARGS_ASSERT_MY_CLEARENV            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_my_dirfd(DIR *dir);
@@ -3403,18 +3522,21 @@ PERL_CALLCONV_NO_RET void
 Perl_my_exit(pTHX_ U32 status)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-#define PERL_ARGS_ASSERT_MY_EXIT
+#define PERL_ARGS_ASSERT_MY_EXIT                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV_NO_RET void
 Perl_my_failure_exit(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-#define PERL_ARGS_ASSERT_MY_FAILURE_EXIT
+#define PERL_ARGS_ASSERT_MY_FAILURE_EXIT        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_my_fflush_all(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MY_FFLUSH_ALL
+#define PERL_ARGS_ASSERT_MY_FFLUSH_ALL          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV Pid_t
 Perl_my_fork(void);
@@ -3423,7 +3545,8 @@ Perl_my_fork(void);
 PERL_CALLCONV I32
 Perl_my_lstat_flags(pTHX_ const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MY_LSTAT_FLAGS
+#define PERL_ARGS_ASSERT_MY_LSTAT_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_my_mkostemp_cloexec(char *templte, int flags)
@@ -3447,12 +3570,13 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MY_POPEN_LIST          \
-        assert(mode); assert(args)
+        Perl_assert_aTHX; assert(mode); assert(args)
 
 PERL_CALLCONV void
 Perl_my_setenv(pTHX_ const char *nam, const char *val)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MY_SETENV
+#define PERL_ARGS_ASSERT_MY_SETENV              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
@@ -3469,7 +3593,8 @@ Perl_my_socketpair(int family, int type, int protocol, int fd[2]);
 PERL_CALLCONV I32
 Perl_my_stat_flags(pTHX_ const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_MY_STAT_FLAGS
+#define PERL_ARGS_ASSERT_MY_STAT_FLAGS          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV const char *
 Perl_my_strerror(pTHX_ const int errnum, utf8ness_t *utf8ness)
@@ -3477,7 +3602,7 @@ Perl_my_strerror(pTHX_ const int errnum, utf8ness_t *utf8ness)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_STRERROR            \
-        assert(utf8ness)
+        Perl_assert_aTHX; assert(utf8ness)
 
 PERL_CALLCONV char *
 Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst)
@@ -3485,7 +3610,7 @@ Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, in
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__strftime__,pTHX_1,0);
 #define PERL_ARGS_ASSERT_MY_STRFTIME            \
-        assert(fmt)
+        Perl_assert_aTHX; assert(fmt)
 
 PERL_CALLCONV NV
 Perl_my_strtod(const char * const s, char **e)
@@ -3498,7 +3623,8 @@ PERL_CALLCONV void
 Perl_my_unexec(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_MY_UNEXEC
+#define PERL_ARGS_ASSERT_MY_UNEXEC              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap)
@@ -3510,24 +3636,28 @@ Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap
 PERL_CALLCONV OP *
 Perl_newANONATTRSUB(pTHX_ I32 floor, OP *proto, OP *attrs, OP *block)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_NEWANONATTRSUB
+#define PERL_ARGS_ASSERT_NEWANONATTRSUB         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newANONHASH(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWANONHASH
+#define PERL_ARGS_ASSERT_NEWANONHASH            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newANONLIST(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWANONLIST
+#define PERL_ARGS_ASSERT_NEWANONLIST            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newANONSUB(pTHX_ I32 floor, OP *proto, OP *block)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_NEWANONSUB
+#define PERL_ARGS_ASSERT_NEWANONSUB             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newARGDEFELEMOP(pTHX_ I32 flags, OP *expr, I32 argindex)
@@ -3535,18 +3665,20 @@ Perl_newARGDEFELEMOP(pTHX_ I32 flags, OP *expr, I32 argindex)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWARGDEFELEMOP        \
-        assert(expr)
+        Perl_assert_aTHX; assert(expr)
 
 PERL_CALLCONV OP *
 Perl_newASSIGNOP(pTHX_ I32 flags, OP *left, I32 optype, OP *right)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWASSIGNOP
+#define PERL_ARGS_ASSERT_NEWASSIGNOP            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV CV *
 Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block, bool o_is_gv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_NEWATTRSUB_X
+#define PERL_ARGS_ASSERT_NEWATTRSUB_X           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newAVREF(pTHX_ OP *o)
@@ -3554,27 +3686,28 @@ Perl_newAVREF(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVREF               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV AV *
 Perl_newAVav(pTHX_ AV *oav)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVAV                \
-        assert(!oav || SvTYPE(oav) == SVt_PVAV)
+        Perl_assert_aTHX; assert(!oav || SvTYPE(oav) == SVt_PVAV)
 
 PERL_CALLCONV AV *
 Perl_newAVhv(pTHX_ HV *ohv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVHV                \
-        assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
 
 PERL_CALLCONV OP *
 Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWBINOP
+#define PERL_ARGS_ASSERT_NEWBINOP               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
@@ -3582,25 +3715,26 @@ Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWCONDOP              \
-        assert(first)
+        Perl_assert_aTHX; assert(first)
 
 PERL_CALLCONV CV *
 Perl_newCONSTSUB(pTHX_ HV *stash, const char *name, SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWCONSTSUB            \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV CV *
 Perl_newCONSTSUB_flags(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags, SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWCONSTSUB_FLAGS      \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV OP *
 Perl_newCVREF(pTHX_ I32 flags, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWCVREF
+#define PERL_ARGS_ASSERT_NEWCVREF               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
@@ -3608,18 +3742,20 @@ Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWDEFEROP             \
-        assert(block)
+        Perl_assert_aTHX; assert(block)
 
 PERL_CALLCONV OP *
 Perl_newDEFSVOP(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWDEFSVOP
+#define PERL_ARGS_ASSERT_NEWDEFSVOP             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_NEWFORM
+#define PERL_ARGS_ASSERT_NEWFORM                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
@@ -3627,7 +3763,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWFOROP               \
-        assert(expr)
+        Perl_assert_aTHX; assert(expr)
 
 PERL_CALLCONV OP *
 Perl_newGIVENOP(pTHX_ OP *cond, OP *block, PADOFFSET defsv_off)
@@ -3636,14 +3772,14 @@ Perl_newGIVENOP(pTHX_ OP *cond, OP *block, PADOFFSET defsv_off)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGIVENOP             \
-        assert(cond); assert(block)
+        Perl_assert_aTHX; assert(cond); assert(block)
 
 PERL_CALLCONV GP *
 Perl_newGP(pTHX_ GV * const gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWGP                  \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV OP *
 Perl_newGVOP(pTHX_ I32 type, I32 flags, GV *gv)
@@ -3651,13 +3787,14 @@ Perl_newGVOP(pTHX_ I32 type, I32 flags, GV *gv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVOP                \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV OP *
 Perl_newGVREF(pTHX_ I32 type, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWGVREF
+#define PERL_ARGS_ASSERT_NEWGVREF               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV GV *
 Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
@@ -3665,7 +3802,7 @@ Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVGEN_FLAGS         \
-        assert(pack)
+        Perl_assert_aTHX; assert(pack)
 
 PERL_CALLCONV OP *
 Perl_newHVREF(pTHX_ OP *o)
@@ -3673,26 +3810,28 @@ Perl_newHVREF(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVREF               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV HV *
 Perl_newHVhv(pTHX_ HV *ohv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVHV                \
-        assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
 
 PERL_CALLCONV OP *
 Perl_newLISTOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWLISTOP
+#define PERL_ARGS_ASSERT_NEWLISTOP              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newLISTOPn(pTHX_ I32 type, I32 flags, ...)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWLISTOPN
+#define PERL_ARGS_ASSERT_NEWLISTOPN             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
@@ -3701,7 +3840,7 @@ Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOGOP               \
-        assert(first); assert(other)
+        Perl_assert_aTHX; assert(first); assert(other)
 
 PERL_CALLCONV OP *
 Perl_newLOOPEX(pTHX_ I32 type, OP *label)
@@ -3709,7 +3848,7 @@ Perl_newLOOPEX(pTHX_ I32 type, OP *label)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPEX              \
-        assert(label)
+        Perl_assert_aTHX; assert(label)
 
 PERL_CALLCONV OP *
 Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
@@ -3717,7 +3856,7 @@ Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPOP              \
-        assert(expr)
+        Perl_assert_aTHX; assert(expr)
 
 PERL_CALLCONV OP *
 Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP *dynamic_meth)
@@ -3725,7 +3864,7 @@ Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP *dynamic_meth)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP              \
-        assert(dynamic_meth)
+        Perl_assert_aTHX; assert(dynamic_meth)
 
 PERL_CALLCONV OP *
 Perl_newMETHOP_named(pTHX_ I32 type, I32 flags, SV * const_meth)
@@ -3733,26 +3872,28 @@ Perl_newMETHOP_named(pTHX_ I32 type, I32 flags, SV * const_meth)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP_NAMED        \
-        assert(const_meth)
+        Perl_assert_aTHX; assert(const_meth)
 
 PERL_CALLCONV CV *
 Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWMYSUB               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_newNULLLIST(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWNULLLIST
+#define PERL_ARGS_ASSERT_NEWNULLLIST            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newOP(pTHX_ I32 optype, I32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWOP
+#define PERL_ARGS_ASSERT_NEWOP                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PADNAMELIST *
 Perl_newPADNAMELIST(size_t max)
@@ -3777,20 +3918,22 @@ PERL_CALLCONV OP *
 Perl_newPMOP(pTHX_ I32 type, I32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWPMOP
+#define PERL_ARGS_ASSERT_NEWPMOP                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_newPROG(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWPROG                \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_newPVOP(pTHX_ I32 type, I32 flags, char *pv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWPVOP
+#define PERL_ARGS_ASSERT_NEWPVOP                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
@@ -3799,7 +3942,7 @@ Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRANGE               \
-        assert(left); assert(right)
+        Perl_assert_aTHX; assert(left); assert(right)
 
 PERL_CALLCONV SV *
 Perl_newRV(pTHX_ SV * const sv)
@@ -3807,19 +3950,21 @@ Perl_newRV(pTHX_ SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRV                  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV OP *
 Perl_newSLICEOP(pTHX_ I32 flags, OP *subscript, OP *listop)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSLICEOP
+#define PERL_ARGS_ASSERT_NEWSLICEOP             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSTATEOP
+#define PERL_ARGS_ASSERT_NEWSTATEOP             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV CV *
 Perl_newSTUB(pTHX_ GV *gv, bool fake)
@@ -3827,13 +3972,14 @@ Perl_newSTUB(pTHX_ GV *gv, bool fake)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWSTUB                \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV SV *
 Perl_newSV(pTHX_ const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSV
+#define PERL_ARGS_ASSERT_NEWSV                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
@@ -3841,7 +3987,7 @@ Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVOP                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV OP *
 Perl_newSVREF(pTHX_ OP *o)
@@ -3849,19 +3995,21 @@ Perl_newSVREF(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVREF               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV SV *
 Perl_newSV_false(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSV_FALSE
+#define PERL_ARGS_ASSERT_NEWSV_FALSE            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSV_true(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSV_TRUE
+#define PERL_ARGS_ASSERT_NEWSV_TRUE             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
@@ -3870,49 +4018,56 @@ Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWSVAVDEFELEM         \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV SV *
 Perl_newSVbool(pTHX_ const bool bool_val)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVBOOL
+#define PERL_ARGS_ASSERT_NEWSVBOOL              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVhek(pTHX_ const HEK * const hek)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVHEK
+#define PERL_ARGS_ASSERT_NEWSVHEK               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVhek_mortal(pTHX_ const HEK * const hek)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVHEK_MORTAL
+#define PERL_ARGS_ASSERT_NEWSVHEK_MORTAL        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSViv(pTHX_ const IV i)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVIV
+#define PERL_ARGS_ASSERT_NEWSVIV                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVnv(pTHX_ const NV n)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVNV
+#define PERL_ARGS_ASSERT_NEWSVNV                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVpv(pTHX_ const char * const s, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVPV
+#define PERL_ARGS_ASSERT_NEWSVPV                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVpv_share(pTHX_ const char *s, U32 hash)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVPV_SHARE
+#define PERL_ARGS_ASSERT_NEWSVPV_SHARE          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVpvf(pTHX_ const char * const pat, ...)
@@ -3921,38 +4076,42 @@ Perl_newSVpvf(pTHX_ const char * const pat, ...)
         __attribute__warn_unused_result__
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_NEWSVPVF               \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV SV *
 Perl_newSVpvn(pTHX_ const char * const s, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVPVN
+#define PERL_ARGS_ASSERT_NEWSVPVN               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVpvn_flags(pTHX_ const char * const s, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVPVN_FLAGS
+#define PERL_ARGS_ASSERT_NEWSVPVN_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVpvn_share(pTHX_ const char *s, I32 len, U32 hash)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVPVN_SHARE
+#define PERL_ARGS_ASSERT_NEWSVPVN_SHARE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVpvz(pTHX_ const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVPVZ
+#define PERL_ARGS_ASSERT_NEWSVPVZ               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVrv(pTHX_ SV * const rv, const char * const classname)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWSVRV                \
-        assert(rv)
+        Perl_assert_aTHX; assert(rv)
 
 PERL_CALLCONV SV *
 Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
@@ -3960,13 +4119,14 @@ Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVSV_FLAGS_NN       \
-        assert(old)
+        Perl_assert_aTHX; assert(old)
 
 PERL_CALLCONV SV *
 Perl_newSVuv(pTHX_ const UV u)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWSVUV
+#define PERL_ARGS_ASSERT_NEWSVUV                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
@@ -3976,19 +4136,21 @@ Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWTRYCATCHOP          \
-        assert(tryblock); assert(catchvar); assert(catchblock)
+        Perl_assert_aTHX; assert(tryblock); assert(catchvar); assert(catchblock)
 
 PERL_CALLCONV OP *
 Perl_newUNOP(pTHX_ I32 type, I32 flags, OP *first)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWUNOP
+#define PERL_ARGS_ASSERT_NEWUNOP                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newUNOP_AUX(pTHX_ I32 type, I32 flags, OP *first, UNOP_AUX_item *aux)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWUNOP_AUX
+#define PERL_ARGS_ASSERT_NEWUNOP_AUX            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newWHENOP(pTHX_ OP *cond, OP *block)
@@ -3996,13 +4158,14 @@ Perl_newWHENOP(pTHX_ OP *cond, OP *block)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWWHENOP              \
-        assert(block)
+        Perl_assert_aTHX; assert(block)
 
 PERL_CALLCONV OP *
 Perl_newWHILEOP(pTHX_ I32 flags, I32 debuggable, LOOP *loop, OP *expr, OP *block, OP *cont, I32 has_my)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWWHILEOP
+#define PERL_ARGS_ASSERT_NEWWHILEOP             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV CV *
 Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename)
@@ -4010,7 +4173,7 @@ Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS                  \
-        assert(subaddr); assert(filename)
+        Perl_assert_aTHX; assert(subaddr); assert(filename)
 
 PERL_CALLCONV CV *
 Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr)
@@ -4018,7 +4181,7 @@ Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWXS_DEFFILE          \
-        assert(name); assert(subaddr)
+        Perl_assert_aTHX; assert(name); assert(subaddr)
 
 PERL_CALLCONV CV *
 Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const filename, const char * const proto, U32 flags)
@@ -4026,7 +4189,7 @@ Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS_FLAGS            \
-        assert(subaddr); assert(filename)
+        Perl_assert_aTHX; assert(subaddr); assert(filename)
 
 PERL_CALLCONV CV *
 Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, const char * const filename, const char * const proto, SV ** const_svp, U32 flags)
@@ -4034,7 +4197,7 @@ Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, con
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWXS_LEN_FLAGS        \
-        assert(subaddr)
+        Perl_assert_aTHX; assert(subaddr)
 
 PERL_CALLCONV OP *
 Perl_new_block_statement(pTHX_ OP *block, OP *cont)
@@ -4042,29 +4205,31 @@ Perl_new_block_statement(pTHX_ OP *block, OP *cont)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEW_BLOCK_STATEMENT    \
-        assert(block)
+        Perl_assert_aTHX; assert(block)
 
 PERL_CALLCONV PERL_SI *
 Perl_new_stackinfo(pTHX_ I32 stitems, I32 cxitems)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEW_STACKINFO
+#define PERL_ARGS_ASSERT_NEW_STACKINFO          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PERL_SI *
 Perl_new_stackinfo_flags(pTHX_ I32 stitems, I32 cxitems, UV flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEW_STACKINFO_FLAGS
+#define PERL_ARGS_ASSERT_NEW_STACKINFO_FLAGS    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_new_version(pTHX_ SV *ver)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEW_VERSION            \
-        assert(ver)
+        Perl_assert_aTHX; assert(ver)
 
 #define PERL_ARGS_ASSERT_NEW_WARNINGS_BITFIELD  \
-        assert(bits)
+        Perl_assert_aTHX; assert(bits)
 
 PERL_CALLCONV PerlIO *
 Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
@@ -4072,7 +4237,7 @@ Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEXTARGV               \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV char *
 Perl_ninstr(const char *big, const char *bigend, const char *little, const char *lend)
@@ -4092,7 +4257,7 @@ Perl_no_bareword_filehandle(pTHX_ const char *fhname)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NO_BAREWORD_FILEHANDLE \
-        assert(fhname)
+        Perl_assert_aTHX; assert(fhname)
 
 PERL_CALLCONV_NO_RET void
 Perl_noperl_die(const char *pat, ...)
@@ -4109,13 +4274,15 @@ Perl_noshutdownhook(void);
 PERL_CALLCONV int
 Perl_nothreadhook(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_NOTHREADHOOK
+#define PERL_ARGS_ASSERT_NOTHREADHOOK           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_notify_parser_that_encoding_changed(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_NOTIFY_PARSER_THAT_ENCODING_CHANGED
+#define PERL_ARGS_ASSERT_NOTIFY_PARSER_THAT_ENCODING_CHANGED \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_oopsAV(pTHX_ OP *o)
@@ -4124,7 +4291,7 @@ Perl_oopsAV(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OOPSAV                 \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_oopsHV(pTHX_ OP *o)
@@ -4133,78 +4300,85 @@ Perl_oopsHV(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OOPSHV                 \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_append_elem(pTHX_ I32 optype, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_APPEND_ELEM
+#define PERL_ARGS_ASSERT_OP_APPEND_ELEM         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_append_list(pTHX_ I32 optype, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_APPEND_LIST
+#define PERL_ARGS_ASSERT_OP_APPEND_LIST         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OPclass
 Perl_op_class(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_CLASS
+#define PERL_ARGS_ASSERT_OP_CLASS               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_op_clear(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_CLEAR               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_contextualize(pTHX_ OP *o, I32 context)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_CONTEXTUALIZE       \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_convert_list(pTHX_ I32 optype, I32 flags, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_OP_CONVERT_LIST
+#define PERL_ARGS_ASSERT_OP_CONVERT_LIST        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_op_dump(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_DUMP                \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_force_list(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_FORCE_LIST
+#define PERL_ARGS_ASSERT_OP_FORCE_LIST          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_op_free(pTHX_ OP *arg)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_FREE
+#define PERL_ARGS_ASSERT_OP_FREE                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_linklist(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_LINKLIST            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_LVALUE_FLAGS
+#define PERL_ARGS_ASSERT_OP_LVALUE_FLAGS        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_op_null(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_NULL                \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_parent(OP *o)
@@ -4215,33 +4389,39 @@ Perl_op_parent(OP *o)
 PERL_CALLCONV OP *
 Perl_op_prepend_elem(pTHX_ I32 optype, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_PREPEND_ELEM
+#define PERL_ARGS_ASSERT_OP_PREPEND_ELEM        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_op_refcnt_lock(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_REFCNT_LOCK
+#define PERL_ARGS_ASSERT_OP_REFCNT_LOCK         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_op_refcnt_unlock(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_REFCNT_UNLOCK
+#define PERL_ARGS_ASSERT_OP_REFCNT_UNLOCK       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_scope(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_SCOPE
+#define PERL_ARGS_ASSERT_OP_SCOPE               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP *insert)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_OP_SIBLING_SPLICE
+#define PERL_ARGS_ASSERT_OP_SIBLING_SPLICE      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_unscope(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_OP_UNSCOPE
+#define PERL_ARGS_ASSERT_OP_UNSCOPE             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
@@ -4250,7 +4430,7 @@ Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_OP_WRAP_FINALLY        \
-        assert(block); assert(finally)
+        Perl_assert_aTHX; assert(block); assert(finally)
 
 PERL_CALLCONV void
 Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
@@ -4259,13 +4439,14 @@ Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_OPDUMP_PRINTF          \
-        assert(ctx); assert(pat)
+        Perl_assert_aTHX; assert(ctx); assert(pat)
 
 PERL_CALLCONV void
 Perl_output_non_portable(pTHX_ const U8 shift)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_OUTPUT_NON_PORTABLE
+#define PERL_ARGS_ASSERT_OUTPUT_NON_PORTABLE    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_package(pTHX_ OP *name, OP *version)
@@ -4273,7 +4454,7 @@ Perl_package(pTHX_ OP *name, OP *version)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PACKAGE                \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV void
 Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist)
@@ -4284,15 +4465,16 @@ Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, 
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_PACKLIST               \
-        assert(cat); assert(pat); assert(patend); assert(beglist); \
-        assert(endlist); assert(pat <= patend); assert(*patend == '\0')
+        Perl_assert_aTHX; assert(cat); assert(pat); assert(patend); \
+        assert(beglist); assert(endlist); assert(pat <= patend); \
+        assert(*patend == '\0')
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_anon(pTHX_ CV *func, I32 optype)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_ANON           \
-        assert(func); \
+        Perl_assert_aTHX; assert(func); \
         assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
 
 PERL_CALLCONV PADOFFSET
@@ -4300,7 +4482,8 @@ Perl_pad_add_name_pv(pTHX_ const char *name, const U32 flags, HV *typestash, HV 
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PV        \
-        assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(name); \
+        assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV PADOFFSET
@@ -4308,7 +4491,8 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags, HV *t
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN       \
-        assert(namepv); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(namepv); \
+        assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV PADOFFSET
@@ -4316,7 +4500,8 @@ Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_SV        \
-        assert(name); assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(name); \
+        assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV void
@@ -4325,40 +4510,42 @@ Perl_pad_add_weakref(pTHX_ CV *func)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_ADD_WEAKREF        \
-        assert(func); \
+        Perl_assert_aTHX; assert(func); \
         assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PAD_ALLOC
+#define PERL_ARGS_ASSERT_PAD_ALLOC              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_pad_block_start(pTHX_ int full)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_PAD_BLOCK_START
+#define PERL_ARGS_ASSERT_PAD_BLOCK_START        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PV          \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PVN         \
-        assert(namepv)
+        Perl_assert_aTHX; assert(namepv)
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_SV          \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV void
 Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
@@ -4368,7 +4555,7 @@ Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_FIXUP_INNER_ANONS  \
-        assert(padlist); assert(old_cv); \
+        Perl_assert_aTHX; assert(padlist); assert(old_cv); \
         assert(SvTYPE(old_cv) == SVt_PVCV || SvTYPE(old_cv) == SVt_PVFM); \
         assert(new_cv); \
         assert(SvTYPE(new_cv) == SVt_PVCV || SvTYPE(new_cv) == SVt_PVFM)
@@ -4377,37 +4564,42 @@ PERL_CALLCONV void
 Perl_pad_free(pTHX_ PADOFFSET po)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_PAD_FREE
+#define PERL_ARGS_ASSERT_PAD_FREE               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_pad_leavemy(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_PAD_LEAVEMY
+#define PERL_ARGS_ASSERT_PAD_LEAVEMY            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PADLIST *
 Perl_pad_new(pTHX_ int flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_PAD_NEW
+#define PERL_ARGS_ASSERT_PAD_NEW                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_PUSH               \
-        assert(padlist)
+        Perl_assert_aTHX; assert(padlist)
 
 PERL_CALLCONV void
 Perl_pad_swipe(pTHX_ PADOFFSET po, bool refadjust)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_PAD_SWIPE
+#define PERL_ARGS_ASSERT_PAD_SWIPE              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_pad_tidy(pTHX_ padtidy_type type)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PAD_TIDY
+#define PERL_ARGS_ASSERT_PAD_TIDY               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PAD **
 Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
@@ -4415,14 +4607,14 @@ Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PADLIST_STORE          \
-        assert(padlist)
+        Perl_assert_aTHX; assert(padlist)
 
 PERL_CALLCONV void
 Perl_padname_free(pTHX_ PADNAME *pn)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAME_FREE           \
-        assert(pn)
+        Perl_assert_aTHX; assert(pn)
 
 PERL_CALLCONV PADNAME *
 Perl_padnamelist_fetch(PADNAMELIST *pnl, SSize_t key)
@@ -4436,67 +4628,77 @@ Perl_padnamelist_free(pTHX_ PADNAMELIST *pnl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_FREE       \
-        assert(pnl)
+        Perl_assert_aTHX; assert(pnl)
 
 PERL_CALLCONV PADNAME **
 Perl_padnamelist_store(pTHX_ PADNAMELIST *pnl, SSize_t key, PADNAME *val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_STORE      \
-        assert(pnl)
+        Perl_assert_aTHX; assert(pnl)
 
 PERL_CALLCONV OP *
 Perl_parse_arithexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_ARITHEXPR
+#define PERL_ARGS_ASSERT_PARSE_ARITHEXPR        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_barestmt(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_BARESTMT
+#define PERL_ARGS_ASSERT_PARSE_BARESTMT         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_block(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_BLOCK
+#define PERL_ARGS_ASSERT_PARSE_BLOCK            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_fullexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_FULLEXPR
+#define PERL_ARGS_ASSERT_PARSE_FULLEXPR         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_fullstmt(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_FULLSTMT
+#define PERL_ARGS_ASSERT_PARSE_FULLSTMT         \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_PARSE_IDENT_MSG        \
-        assert(s); assert(end); assert(s < end)
+        Perl_assert_aTHX; assert(s); assert(end); assert(s < end)
 
 PERL_CALLCONV SV *
 Perl_parse_label(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_LABEL
+#define PERL_ARGS_ASSERT_PARSE_LABEL            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_listexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_LISTEXPR
+#define PERL_ARGS_ASSERT_PARSE_LISTEXPR         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_stmtseq(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_STMTSEQ
+#define PERL_ARGS_ASSERT_PARSE_STMTSEQ          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_subsignature(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_SUBSIGNATURE
+#define PERL_ARGS_ASSERT_PARSE_SUBSIGNATURE     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_parse_termexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PARSE_TERMEXPR
+#define PERL_ARGS_ASSERT_PARSE_TERMEXPR         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV U32
 Perl_parse_unicode_opts(pTHX_ const char **popt)
@@ -4504,7 +4706,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSE_UNICODE_OPTS     \
-        assert(popt)
+        Perl_assert_aTHX; assert(popt)
 
 PERL_CALLCONV void
 Perl_parser_free(pTHX_ const yy_parser *parser)
@@ -4512,13 +4714,14 @@ Perl_parser_free(pTHX_ const yy_parser *parser)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSER_FREE            \
-        assert(parser)
+        Perl_assert_aTHX; assert(parser)
 
 PERL_CALLCONV void
 Perl_peep(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_PEEP
+#define PERL_ARGS_ASSERT_PEEP                   \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PerlInterpreter *
 perl_alloc(void);
@@ -4561,7 +4764,8 @@ Perl_perly_sighandler(int sig, Siginfo_t *info, void *uap, bool safe);
 PERL_CALLCONV void
 Perl_pmop_dump(pTHX_ PMOP *pm)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PMOP_DUMP
+#define PERL_ARGS_ASSERT_PMOP_DUMP              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
@@ -4570,12 +4774,13 @@ Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PMRUNTIME              \
-        assert(o); assert(expr)
+        Perl_assert_aTHX; assert(o); assert(expr)
 
 PERL_CALLCONV void
 Perl_pop_scope(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_POP_SCOPE
+#define PERL_ARGS_ASSERT_POP_SCOPE              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
@@ -4583,14 +4788,14 @@ Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_POPULATE_ISA           \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV REGEXP *
 Perl_pregcomp(pTHX_ SV * const pattern, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGCOMP               \
-        assert(pattern)
+        Perl_assert_aTHX; assert(pattern)
 
 PERL_CALLCONV I32
 Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
@@ -4601,28 +4806,29 @@ Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *st
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 #define PERL_ARGS_ASSERT_PREGEXEC               \
-        assert(prog); assert(stringarg); assert(strend); assert(strbeg); \
-        assert(screamer); assert(strbeg <= stringarg); \
+        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend); \
+        assert(strbeg); assert(screamer); assert(strbeg <= stringarg); \
         assert(stringarg <= strend)
 
 PERL_CALLCONV void
 Perl_pregfree(pTHX_ REGEXP *r)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PREGFREE
+#define PERL_ARGS_ASSERT_PREGFREE               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_pregfree2(pTHX_ REGEXP *rx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGFREE2              \
-        assert(rx)
+        Perl_assert_aTHX; assert(rx)
 
 PERL_CALLCONV const char *
 Perl_prescan_version(pTHX_ const char *s, bool strict, const char **errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PRESCAN_VERSION        \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV void *
 Perl_ptr_table_fetch(pTHX_ PTR_TBL_t * const tbl, const void * const sv)
@@ -4630,25 +4836,27 @@ Perl_ptr_table_fetch(pTHX_ PTR_TBL_t * const tbl, const void * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PTR_TABLE_FETCH        \
-        assert(tbl)
+        Perl_assert_aTHX; assert(tbl)
 
 PERL_CALLCONV void
 Perl_ptr_table_free(pTHX_ PTR_TBL_t * const tbl)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PTR_TABLE_FREE
+#define PERL_ARGS_ASSERT_PTR_TABLE_FREE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PTR_TBL_t *
 Perl_ptr_table_new(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_PTR_TABLE_NEW
+#define PERL_ARGS_ASSERT_PTR_TABLE_NEW          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_ptr_table_split(pTHX_ PTR_TBL_t * const tbl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PTR_TABLE_SPLIT        \
-        assert(tbl)
+        Perl_assert_aTHX; assert(tbl)
 
 PERL_CALLCONV void
 Perl_ptr_table_store(pTHX_ PTR_TBL_t * const tbl, const void * const oldsv, void * const newsv)
@@ -4656,12 +4864,13 @@ Perl_ptr_table_store(pTHX_ PTR_TBL_t * const tbl, const void * const oldsv, void
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_PTR_TABLE_STORE        \
-        assert(tbl); assert(newsv)
+        Perl_assert_aTHX; assert(tbl); assert(newsv)
 
 PERL_CALLCONV void
 Perl_push_scope(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_PUSH_SCOPE
+#define PERL_ARGS_ASSERT_PUSH_SCOPE             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim)
@@ -4669,14 +4878,14 @@ Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pv
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_DISPLAY             \
-        assert(dsv); assert(pv)
+        Perl_assert_aTHX; assert(dsv); assert(pv)
 
 PERL_CALLCONV char *
 Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, STRLEN max, STRLEN * const escaped, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_ESCAPE              \
-        assert(str)
+        Perl_assert_aTHX; assert(str)
 
 PERL_CALLCONV char *
 Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, char const * const start_color, char const * const end_color, const U32 flags)
@@ -4684,7 +4893,7 @@ Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_PRETTY              \
-        assert(dsv); assert(str)
+        Perl_assert_aTHX; assert(dsv); assert(str)
 
 PERL_CALLCONV char *
 Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV flags)
@@ -4692,31 +4901,34 @@ Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV f
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_UNI_DISPLAY         \
-        assert(dsv); assert(spv)
+        Perl_assert_aTHX; assert(dsv); assert(spv)
 
 PERL_CALLCONV char *
 Perl_rcpv_copy(pTHX_ char * const pv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_RCPV_COPY
+#define PERL_ARGS_ASSERT_RCPV_COPY              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_rcpv_free(pTHX_ char * const pv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_RCPV_FREE
+#define PERL_ARGS_ASSERT_RCPV_FREE              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_rcpv_new(pTHX_ const char * const pv, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__malloc__
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_RCPV_NEW
+#define PERL_ARGS_ASSERT_RCPV_NEW               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV REGEXP *
 Perl_re_compile(pTHX_ SV * const pattern, U32 orig_rx_flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_COMPILE             \
-        assert(pattern)
+        Perl_assert_aTHX; assert(pattern)
 
 PERL_CALLCONV char *
 Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg, char *strpos, char *strend, const U32 flags, re_scream_pos_data *data)
@@ -4726,22 +4938,22 @@ Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_RE_INTUIT_START        \
-        assert(rx); assert(strbeg); assert(strpos); assert(strend); \
-        assert(strbeg <= strpos); assert(strpos <= strend)
+        Perl_assert_aTHX; assert(rx); assert(strbeg); assert(strpos); \
+        assert(strend); assert(strbeg <= strpos); assert(strpos <= strend)
 
 PERL_CALLCONV SV *
 Perl_re_intuit_string(pTHX_ REGEXP * const r)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_INTUIT_STRING       \
-        assert(r)
+        Perl_assert_aTHX; assert(r)
 
 PERL_CALLCONV REGEXP *
 Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count, OP *expr, const regexp_engine *eng, REGEXP *old_re, bool *is_bare_re, const U32 rx_flags, const U32 pm_flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_RE_OP_COMPILE          \
-        assert(eng)
+        Perl_assert_aTHX; assert(eng)
 
 PERL_CALLCONV Malloc_t
 Perl_realloc(Malloc_t where, MEM_SIZE nbytes)
@@ -4751,12 +4963,14 @@ Perl_realloc(Malloc_t where, MEM_SIZE nbytes)
 PERL_CALLCONV void
 Perl_reentrant_free(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_REENTRANT_FREE
+#define PERL_ARGS_ASSERT_REENTRANT_FREE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_reentrant_init(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_REENTRANT_INIT
+#define PERL_ARGS_ASSERT_REENTRANT_INIT         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void *
 Perl_reentrant_retry(const char *f, ...)
@@ -4767,74 +4981,78 @@ Perl_reentrant_retry(const char *f, ...)
 PERL_CALLCONV void
 Perl_reentrant_size(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_REENTRANT_SIZE
+#define PERL_ARGS_ASSERT_REENTRANT_SIZE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV HV *
 Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *c, U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_REFCOUNTED_HE_CHAIN_2HV
+#define PERL_ARGS_ASSERT_REFCOUNTED_HE_CHAIN_2HV \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_pv(pTHX_ const struct refcounted_he *chain, const char *key, U32 hash, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PV \
-        assert(key)
+        Perl_assert_aTHX; assert(key)
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_pvn(pTHX_ const struct refcounted_he *chain, const char *keypv, STRLEN keylen, U32 hash, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PVN \
-        assert(keypv)
+        Perl_assert_aTHX; assert(keypv)
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain, SV *key, U32 hash, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_SV \
-        assert(key)
+        Perl_assert_aTHX; assert(key)
 
 PERL_CALLCONV void
 Perl_refcounted_he_free(pTHX_ struct refcounted_he *he)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_REFCOUNTED_HE_FREE
+#define PERL_ARGS_ASSERT_REFCOUNTED_HE_FREE     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_inc(pTHX_ struct refcounted_he *he)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_REFCOUNTED_HE_INC
+#define PERL_ARGS_ASSERT_REFCOUNTED_HE_INC      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_pv(pTHX_ struct refcounted_he *parent, const char *key, U32 hash, SV *value, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PV   \
-        assert(key)
+        Perl_assert_aTHX; assert(key)
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_pvn(pTHX_ struct refcounted_he *parent, const char *keypv, STRLEN keylen, U32 hash, SV *value, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PVN  \
-        assert(keypv)
+        Perl_assert_aTHX; assert(keypv)
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash, SV *value, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_SV   \
-        assert(key)
+        Perl_assert_aTHX; assert(key)
 
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF         \
-        assert(rx)
+        Perl_assert_aTHX; assert(rx)
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_all(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ALL     \
-        assert(r)
+        Perl_assert_aTHX; assert(r)
 
 PERL_CALLCONV bool
 Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key, const U32 flags)
@@ -4842,7 +5060,7 @@ Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key, const U32 fla
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_EXISTS  \
-        assert(r); assert(key)
+        Perl_assert_aTHX; assert(r); assert(key)
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv, const U32 flags)
@@ -4850,56 +5068,56 @@ Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv, const U32 f
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FETCH   \
-        assert(r); assert(namesv)
+        Perl_assert_aTHX; assert(r); assert(namesv)
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FIRSTKEY \
-        assert(r)
+        Perl_assert_aTHX; assert(r)
 
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ITER    \
-        assert(rx)
+        Perl_assert_aTHX; assert(rx)
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_NEXTKEY \
-        assert(r)
+        Perl_assert_aTHX; assert(r)
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_scalar(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_SCALAR  \
-        assert(r)
+        Perl_assert_aTHX; assert(r)
 
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH \
-        assert(re)
+        Perl_assert_aTHX; assert(re)
 
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH_FLAGS \
-        assert(re)
+        Perl_assert_aTHX; assert(re)
 
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_LENGTH \
-        assert(r); assert(sv)
+        Perl_assert_aTHX; assert(r); assert(sv)
 
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_STORE \
-        assert(rx)
+        Perl_assert_aTHX; assert(rx)
 
 #define PERL_ARGS_ASSERT_REG_QR_PACKAGE         \
-        assert(rx)
+        Perl_assert_aTHX; assert(rx)
 
 #define PERL_ARGS_ASSERT_REG_TEMP_COPY          \
-        assert(ssv)
+        Perl_assert_aTHX; assert(ssv)
 
 PERL_CALLCONV void
 Perl_regdump(pTHX_ const regexp *r)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REGDUMP                \
-        assert(r)
+        Perl_assert_aTHX; assert(r)
 
 PERL_CALLCONV I32
 Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *sv, void *data, U32 flags)
@@ -4910,20 +5128,22 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char 
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 #define PERL_ARGS_ASSERT_REGEXEC_FLAGS          \
-        assert(rx); assert(stringarg); assert(strend); assert(strbeg); \
-        assert(sv); assert(strbeg <= stringarg); assert(stringarg <= strend)
+        Perl_assert_aTHX; assert(rx); assert(stringarg); assert(strend); \
+        assert(strbeg); assert(sv); assert(strbeg <= stringarg); \
+        assert(stringarg <= strend)
 
 PERL_CALLCONV void
 Perl_regfree_internal(pTHX_ REGEXP * const rx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REGFREE_INTERNAL       \
-        assert(rx)
+        Perl_assert_aTHX; assert(rx)
 
 PERL_CALLCONV void
 Perl_reginitcolors(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_REGINITCOLORS
+#define PERL_ARGS_ASSERT_REGINITCOLORS          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_release_RExC_state(pTHX_ void *vstate)
@@ -4931,7 +5151,7 @@ Perl_release_RExC_state(pTHX_ void *vstate)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RELEASE_REXC_STATE     \
-        assert(vstate)
+        Perl_assert_aTHX; assert(vstate)
 
 PERL_CALLCONV void
 Perl_repeatcpy(char *to, const char *from, SSize_t len, IV count)
@@ -4944,29 +5164,32 @@ PERL_CALLCONV void
 Perl_report_evil_fh(pTHX_ const GV *gv)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_REPORT_EVIL_FH
+#define PERL_ARGS_ASSERT_REPORT_EVIL_FH         \
+        Perl_assert_aTHX
 
-#define PERL_ARGS_ASSERT_REPORT_UNINIT
+#define PERL_ARGS_ASSERT_REPORT_UNINIT          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_report_wrongway_fh(pTHX_ const GV *gv, const char have)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_REPORT_WRONGWAY_FH
+#define PERL_ARGS_ASSERT_REPORT_WRONGWAY_FH     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_require_pv(pTHX_ const char *pv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REQUIRE_PV             \
-        assert(pv)
+        Perl_assert_aTHX; assert(pv)
 
 PERL_CALLCONV void
 Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RESUME_COMPCV          \
-        assert(buffer)
+        Perl_assert_aTHX; assert(buffer)
 
 PERL_CALLCONV char *
 Perl_rninstr(const char *big, const char *bigend, const char *little, const char *lend)
@@ -4984,7 +5207,8 @@ PERL_CALLCONV void
 Perl_rpeep(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_RPEEP
+#define PERL_ARGS_ASSERT_RPEEP                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_rpp_free_2_(pTHX_ SV * const sv1, SV * const sv2, const U32 rc1, const U32 rc2)
@@ -4992,23 +5216,26 @@ Perl_rpp_free_2_(pTHX_ SV * const sv1, SV * const sv2, const U32 rc1, const U32 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_RPP_FREE_2_            \
-        assert(sv1); assert(sv2)
+        Perl_assert_aTHX; assert(sv1); assert(sv2)
 
 PERL_CALLCONV void
 Perl_rpp_obliterate_stack_to(pTHX_ I32 ix)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_RPP_OBLITERATE_STACK_TO
+#define PERL_ARGS_ASSERT_RPP_OBLITERATE_STACK_TO \
+        Perl_assert_aTHX
 
 PERL_CALLCONV Sighandler_t
 Perl_rsignal(pTHX_ int i, Sighandler_t t)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_RSIGNAL
+#define PERL_ARGS_ASSERT_RSIGNAL                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_rsignal_restore(pTHX_ int i, Sigsave_t *t)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_RSIGNAL_RESTORE
+#define PERL_ARGS_ASSERT_RSIGNAL_RESTORE        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_rsignal_save(pTHX_ int i, Sighandler_t t1, Sigsave_t *save)
@@ -5016,29 +5243,32 @@ Perl_rsignal_save(pTHX_ int i, Sighandler_t t1, Sigsave_t *save)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RSIGNAL_SAVE           \
-        assert(save)
+        Perl_assert_aTHX; assert(save)
 
 PERL_CALLCONV Sighandler_t
 Perl_rsignal_state(pTHX_ int i)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_RSIGNAL_STATE
+#define PERL_ARGS_ASSERT_RSIGNAL_STATE          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_runops_debug(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_RUNOPS_DEBUG
+#define PERL_ARGS_ASSERT_RUNOPS_DEBUG           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_runops_standard(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_RUNOPS_STANDARD
+#define PERL_ARGS_ASSERT_RUNOPS_STANDARD        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV CV *
 Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RV2CV_OP_CV            \
-        assert(cvop)
+        Perl_assert_aTHX; assert(cvop)
 
 PERL_CALLCONV void
 Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
@@ -5047,7 +5277,7 @@ Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RXRES_SAVE             \
-        assert(rsp); assert(rx)
+        Perl_assert_aTHX; assert(rsp); assert(rx)
 
 PERL_CALLCONV Malloc_t
 Perl_safesyscalloc(MEM_SIZE elements, MEM_SIZE size)
@@ -5075,28 +5305,28 @@ Perl_save_I16(pTHX_ I16 *intp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I16               \
-        assert(intp)
+        Perl_assert_aTHX; assert(intp)
 
 PERL_CALLCONV void
 Perl_save_I32(pTHX_ I32 *intp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I32               \
-        assert(intp)
+        Perl_assert_aTHX; assert(intp)
 
 PERL_CALLCONV void
 Perl_save_I8(pTHX_ I8 *bytep)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I8                \
-        assert(bytep)
+        Perl_assert_aTHX; assert(bytep)
 
 PERL_CALLCONV void
 Perl_save_adelete(pTHX_ AV *av, SSize_t key)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ADELETE           \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
 Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
@@ -5104,40 +5334,42 @@ Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_AELEM_FLAGS       \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(sptr)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        assert(sptr)
 
 PERL_CALLCONV SSize_t
 Perl_save_alloc(pTHX_ SSize_t size, I32 pad)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_ALLOC
+#define PERL_ARGS_ASSERT_SAVE_ALLOC             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_aptr(pTHX_ AV **aptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_APTR              \
-        assert(aptr)
+        Perl_assert_aTHX; assert(aptr)
 
 PERL_CALLCONV AV *
 Perl_save_ary(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ARY               \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_save_bool(pTHX_ bool *boolp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_BOOL              \
-        assert(boolp)
+        Perl_assert_aTHX; assert(boolp)
 
 PERL_CALLCONV void
 Perl_save_clearsv(pTHX_ SV **svp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_CLEARSV           \
-        assert(svp)
+        Perl_assert_aTHX; assert(svp)
 
 PERL_CALLCONV void
 Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
@@ -5145,54 +5377,56 @@ Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DELETE            \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(key)
 
 PERL_CALLCONV void
 Perl_save_destructor(pTHX_ DESTRUCTORFUNC_NOCONTEXT_t f, void *p)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR        \
-        assert(p)
+        Perl_assert_aTHX; assert(p)
 
 PERL_CALLCONV void
 Perl_save_destructor_x(pTHX_ DESTRUCTORFUNC_t f, void *p)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR_X
+#define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR_X      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_freercpv(pTHX_ char *rcpv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_FREERCPV          \
-        assert(rcpv)
+        Perl_assert_aTHX; assert(rcpv)
 
 PERL_CALLCONV void
 Perl_save_generic_pvref(pTHX_ char **str)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_PVREF     \
-        assert(str)
+        Perl_assert_aTHX; assert(str)
 
 PERL_CALLCONV void
 Perl_save_generic_svref(pTHX_ SV **sptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_SVREF     \
-        assert(sptr)
+        Perl_assert_aTHX; assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_gp(pTHX_ GV *gv, I32 empty)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GP                \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV HV *
 Perl_save_hash(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HASH              \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
@@ -5200,7 +5434,8 @@ Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_HDELETE           \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(keysv)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(keysv)
 
 PERL_CALLCONV void
 Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
@@ -5209,140 +5444,149 @@ Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_HELEM_FLAGS       \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(sptr)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(key); assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_hints(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_HINTS
+#define PERL_ARGS_ASSERT_SAVE_HINTS             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_hptr(pTHX_ HV **hptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HPTR              \
-        assert(hptr)
+        Perl_assert_aTHX; assert(hptr)
 
 PERL_CALLCONV void
 Perl_save_int(pTHX_ int *intp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_INT               \
-        assert(intp)
+        Perl_assert_aTHX; assert(intp)
 
 PERL_CALLCONV void
 Perl_save_item(pTHX_ SV *item)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ITEM              \
-        assert(item)
+        Perl_assert_aTHX; assert(item)
 
 PERL_CALLCONV void
 Perl_save_iv(pTHX_ IV *ivp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_IV                \
-        assert(ivp)
+        Perl_assert_aTHX; assert(ivp)
 
 PERL_CALLCONV void
 Perl_save_padsv(pTHX_ PADOFFSET padix)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_PADSV
+#define PERL_ARGS_ASSERT_SAVE_PADSV             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_padsv_and_mortalize(pTHX_ PADOFFSET off)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_PADSV_AND_MORTALIZE
+#define PERL_ARGS_ASSERT_SAVE_PADSV_AND_MORTALIZE \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_pptr(pTHX_ char **pptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_PPTR              \
-        assert(pptr)
+        Perl_assert_aTHX; assert(pptr)
 
 PERL_CALLCONV void
 Perl_save_pushi32ptr(pTHX_ const I32 i, void * const ptr, const int type)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_PUSHI32PTR
+#define PERL_ARGS_ASSERT_SAVE_PUSHI32PTR        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_pushptr(pTHX_ void * const ptr, const int type)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_PUSHPTR
+#define PERL_ARGS_ASSERT_SAVE_PUSHPTR           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_pushptrptr(pTHX_ void * const ptr1, void * const ptr2, const int type)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_PUSHPTRPTR
+#define PERL_ARGS_ASSERT_SAVE_PUSHPTRPTR        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_rcpv(pTHX_ char **prcpv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_RCPV              \
-        assert(prcpv)
+        Perl_assert_aTHX; assert(prcpv)
 
 PERL_CALLCONV void
 Perl_save_re_context(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVE_RE_CONTEXT
+#define PERL_ARGS_ASSERT_SAVE_RE_CONTEXT        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_save_scalar(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SCALAR            \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_save_set_svflags(pTHX_ SV *sv, U32 mask, U32 val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SET_SVFLAGS       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_save_shared_pvref(pTHX_ char **str)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SHARED_PVREF      \
-        assert(str)
+        Perl_assert_aTHX; assert(str)
 
 PERL_CALLCONV void
 Perl_save_sptr(pTHX_ SV **sptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SPTR              \
-        assert(sptr)
+        Perl_assert_aTHX; assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_strlen(pTHX_ STRLEN *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_STRLEN            \
-        assert(ptr)
+        Perl_assert_aTHX; assert(ptr)
 
 PERL_CALLCONV SV *
 Perl_save_svref(pTHX_ SV **sptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SVREF             \
-        assert(sptr)
+        Perl_assert_aTHX; assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_vptr(pTHX_ void *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_VPTR              \
-        assert(ptr)
+        Perl_assert_aTHX; assert(ptr)
 
 PERL_CALLCONV char *
 Perl_savesharedpv(pTHX_ const char *pv)
         Perl_attribute_nonnull_aTHX
         __attribute__malloc__
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_SAVESHAREDPV
+#define PERL_ARGS_ASSERT_SAVESHAREDPV           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
@@ -5351,34 +5595,39 @@ Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SAVESHAREDPVN          \
-        assert(pv)
+        Perl_assert_aTHX; assert(pv)
 
 PERL_CALLCONV void
 Perl_savestack_grow(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVESTACK_GROW
+#define PERL_ARGS_ASSERT_SAVESTACK_GROW         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_savestack_grow_cnt(pTHX_ I32 need)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVESTACK_GROW_CNT
+#define PERL_ARGS_ASSERT_SAVESTACK_GROW_CNT     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_savetmps(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SAVETMPS
+#define PERL_ARGS_ASSERT_SAVETMPS               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_sawparens(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SAWPARENS
+#define PERL_ARGS_ASSERT_SAWPARENS              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_scalar(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SCALAR
+#define PERL_ARGS_ASSERT_SCALAR                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_scalarvoid(pTHX_ OP *arg)
@@ -5386,7 +5635,7 @@ Perl_scalarvoid(pTHX_ OP *arg)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SCALARVOID             \
-        assert(arg)
+        Perl_assert_aTHX; assert(arg)
 
 PERL_CALLCONV NV
 Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
@@ -5394,7 +5643,7 @@ Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_BIN               \
-        assert(start); assert(retlen)
+        Perl_assert_aTHX; assert(start); assert(retlen)
 
 PERL_CALLCONV NV
 Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
@@ -5402,7 +5651,7 @@ Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_HEX               \
-        assert(start); assert(retlen)
+        Perl_assert_aTHX; assert(start); assert(retlen)
 
 PERL_CALLCONV char *
 Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp)
@@ -5410,7 +5659,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_NUM               \
-        assert(start); assert(lvalp)
+        Perl_assert_aTHX; assert(start); assert(lvalp)
 
 PERL_CALLCONV NV
 Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
@@ -5418,10 +5667,10 @@ Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_OCT               \
-        assert(start); assert(retlen)
+        Perl_assert_aTHX; assert(start); assert(retlen)
 
 #define PERL_ARGS_ASSERT_SCAN_STR               \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 PERL_CALLCONV const char *
 Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
@@ -5429,7 +5678,7 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_VERSION           \
-        assert(s); assert(rv)
+        Perl_assert_aTHX; assert(s); assert(rv)
 
 PERL_CALLCONV char *
 Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
@@ -5438,20 +5687,22 @@ Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_VSTRING           \
-        assert(s); assert(e); assert(sv); assert(s < e)
+        Perl_assert_aTHX; assert(s); assert(e); assert(sv); assert(s < e)
 
 #define PERL_ARGS_ASSERT_SCAN_WORD              \
-        assert(s); assert(dest); assert(slp)
+        Perl_assert_aTHX; assert(s); assert(dest); assert(slp)
 
 PERL_CALLCONV U64
 Perl_seed(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SEED
+#define PERL_ARGS_ASSERT_SEED                   \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_set_caret_X(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SET_CARET_X
+#define PERL_ARGS_ASSERT_SET_CARET_X            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_set_context(void *t)
@@ -5464,21 +5715,21 @@ Perl_set_numeric_standard(pTHX_ const char *file, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_STANDARD   \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV void
 Perl_set_numeric_underlying(pTHX_ const char *file, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_UNDERLYING \
-        assert(file)
+        Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV void
 Perl_setdefout(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SETDEFOUT              \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 PERL_CALLCONV void
 Perl_setfd_cloexec(int fd)
@@ -5489,13 +5740,15 @@ PERL_CALLCONV void
 Perl_setfd_cloexec_for_nonsysfd(pTHX_ int fd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SETFD_CLOEXEC_FOR_NONSYSFD
+#define PERL_ARGS_ASSERT_SETFD_CLOEXEC_FOR_NONSYSFD \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_setfd_cloexec_or_inhexec_by_sysfdness(pTHX_ int fd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SETFD_CLOEXEC_OR_INHEXEC_BY_SYSFDNESS
+#define PERL_ARGS_ASSERT_SETFD_CLOEXEC_OR_INHEXEC_BY_SYSFDNESS \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_setfd_inhexec(int fd)
@@ -5506,14 +5759,15 @@ PERL_CALLCONV void
 Perl_setfd_inhexec_for_sysfd(pTHX_ int fd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SETFD_INHEXEC_FOR_SYSFD
+#define PERL_ARGS_ASSERT_SETFD_INHEXEC_FOR_SYSFD \
+        Perl_assert_aTHX
 
 PERL_CALLCONV HEK *
 Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SHARE_HEK              \
-        assert(str)
+        Perl_assert_aTHX; assert(str)
 
 PERL_CALLCONV Signal_t
 Perl_sighandler1(int sig)
@@ -5526,21 +5780,21 @@ Perl_sighandler3(int sig, Siginfo_t *info, void *uap)
 #define PERL_ARGS_ASSERT_SIGHANDLER3
 
 #define PERL_ARGS_ASSERT_SKIPSPACE_FLAGS        \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV void
 Perl_sortsv(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV                 \
-        assert(cmp)
+        Perl_assert_aTHX; assert(cmp)
 
 PERL_CALLCONV void
 Perl_sortsv_flags(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV_FLAGS           \
-        assert(cmp)
+        Perl_assert_aTHX; assert(cmp)
 
 PERL_CALLCONV SV **
 Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
@@ -5548,7 +5802,7 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_STACK_GROW             \
-        assert(sp); assert(p)
+        Perl_assert_aTHX; assert(sp); assert(p)
 
 PERL_CALLCONV PerlIO *
 Perl_start_glob(pTHX_ SV *tmpglob, IO *io)
@@ -5557,12 +5811,13 @@ Perl_start_glob(pTHX_ SV *tmpglob, IO *io)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_START_GLOB             \
-        assert(tmpglob); assert(io)
+        Perl_assert_aTHX; assert(tmpglob); assert(io)
 
 PERL_CALLCONV I32
 Perl_start_subparse(pTHX_ I32 is_format, U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_START_SUBPARSE
+#define PERL_ARGS_ASSERT_START_SUBPARSE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV NV
 Perl_str_to_version(pTHX_ SV *sv)
@@ -5570,7 +5825,7 @@ Perl_str_to_version(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_STR_TO_VERSION         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sub_crush_depth(pTHX_ CV *cv)
@@ -5578,7 +5833,8 @@ Perl_sub_crush_depth(pTHX_ CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUB_CRUSH_DEPTH        \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_subsignature_append_fence_op(pTHX_ OP *o)
@@ -5586,7 +5842,7 @@ Perl_subsignature_append_fence_op(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_FENCE_OP \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_subsignature_append_named(pTHX_ const char *paramname, PADOFFSET padix, OPCODE defmode, OP *defexpr)
@@ -5594,45 +5850,49 @@ Perl_subsignature_append_named(pTHX_ const char *paramname, PADOFFSET padix, OPC
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_NAMED \
-        assert(paramname)
+        Perl_assert_aTHX; assert(paramname)
 
 PERL_CALLCONV void
 Perl_subsignature_append_positional(pTHX_ PADOFFSET padix, OPCODE defmode, OP *defexpr)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_POSITIONAL
+#define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_POSITIONAL \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_subsignature_append_slurpy(pTHX_ I32 sigil, PADOFFSET padix)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_SLURPY
+#define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_SLURPY \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_subsignature_finish(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SUBSIGNATURE_FINISH
+#define PERL_ARGS_ASSERT_SUBSIGNATURE_FINISH    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_subsignature_start(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SUBSIGNATURE_START
+#define PERL_ARGS_ASSERT_SUBSIGNATURE_START     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SUSPEND_COMPCV         \
-        assert(buffer)
+        Perl_assert_aTHX; assert(buffer)
 
 PERL_CALLCONV bool
 Perl_sv_2bool_flags(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2BOOL_FLAGS         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV CV *
 Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref)
@@ -5640,26 +5900,27 @@ Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_2CV                 \
-        assert(st); assert(gvp)
+        Perl_assert_aTHX; assert(st); assert(gvp)
 
 PERL_CALLCONV IO *
 Perl_sv_2io(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IO                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV IV
 Perl_sv_2iv_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IV_FLAGS           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SV *
 Perl_sv_2mortal(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_2MORTAL
+#define PERL_ARGS_ASSERT_SV_2MORTAL             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_sv_2num_flags(pTHX_ SV * const sv, int flags)
@@ -5667,42 +5928,42 @@ Perl_sv_2num_flags(pTHX_ SV * const sv, int flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_2NUM_FLAGS          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV NV
 Perl_sv_2nv_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2NV_FLAGS           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pv_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PV_FLAGS           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pvbyte_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVBYTE_FLAGS       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pvutf8_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVUTF8_FLAGS       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV UV
 Perl_sv_2uv_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2UV_FLAGS           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_backoff(SV * const sv)
@@ -5716,14 +5977,14 @@ Perl_sv_bless(pTHX_ SV * const sv, HV * const stash)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_BLESS               \
-        assert(sv); assert(stash)
+        Perl_assert_aTHX; assert(sv); assert(stash)
 
 PERL_CALLCONV bool
 Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CAN_SWIPE_PV_BUF    \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr, int tlen)
@@ -5734,14 +5995,15 @@ Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_SV_CAT_DECODE          \
-        assert(dsv); assert(encoding); assert(ssv); assert(offset); assert(tstr)
+        Perl_assert_aTHX; assert(dsv); assert(encoding); assert(ssv); \
+        assert(offset); assert(tstr)
 
 PERL_CALLCONV void
 Perl_sv_catpv(pTHX_ SV * const dsv, const char *sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV               \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
@@ -5749,14 +6011,14 @@ Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPV_FLAGS         \
-        assert(dsv); assert(sstr)
+        Perl_assert_aTHX; assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
 Perl_sv_catpv_mg(pTHX_ SV * const dsv, const char * const sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV_MG            \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_catpvf(pTHX_ SV * const sv, const char * const pat, ...)
@@ -5765,7 +6027,7 @@ Perl_sv_catpvf(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_CATPVF              \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
@@ -5774,7 +6036,7 @@ Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_CATPVF_MG           \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, const I32 flags)
@@ -5782,60 +6044,66 @@ Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, c
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPVN_FLAGS        \
-        assert(dsv); assert(sstr)
+        Perl_assert_aTHX; assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
 Perl_sv_catsv_flags(pTHX_ SV * const dsv, SV * const sstr, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATSV_FLAGS         \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_chop(pTHX_ SV * const sv, const char * const ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CHOP                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SSize_t
 Perl_sv_clean_all(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SV_CLEAN_ALL
+#define PERL_ARGS_ASSERT_SV_CLEAN_ALL           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_clean_objs(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SV_CLEAN_OBJS
+#define PERL_ARGS_ASSERT_SV_CLEAN_OBJS          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_clear(pTHX_ SV * const orig_sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CLEAR               \
-        assert(orig_sv)
+        Perl_assert_aTHX; assert(orig_sv)
 
 PERL_CALLCONV I32
 Perl_sv_cmp(pTHX_ SV * const sv1, SV * const sv2)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_CMP
+#define PERL_ARGS_ASSERT_SV_CMP                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_sv_cmp_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_CMP_FLAGS
+#define PERL_ARGS_ASSERT_SV_CMP_FLAGS           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_sv_cmp_locale(pTHX_ SV * const sv1, SV * const sv2)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_CMP_LOCALE
+#define PERL_ARGS_ASSERT_SV_CMP_LOCALE          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_sv_cmp_locale_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_CMP_LOCALE_FLAGS
+#define PERL_ARGS_ASSERT_SV_CMP_LOCALE_FLAGS    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags)
@@ -5843,17 +6111,19 @@ Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_COPYPV_FLAGS        \
-        assert(dsv); assert(ssv)
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 PERL_CALLCONV void
 Perl_sv_dec(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_DEC
+#define PERL_ARGS_ASSERT_SV_DEC                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_dec_nomg(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_DEC_NOMG
+#define PERL_ARGS_ASSERT_SV_DEC_NOMG            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv)
@@ -5861,7 +6131,7 @@ Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_DEL_BACKREF         \
-        assert(tsv); assert(sv)
+        Perl_assert_aTHX; assert(tsv); assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from(pTHX_ SV *sv, const char * const name)
@@ -5870,7 +6140,7 @@ Perl_sv_derived_from(pTHX_ SV *sv, const char * const name)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM        \
-        assert(sv); assert(name)
+        Perl_assert_aTHX; assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
@@ -5879,7 +6149,7 @@ Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_HV     \
-        assert(sv); assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(sv); assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
@@ -5888,7 +6158,7 @@ Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_PV     \
-        assert(sv); assert(name)
+        Perl_assert_aTHX; assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
@@ -5897,7 +6167,7 @@ Perl_sv_derived_from_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_PVN    \
-        assert(sv); assert(name)
+        Perl_assert_aTHX; assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
@@ -5906,12 +6176,13 @@ Perl_sv_derived_from_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SV     \
-        assert(sv); assert(namesv)
+        Perl_assert_aTHX; assert(sv); assert(namesv)
 
 PERL_CALLCONV bool
 Perl_sv_destroyable(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_DESTROYABLE
+#define PERL_ARGS_ASSERT_SV_DESTROYABLE         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_does(pTHX_ SV *sv, const char * const name)
@@ -5920,7 +6191,7 @@ Perl_sv_does(pTHX_ SV *sv, const char * const name)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES                \
-        assert(sv); assert(name)
+        Perl_assert_aTHX; assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_does_pv(pTHX_ SV *sv, const char * const name, U32 flags)
@@ -5929,7 +6200,7 @@ Perl_sv_does_pv(pTHX_ SV *sv, const char * const name, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_PV             \
-        assert(sv); assert(name)
+        Perl_assert_aTHX; assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_does_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
@@ -5938,7 +6209,7 @@ Perl_sv_does_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 fl
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_PVN            \
-        assert(sv); assert(name)
+        Perl_assert_aTHX; assert(sv); assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
@@ -5947,47 +6218,52 @@ Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_SV             \
-        assert(sv); assert(namesv)
+        Perl_assert_aTHX; assert(sv); assert(namesv)
 
 PERL_CALLCONV void
 Perl_sv_dump(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_DUMP
+#define PERL_ARGS_ASSERT_SV_DUMP                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_dump_depth(pTHX_ SV *sv, I32 depth)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_DUMP_DEPTH
+#define PERL_ARGS_ASSERT_SV_DUMP_DEPTH          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_sv_eq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_EQ_FLAGS
+#define PERL_ARGS_ASSERT_SV_EQ_FLAGS            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_force_normal_flags(pTHX_ SV * const sv, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FORCE_NORMAL_FLAGS  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_free(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_FREE
+#define PERL_ARGS_ASSERT_SV_FREE                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_free2(pTHX_ SV * const sv, const U32 refcnt)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FREE2               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_free_arenas(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SV_FREE_ARENAS
+#define PERL_ARGS_ASSERT_SV_FREE_ARENAS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_sv_get_backrefs(SV * const sv)
@@ -6001,31 +6277,33 @@ Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_GETS                \
-        assert(sv); assert(fp)
+        Perl_assert_aTHX; assert(sv); assert(fp)
 
 PERL_CALLCONV char *
 Perl_sv_grow(pTHX_ SV * const sv, STRLEN newlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_grow_fresh(pTHX_ SV * const sv, STRLEN newlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW_FRESH          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_inc(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_INC
+#define PERL_ARGS_ASSERT_SV_INC                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_inc_nomg(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_INC_NOMG
+#define PERL_ARGS_ASSERT_SV_INC_NOMG            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char *little, const STRLEN littlelen, const U32 flags)
@@ -6033,14 +6311,14 @@ Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_SV_INSERT_FLAGS        \
-        assert(bigstr); assert(little)
+        Perl_assert_aTHX; assert(bigstr); assert(little)
 
 PERL_CALLCONV int
 Perl_sv_isa(pTHX_ SV *sv, const char * const name)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_ISA                 \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV bool
 Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
@@ -6049,162 +6327,178 @@ Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_ISA_SV              \
-        assert(sv); assert(namesv)
+        Perl_assert_aTHX; assert(sv); assert(namesv)
 
 PERL_CALLCONV int
 Perl_sv_isobject(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_ISOBJECT
+#define PERL_ARGS_ASSERT_SV_ISOBJECT            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_sv_langinfo(pTHX_ const nl_item item)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_LANGINFO
+#define PERL_ARGS_ASSERT_SV_LANGINFO            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV STRLEN
 Perl_sv_len(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_LEN
+#define PERL_ARGS_ASSERT_SV_LEN                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV STRLEN
 Perl_sv_len_utf8(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_LEN_UTF8
+#define PERL_ARGS_ASSERT_SV_LEN_UTF8            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV STRLEN
 Perl_sv_len_utf8_nomg(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_LEN_UTF8_NOMG       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_magic(pTHX_ SV * const sv, SV * const obj, const int how, const char * const name, const I32 namlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGIC               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicext(pTHX_ SV * const sv, SV * const obj, const int how, const MGVTBL * const vtbl, const char * const name, const I32 namlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGICEXT            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #define PERL_ARGS_ASSERT_SV_MAGICEXT_MGLOB      \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SV *
 Perl_sv_mortalcopy_flags(pTHX_ SV * const oldsv, U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_SV_MORTALCOPY_FLAGS
+#define PERL_ARGS_ASSERT_SV_MORTALCOPY_FLAGS    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_sv_newmortal(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_SV_NEWMORTAL
+#define PERL_ARGS_ASSERT_SV_NEWMORTAL           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_sv_newref(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NEWREF
+#define PERL_ARGS_ASSERT_SV_NEWREF              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_nosharing(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NOSHARING
+#define PERL_ARGS_ASSERT_SV_NOSHARING           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_sv_numcmp_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NUMCMP_FLAGS
+#define PERL_ARGS_ASSERT_SV_NUMCMP_FLAGS        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numeq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NUMEQ_FLAGS
+#define PERL_ARGS_ASSERT_SV_NUMEQ_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numge_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NUMGE_FLAGS
+#define PERL_ARGS_ASSERT_SV_NUMGE_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numgt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NUMGT_FLAGS
+#define PERL_ARGS_ASSERT_SV_NUMGT_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numle_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NUMLE_FLAGS
+#define PERL_ARGS_ASSERT_SV_NUMLE_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numlt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NUMLT_FLAGS
+#define PERL_ARGS_ASSERT_SV_NUMLT_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numne_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_NUMNE_FLAGS
+#define PERL_ARGS_ASSERT_SV_NUMNE_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_sv_peek(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_PEEK
+#define PERL_ARGS_ASSERT_SV_PEEK                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_pos_b2u(pTHX_ SV * const sv, I32 * const offsetp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_B2U             \
-        assert(offsetp)
+        Perl_assert_aTHX; assert(offsetp)
 
 PERL_CALLCONV STRLEN
 Perl_sv_pos_b2u_flags(pTHX_ SV * const sv, STRLEN const offset, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_B2U_FLAGS       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_pos_u2b(pTHX_ SV * const sv, I32 * const offsetp, I32 * const lenp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_U2B             \
-        assert(offsetp)
+        Perl_assert_aTHX; assert(offsetp)
 
 PERL_CALLCONV STRLEN
 Perl_sv_pos_u2b_flags(pTHX_ SV * const sv, STRLEN uoffset, STRLEN * const lenp, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_U2B_FLAGS       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_pvn_force_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE_FLAGS     \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_pvutf8n_force(pTHX_ SV * const sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding)
@@ -6212,14 +6506,14 @@ Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_RECODE_TO_UTF8      \
-        assert(sv); assert(encoding)
+        Perl_assert_aTHX; assert(sv); assert(encoding)
 
 PERL_CALLCONV SV *
 Perl_sv_ref(pTHX_ SV *dst, const SV * const sv, const int ob)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REF                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV const char *
 Perl_sv_reftype(pTHX_ const SV * const sv, const int ob)
@@ -6227,14 +6521,14 @@ Perl_sv_reftype(pTHX_ const SV * const sv, const int ob)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REFTYPE             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_regex_global_pos_clear(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_CLEAR \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_regex_global_pos_get(pTHX_ SV *sv, STRLEN *posp, U32 flags)
@@ -6243,14 +6537,14 @@ Perl_sv_regex_global_pos_get(pTHX_ SV *sv, STRLEN *posp, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_GET \
-        assert(sv); assert(posp)
+        Perl_assert_aTHX; assert(sv); assert(posp)
 
 PERL_CALLCONV void
 Perl_sv_regex_global_pos_set(pTHX_ SV *sv, STRLEN pos, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_SET \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_replace(pTHX_ SV * const sv, SV * const nsv)
@@ -6258,123 +6552,125 @@ Perl_sv_replace(pTHX_ SV * const sv, SV * const nsv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REPLACE             \
-        assert(sv); assert(nsv)
+        Perl_assert_aTHX; assert(sv); assert(nsv)
 
 PERL_CALLCONV void
 Perl_sv_report_used(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_REPORT_USED
+#define PERL_ARGS_ASSERT_SV_REPORT_USED         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_reset(pTHX_ const char *s, HV * const stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RESET               \
-        assert(s); assert(!stash || SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(s); assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_sv_resetpvn(pTHX_ const char *s, STRLEN len, HV * const stash)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_SV_RESETPVN
+#define PERL_ARGS_ASSERT_SV_RESETPVN            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_sv_rvunweaken(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVUNWEAKEN          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SV *
 Perl_sv_rvweaken(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVWEAKEN            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_bool(pTHX_ SV *sv, const bool bool_val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_BOOL            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_false(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_FALSE           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_true(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_TRUE            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_set_undef(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_UNDEF           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_sethek(pTHX_ SV * const sv, const HEK * const hek)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETHEK              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setiv(pTHX_ SV * const sv, const IV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setiv_mg(pTHX_ SV * const sv, const IV i)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV_MG            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setnv(pTHX_ SV * const sv, const NV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setnv_mg(pTHX_ SV * const sv, const NV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV_MG            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpv(pTHX_ SV * const sv, const char * const ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char  *
 Perl_sv_setpv_bufsize(pTHX_ SV * const sv, const STRLEN cur, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_BUFSIZE       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpv_mg(pTHX_ SV * const sv, const char * const ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_MG            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpvf(pTHX_ SV * const sv, const char * const pat, ...)
@@ -6383,7 +6679,7 @@ Perl_sv_setpvf(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETPVF              \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_setpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
@@ -6392,21 +6688,21 @@ Perl_sv_setpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETPVF_MG           \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_setpvn(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpvn_fresh(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN_FRESH        \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
@@ -6414,28 +6710,28 @@ Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETPVN_MG           \
-        assert(sv); assert(ptr)
+        Perl_assert_aTHX; assert(sv); assert(ptr)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_iv(pTHX_ SV * const rv, const char * const classname, const IV iv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_IV           \
-        assert(rv)
+        Perl_assert_aTHX; assert(rv)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_nv(pTHX_ SV * const rv, const char * const classname, const NV nv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_NV           \
-        assert(rv)
+        Perl_assert_aTHX; assert(rv)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_pv(pTHX_ SV * const rv, const char * const classname, void * const pv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_PV           \
-        assert(rv)
+        Perl_assert_aTHX; assert(rv)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char * const pv, const STRLEN n)
@@ -6443,14 +6739,14 @@ Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETREF_PVN          \
-        assert(rv); assert(pv)
+        Perl_assert_aTHX; assert(rv); assert(pv)
 
 PERL_CALLCONV SV *
 Perl_sv_setref_uv(pTHX_ SV * const rv, const char * const classname, const UV uv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_UV           \
-        assert(rv)
+        Perl_assert_aTHX; assert(rv)
 
 PERL_CALLCONV void
 Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref)
@@ -6458,7 +6754,7 @@ Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC           \
-        assert(sv); assert(ref)
+        Perl_assert_aTHX; assert(sv); assert(ref)
 
 PERL_CALLCONV void
 Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref)
@@ -6466,7 +6762,7 @@ Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC_MG        \
-        assert(sv); assert(ref)
+        Perl_assert_aTHX; assert(sv); assert(ref)
 
 PERL_CALLCONV void
 Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref)
@@ -6474,7 +6770,7 @@ Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC         \
-        assert(sv); assert(ref)
+        Perl_assert_aTHX; assert(sv); assert(ref)
 
 PERL_CALLCONV void
 Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref)
@@ -6482,47 +6778,48 @@ Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC_MG      \
-        assert(sv); assert(ref)
+        Perl_assert_aTHX; assert(sv); assert(ref)
 
 PERL_CALLCONV void
 Perl_sv_setsv_flags(pTHX_ SV *dsv, SV *ssv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_FLAGS         \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_setsv_mg(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_MG            \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_setuv(pTHX_ SV * const sv, const UV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV               \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setuv_mg(pTHX_ SV * const sv, const UV u)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV_MG            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_streq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_STREQ_FLAGS
+#define PERL_ARGS_ASSERT_SV_STREQ_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_sv_strftime_ints(pTHX_ SV *fmt, int sec, int min, int hour, int mday, int mon, int year, int isdst)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_INTS       \
-        assert(fmt)
+        Perl_assert_aTHX; assert(fmt)
 
 PERL_CALLCONV SV *
 Perl_sv_strftime_tm(pTHX_ SV *fmt, const struct tm *mytm)
@@ -6530,12 +6827,13 @@ Perl_sv_strftime_tm(pTHX_ SV *fmt, const struct tm *mytm)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_TM         \
-        assert(fmt); assert(mytm)
+        Perl_assert_aTHX; assert(fmt); assert(mytm)
 
 PERL_CALLCONV SV *
 Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_STRING_FROM_ERRNUM
+#define PERL_ARGS_ASSERT_SV_STRING_FROM_ERRNUM  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_tainted(pTHX_ SV * const sv)
@@ -6543,12 +6841,13 @@ Perl_sv_tainted(pTHX_ SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_TAINTED             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV I32
 Perl_sv_true(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SV_TRUE
+#define PERL_ARGS_ASSERT_SV_TRUE                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
@@ -6557,77 +6856,77 @@ Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_UNI_DISPLAY         \
-        assert(dsv); assert(ssv)
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 PERL_CALLCONV int
 Perl_sv_unmagic(pTHX_ SV * const sv, const int type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGIC             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV int
 Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGICEXT          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_unref_flags(pTHX_ SV * const ref, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNREF_FLAGS         \
-        assert(ref)
+        Perl_assert_aTHX; assert(ref)
 
 PERL_CALLCONV void
 Perl_sv_untaint(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNTAINT             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_upgrade(pTHX_ SV * const sv, svtype new_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UPGRADE             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_usepvn_flags(pTHX_ SV * const sv, char *ptr, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_USEPVN_FLAGS        \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_utf8_decode(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DECODE         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_utf8_downgrade_flags(pTHX_ SV * const sv, const bool fail_ok, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_FLAGS \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_utf8_encode(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_ENCODE         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV * const sv, const I32 flags, STRLEN extra)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS_GROW \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -6635,7 +6934,7 @@ Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const arg
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF             \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -6643,7 +6942,7 @@ Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF_MG          \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
@@ -6651,7 +6950,7 @@ Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patle
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN            \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted, const U32 flags)
@@ -6659,7 +6958,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN_FLAGS      \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -6667,7 +6966,7 @@ Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const arg
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF             \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -6675,7 +6974,7 @@ Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF_MG          \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
 Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
@@ -6683,24 +6982,26 @@ Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patle
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVFN            \
-        assert(sv); assert(pat)
+        Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV const char *
 Perl_sv_vstring_get(pTHX_ SV * const sv, STRLEN *lenp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_VSTRING_GET         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_switch_to_global_locale(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SWITCH_TO_GLOBAL_LOCALE
+#define PERL_ARGS_ASSERT_SWITCH_TO_GLOBAL_LOCALE \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sync_locale(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_SYNC_LOCALE
+#define PERL_ARGS_ASSERT_SYNC_LOCALE            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sys_init(int *argc, char ***argv)
@@ -6724,14 +7025,15 @@ Perl_sys_term(void);
 PERL_CALLCONV void
 Perl_taint_env(pTHX)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_TAINT_ENV
+#define PERL_ARGS_ASSERT_TAINT_ENV              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_taint_proper(pTHX_ const char *f, const char * const s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_TAINT_PROPER           \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV OP *
 Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * const mg, const U32 flags, U32 argc, ...)
@@ -6742,12 +7044,13 @@ Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * con
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_TIED_METHOD            \
-        assert(methname); assert(mark); assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(methname); assert(mark); assert(sv); assert(mg)
 
 PERL_CALLCONV SSize_t
 Perl_tmps_grow_p(pTHX_ SSize_t ix)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_TMPS_GROW_P
+#define PERL_ARGS_ASSERT_TMPS_GROW_P            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV UV
 Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
@@ -6755,7 +7058,7 @@ Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_FOLD_FLAGS_     \
-        assert(p); assert(lenp)
+        Perl_assert_aTHX; assert(p); assert(lenp)
 
 PERL_CALLCONV UV
 Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -6763,7 +7066,7 @@ Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_LOWER           \
-        assert(p); assert(lenp)
+        Perl_assert_aTHX; assert(p); assert(lenp)
 
 PERL_CALLCONV UV
 Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -6771,7 +7074,7 @@ Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_TITLE           \
-        assert(p); assert(lenp)
+        Perl_assert_aTHX; assert(p); assert(lenp)
 
 PERL_CALLCONV UV
 Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -6779,7 +7082,7 @@ Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_UPPER           \
-        assert(p); assert(lenp)
+        Perl_assert_aTHX; assert(p); assert(lenp)
 
 PERL_CALLCONV UV
 Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, U8 flags)
@@ -6788,7 +7091,7 @@ Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_FOLD_FLAGS_    \
-        assert(p); assert(e); assert(ustrp); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV UV
 Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
@@ -6797,7 +7100,7 @@ Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_LOWER_FLAGS_   \
-        assert(p); assert(e); assert(ustrp); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV UV
 Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
@@ -6806,7 +7109,7 @@ Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_TITLE_FLAGS_   \
-        assert(p); assert(e); assert(ustrp); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV UV
 Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
@@ -6815,17 +7118,19 @@ Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_UPPER_FLAGS_   \
-        assert(p); assert(e); assert(ustrp); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
 
 PERL_CALLCONV bool
 Perl_try_amagic_bin(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_TRY_AMAGIC_BIN
+#define PERL_ARGS_ASSERT_TRY_AMAGIC_BIN         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_try_amagic_un(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_TRY_AMAGIC_UN
+#define PERL_ARGS_ASSERT_TRY_AMAGIC_UN          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** const peob)
@@ -6843,28 +7148,30 @@ Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_UNPACKSTRING           \
-        assert(pat); assert(patend); assert(s); assert(strend); \
+        Perl_assert_aTHX; assert(pat); assert(patend); assert(s); assert(strend); \
         assert(pat <= patend); assert(s <= strend)
 
 PERL_CALLCONV void
 Perl_unshare_hek(pTHX_ HEK *hek)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_UNSHARE_HEK
+#define PERL_ARGS_ASSERT_UNSHARE_HEK            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_unsharepvn(pTHX_ const char *sv, I32 len, U32 hash)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_UNSHAREPVN
+#define PERL_ARGS_ASSERT_UNSHAREPVN             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_upg_version(pTHX_ SV *ver, bool qv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UPG_VERSION            \
-        assert(ver)
+        Perl_assert_aTHX; assert(ver)
 
 #define PERL_ARGS_ASSERT_UTF16_TO_UTF8_BASE     \
-        assert(p); assert(d); assert(newlen)
+        Perl_assert_aTHX; assert(p); assert(d); assert(newlen)
 
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
@@ -6873,7 +7180,7 @@ Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UTF8_LENGTH            \
-        assert(s0); assert(e); assert(s0 <= e)
+        Perl_assert_aTHX; assert(s0); assert(e); assert(s0 <= e)
 
 PERL_CALLCONV U8 *
 Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
@@ -6881,7 +7188,7 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES          \
-        assert(s); assert(lenp)
+        Perl_assert_aTHX; assert(s); assert(lenp)
 
 PERL_CALLCONV bool
 Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to_bytes_arg result_as)
@@ -6890,10 +7197,10 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES_         \
-        assert(s_ptr); assert(lenp); assert(free_me)
+        Perl_assert_aTHX; assert(s_ptr); assert(lenp); assert(free_me)
 
 #define PERL_ARGS_ASSERT_UTF8_TO_UTF16_BASE     \
-        assert(s); assert(d); assert(newlen)
+        Perl_assert_aTHX; assert(s); assert(d); assert(newlen)
 
 PERL_CALLCONV bool
 Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs)
@@ -6909,14 +7216,14 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_UTILIZE                \
-        assert(idop)
+        Perl_assert_aTHX; assert(idop)
 
 PERL_CALLCONV U8 *
 Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **msgs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS_MSGS \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_CALLCONV bool
 Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
@@ -6924,22 +7231,23 @@ Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVE   \
-        assert(s); assert(end); assert(s <= end)
+        Perl_assert_aTHX; assert(s); assert(end); assert(s <= end)
 
 PERL_CALLCONV bool
 Perl_valid_identifier_pvn(pTHX_ const char *s, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVN   \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV bool
 Perl_valid_identifier_sv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_VALID_IDENTIFIER_SV
+#define PERL_ARGS_ASSERT_VALID_IDENTIFIER_SV    \
+        Perl_assert_aTHX
 
 #define PERL_ARGS_ASSERT_VALIDATE_PROTO         \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV int
 Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
@@ -6947,37 +7255,38 @@ Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VCMP                   \
-        assert(lhv); assert(rhv)
+        Perl_assert_aTHX; assert(lhv); assert(rhv)
 
 PERL_CALLCONV_NO_RET void
 Perl_vcroak(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-#define PERL_ARGS_ASSERT_VCROAK
+#define PERL_ARGS_ASSERT_VCROAK                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_vdeb(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VDEB                   \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV void
 Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VFATAL_WARNER          \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV char *
 Perl_vform(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VFORM                  \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 #define PERL_ARGS_ASSERT_VIVIFY_DEFELEM         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SV *
 Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
@@ -6986,21 +7295,21 @@ Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_VIVIFY_REF             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_vload_module(pTHX_ U32 flags, SV *name, SV *ver, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VLOAD_MODULE           \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV SV *
 Perl_vmess(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VMESS                  \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV SV *
 Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
@@ -7008,49 +7317,49 @@ Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_VNEWSVPVF              \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV SV *
 Perl_vnormal(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VNORMAL                \
-        assert(vs)
+        Perl_assert_aTHX; assert(vs)
 
 PERL_CALLCONV SV *
 Perl_vnumify(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VNUMIFY                \
-        assert(vs)
+        Perl_assert_aTHX; assert(vs)
 
 PERL_CALLCONV SV *
 Perl_vstringify(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VSTRINGIFY             \
-        assert(vs)
+        Perl_assert_aTHX; assert(vs)
 
 PERL_CALLCONV SV *
 Perl_vverify(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VVERIFY                \
-        assert(vs)
+        Perl_assert_aTHX; assert(vs)
 
 PERL_CALLCONV void
 Perl_vwarn(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VWARN                  \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV void
 Perl_vwarner(pTHX_ U32 err, const char *pat, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VWARNER                \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV I32
 Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
@@ -7058,7 +7367,7 @@ Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WAIT4PID               \
-        assert(statusp)
+        Perl_assert_aTHX; assert(statusp)
 
 PERL_CALLCONV void
 Perl_warn(pTHX_ const char *pat, ...)
@@ -7066,14 +7375,14 @@ Perl_warn(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_WARN                   \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV void
 Perl_warn_sv(pTHX_ SV *baseex)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WARN_SV                \
-        assert(baseex)
+        Perl_assert_aTHX; assert(baseex)
 
 PERL_CALLCONV void
 Perl_warner(pTHX_ U32 err, const char *pat, ...)
@@ -7081,13 +7390,14 @@ Perl_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_WARNER                 \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 PERL_CALLCONV I32
 Perl_was_lvalue_sub(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_WAS_LVALUE_SUB
+#define PERL_ARGS_ASSERT_WAS_LVALUE_SUB         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_watch(pTHX_ char **addr)
@@ -7095,28 +7405,28 @@ Perl_watch(pTHX_ char **addr)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WATCH                  \
-        assert(addr)
+        Perl_assert_aTHX; assert(addr)
 
 PERL_CALLCONV I32
 Perl_whichsig_pv(pTHX_ const char *sig)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PV            \
-        assert(sig)
+        Perl_assert_aTHX; assert(sig)
 
 PERL_CALLCONV I32
 Perl_whichsig_pvn(pTHX_ const char *sig, STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PVN           \
-        assert(sig)
+        Perl_assert_aTHX; assert(sig)
 
 PERL_CALLCONV I32
 Perl_whichsig_sv(pTHX_ SV *sigsv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_SV            \
-        assert(sigsv)
+        Perl_assert_aTHX; assert(sigsv)
 
 PERL_CALLCONV void
 Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t *old_plugin_p)
@@ -7124,7 +7434,7 @@ Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_INFIX_PLUGIN      \
-        assert(new_plugin); assert(old_plugin_p)
+        Perl_assert_aTHX; assert(new_plugin); assert(old_plugin_p)
 
 PERL_CALLCONV void
 Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_plugin_t *old_plugin_p)
@@ -7132,7 +7442,7 @@ Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_pl
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_KEYWORD_PLUGIN    \
-        assert(new_plugin); assert(old_plugin_p)
+        Perl_assert_aTHX; assert(new_plugin); assert(old_plugin_p)
 
 PERL_CALLCONV void
 Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t *old_checker_p)
@@ -7140,7 +7450,7 @@ Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_WRAP_OP_CHECKER        \
-        assert(new_checker); assert(old_checker_p)
+        Perl_assert_aTHX; assert(new_checker); assert(old_checker_p)
 
 PERL_CALLCONV void
 Perl_write_to_stderr(pTHX_ SV *msv)
@@ -7148,12 +7458,13 @@ Perl_write_to_stderr(pTHX_ SV *msv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WRITE_TO_STDERR        \
-        assert(msv)
+        Perl_assert_aTHX; assert(msv)
 
 PERL_CALLCONV void
 Perl_xs_boot_epilog(pTHX_ const SSize_t ax)
         Perl_attribute_nonnull_aTHX;
-#define PERL_ARGS_ASSERT_XS_BOOT_EPILOG
+#define PERL_ARGS_ASSERT_XS_BOOT_EPILOG         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV Stack_off_t
 Perl_xs_handshake(const U32 key, void *v_my_perl, const char *file, ...)
@@ -7168,7 +7479,7 @@ Perl_yyerror(pTHX_ const char * const s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR                \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV int
 Perl_yyerror_pv(pTHX_ const char * const s, U32 flags)
@@ -7176,33 +7487,38 @@ Perl_yyerror_pv(pTHX_ const char * const s, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR_PV             \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV int
 Perl_yyerror_pvn(pTHX_ const char * const s, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_YYERROR_PVN
+#define PERL_ARGS_ASSERT_YYERROR_PVN            \
+        Perl_assert_aTHX
 
-#define PERL_ARGS_ASSERT_YYLEX
+#define PERL_ARGS_ASSERT_YYLEX                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_yyparse(pTHX_ int gramtype)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_YYPARSE
+#define PERL_ARGS_ASSERT_YYPARSE                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_yyquit(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_YYQUIT
+#define PERL_ARGS_ASSERT_YYQUIT                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_yyunlex(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#define PERL_ARGS_ASSERT_YYUNLEX
+#define PERL_ARGS_ASSERT_YYUNLEX                \
+        Perl_assert_aTHX
 
 #if defined(DEBUGGING)
 PERL_CALLCONV int
@@ -7212,26 +7528,27 @@ Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GET_DEBUG_OPTS        \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV void
 Perl_hv_assert(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_ASSERT             \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_pad_setsv(pTHX_ PADOFFSET po, SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PAD_SETSV             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SV *
 Perl_pad_sv(pTHX_ PADOFFSET po)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PAD_SV
+# define PERL_ARGS_ASSERT_PAD_SV                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_set_padlist(CV *cv, PADLIST *padlist)
@@ -7247,7 +7564,7 @@ Perl_dump_sv_child(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DUMP_SV_CHILD         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #endif /* defined(DEBUG_LEAKING_SCALARS_FORK_DUMP) */
 #if defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE)
@@ -7255,7 +7572,8 @@ PERL_CALLCONV I32
 Perl_my_chsize(pTHX_ int fd, Off_t length)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_MY_CHSIZE
+# define PERL_ARGS_ASSERT_MY_CHSIZE             \
+        Perl_assert_aTHX
 
 #endif
 #if !defined(HAS_GETENV_LEN)
@@ -7266,7 +7584,7 @@ Perl_getenv_len(pTHX_ const char *env_elem, unsigned long *len)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GETENV_LEN            \
-        assert(env_elem); assert(len)
+        Perl_assert_aTHX; assert(env_elem); assert(len)
 
 #endif /* !defined(HAS_GETENV_LEN) */
 #if !defined(HAS_MKOSTEMP)
@@ -7295,7 +7613,7 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_IPCCTL             \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
@@ -7304,7 +7622,7 @@ Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_IPCGET             \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV SSize_t
 Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
@@ -7313,7 +7631,7 @@ Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_MSGRCV             \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
@@ -7322,7 +7640,7 @@ Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_MSGSND             \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_semop(pTHX_ SV **mark, SV **sp)
@@ -7331,7 +7649,7 @@ Perl_do_semop(pTHX_ SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_SEMOP              \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV I32
 Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
@@ -7340,7 +7658,7 @@ Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_SHMIO              \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 #endif /* defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM) */
 #if defined(HAS_PIPE)
@@ -7351,7 +7669,7 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLPROC_PIPE_CLOEXEC \
-        assert(pipefd)
+        Perl_assert_aTHX; assert(pipefd)
 
 #endif /* defined(HAS_PIPE) */
 #if !defined(HAS_RENAME)
@@ -7362,7 +7680,7 @@ Perl_same_dirent(pTHX_ const char *a, const char *b)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SAME_DIRENT           \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 #endif /* !defined(HAS_RENAME) */
 #if !defined(HAS_SIGNBIT)
@@ -7379,14 +7697,16 @@ Perl_PerlSock_accept_cloexec(pTHX_ int listenfd, struct sockaddr *addr, Sock_siz
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_PERLSOCK_ACCEPT_CLOEXEC
+# define PERL_ARGS_ASSERT_PERLSOCK_ACCEPT_CLOEXEC \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_PERLSOCK_SOCKET_CLOEXEC
+# define PERL_ARGS_ASSERT_PERLSOCK_SOCKET_CLOEXEC \
+        Perl_assert_aTHX
 
 #endif /* defined(HAS_SOCKET) */
 #if   defined(HAS_SOCKETPAIR) ||                                     \
@@ -7399,7 +7719,7 @@ Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKETPAIR_CLOEXEC \
-        assert(pairfd)
+        Perl_assert_aTHX; assert(pairfd)
 
 #endif /*   defined(HAS_SOCKETPAIR) ||
           ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) &&
@@ -7425,12 +7745,14 @@ Perl_my_strnlen(const char *str, Size_t maxlen)
 PERL_CALLCONV void
 Perl_sys_intern_clear(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SYS_INTERN_CLEAR
+# define PERL_ARGS_ASSERT_SYS_INTERN_CLEAR      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sys_intern_init(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SYS_INTERN_INIT
+# define PERL_ARGS_ASSERT_SYS_INTERN_INIT       \
+        Perl_assert_aTHX
 
 # if defined(USE_ITHREADS)
 PERL_CALLCONV void
@@ -7439,7 +7761,7 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SYS_INTERN_DUP      \
-        assert(src); assert(dst)
+        Perl_assert_aTHX; assert(src); assert(dst)
 
 # endif /* defined(USE_ITHREADS) */
 #endif /* defined(HAVE_INTERP_INTERN) */
@@ -7488,7 +7810,7 @@ Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MY_CXT_INIT           \
-        assert(indexp)
+        Perl_assert_aTHX; assert(indexp)
 
 PERL_CALLCONV SV *
 Perl_newSVpvf_nocontext(const char * const pat, ...)
@@ -7550,14 +7872,14 @@ Perl_dump_mstats(pTHX_ const char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_MSTATS           \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV int
 Perl_get_mstats(pTHX_ perl_mstats_t *buf, int buflen, int level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_MSTATS            \
-        assert(buf)
+        Perl_assert_aTHX; assert(buf)
 
 PERL_CALLCONV MEM_SIZE
 Perl_malloc_good_size(size_t nbytes)
@@ -7585,7 +7907,7 @@ Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR         \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV UV
 Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
@@ -7593,7 +7915,7 @@ Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVUNI         \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV UV
 Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
@@ -7601,7 +7923,7 @@ Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVUNI        \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV U8 *
 Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
@@ -7609,20 +7931,21 @@ Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UVUNI_TO_UTF8         \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 # if defined(PERL_IN_MATHOMS_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_PERLY_C)   || defined(PERL_IN_TOKE_C)
 PERL_CALLCONV OP *
 Perl_ref(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_REF
+#   define PERL_ARGS_ASSERT_REF                 \
+        Perl_assert_aTHX
 
 # endif
 #endif /* !defined(NO_MATHOMS) */
 #if defined(PERL_ANY_COW)
 # define PERL_ARGS_ASSERT_SV_SETSV_COW          \
-        assert(ssv)
+        Perl_assert_aTHX; assert(ssv)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
@@ -7638,7 +7961,7 @@ Perl_opslab_force_free(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FORCE_FREE     \
-        assert(slab)
+        Perl_assert_aTHX; assert(slab)
 
 PERL_CALLCONV void
 Perl_opslab_free(pTHX_ OPSLAB *slab)
@@ -7646,7 +7969,7 @@ Perl_opslab_free(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE           \
-        assert(slab)
+        Perl_assert_aTHX; assert(slab)
 
 PERL_CALLCONV void
 Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
@@ -7654,7 +7977,7 @@ Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE_NOPAD     \
-        assert(slab)
+        Perl_assert_aTHX; assert(slab)
 
 PERL_CALLCONV void
 Perl_parser_free_nexttoke_ops(pTHX_ yy_parser *parser, OPSLAB *slab)
@@ -7663,7 +7986,7 @@ Perl_parser_free_nexttoke_ops(pTHX_ yy_parser *parser, OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PARSER_FREE_NEXTTOKE_OPS \
-        assert(parser); assert(slab)
+        Perl_assert_aTHX; assert(parser); assert(slab)
 
 # if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV void
@@ -7671,14 +7994,14 @@ Perl_Slab_to_ro(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RO          \
-        assert(slab)
+        Perl_assert_aTHX; assert(slab)
 
 PERL_CALLCONV void
 Perl_Slab_to_rw(pTHX_ OPSLAB * const slab)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RW          \
-        assert(slab)
+        Perl_assert_aTHX; assert(slab)
 
 # endif /* defined(PERL_DEBUG_READONLY_OPS) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -7870,7 +8193,7 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 *s, const U8 *send, const bool utf8_target)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISSCRIPT_RUN          \
-        assert(s); assert(send); assert(s <= send)
+        Perl_assert_aTHX; assert(s); assert(send); assert(s <= send)
 
 # if !defined(HAS_MEMRCHR)
 
@@ -8031,14 +8354,14 @@ Perl_finalize_optree(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OPTREE       \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_optimize_optree(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE       \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 #endif /* defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API) */
 #if defined(PERL_DEBUG_READONLY_COW)
@@ -8048,7 +8371,7 @@ Perl_sv_buf_to_ro(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_BUF_TO_RO          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #endif /* defined(PERL_DEBUG_READONLY_COW) */
 #if defined(PERL_DEBUG_READONLY_OPS)
@@ -8057,12 +8380,13 @@ Perl_op_refcnt_dec(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_OP_REFCNT_DEC         \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_op_refcnt_inc(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_OP_REFCNT_INC
+# define PERL_ARGS_ASSERT_OP_REFCNT_INC         \
+        Perl_assert_aTHX
 
 #endif /* defined(PERL_DEBUG_READONLY_OPS) */
 #if defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION)
@@ -8072,7 +8396,7 @@ Perl_do_exec(pTHX_ const char *cmd)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
-        assert(cmd)
+        Perl_assert_aTHX; assert(cmd)
 
 #else /* if !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
 PERL_CALLCONV bool
@@ -8081,7 +8405,7 @@ Perl_do_exec(pTHX_ const char *cmd)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
-        assert(cmd)
+        Perl_assert_aTHX; assert(cmd)
 
 #endif /* !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
 #if defined(PERL_IMPLICIT_SYS)
@@ -8122,7 +8446,8 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags, const struct IPerlMem **
 PERL_CALLCONV I32
 Perl_my_pclose(pTHX_ PerlIO *ptr)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_MY_PCLOSE
+# define PERL_ARGS_ASSERT_MY_PCLOSE             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PerlIO *
 Perl_my_popen(pTHX_ const char *cmd, const char *mode)
@@ -8130,7 +8455,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_MY_POPEN              \
-        assert(cmd); assert(mode)
+        Perl_assert_aTHX; assert(cmd); assert(mode)
 
 # if defined(USE_ITHREADS)
 
@@ -8140,7 +8465,7 @@ S_PerlEnv_putenv(pTHX_ char *str)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_PERLENV_PUTENV    \
-        assert(str)
+        Perl_assert_aTHX; assert(str)
 
 #   endif
 # endif /* defined(USE_ITHREADS) */
@@ -8151,7 +8476,7 @@ S_get_aux_mg(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_AUX_MG            \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 #endif
 #if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
@@ -8161,25 +8486,29 @@ Perl_XS_builtin_indexed(pTHX_ CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_XS_BUILTIN_INDEXED    \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_finish_export_lexical(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL
+# define PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_import_builtin_bundle(pTHX_ U16 ver)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_IMPORT_BUILTIN_BUNDLE
+# define PERL_ARGS_ASSERT_IMPORT_BUILTIN_BUNDLE \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_prepare_export_lexical(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL
+# define PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL \
+        Perl_assert_aTHX
 
 #endif /* defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C) */
 #if defined(PERL_IN_CLASS_C)
@@ -8188,7 +8517,7 @@ S_class_cleanup_definition(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_CLEANUP_DEFINITION \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 #endif
 #if defined(PERL_IN_CLASS_C) || defined(PERL_IN_GLOBALS_C) || \
@@ -8200,7 +8529,7 @@ Perl_ck_aassign(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_AASSIGN            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_anoncode(pTHX_ OP *o)
@@ -8209,7 +8538,7 @@ Perl_ck_anoncode(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ANONCODE           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_anonhash(pTHX_ OP *o)
@@ -8218,7 +8547,7 @@ Perl_ck_anonhash(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ANONHASH           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_backtick(pTHX_ OP *o)
@@ -8227,7 +8556,7 @@ Perl_ck_backtick(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_BACKTICK           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_bitop(pTHX_ OP *o)
@@ -8236,7 +8565,7 @@ Perl_ck_bitop(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_BITOP              \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_classname(pTHX_ OP *o)
@@ -8245,7 +8574,7 @@ Perl_ck_classname(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CLASSNAME          \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_cmp(pTHX_ OP *o)
@@ -8254,7 +8583,7 @@ Perl_ck_cmp(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CMP                \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_concat(pTHX_ OP *o)
@@ -8263,7 +8592,7 @@ Perl_ck_concat(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CONCAT             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_defined(pTHX_ OP *o)
@@ -8272,7 +8601,7 @@ Perl_ck_defined(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_DEFINED            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_delete(pTHX_ OP *o)
@@ -8281,7 +8610,7 @@ Perl_ck_delete(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_DELETE             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_each(pTHX_ OP *o)
@@ -8290,7 +8619,7 @@ Perl_ck_each(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EACH               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_eof(pTHX_ OP *o)
@@ -8299,7 +8628,7 @@ Perl_ck_eof(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EOF                \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_eval(pTHX_ OP *o)
@@ -8308,7 +8637,7 @@ Perl_ck_eval(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EVAL               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_exec(pTHX_ OP *o)
@@ -8317,7 +8646,7 @@ Perl_ck_exec(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EXEC               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_exists(pTHX_ OP *o)
@@ -8326,7 +8655,7 @@ Perl_ck_exists(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EXISTS             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_ftst(pTHX_ OP *o)
@@ -8335,7 +8664,7 @@ Perl_ck_ftst(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_FTST               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_fun(pTHX_ OP *o)
@@ -8344,7 +8673,7 @@ Perl_ck_fun(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_FUN                \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_glob(pTHX_ OP *o)
@@ -8353,7 +8682,7 @@ Perl_ck_glob(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_GLOB               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_grep(pTHX_ OP *o)
@@ -8362,7 +8691,7 @@ Perl_ck_grep(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_GREP               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_helemexistsor(pTHX_ OP *o)
@@ -8371,7 +8700,7 @@ Perl_ck_helemexistsor(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_HELEMEXISTSOR      \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_index(pTHX_ OP *o)
@@ -8380,7 +8709,7 @@ Perl_ck_index(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_INDEX              \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_isa(pTHX_ OP *o)
@@ -8389,7 +8718,7 @@ Perl_ck_isa(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ISA                \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_join(pTHX_ OP *o)
@@ -8398,7 +8727,7 @@ Perl_ck_join(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_JOIN               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_length(pTHX_ OP *o)
@@ -8407,7 +8736,7 @@ Perl_ck_length(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LENGTH             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_lfun(pTHX_ OP *o)
@@ -8416,7 +8745,7 @@ Perl_ck_lfun(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LFUN               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_listiob(pTHX_ OP *o)
@@ -8425,7 +8754,7 @@ Perl_ck_listiob(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LISTIOB            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_match(pTHX_ OP *o)
@@ -8434,7 +8763,7 @@ Perl_ck_match(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_MATCH              \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_method(pTHX_ OP *o)
@@ -8443,7 +8772,7 @@ Perl_ck_method(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_METHOD             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_null(pTHX_ OP *o)
@@ -8452,7 +8781,7 @@ Perl_ck_null(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_NULL               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_open(pTHX_ OP *o)
@@ -8461,7 +8790,7 @@ Perl_ck_open(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_OPEN               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_prototype(pTHX_ OP *o)
@@ -8470,7 +8799,7 @@ Perl_ck_prototype(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_PROTOTYPE          \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_readline(pTHX_ OP *o)
@@ -8479,7 +8808,7 @@ Perl_ck_readline(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_READLINE           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_refassign(pTHX_ OP *o)
@@ -8488,7 +8817,7 @@ Perl_ck_refassign(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REFASSIGN          \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_repeat(pTHX_ OP *o)
@@ -8497,7 +8826,7 @@ Perl_ck_repeat(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REPEAT             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_require(pTHX_ OP *o)
@@ -8506,7 +8835,7 @@ Perl_ck_require(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REQUIRE            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_return(pTHX_ OP *o)
@@ -8515,7 +8844,7 @@ Perl_ck_return(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RETURN             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_rfun(pTHX_ OP *o)
@@ -8524,7 +8853,7 @@ Perl_ck_rfun(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RFUN               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_rvconst(pTHX_ OP *o)
@@ -8533,7 +8862,7 @@ Perl_ck_rvconst(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RVCONST            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_sassign(pTHX_ OP *o)
@@ -8542,7 +8871,7 @@ Perl_ck_sassign(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SASSIGN            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_scmp(pTHX_ OP *o)
@@ -8551,7 +8880,7 @@ Perl_ck_scmp(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SCMP               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_select(pTHX_ OP *o)
@@ -8560,7 +8889,7 @@ Perl_ck_select(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SELECT             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_shift(pTHX_ OP *o)
@@ -8569,7 +8898,7 @@ Perl_ck_shift(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SHIFT              \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_smartmatch(pTHX_ OP *o)
@@ -8578,7 +8907,7 @@ Perl_ck_smartmatch(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SMARTMATCH         \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_sort(pTHX_ OP *o)
@@ -8587,7 +8916,7 @@ Perl_ck_sort(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SORT               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_spair(pTHX_ OP *o)
@@ -8596,7 +8925,7 @@ Perl_ck_spair(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SPAIR              \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_split(pTHX_ OP *o)
@@ -8605,7 +8934,7 @@ Perl_ck_split(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SPLIT              \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_stringify(pTHX_ OP *o)
@@ -8614,7 +8943,7 @@ Perl_ck_stringify(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_STRINGIFY          \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_subr(pTHX_ OP *o)
@@ -8623,7 +8952,7 @@ Perl_ck_subr(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SUBR               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_substr(pTHX_ OP *o)
@@ -8632,7 +8961,7 @@ Perl_ck_substr(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SUBSTR             \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_svconst(pTHX_ OP *o)
@@ -8641,7 +8970,7 @@ Perl_ck_svconst(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SVCONST            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_tell(pTHX_ OP *o)
@@ -8650,7 +8979,7 @@ Perl_ck_tell(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TELL               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_trunc(pTHX_ OP *o)
@@ -8659,7 +8988,7 @@ Perl_ck_trunc(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TRUNC              \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV OP *
 Perl_ck_trycatch(pTHX_ OP *o)
@@ -8668,7 +8997,7 @@ Perl_ck_trycatch(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TRYCATCH           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 #endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_GLOBALS_C) ||
           defined(PERL_IN_OP_C)    || defined(PERL_IN_PEEP_C) */
@@ -8681,8 +9010,8 @@ Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_ADJUST      \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
@@ -8690,40 +9019,43 @@ Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_FIELD       \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(pn)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        assert(pn)
 
 PERL_CALLCONV void
 Perl_class_apply_attributes(pTHX_ HV *stash, OP *attrlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_ATTRIBUTES \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_class_apply_field_attributes(pTHX_ PADNAME *pn, OP *attrlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_FIELD_ATTRIBUTES \
-        assert(pn)
+        Perl_assert_aTHX; assert(pn)
 
 PERL_CALLCONV void
 Perl_class_prepare_initfield_parse(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_CLASS_PREPARE_INITFIELD_PARSE
+# define PERL_ARGS_ASSERT_CLASS_PREPARE_INITFIELD_PARSE \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_class_prepare_method_parse(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_METHOD_PARSE \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
 Perl_class_seal_stash(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SEAL_STASH      \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
@@ -8731,26 +9063,27 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CLASS_SET_FIELD_DEFOP \
-        assert(pn); assert(defop)
+        Perl_assert_aTHX; assert(pn); assert(defop)
 
 PERL_CALLCONV void
 Perl_class_setup_stash(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SETUP_STASH     \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV OP *
 Perl_class_wrap_method_body(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_CLASS_WRAP_METHOD_BODY
+# define PERL_ARGS_ASSERT_CLASS_WRAP_METHOD_BODY \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_croak_kw_unless_class(pTHX_ const char *kw)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CROAK_KW_UNLESS_CLASS \
-        assert(kw)
+        Perl_assert_aTHX; assert(kw)
 
 #endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    ||
           defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) ||
@@ -8761,7 +9094,7 @@ S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DEB_STACK_N           \
-        assert(stack_base)
+        Perl_assert_aTHX; assert(stack_base)
 
 #endif
 #if defined(PERL_IN_DOIO_C)
@@ -8771,14 +9104,14 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_ARGVOUT_FINAL         \
-        assert(mg); assert(io)
+        Perl_assert_aTHX; assert(mg); assert(io)
 
 static void
 S_exec_failed(pTHX_ const char *cmd, int fd, int do_report)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_EXEC_FAILED           \
-        assert(cmd)
+        Perl_assert_aTHX; assert(cmd)
 
 static bool
 S_is_fork_open(const char *name)
@@ -8794,7 +9127,7 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_OPENN_CLEANUP         \
-        assert(gv); assert(io); assert(mode); assert(oname)
+        Perl_assert_aTHX; assert(gv); assert(io); assert(mode); assert(oname)
 
 static IO *
 S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int *savefd, char *savetype)
@@ -8806,15 +9139,16 @@ S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int 
         Perl_attribute_nonnull(pTHX_5)
         Perl_attribute_nonnull(pTHX_6);
 # define PERL_ARGS_ASSERT_OPENN_SETUP           \
-        assert(gv); assert(mode); assert(saveifp); assert(saveofp); \
-        assert(savefd); assert(savetype)
+        Perl_assert_aTHX; assert(gv); assert(mode); assert(saveifp); \
+        assert(saveofp); assert(savefd); assert(savetype)
 
 # if !defined(DOSISH)
 static bool
 S_ingroup(pTHX_ Gid_t testgid, bool effective)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_INGROUP
+#   define PERL_ARGS_ASSERT_INGROUP             \
+        Perl_assert_aTHX
 
 # endif
 #endif /* defined(PERL_IN_DOIO_C) */
@@ -8826,7 +9160,7 @@ S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COMPLEX      \
-        assert(sv); assert(tbl)
+        Perl_assert_aTHX; assert(sv); assert(tbl)
 
 static Size_t
 S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
@@ -8835,7 +9169,7 @@ S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT        \
-        assert(sv); assert(tbl)
+        Perl_assert_aTHX; assert(sv); assert(tbl)
 
 static Size_t
 S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
@@ -8844,7 +9178,8 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP \
-        assert(sv); assert(invmap); assert(SvTYPE(invmap) == SVt_PVAV)
+        Perl_assert_aTHX; assert(sv); assert(invmap); \
+        assert(SvTYPE(invmap) == SVt_PVAV)
 
 static Size_t
 S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
@@ -8853,7 +9188,8 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_INVMAP       \
-        assert(sv); assert(invmap); assert(SvTYPE(invmap) == SVt_PVAV)
+        Perl_assert_aTHX; assert(sv); assert(invmap); \
+        assert(SvTYPE(invmap) == SVt_PVAV)
 
 static Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
@@ -8862,7 +9198,7 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_SIMPLE       \
-        assert(sv); assert(tbl)
+        Perl_assert_aTHX; assert(sv); assert(tbl)
 
 #endif /* defined(PERL_IN_DOOP_C) */
 #if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
@@ -8883,66 +9219,71 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
 #endif
 #if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
-# define PERL_ARGS_ASSERT_ADD_RANGE_TO_INVLIST_
+# define PERL_ARGS_ASSERT_ADD_RANGE_TO_INVLIST_ \
+        Perl_assert_aTHX
 
 # define PERL_ARGS_ASSERT_INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND_ \
-        assert(b); assert(i)
+        Perl_assert_aTHX; assert(b); assert(i)
 
 # define PERL_ARGS_ASSERT_INVLIST_INVERT_       \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 # define PERL_ARGS_ASSERT_INVLIST_UNION_MAYBE_COMPLEMENT_2ND_ \
-        assert(b); assert(output)
+        Perl_assert_aTHX; assert(b); assert(output)
 
-# define PERL_ARGS_ASSERT_NEW_INVLIST_
+# define PERL_ARGS_ASSERT_NEW_INVLIST_          \
+        Perl_assert_aTHX
 
 # define PERL_ARGS_ASSERT_SETUP_CANNED_INVLIST_ \
-        assert(other_elements_ptr)
+        Perl_assert_aTHX; assert(other_elements_ptr)
 
 #endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
     defined(PERL_IN_TOKE_C)
 # define PERL_ARGS_ASSERT_FORM_ALIEN_DIGIT_MSG  \
-        assert(first_bad); assert(send); assert(first_bad < send)
+        Perl_assert_aTHX; assert(first_bad); assert(send); \
+        assert(first_bad < send)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_C         \
-        assert(result); assert(message)
+        Perl_assert_aTHX; assert(result); assert(message)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_O         \
-        assert(s); assert(*s); assert(send); assert(uv); assert(message); \
-        assert(*s < send)
+        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv); \
+        assert(message); assert(*s < send)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_X         \
-        assert(s); assert(*s); assert(send); assert(uv); assert(message); \
-        assert(*s < send)
+        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv); \
+        assert(message); assert(*s < send)
 
 #endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) ||
           defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) || \
     defined(PERL_IN_TOKE_C)   || defined(PERL_IN_UTF8_C)
-# define PERL_ARGS_ASSERT_FORM_CP_TOO_LARGE_MSG
+# define PERL_ARGS_ASSERT_FORM_CP_TOO_LARGE_MSG \
+        Perl_assert_aTHX
 
 #endif
 #if defined(PERL_IN_DUMP_C)
 static CV *
 S_deb_curcv(pTHX_ I32 ix)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_DEB_CURCV
+# define PERL_ARGS_ASSERT_DEB_CURCV             \
+        Perl_assert_aTHX
 
 static void
 S_debprof(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DEBPROF               \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static SV *
 S_pm_description(pTHX_ const PMOP *pm)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PM_DESCRIPTION        \
-        assert(pm)
+        Perl_assert_aTHX; assert(pm)
 
 static char *
 S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim, I32 pretty_flags)
@@ -8950,12 +9291,13 @@ S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PV_DISPLAY_FLAGS      \
-        assert(dsv); assert(pv)
+        Perl_assert_aTHX; assert(dsv); assert(pv)
 
 static UV
 S_sequence_num(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SEQUENCE_NUM
+# define PERL_ARGS_ASSERT_SEQUENCE_NUM          \
+        Perl_assert_aTHX
 
 #endif /* defined(PERL_IN_DUMP_C) */
 #if defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) || \
@@ -8966,14 +9308,14 @@ Perl_hv_kill_backrefs(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HV_KILL_BACKREFS      \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 #endif /* defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) ||
           defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 # define PERL_ARGS_ASSERT_INVLIST_DUMP_         \
-        assert(file); assert(indent); assert(invlist)
+        Perl_assert_aTHX; assert(file); assert(indent); assert(invlist)
 
 #endif
 #if defined(PERL_IN_GV_C)
@@ -8983,21 +9325,21 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len, const U32 i
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_DEFAULT_STASH    \
-        assert(stash); assert(name)
+        Perl_assert_aTHX; assert(stash); assert(name)
 
 static void
 S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_INIT_SVTYPE        \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 static bool
 S_gv_is_in_main(pTHX_ const char *name, STRLEN len, const U32 is_utf8)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_IS_IN_MAIN         \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 static bool
 S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svtype sv_type)
@@ -9006,15 +9348,15 @@ S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svt
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE         \
-        assert(gv); assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
-        assert(name)
+        Perl_assert_aTHX; assert(gv); assert(stash); \
+        assert(SvTYPE(stash) == SVt_PVHV); assert(name)
 
 static void
 S_gv_magicalize_isa(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE_ISA     \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 static void
 S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
@@ -9022,7 +9364,7 @@ S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_MAYBE_MULTIMAGIC_GV   \
-        assert(gv); assert(name)
+        Perl_assert_aTHX; assert(gv); assert(name)
 
 static bool
 S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len, const char *nambeg, STRLEN full_len, const U32 is_utf8, const I32 add)
@@ -9033,8 +9375,8 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME   \
-        assert(stash); assert(gv); assert(name); assert(*name); assert(len); \
-        assert(nambeg); assert(nambeg <= *name)
+        Perl_assert_aTHX; assert(stash); assert(gv); assert(name); assert(*name); \
+        assert(len); assert(nambeg); assert(nambeg <= *name)
 
 static void
 S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len, const U32 flags)
@@ -9042,21 +9384,21 @@ S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_REQUIRE_TIE_MOD       \
-        assert(gv); assert(name)
+        Perl_assert_aTHX; assert(gv); assert(name)
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE GV *
 S_gv_fetchmeth_internal(pTHX_ HV *stash, SV *meth, const char *name, STRLEN len, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_GV_FETCHMETH_INTERNAL \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_STATIC_INLINE HV *
 S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_GV_STASHPVN_INTERNAL \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_GV_C) */
@@ -9069,13 +9411,13 @@ Perl_sv_add_backref(pTHX_ SV * const tsv, SV * const sv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_ADD_BACKREF        \
-        assert(tsv); assert(sv)
+        Perl_assert_aTHX; assert(tsv); assert(sv)
 
 #endif /* defined(PERL_IN_GV_C)  || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 # define PERL_ARGS_ASSERT_GV_STASHSVPVN_CACHED  \
-        assert(namesv || name)
+        Perl_assert_aTHX; assert(namesv || name)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV HV *
@@ -9090,41 +9432,41 @@ S_clear_placeholders(pTHX_ HV *hv, U32 items)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_PLACEHOLDERS    \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static void
 S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HSPLIT                \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static struct xpvhv_aux *
 S_hv_auxinit(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_AUXINIT            \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static SV *
 S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int k_flags, I32 d_flags, U32 hash)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_HV_DELETE_COMMON      \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 static SV *
 S_hv_free_ent_ret(pTHX_ HE *entry)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENT_RET       \
-        assert(entry)
+        Perl_assert_aTHX; assert(entry)
 
 static void
 S_hv_free_entries(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENTRIES       \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 static void
 S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
@@ -9142,14 +9484,14 @@ S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_HV_NOTALLOWED         \
-        assert(key); assert(msg)
+        Perl_assert_aTHX; assert(key); assert(msg)
 
 static SV *
 S_refcounted_he_value(pTHX_ const struct refcounted_he *he)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_REFCOUNTED_HE_VALUE   \
-        assert(he)
+        Perl_assert_aTHX; assert(he)
 
 static HEK *
 S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
@@ -9165,19 +9507,21 @@ S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SHARE_HEK_FLAGS       \
-        assert(str)
+        Perl_assert_aTHX; assert(str)
 
 static void
 S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_UNSHARE_HEK_OR_PVN
+# define PERL_ARGS_ASSERT_UNSHARE_HEK_OR_PVN    \
+        Perl_assert_aTHX
 
 # if !defined(PURIFY)
 static HE *
 S_new_he(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_NEW_HE
+#   define PERL_ARGS_ASSERT_NEW_HE              \
+        Perl_assert_aTHX
 
 # endif
 #endif /* defined(PERL_IN_HV_C) */
@@ -9188,7 +9532,7 @@ Perl_sv_kill_backrefs(pTHX_ SV * const sv, AV * const av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_KILL_BACKREFS      \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) ||
           defined(PERL_IN_SV_C) */
@@ -9200,14 +9544,16 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HFREE_NEXT_ENTRY      \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(indexp)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(indexp)
 
 #endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_LOCALE_C)
 static utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const locale_category_index cat_index)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I
+# define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I \
+        Perl_assert_aTHX
 
 static void
 S_ints_to_tm(pTHX_ struct tm *mytm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int isdst)
@@ -9215,19 +9561,20 @@ S_ints_to_tm(pTHX_ struct tm *mytm, const char *locale, int sec, int min, int ho
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INTS_TO_TM            \
-        assert(mytm); assert(locale)
+        Perl_assert_aTHX; assert(mytm); assert(locale)
 
 static bool
 S_is_locale_utf8(pTHX_ const char *locale)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_LOCALE_UTF8        \
-        assert(locale)
+        Perl_assert_aTHX; assert(locale)
 
 static HV *
 S_my_localeconv(pTHX_ const int item)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_MY_LOCALECONV
+# define PERL_ARGS_ASSERT_MY_LOCALECONV         \
+        Perl_assert_aTHX
 
 static void
 S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2])
@@ -9237,8 +9584,8 @@ S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 wh
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(locale); \
-        assert(strings); assert(integers)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(locale); assert(strings); assert(integers)
 
 static bool
 S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool called_externally)
@@ -9249,7 +9596,7 @@ S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 # define PERL_ARGS_ASSERT_STRFTIME8             \
-        assert(fmt); assert(sv); assert(locale); assert(mytm); \
+        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale); assert(mytm); \
         assert(result_utf8ness)
 
 static bool
@@ -9261,7 +9608,7 @@ S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm
         Perl_attribute_nonnull(pTHX_4)
         __attribute__format__(__strftime__,pTHX_1,0);
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
-        assert(fmt); assert(sv); assert(locale); assert(mytm)
+        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale); assert(mytm)
 
 static SV *
 S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
@@ -9270,7 +9617,7 @@ S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SV_STRFTIME_COMMON    \
-        assert(fmt); assert(locale); assert(mytm)
+        Perl_assert_aTHX; assert(fmt); assert(locale); assert(mytm)
 
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 static const char *
@@ -9279,44 +9626,48 @@ S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item, const char *locale, SV *sv, u
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \
-        assert(locale); assert(sv)
+        Perl_assert_aTHX; assert(locale); assert(sv)
 
 # endif /* defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO) */
 # if defined(USE_LOCALE)
 static const char *
 S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING
+#   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING \
+        Perl_assert_aTHX
 
 static const char *
 S_external_call_langinfo(pTHX_ const nl_item item, SV *sv, utf8ness_t *utf8ness)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_EXTERNAL_CALL_LANGINFO \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static locale_category_index
 S_get_category_index_helper(pTHX_ const int category, bool *success, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER
+#   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER \
+        Perl_assert_aTHX
 
 static const char *
 S_native_querylocale_i(pTHX_ const locale_category_index cat_index)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I
+#   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I \
+        Perl_assert_aTHX
 
 static void
 S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_NEW_LC_ALL          \
-        assert(lc_all)
+        Perl_assert_aTHX; assert(lc_all)
 
 static void
 S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING
+#   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING \
+        Perl_assert_aTHX
 
 static parse_LC_ALL_string_return
 S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line)
@@ -9324,22 +9675,25 @@ S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
-        assert(string); assert(output)
+        Perl_assert_aTHX; assert(string); assert(output)
 
 static void
 S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index, const char *original_locale, const line_t caller_line)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I
+#   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I \
+        Perl_assert_aTHX
 
 static const char *
 S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_SAVE_TO_BUFFER
+#   define PERL_ARGS_ASSERT_SAVE_TO_BUFFER      \
+        Perl_assert_aTHX
 
 static void
 S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_size)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE
+#   define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE \
+        Perl_assert_aTHX
 
 PERL_STATIC_NO_RET void
 S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, const char *current, const char *failed, const line_t proxy_caller_line, const line_t immediate_caller_line, const char *higher_caller_file, const line_t higher_caller_line)
@@ -9348,21 +9702,22 @@ S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, con
         Perl_attribute_nonnull(pTHX_6)
         __attribute__noreturn__;
 #   define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_VIA_I \
-        assert(failed); assert(higher_caller_file)
+        Perl_assert_aTHX; assert(failed); assert(higher_caller_file)
 
 static const char *
 S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_locale, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I     \
-        assert(new_locale)
+        Perl_assert_aTHX; assert(new_locale)
 
 #   if defined(DEBUGGING)
 static char *
 S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const char *locale, const char *retval, const line_t line)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I
+#     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I \
+        Perl_assert_aTHX
 
 #   endif
 #   if   defined(HAS_LOCALECONV) && \
@@ -9375,8 +9730,8 @@ S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 whic
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #     define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(locale); \
-        assert(strings); assert(integers)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(locale); assert(strings); assert(integers)
 
 #   endif /*   defined(HAS_LOCALECONV) &&
              ( defined(USE_LOCALE_MONETARY) ||
@@ -9388,7 +9743,7 @@ S_langinfo_sv_i(pTHX_ const nl_item item, locale_category_index cat_index, const
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #     define PERL_ARGS_ASSERT_LANGINFO_SV_I     \
-        assert(locale); assert(sv)
+        Perl_assert_aTHX; assert(locale); assert(sv)
 
 #   endif /* defined(HAS_NL_LANGINFO) */
 #   if defined(LC_ALL)
@@ -9397,7 +9752,7 @@ S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
-        assert(lc_all_string)
+        Perl_assert_aTHX; assert(lc_all_string)
 
 #   else
 static void
@@ -9405,7 +9760,7 @@ S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_li
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
-        assert(curlocales)
+        Perl_assert_aTHX; assert(curlocales)
 
 #   endif
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -9413,7 +9768,8 @@ PERL_STATIC_INLINE const char *
 S_mortalized_pv_copy(pTHX_ const char * const pv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#     define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY
+#     define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY \
+        Perl_assert_aTHX
 
 #   endif
 #   if defined(USE_LOCALE_COLLATE)
@@ -9422,7 +9778,7 @@ S_new_collate(pTHX_ const char *newcoll, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_COLLATE       \
-        assert(newcoll)
+        Perl_assert_aTHX; assert(newcoll)
 
 #     if defined(DEBUGGING)
 static void
@@ -9431,7 +9787,7 @@ S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #       define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN \
-        assert(s); assert(e); assert(s <= e)
+        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e)
 
 #     endif /* defined(DEBUGGING) */
 #   endif /* defined(USE_LOCALE_COLLATE) */
@@ -9447,7 +9803,7 @@ S_new_ctype(pTHX_ const char *newctype, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_CTYPE         \
-        assert(newctype)
+        Perl_assert_aTHX; assert(newctype)
 
 #   endif /* defined(USE_LOCALE_CTYPE) */
 #   if defined(USE_LOCALE_NUMERIC)
@@ -9456,14 +9812,15 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_NUMERIC       \
-        assert(newnum)
+        Perl_assert_aTHX; assert(newnum)
 
 #   endif
 #   if defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING)
 static const char *
 S_get_LC_ALL_display(pTHX)
         Perl_attribute_nonnull_aTHX;
-#     define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY
+#     define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY \
+        Perl_assert_aTHX
 
 #   endif
 #   if defined(USE_POSIX_2008_LOCALE)
@@ -9472,17 +9829,19 @@ S_bool_setlocale_2008_i(pTHX_ const locale_category_index index, const char *new
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_BOOL_SETLOCALE_2008_I \
-        assert(new_locale)
+        Perl_assert_aTHX; assert(new_locale)
 
 static const char *
 S_querylocale_2008_i(pTHX_ const locale_category_index index, const line_t line)
         Perl_attribute_nonnull_aTHX;
-#     define PERL_ARGS_ASSERT_QUERYLOCALE_2008_I
+#     define PERL_ARGS_ASSERT_QUERYLOCALE_2008_I \
+        Perl_assert_aTHX
 
 static locale_t
 S_use_curlocale_scratch(pTHX)
         Perl_attribute_nonnull_aTHX;
-#     define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH
+#     define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH \
+        Perl_assert_aTHX
 
 #     if !defined(USE_QUERYLOCALE)
 static void
@@ -9490,7 +9849,7 @@ S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *ne
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #       define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I \
-        assert(new_locale)
+        Perl_assert_aTHX; assert(new_locale)
 
 #     endif
 #   elif  defined(USE_LOCALE_THREADS) &&                  \
@@ -9502,12 +9861,13 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R \
-        assert(locale)
+        Perl_assert_aTHX; assert(locale)
 
 static const char *
 S_less_dicey_setlocale_r(pTHX_ const int category, const char *locale)
         Perl_attribute_nonnull_aTHX;
-#     define PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R
+#     define PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R \
+        Perl_assert_aTHX
 
 #   endif /*  defined(USE_LOCALE_THREADS) &&
              !defined(USE_POSIX_2008_LOCALE) &&
@@ -9525,12 +9885,14 @@ S_Win_wstring_to_byte_string(const UINT code_page, const wchar_t *wstring);
 static const char *
 S_win32_setlocale(pTHX_ int category, const char *locale)
         Perl_attribute_nonnull_aTHX;
-#     define PERL_ARGS_ASSERT_WIN32_SETLOCALE
+#     define PERL_ARGS_ASSERT_WIN32_SETLOCALE   \
+        Perl_assert_aTHX
 
 static const char *
 S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
         Perl_attribute_nonnull_aTHX;
-#     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE
+#     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE   \
+        Perl_assert_aTHX
 
 #   endif /* defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) */
 #   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
@@ -9538,7 +9900,8 @@ S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
 static const char *
 S_find_locale_from_environment(pTHX_ const locale_category_index index)
         Perl_attribute_nonnull_aTHX;
-#     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT
+#     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT \
+        Perl_assert_aTHX
 
 #   endif
 # endif /* defined(USE_LOCALE) */
@@ -9549,7 +9912,7 @@ S_get_displayable_string(pTHX_ const char * const s, const char * const e, const
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING \
-        assert(s); assert(e); assert(s <= e)
+        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e)
 
 # endif /* defined(USE_LOCALE) || defined(DEBUGGING) */
 #endif /* defined(PERL_IN_LOCALE_C) */
@@ -9571,7 +9934,7 @@ S_fixup_errno_string(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FIXUP_ERRNO_STRING    \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static SV *
 S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV *val)
@@ -9580,7 +9943,7 @@ S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MAGIC_METHCALL1       \
-        assert(sv); assert(mg); assert(meth)
+        Perl_assert_aTHX; assert(sv); assert(mg); assert(meth)
 
 static int
 S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
@@ -9589,24 +9952,26 @@ S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MAGIC_METHPACK        \
-        assert(sv); assert(mg); assert(meth)
+        Perl_assert_aTHX; assert(sv); assert(mg); assert(meth)
 
 static void
 S_restore_magic(pTHX_ void *p)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RESTORE_MAGIC
+# define PERL_ARGS_ASSERT_RESTORE_MAGIC         \
+        Perl_assert_aTHX
 
 static void
 S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_MAGIC_FLAGS      \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static void
 S_unwind_handler_stack(pTHX_ void *p)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_UNWIND_HANDLER_STACK
+# define PERL_ARGS_ASSERT_UNWIND_HANDLER_STACK  \
+        Perl_assert_aTHX
 
 #endif /* defined(PERL_IN_MG_C) */
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C)
@@ -9627,7 +9992,7 @@ Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MG_FREE_STRUCT        \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 #endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_MRO_C)
@@ -9637,8 +10002,8 @@ S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN l
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_MRO_CLEAN_ISAREV      \
-        assert(isa); assert(SvTYPE(isa) == SVt_PVHV); assert(name); \
-        assert(!exceptions || SvTYPE(exceptions) == SVt_PVHV)
+        Perl_assert_aTHX; assert(isa); assert(SvTYPE(isa) == SVt_PVHV); \
+        assert(name); assert(!exceptions || SvTYPE(exceptions) == SVt_PVHV)
 
 static void
 S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *stash, HV *oldstash, SV *namesv)
@@ -9647,7 +10012,7 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *s
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_MRO_GATHER_AND_RENAME \
-        assert(stashes); assert(SvTYPE(stashes) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(stashes); assert(SvTYPE(stashes) == SVt_PVHV); \
         assert(seen_stashes); assert(SvTYPE(seen_stashes) == SVt_PVHV); \
         assert(!stash || SvTYPE(stash) == SVt_PVHV); \
         assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(namesv)
@@ -9657,7 +10022,7 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA_DFS \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
 
 #endif /* defined(PERL_IN_MRO_C) */
 #if defined(PERL_IN_OP_C)
@@ -9667,7 +10032,8 @@ S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS           \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(target)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        assert(target)
 
 static void
 S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
@@ -9676,14 +10042,15 @@ S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS_MY        \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(target); \
-        assert(imopsp)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        assert(target); assert(imopsp)
 
 static I32
 S_assignment_type(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_ASSIGNMENT_TYPE
+# define PERL_ARGS_ASSERT_ASSIGNMENT_TYPE       \
+        Perl_assert_aTHX
 
 static void
 S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
@@ -9692,7 +10059,7 @@ S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_BAD_TYPE_GV           \
-        assert(gv); assert(kid); assert(t)
+        Perl_assert_aTHX; assert(gv); assert(kid); assert(t)
 
 static void
 S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
@@ -9701,14 +10068,14 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_BAD_TYPE_PV           \
-        assert(t); assert(o); assert(kid)
+        Perl_assert_aTHX; assert(t); assert(o); assert(kid)
 
 static void
 S_check_alt_hash_fields_hekify(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CHECK_ALT_HASH_FIELDS_HEKIFY \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static CV *
 S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv)
@@ -9717,7 +10084,7 @@ S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * co
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CLEAR_SPECIAL_BLOCKS  \
-        assert(fullname); assert(gv); assert(cv); \
+        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static void
@@ -9725,52 +10092,54 @@ S_cop_free(pTHX_ COP *cop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_COP_FREE              \
-        assert(cop)
+        Perl_assert_aTHX; assert(cop)
 
 static OP *
 S_dup_attrlist(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DUP_ATTRLIST          \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static void
 S_find_and_forget_pmops(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FIND_AND_FORGET_PMOPS \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static OP *
 S_fold_constants(pTHX_ OP * const o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FOLD_CONSTANTS        \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static OP *
 S_force_list(pTHX_ OP *arg, bool nullit)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_FORCE_LIST
+# define PERL_ARGS_ASSERT_FORCE_LIST            \
+        Perl_assert_aTHX
 
 static void
 S_forget_pmop(pTHX_ PMOP * const o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORGET_PMOP           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static void
 S_gen_constant_list(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GEN_CONSTANT_LIST
+# define PERL_ARGS_ASSERT_GEN_CONSTANT_LIST     \
+        Perl_assert_aTHX
 
 static void
 S_inplace_aassign(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INPLACE_AASSIGN       \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static bool
 S_is_dup_mode(const OP *o)
@@ -9788,19 +10157,21 @@ S_is_handle_constructor(const OP *o, I32 numargs)
 static OP *
 S_listkids(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_LISTKIDS
+# define PERL_ARGS_ASSERT_LISTKIDS              \
+        Perl_assert_aTHX
 
 static bool
 S_looks_like_bool(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_LOOKS_LIKE_BOOL       \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static OP *
 S_modkids(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_MODKIDS
+# define PERL_ARGS_ASSERT_MODKIDS               \
+        Perl_assert_aTHX
 
 static void
 S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
@@ -9809,21 +10180,21 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MOVE_PROTO_ATTR       \
-        assert(proto); assert(attrs); assert(name)
+        Perl_assert_aTHX; assert(proto); assert(attrs); assert(name)
 
 static OP *
 S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MY_KID                \
-        assert(imopsp)
+        Perl_assert_aTHX; assert(imopsp)
 
 static OP *
 S_newGIVWHENOP(pTHX_ OP *cond, OP *block, I32 enter_opcode, I32 leave_opcode, PADOFFSET entertarg)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_NEWGIVWHENOP          \
-        assert(block)
+        Perl_assert_aTHX; assert(block)
 
 static OP *
 S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
@@ -9832,7 +10203,7 @@ S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_LOGOP             \
-        assert(firstp); assert(otherp)
+        Perl_assert_aTHX; assert(firstp); assert(otherp)
 
 static OP *
 S_no_fh_allowed(pTHX_ OP *o)
@@ -9840,7 +10211,7 @@ S_no_fh_allowed(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NO_FH_ALLOWED         \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static OP *
 S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
@@ -9849,7 +10220,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_PMTRANS               \
-        assert(o); assert(expr); assert(repl)
+        Perl_assert_aTHX; assert(o); assert(expr); assert(repl)
 
 static bool
 S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * const gv, CV * const cv)
@@ -9858,18 +10229,20 @@ S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS \
-        assert(fullname); assert(gv); assert(cv); \
+        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static OP *
 S_ref_array_or_hash(pTHX_ OP *cond)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_REF_ARRAY_OR_HASH
+# define PERL_ARGS_ASSERT_REF_ARRAY_OR_HASH     \
+        Perl_assert_aTHX
 
 static OP *
 S_refkids(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_REFKIDS
+# define PERL_ARGS_ASSERT_REFKIDS               \
+        Perl_assert_aTHX
 
 static bool
 S_scalar_mod_type(const OP *o, I32 type)
@@ -9881,12 +10254,13 @@ S_scalarboolean(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SCALARBOOLEAN         \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static OP *
 S_scalarkids(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SCALARKIDS
+# define PERL_ARGS_ASSERT_SCALARKIDS            \
+        Perl_assert_aTHX
 
 static OP *
 S_search_const(pTHX_ OP *o)
@@ -9894,14 +10268,14 @@ S_search_const(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SEARCH_CONST          \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static void
 S_simplify_sort(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SIMPLIFY_SORT         \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static OP *
 S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
@@ -9910,7 +10284,7 @@ S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOO_FEW_ARGUMENTS_PV  \
-        assert(o); assert(name)
+        Perl_assert_aTHX; assert(o); assert(name)
 
 static OP *
 S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
@@ -9918,12 +10292,13 @@ S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_TOO_MANY_ARGUMENTS_PV \
-        assert(o); assert(name)
+        Perl_assert_aTHX; assert(o); assert(name)
 
 static OP *
 S_voidnonfinal(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_VOIDNONFINAL
+# define PERL_ARGS_ASSERT_VOIDNONFINAL          \
+        Perl_assert_aTHX
 
 # if defined(DEBUGGING)
 static const char *
@@ -9931,7 +10306,7 @@ S_get_displayable_tr_operand(pTHX_ const U8 *s, STRLEN len, bool is_utf8)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_TR_OPERAND \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -9944,21 +10319,22 @@ S_is_standard_filehandle_name(const char *fhname)
 PERL_STATIC_INLINE OP *
 S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP *dynamic_meth, SV * const_meth)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_NEWMETHOP_INTERNAL
+#   define PERL_ARGS_ASSERT_NEWMETHOP_INTERNAL  \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE OP *
 S_op_integerize(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_INTEGERIZE       \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_STATIC_INLINE OP *
 S_op_std_init(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_STD_INIT         \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_STATIC_INLINE U16
 S_opslab_slot_offset(const OPSLAB *slab, const OPSLOT *slot)
@@ -9981,7 +10357,8 @@ PERL_CALLCONV void
 Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_CHECK_HASH_FIELDS_AND_HEKIFY
+# define PERL_ARGS_ASSERT_CHECK_HASH_FIELDS_AND_HEKIFY \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_no_bareword_allowed(pTHX_ OP *o)
@@ -9989,7 +10366,7 @@ Perl_no_bareword_allowed(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_NO_BAREWORD_ALLOWED   \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_op_prune_chain_head(OP **op_p)
@@ -10004,7 +10381,7 @@ Perl_op_varname(pTHX_ const OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OP_VARNAME            \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 PERL_CALLCONV void
 Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is_slice)
@@ -10013,7 +10390,7 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_WARN_ELEM_SCALAR_CONTEXT \
-        assert(o); assert(name)
+        Perl_assert_aTHX; assert(o); assert(name)
 
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
@@ -10027,14 +10404,15 @@ Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv, SV * const *new
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_REPORT_REDEFINED_CV   \
-        assert(name); assert(old_cv)
+        Perl_assert_aTHX; assert(name); assert(old_cv)
 
 PERL_CALLCONV SV *
 Perl_varname(pTHX_ const GV * const gv, const char gvtype, PADOFFSET targ, const SV * const keyname, SSize_t aindex, int subscript_type)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_VARNAME
+# define PERL_ARGS_ASSERT_VARNAME               \
+        Perl_assert_aTHX
 
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_PAD_C)
@@ -10043,14 +10421,15 @@ S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_ALLOC_NAME        \
-        assert(name); assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(name); \
+        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 static void
 S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_CHECK_DUP         \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 static PADOFFSET
 S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags)
@@ -10060,12 +10439,14 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv,
         Perl_attribute_nonnull(pTHX_8)
         Perl_attribute_nonnull(pTHX_9);
 # define PERL_ARGS_ASSERT_PAD_FINDLEX           \
-        assert(namepv); assert(cv); assert(out_name); assert(out_flags)
+        Perl_assert_aTHX; assert(namepv); assert(cv); assert(out_name); \
+        assert(out_flags)
 
 static void
 S_pad_reset(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PAD_RESET
+# define PERL_ARGS_ASSERT_PAD_RESET             \
+        Perl_assert_aTHX
 
 # if defined(DEBUGGING)
 static void
@@ -10074,7 +10455,7 @@ S_cv_dump(pTHX_ const CV *cv, const char *title)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_CV_DUMP             \
-        assert(cv); assert(title)
+        Perl_assert_aTHX; assert(cv); assert(title)
 
 # endif /* defined(DEBUGGING) */
 #endif /* defined(PERL_IN_PAD_C) */
@@ -10084,14 +10465,14 @@ S_finalize_op(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OP           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static void
 S_optimize_op(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OP           \
-        assert(o)
+        Perl_assert_aTHX; assert(o)
 
 static OP *
 S_traverse_op_tree(pTHX_ OP *top, OP *o)
@@ -10099,7 +10480,7 @@ S_traverse_op_tree(pTHX_ OP *top, OP *o)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_TRAVERSE_OP_TREE      \
-        assert(top); assert(o)
+        Perl_assert_aTHX; assert(top); assert(o)
 
 #endif /* defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_PERL_C)
@@ -10109,82 +10490,91 @@ S_find_beginning(pTHX_ SV *linestr_sv, PerlIO *rsfp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_BEGINNING        \
-        assert(linestr_sv); assert(rsfp)
+        Perl_assert_aTHX; assert(linestr_sv); assert(rsfp)
 
 static void
 S_forbid_setid(pTHX_ const char flag, const bool suidscript)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_FORBID_SETID
+# define PERL_ARGS_ASSERT_FORBID_SETID          \
+        Perl_assert_aTHX
 
 static void
 S_incpush(pTHX_ const char * const dir, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH               \
-        assert(dir)
+        Perl_assert_aTHX; assert(dir)
 
 static void
 S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH_USE_SEP       \
-        assert(p)
+        Perl_assert_aTHX; assert(p)
 
 static void
 S_init_ids(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_INIT_IDS
+# define PERL_ARGS_ASSERT_INIT_IDS              \
+        Perl_assert_aTHX
 
 static void
 S_init_interp(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_INIT_INTERP
+# define PERL_ARGS_ASSERT_INIT_INTERP           \
+        Perl_assert_aTHX
 
 static void
 S_init_main_stash(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_INIT_MAIN_STASH
+# define PERL_ARGS_ASSERT_INIT_MAIN_STASH       \
+        Perl_assert_aTHX
 
 static void
 S_init_perllib(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_INIT_PERLLIB
+# define PERL_ARGS_ASSERT_INIT_PERLLIB          \
+        Perl_assert_aTHX
 
 static void
 S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INIT_POSTDUMP_SYMBOLS \
-        assert(argv)
+        Perl_assert_aTHX; assert(argv)
 
 static void
 S_init_predump_symbols(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_INIT_PREDUMP_SYMBOLS
+# define PERL_ARGS_ASSERT_INIT_PREDUMP_SYMBOLS  \
+        Perl_assert_aTHX
 
 static SV *
 S_mayberelocate(pTHX_ const char * const dir, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MAYBERELOCATE         \
-        assert(dir)
+        Perl_assert_aTHX; assert(dir)
 
 PERL_STATIC_NO_RET void
 S_minus_v(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-# define PERL_ARGS_ASSERT_MINUS_V
+# define PERL_ARGS_ASSERT_MINUS_V               \
+        Perl_assert_aTHX
 
 PERL_STATIC_NO_RET void
 S_my_exit_jump(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-# define PERL_ARGS_ASSERT_MY_EXIT_JUMP
+# define PERL_ARGS_ASSERT_MY_EXIT_JUMP          \
+        Perl_assert_aTHX
 
 static void
 S_nuke_stacks(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_NUKE_STACKS
+# define PERL_ARGS_ASSERT_NUKE_STACKS           \
+        Perl_assert_aTHX
 
 static PerlIO *
 S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
@@ -10192,24 +10582,27 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_OPEN_SCRIPT           \
-        assert(scriptname); assert(suidscript)
+        Perl_assert_aTHX; assert(scriptname); assert(suidscript)
 
 static void *
 S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PARSE_BODY
+# define PERL_ARGS_ASSERT_PARSE_BODY            \
+        Perl_assert_aTHX
 
 PERL_STATIC_NO_RET void
 S_run_body(pTHX_ I32 oldscope)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-# define PERL_ARGS_ASSERT_RUN_BODY
+# define PERL_ARGS_ASSERT_RUN_BODY              \
+        Perl_assert_aTHX
 
 PERL_STATIC_NO_RET void
 S_usage(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-# define PERL_ARGS_ASSERT_USAGE
+# define PERL_ARGS_ASSERT_USAGE                 \
+        Perl_assert_aTHX
 
 # if !defined(PERL_IS_MINIPERL)
 static SV *
@@ -10219,7 +10612,8 @@ S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #   define PERL_ARGS_ASSERT_INCPUSH_IF_EXISTS   \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(dir); assert(stem)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        assert(dir); assert(stem)
 
 # endif /* !defined(PERL_IS_MINIPERL) */
 # if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
@@ -10228,17 +10622,17 @@ S_validate_suid(pTHX_ PerlIO *rsfp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_VALIDATE_SUID       \
-        assert(rsfp)
+        Perl_assert_aTHX; assert(rsfp)
 
 # endif
 #endif /* defined(PERL_IN_PERL_C) */
 #if defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) || \
     defined(PERL_IN_UTF8_C)
 # define PERL_ARGS_ASSERT_INVLISTEQ_            \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 # define PERL_ARGS_ASSERT_NEW_INVLIST_C_ARRAY_  \
-        assert(list)
+        Perl_assert_aTHX; assert(list)
 
 #endif
 #if defined(PERL_IN_PP_C)
@@ -10248,12 +10642,13 @@ S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_CHOMP              \
-        assert(retval); assert(sv)
+        Perl_assert_aTHX; assert(retval); assert(sv)
 
 static OP *
 S_do_delete_local(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_DO_DELETE_LOCAL
+# define PERL_ARGS_ASSERT_DO_DELETE_LOCAL       \
+        Perl_assert_aTHX
 
 static SV *
 S_refto(pTHX_ SV *sv)
@@ -10261,7 +10656,7 @@ S_refto(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REFTO                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #endif /* defined(PERL_IN_PP_C) */
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C)
@@ -10273,7 +10668,7 @@ Perl_softref2xv(pTHX_ SV * const sv, const char * const what, const svtype type)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SOFTREF2XV            \
-        assert(sv); assert(what)
+        Perl_assert_aTHX; assert(sv); assert(what)
 
 #endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
 #if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
@@ -10288,7 +10683,7 @@ Perl_to_upper_title_latin1_(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_TO_UPPER_TITLE_LATIN1_ \
-        assert(p); assert(lenp)
+        Perl_assert_aTHX; assert(p); assert(lenp)
 
 #endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_PP_CTL_C)
@@ -10298,32 +10693,34 @@ S_check_type_and_open(pTHX_ SV *name)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_TYPE_AND_OPEN   \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 static void
 S_destroy_matcher(pTHX_ PMOP *matcher)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DESTROY_MATCHER       \
-        assert(matcher)
+        Perl_assert_aTHX; assert(matcher)
 
 static OP *
 S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DO_SMARTMATCH         \
-        assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV); \
         assert(!seen_other || SvTYPE(seen_other) == SVt_PVHV)
 
 static OP *
 S_docatch(pTHX_ Perl_ppaddr_t firstpp)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_DOCATCH
+# define PERL_ARGS_ASSERT_DOCATCH               \
+        Perl_assert_aTHX
 
 static bool
 S_doeval_compile(pTHX_ U8 gimme, CV *outside, U32 seq, HV *hh)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DOEVAL_COMPILE        \
+        Perl_assert_aTHX; \
         assert(!outside || SvTYPE(outside) == SVt_PVCV || SvTYPE(outside) == SVt_PVFM); \
         assert(!hh || SvTYPE(hh) == SVt_PVHV)
 
@@ -10336,26 +10733,29 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
         Perl_attribute_nonnull(pTHX_6)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOFINDLABEL           \
-        assert(o); assert(label); assert(opstack); assert(oplimit)
+        Perl_assert_aTHX; assert(o); assert(label); assert(opstack); \
+        assert(oplimit)
 
 static MAGIC *
 S_doparseform(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DOPARSEFORM           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static I32
 S_dopoptoeval(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_DOPOPTOEVAL
+# define PERL_ARGS_ASSERT_DOPOPTOEVAL           \
+        Perl_assert_aTHX
 
 static I32
 S_dopoptogivenfor(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_DOPOPTOGIVENFOR
+# define PERL_ARGS_ASSERT_DOPOPTOGIVENFOR       \
+        Perl_assert_aTHX
 
 static I32
 S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
@@ -10363,13 +10763,14 @@ S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLABEL          \
-        assert(label)
+        Perl_assert_aTHX; assert(label)
 
 static I32
 S_dopoptoloop(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_DOPOPTOLOOP
+# define PERL_ARGS_ASSERT_DOPOPTOLOOP           \
+        Perl_assert_aTHX
 
 static I32
 S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
@@ -10377,13 +10778,14 @@ S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOSUB_AT         \
-        assert(cxstk)
+        Perl_assert_aTHX; assert(cxstk)
 
 static I32
 S_dopoptowhen(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_DOPOPTOWHEN
+# define PERL_ARGS_ASSERT_DOPOPTOWHEN           \
+        Perl_assert_aTHX
 
 static PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
@@ -10391,7 +10793,7 @@ S_make_matcher(pTHX_ REGEXP *re)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MAKE_MATCHER          \
-        assert(re)
+        Perl_assert_aTHX; assert(re)
 
 static bool
 S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
@@ -10400,7 +10802,7 @@ S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MATCHER_MATCHES_SV    \
-        assert(matcher); assert(sv)
+        Perl_assert_aTHX; assert(matcher); assert(sv)
 
 static bool
 S_num_overflow(NV value, I32 fldsize, I32 frcsize)
@@ -10413,14 +10815,14 @@ S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_RUN_USER_FILTER       \
-        assert(buf_sv)
+        Perl_assert_aTHX; assert(buf_sv)
 
 static void
 S_rxres_free(pTHX_ void **rsp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RXRES_FREE            \
-        assert(rsp)
+        Perl_assert_aTHX; assert(rsp)
 
 static void
 S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
@@ -10428,14 +10830,15 @@ S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RXRES_RESTORE         \
-        assert(rsp); assert(rx)
+        Perl_assert_aTHX; assert(rsp); assert(rx)
 
 static void
 S_save_lines(pTHX_ AV *array, SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_LINES            \
-        assert(!array || SvTYPE(array) == SVt_PVAV); assert(sv)
+        Perl_assert_aTHX; assert(!array || SvTYPE(array) == SVt_PVAV); \
+        assert(sv)
 
 # if !defined(PERL_DISABLE_PMC)
 static PerlIO *
@@ -10444,7 +10847,7 @@ S_doopen_pm(pTHX_ SV *name)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOOPEN_PM           \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 # endif /* !defined(PERL_DISABLE_PMC) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -10462,7 +10865,8 @@ PERL_CALLCONV bool
 Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_INVOKE_EXCEPTION_HOOK
+# define PERL_ARGS_ASSERT_INVOKE_EXCEPTION_HOOK \
+        Perl_assert_aTHX
 
 #endif
 #if defined(PERL_IN_PP_HOT_C)
@@ -10472,7 +10876,7 @@ S_do_oddball(pTHX_ SV **oddkey, SV **firstkey)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_ODDBALL            \
-        assert(oddkey); assert(firstkey)
+        Perl_assert_aTHX; assert(oddkey); assert(firstkey)
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE HV *
@@ -10480,7 +10884,7 @@ S_opmethod_stash(pTHX_ SV *meth)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_OPMETHOD_STASH      \
-        assert(meth)
+        Perl_assert_aTHX; assert(meth)
 
 PERL_STATIC_FORCE_INLINE bool
 S_should_we_output_Debug_r(pTHX_ regexp *prog)
@@ -10489,7 +10893,7 @@ S_should_we_output_Debug_r(pTHX_ regexp *prog)
         __attribute__warn_unused_result__
         __attribute__always_inline__;
 #   define PERL_ARGS_ASSERT_SHOULD_WE_OUTPUT_DEBUG_R \
-        assert(prog)
+        Perl_assert_aTHX; assert(prog)
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_PP_HOT_C) */
@@ -10500,7 +10904,7 @@ S_div128(pTHX_ SV *pnum, bool *done)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DIV128                \
-        assert(pnum); assert(done)
+        Perl_assert_aTHX; assert(pnum); assert(done)
 
 static char
 S_first_symbol(const char *pat, const char *patend)
@@ -10516,7 +10920,7 @@ S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_NUM               \
-        assert(patptr); assert(lenptr)
+        Perl_assert_aTHX; assert(patptr); assert(lenptr)
 
 static const char *
 S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
@@ -10524,7 +10928,8 @@ S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GROUP_END             \
-        assert(patptr); assert(patend); assert(patptr <= patend)
+        Perl_assert_aTHX; assert(patptr); assert(patend); \
+        assert(patptr <= patend)
 
 static SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)
@@ -10532,21 +10937,21 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_AN_INT             \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static SSize_t
 S_measure_struct(pTHX_ struct tempsym *symptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MEASURE_STRUCT        \
-        assert(symptr)
+        Perl_assert_aTHX; assert(symptr)
 
 static SV *
 S_mul128(pTHX_ SV *sv, U8 m)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MUL128                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static char *
 S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swap)
@@ -10568,7 +10973,7 @@ S_next_symbol(pTHX_ struct tempsym *symptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_NEXT_SYMBOL           \
-        assert(symptr)
+        Perl_assert_aTHX; assert(symptr)
 
 static SV **
 S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
@@ -10578,7 +10983,8 @@ S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PACK_REC              \
-        assert(cat); assert(symptr); assert(beglist); assert(endlist)
+        Perl_assert_aTHX; assert(cat); assert(symptr); assert(beglist); \
+        assert(endlist)
 
 static char *
 S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
@@ -10586,7 +10992,7 @@ S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_EXP_GROW           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static SSize_t
 S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, const char *strend, const char **new_s)
@@ -10596,8 +11002,8 @@ S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, co
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_UNPACK_REC            \
-        assert(symptr); assert(s); assert(strbeg); assert(strend); \
-        assert(strbeg <= s); assert(s <= strend)
+        Perl_assert_aTHX; assert(symptr); assert(s); assert(strbeg); \
+        assert(strend); assert(strbeg <= s); assert(s <= strend)
 
 #endif /* defined(PERL_IN_PP_PACK_C) */
 #if defined(PERL_IN_PP_SORT_C)
@@ -10608,7 +11014,7 @@ S_sortcv(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV                \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 static I32
 S_sortcv_stacked(pTHX_ SV * const a, SV * const b)
@@ -10616,7 +11022,7 @@ S_sortcv_stacked(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_STACKED        \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 static I32
 S_sortcv_xsub(pTHX_ SV * const a, SV * const b)
@@ -10624,7 +11030,7 @@ S_sortcv_xsub(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_XSUB           \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE I32
@@ -10633,7 +11039,7 @@ S_amagic_cmp(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP          \
-        assert(str1); assert(str2)
+        Perl_assert_aTHX; assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
 S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2)
@@ -10641,7 +11047,7 @@ S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP_DESC     \
-        assert(str1); assert(str2)
+        Perl_assert_aTHX; assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
 S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b)
@@ -10649,7 +11055,7 @@ S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP       \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
 S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -10657,7 +11063,7 @@ S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP_DESC  \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
 S_amagic_ncmp(pTHX_ SV * const a, SV * const b)
@@ -10665,7 +11071,7 @@ S_amagic_ncmp(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP         \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
 S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -10673,7 +11079,7 @@ S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP_DESC    \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
 S_cmp_desc(pTHX_ SV * const str1, SV * const str2)
@@ -10681,7 +11087,7 @@ S_cmp_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_CMP_DESC            \
-        assert(str1); assert(str2)
+        Perl_assert_aTHX; assert(str1); assert(str2)
 
 PERL_STATIC_FORCE_INLINE void
 S_sortsv_flags_impl(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
@@ -10689,7 +11095,7 @@ S_sortsv_flags_impl(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flag
         Perl_attribute_nonnull(pTHX_3)
         __attribute__always_inline__;
 #   define PERL_ARGS_ASSERT_SORTSV_FLAGS_IMPL   \
-        assert(cmp)
+        Perl_assert_aTHX; assert(cmp)
 
 PERL_STATIC_INLINE I32
 S_sv_i_ncmp(pTHX_ SV * const a, SV * const b)
@@ -10697,7 +11103,7 @@ S_sv_i_ncmp(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP           \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
 S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -10705,7 +11111,7 @@ S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP_DESC      \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
 S_sv_ncmp(pTHX_ SV *a, SV *b)
@@ -10713,7 +11119,7 @@ S_sv_ncmp(pTHX_ SV *a, SV *b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP             \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE I32
 S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -10721,7 +11127,7 @@ S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP_DESC        \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 #   if defined(USE_LOCALE_COLLATE)
 PERL_STATIC_INLINE I32
@@ -10730,7 +11136,7 @@ S_amagic_cmp_locale(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE \
-        assert(str1); assert(str2)
+        Perl_assert_aTHX; assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
 S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
@@ -10738,7 +11144,7 @@ S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE_DESC \
-        assert(str1); assert(str2)
+        Perl_assert_aTHX; assert(str1); assert(str2)
 
 PERL_STATIC_INLINE I32
 S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
@@ -10746,7 +11152,7 @@ S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_CMP_LOCALE_DESC   \
-        assert(str1); assert(str2)
+        Perl_assert_aTHX; assert(str1); assert(str2)
 
 #   endif /* defined(USE_LOCALE_COLLATE) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
@@ -10761,20 +11167,21 @@ S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DOFORM                \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
-        assert(gv)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(gv)
 
 static SV *
 S_space_join_names_mortal(pTHX_ char * const *array)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SPACE_JOIN_NAMES_MORTAL
+# define PERL_ARGS_ASSERT_SPACE_JOIN_NAMES_MORTAL \
+        Perl_assert_aTHX
 
 static void
 S_warn_not_dirhandle(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_NOT_DIRHANDLE    \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 # if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
 static int
@@ -10784,49 +11191,49 @@ S_dooneliner(pTHX_ const char *cmd, const char *filename)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOONELINER          \
-        assert(cmd); assert(filename)
+        Perl_assert_aTHX; assert(cmd); assert(filename)
 
 # endif /* !defined(HAS_MKDIR) || !defined(HAS_RMDIR) */
 #endif /* defined(PERL_IN_PP_SYS_C) */
 #if defined(PERL_IN_REGCOMP_ANY)
 # define PERL_ARGS_ASSERT_ADD_ABOVE_LATIN1_FOLDS \
-        assert(pRExC_state); assert(invlist)
+        Perl_assert_aTHX; assert(pRExC_state); assert(invlist)
 
 # define PERL_ARGS_ASSERT_CONSTRUCT_AHOCORASICK_FROM_TRIE \
-        assert(pRExC_state); assert(source)
+        Perl_assert_aTHX; assert(pRExC_state); assert(source)
 
 # define PERL_ARGS_ASSERT_GET_ANYOFHBBM_CONTENTS \
-        assert(n)
+        Perl_assert_aTHX; assert(n)
 
 # define PERL_ARGS_ASSERT_GET_ANYOFM_CONTENTS   \
-        assert(n)
+        Perl_assert_aTHX; assert(n)
 
 # define PERL_ARGS_ASSERT_JOIN_EXACT            \
-        assert(pRExC_state); assert(scan); assert(min_subtract); \
-        assert(unfolded_multi_char)
+        Perl_assert_aTHX; assert(pRExC_state); assert(scan); \
+        assert(min_subtract); assert(unfolded_multi_char)
 
 # define PERL_ARGS_ASSERT_MAKE_TRIE             \
-        assert(pRExC_state); assert(startbranch); assert(first); assert(last); \
-        assert(tail)
+        Perl_assert_aTHX; assert(pRExC_state); assert(startbranch); \
+        assert(first); assert(last); assert(tail)
 
 # define PERL_ARGS_ASSERT_POPULATE_ANYOF_BITMAP_FROM_INVLIST \
-        assert(node); assert(invlist_ptr)
+        Perl_assert_aTHX; assert(node); assert(invlist_ptr)
 
 # define PERL_ARGS_ASSERT_REG_ADD_DATA          \
         assert(pRExC_state); assert(s)
 
 # define PERL_ARGS_ASSERT_SCAN_COMMIT           \
-        assert(pRExC_state); assert(data); assert(minlenp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(data); assert(minlenp)
 
 # define PERL_ARGS_ASSERT_SET_ANYOF_ARG         \
-        assert(pRExC_state); assert(node)
+        Perl_assert_aTHX; assert(pRExC_state); assert(node)
 
 # define PERL_ARGS_ASSERT_SSC_INIT              \
-        assert(pRExC_state); assert(ssc)
+        Perl_assert_aTHX; assert(pRExC_state); assert(ssc)
 
 # define PERL_ARGS_ASSERT_STUDY_CHUNK           \
-        assert(pRExC_state); assert(scanp); assert(minlenp); assert(deltap); \
-        assert(last)
+        Perl_assert_aTHX; assert(pRExC_state); assert(scanp); assert(minlenp); \
+        assert(deltap); assert(last)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
@@ -10930,21 +11337,24 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharm
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DUMP_TRIE           \
-        assert(trie); assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(trie); \
+        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
         assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST \
-        assert(trie); assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(trie); \
+        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
         assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE \
-        assert(trie); assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(trie); \
+        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
         assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
 
 # endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_INVLIST_CONTENTS    \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 #   define PERL_ARGS_ASSERT_INVLIST_HIGHEST_RANGE_START \
         assert(invlist)
@@ -10978,7 +11388,7 @@ S_invlist_lowest(SV * const invlist)
 #endif /* defined(PERL_IN_REGCOMP_ANY) */
 #if defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C)
 # define PERL_ARGS_ASSERT_INVLIST_CLONE         \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
@@ -10989,14 +11399,15 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
 #endif /* defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_REGCOMP_C)
 # define PERL_ARGS_ASSERT_ADD_MULTI_MATCH       \
+        Perl_assert_aTHX; \
         assert(!multi_char_matches || SvTYPE(multi_char_matches) == SVt_PVAV); \
         assert(multi_string)
 
 # define PERL_ARGS_ASSERT_CHANGE_ENGINE_SIZE    \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_COMPILE_WILDCARD      \
-        assert(subpattern)
+        Perl_assert_aTHX; assert(subpattern)
 
 # define PERL_ARGS_ASSERT_COMPUTE_EXACTISH      \
         assert(pRExC_state)
@@ -11005,50 +11416,54 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
         assert(src); assert(tgt)
 
 # define PERL_ARGS_ASSERT_EXECUTE_WILDCARD      \
-        assert(prog); assert(stringarg); assert(strend); assert(strbeg); \
-        assert(screamer); assert(strbeg <= stringarg); \
+        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend); \
+        assert(strbeg); assert(screamer); assert(strbeg <= stringarg); \
         assert(stringarg <= strend); assert(*strend == '\0')
 
 # define PERL_ARGS_ASSERT_GET_QUANTIFIER_VALUE  \
-        assert(pRExC_state); assert(start); assert(end); assert(start < end)
+        Perl_assert_aTHX; assert(pRExC_state); assert(start); assert(end); \
+        assert(start < end)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_N         \
-        assert(pRExC_state); assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_HANDLE_NAMED_BACKREF  \
-        assert(pRExC_state); assert(flagp); assert(backref_parse_start)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp); \
+        assert(backref_parse_start)
 
 # define PERL_ARGS_ASSERT_HANDLE_NAMES_WILDCARD \
-        assert(wname); assert(prop_definition); assert(strings)
+        Perl_assert_aTHX; assert(wname); assert(prop_definition); \
+        assert(strings)
 
 # define PERL_ARGS_ASSERT_HANDLE_POSSIBLE_POSIX \
-        assert(pRExC_state); assert(s)
+        Perl_assert_aTHX; assert(pRExC_state); assert(s)
 
 # define PERL_ARGS_ASSERT_HANDLE_REGEX_SETS     \
-        assert(pRExC_state); assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_HANDLE_USER_DEFINED_PROPERTY \
-        assert(name); assert(contents); assert(user_defined_ptr); assert(msg)
+        Perl_assert_aTHX; assert(name); assert(contents); \
+        assert(user_defined_ptr); assert(msg)
 
 # define PERL_ARGS_ASSERT_IS_SSC_WORTH_IT       \
         assert(pRExC_state); assert(ssc)
 
 # define PERL_ARGS_ASSERT_NEXTCHAR              \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_OPTIMIZE_REGCLASS     \
-        assert(pRExC_state); assert(anyof_flags); assert(invert); assert(ret); \
-        assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(anyof_flags); \
+        assert(invert); assert(ret); assert(flagp)
 
 # define PERL_ARGS_ASSERT_OUTPUT_POSIX_WARNINGS \
-        assert(pRExC_state); assert(posix_warnings); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(posix_warnings); \
         assert(SvTYPE(posix_warnings) == SVt_PVAV)
 
 # define PERL_ARGS_ASSERT_PARSE_LPAREN_QUESTION_FLAGS \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_PARSE_UNIPROP_STRING  \
-        assert(name); assert(user_defined_ptr); assert(msg)
+        Perl_assert_aTHX; assert(name); assert(user_defined_ptr); assert(msg)
 
 PERL_STATIC_NO_RET void
 S_re_croak(pTHX_ bool utf8, const char *pat, ...)
@@ -11057,79 +11472,80 @@ S_re_croak(pTHX_ bool utf8, const char *pat, ...)
         __attribute__noreturn__
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 # define PERL_ARGS_ASSERT_RE_CROAK              \
-        assert(pat)
+        Perl_assert_aTHX; assert(pat)
 
 # define PERL_ARGS_ASSERT_REG                   \
-        assert(pRExC_state); assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_REG1NODE              \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_REG2NODE              \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_REG_LA_NOTHING        \
-        assert(pRExC_state); assert(type)
+        Perl_assert_aTHX; assert(pRExC_state); assert(type)
 
 # define PERL_ARGS_ASSERT_REG_LA_OPFAIL         \
-        assert(pRExC_state); assert(type)
+        Perl_assert_aTHX; assert(pRExC_state); assert(type)
 
 # define PERL_ARGS_ASSERT_REG_NODE              \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_REG_SCAN_NAME         \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_REGATOM               \
-        assert(pRExC_state); assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_REGBRANCH             \
-        assert(pRExC_state); assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_REGCLASS              \
-        assert(pRExC_state); assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_REGEX_SET_PRECEDENCE
 
 # define PERL_ARGS_ASSERT_REGINSERT             \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_REGNODE_GUTS          \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_REGPIECE              \
-        assert(pRExC_state); assert(flagp)
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_REGPNODE              \
-        assert(pRExC_state); assert(arg)
+        Perl_assert_aTHX; assert(pRExC_state); assert(arg)
 
 # define PERL_ARGS_ASSERT_REGTAIL               \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_SET_REGEX_PV          \
-        assert(pRExC_state); assert(Rx)
+        Perl_assert_aTHX; assert(pRExC_state); assert(Rx)
 
 # define PERL_ARGS_ASSERT_SKIP_BRACKETED_WHITE_SPACE \
-        assert(pRExC_state); assert(p_start); assert(p); assert(*p); \
-        assert(stop_p); assert(p_start <= *p); assert(*p <= stop_p)
+        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p); \
+        assert(*p); assert(stop_p); assert(p_start <= *p); assert(*p <= stop_p)
 
 # define PERL_ARGS_ASSERT_SKIP_TO_BE_IGNORED_TEXT \
-        assert(pRExC_state); assert(p)
+        Perl_assert_aTHX; assert(pRExC_state); assert(p)
 
 # define PERL_ARGS_ASSERT_SSC_FINALIZE          \
-        assert(pRExC_state); assert(ssc)
+        Perl_assert_aTHX; assert(pRExC_state); assert(ssc)
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_REGNODE_GUTS_DEBUG  \
-        assert(pRExC_state)
+        Perl_assert_aTHX; assert(pRExC_state)
 
 #   define PERL_ARGS_ASSERT_REGTAIL_STUDY       \
-        assert(pRExC_state); assert(p); assert(val)
+        Perl_assert_aTHX; assert(pRExC_state); assert(p); assert(val)
 
 #   if defined(ENABLE_REGEX_SETS_DEBUGGING)
 #     define PERL_ARGS_ASSERT_DUMP_REGEX_SETS_STRUCTURES \
-        assert(pRExC_state); assert(stack); assert(SvTYPE(stack) == SVt_PVAV); \
-        assert(fence_stack); assert(SvTYPE(fence_stack) == SVt_PVAV)
+        Perl_assert_aTHX; assert(pRExC_state); assert(stack); \
+        assert(SvTYPE(stack) == SVt_PVAV); assert(fence_stack); \
+        assert(SvTYPE(fence_stack) == SVt_PVAV)
 
 #   endif
 # endif /* defined(DEBUGGING) */
@@ -11355,8 +11771,8 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const I
         assert(s1); assert(s2)
 
 #   define PERL_ARGS_ASSERT_REG_SKIPCOMMENT     \
-        assert(pRExC_state); assert(p_start); assert(p); assert(*p); \
-        assert(p_end); assert(p_start <= *p); assert(*p <= p_end)
+        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p); \
+        assert(*p); assert(p_end); assert(p_start <= *p); assert(*p <= p_end)
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE Size_t
@@ -11375,10 +11791,10 @@ S_reg_skipcomment(pTHX_ RExC_state_t *pRExC_state, const char *p_start, char **p
 #endif /* defined(PERL_IN_REGCOMP_C) */
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGCOMP_INVLIST_C)
 # define PERL_ARGS_ASSERT_POPULATE_BITMAP_FROM_INVLIST \
-        assert(invlist); assert(bitmap)
+        Perl_assert_aTHX; assert(invlist); assert(bitmap)
 
 # define PERL_ARGS_ASSERT_POPULATE_INVLIST_FROM_BITMAP \
-        assert(bitmap); assert(invlist)
+        Perl_assert_aTHX; assert(bitmap); assert(invlist)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
@@ -11398,8 +11814,8 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 *bitmap, const Size_t bitmap_le
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_TOKE_C)
 # define PERL_ARGS_ASSERT_IS_GRAPHEME           \
-        assert(strbeg); assert(s); assert(strend); assert(strbeg <= s); \
-        assert(s < strend)
+        Perl_assert_aTHX; assert(strbeg); assert(s); assert(strend); \
+        assert(strbeg <= s); assert(s < strend)
 
 #endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
@@ -11422,38 +11838,40 @@ Perl_regcurly(const char *s, const char *e, const char *result[5])
 #endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C) */
 #if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 # define PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 # define PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_COMMON \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 # define PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_INVLIST \
-        assert(sv); assert(invlist)
+        Perl_assert_aTHX; assert(sv); assert(invlist)
 
 # define PERL_ARGS_ASSERT_PUT_CODE_POINT        \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 # define PERL_ARGS_ASSERT_PUT_RANGE             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
-# define PERL_ARGS_ASSERT_REGDUMP_EXTFLAGS
+# define PERL_ARGS_ASSERT_REGDUMP_EXTFLAGS      \
+        Perl_assert_aTHX
 
-# define PERL_ARGS_ASSERT_REGDUMP_INTFLAGS
+# define PERL_ARGS_ASSERT_REGDUMP_INTFLAGS      \
+        Perl_assert_aTHX
 
 #endif /* defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING) */
 #if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
 # define PERL_ARGS_ASSERT_APPEND_RANGE_TO_INVLIST_ \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 static void
 S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INITIALIZE_INVLIST_GUTS \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 # define PERL_ARGS_ASSERT_INVLIST_REPLACE_LIST_DESTROYS_SRC \
-        assert(dest); assert(src)
+        Perl_assert_aTHX; assert(dest); assert(src)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static void
@@ -11474,7 +11892,7 @@ S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src)
         assert(invlist)
 
 #   define PERL_ARGS_ASSERT_INVLIST_CLEAR       \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 #   define PERL_ARGS_ASSERT_INVLIST_MAX         \
         assert(invlist)
@@ -11520,31 +11938,31 @@ S_invlist_trim(SV *invlist)
 #endif /* defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD) */
 #if defined(PERL_IN_REGCOMP_STUDY_C)
 # define PERL_ARGS_ASSERT_GET_ANYOF_CP_LIST_FOR_SSC \
-        assert(pRExC_state); assert(node)
+        Perl_assert_aTHX; assert(pRExC_state); assert(node)
 
 # define PERL_ARGS_ASSERT_MAKE_EXACTF_INVLIST   \
-        assert(pRExC_state); assert(node)
+        Perl_assert_aTHX; assert(pRExC_state); assert(node)
 
 # define PERL_ARGS_ASSERT_RCK_ELIDE_NOTHING     \
-        assert(node)
+        Perl_assert_aTHX; assert(node)
 
 # define PERL_ARGS_ASSERT_SSC_ADD_RANGE         \
-        assert(ssc)
+        Perl_assert_aTHX; assert(ssc)
 
 # define PERL_ARGS_ASSERT_SSC_AND               \
-        assert(pRExC_state); assert(ssc); assert(and_with)
+        Perl_assert_aTHX; assert(pRExC_state); assert(ssc); assert(and_with)
 
 # define PERL_ARGS_ASSERT_SSC_ANYTHING          \
-        assert(ssc)
+        Perl_assert_aTHX; assert(ssc)
 
 # define PERL_ARGS_ASSERT_SSC_CLEAR_LOCALE      \
         assert(ssc)
 
 # define PERL_ARGS_ASSERT_SSC_CP_AND            \
-        assert(ssc)
+        Perl_assert_aTHX; assert(ssc)
 
 # define PERL_ARGS_ASSERT_SSC_INTERSECTION      \
-        assert(ssc); assert(invlist)
+        Perl_assert_aTHX; assert(ssc); assert(invlist)
 
 # define PERL_ARGS_ASSERT_SSC_IS_ANYTHING       \
         assert(ssc)
@@ -11553,13 +11971,13 @@ S_invlist_trim(SV *invlist)
         assert(pRExC_state); assert(ssc)
 
 # define PERL_ARGS_ASSERT_SSC_OR                \
-        assert(pRExC_state); assert(ssc); assert(or_with)
+        Perl_assert_aTHX; assert(pRExC_state); assert(ssc); assert(or_with)
 
 # define PERL_ARGS_ASSERT_SSC_UNION             \
-        assert(ssc); assert(invlist)
+        Perl_assert_aTHX; assert(ssc); assert(invlist)
 
 # define PERL_ARGS_ASSERT_UNWIND_SCAN_FRAMES    \
-        assert(p)
+        Perl_assert_aTHX; assert(p)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static SV *
@@ -11631,35 +12049,36 @@ S_unwind_scan_frames(pTHX_ void *p)
 #endif /* defined(PERL_IN_REGCOMP_STUDY_C) */
 #if defined(PERL_IN_REGEXEC_C)
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_LB        \
-        assert(curpos); assert(*curpos); assert(strend); \
+        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend); \
         assert(*curpos < strend)
 
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_SB        \
-        assert(curpos); assert(*curpos); assert(strend); \
+        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend); \
         assert(*curpos < strend)
 
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_WB_       \
-        assert(curpos); assert(*curpos); assert(strend); \
+        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend); \
         assert(*curpos < strend)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_GCB        \
-        assert(strbeg); assert(curpos); assert(*curpos); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos); \
         assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_LB_        \
-        assert(strbeg); assert(curpos); assert(*curpos); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos); \
         assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_SB         \
-        assert(strbeg); assert(curpos); assert(*curpos); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos); \
         assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_WB_BUT_OVER_EXTEND_FO \
-        assert(previous); assert(strbeg); assert(curpos); assert(*curpos); \
-        assert(strbeg <= *curpos)
+        Perl_assert_aTHX; assert(previous); assert(strbeg); assert(curpos); \
+        assert(*curpos); assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_FIND_BYCLASS          \
-        assert(prog); assert(c); assert(s); assert(strend); assert(s <= strend)
+        Perl_assert_aTHX; assert(prog); assert(c); assert(s); assert(strend); \
+        assert(s <= strend)
 
 # define PERL_ARGS_ASSERT_FIND_NEXT_MASKED      \
         assert(s); assert(send); assert(s <= send)
@@ -11670,37 +12089,39 @@ S_unwind_scan_frames(pTHX_ void *p)
 # define PERL_ARGS_ASSERT_FIND_SPAN_END_MASK    \
         assert(s); assert(send); assert(s <= send)
 
-# define PERL_ARGS_ASSERT_ISFOO_LC
+# define PERL_ARGS_ASSERT_ISFOO_LC              \
+        Perl_assert_aTHX
 
 # define PERL_ARGS_ASSERT_ISFOO_UTF8_LC         \
-        assert(character); assert(e); assert(character < e)
+        Perl_assert_aTHX; assert(character); assert(e); assert(character < e)
 
 # define PERL_ARGS_ASSERT_ISGCB                 \
-        assert(strbeg); assert(curpos); assert(strbeg <= curpos)
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); \
+        assert(strbeg <= curpos)
 
 # define PERL_ARGS_ASSERT_ISLB                  \
-        assert(strbeg); assert(curpos); assert(strend); assert(strbeg <= curpos); \
-        assert(curpos < strend)
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend); \
+        assert(strbeg <= curpos); assert(curpos < strend)
 
 # define PERL_ARGS_ASSERT_ISSB                  \
-        assert(strbeg); assert(curpos); assert(strend); assert(strbeg <= curpos); \
-        assert(curpos < strend)
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend); \
+        assert(strbeg <= curpos); assert(curpos < strend)
 
 # define PERL_ARGS_ASSERT_ISWB                  \
-        assert(strbeg); assert(curpos); assert(strend); assert(strbeg <= curpos); \
-        assert(curpos < strend)
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend); \
+        assert(strbeg <= curpos); assert(curpos < strend)
 
 # define PERL_ARGS_ASSERT_REG_CHECK_NAMED_BUFF_MATCHED \
         assert(rex); assert(scan)
 
 # define PERL_ARGS_ASSERT_REGCP_RESTORE         \
-        assert(rex); assert(maxopenparen_p)
+        Perl_assert_aTHX; assert(rex); assert(maxopenparen_p)
 
 # define PERL_ARGS_ASSERT_REGCPPOP              \
-        assert(rex); assert(maxopenparen_p)
+        Perl_assert_aTHX; assert(rex); assert(maxopenparen_p)
 
 # define PERL_ARGS_ASSERT_REGCPPUSH             \
-        assert(rex)
+        Perl_assert_aTHX; assert(rex)
 
 # define PERL_ARGS_ASSERT_REGHOP3               \
         assert(s); assert(lim)
@@ -11709,35 +12130,36 @@ S_unwind_scan_frames(pTHX_ void *p)
         assert(s); assert(lim)
 
 # define PERL_ARGS_ASSERT_REGINCLASS            \
-        assert(n); assert(p); assert(p_end); assert(p < p_end)
+        Perl_assert_aTHX; assert(n); assert(p); assert(p_end); assert(p < p_end)
 
 # define PERL_ARGS_ASSERT_REGMATCH              \
-        assert(reginfo); assert(startpos); assert(prog)
+        Perl_assert_aTHX; assert(reginfo); assert(startpos); assert(prog)
 
 # define PERL_ARGS_ASSERT_REGREPEAT             \
-        assert(prog); assert(startposp); assert(p); assert(loceol); \
-        assert(reginfo); assert(max)
+        Perl_assert_aTHX; assert(prog); assert(startposp); assert(p); \
+        assert(loceol); assert(reginfo); assert(max)
 
 # define PERL_ARGS_ASSERT_REGTRY                \
-        assert(reginfo); assert(startposp)
+        Perl_assert_aTHX; assert(reginfo); assert(startposp)
 
 # define PERL_ARGS_ASSERT_TO_BYTE_SUBSTR        \
-        assert(prog)
+        Perl_assert_aTHX; assert(prog)
 
 # define PERL_ARGS_ASSERT_TO_UTF8_SUBSTR        \
-        assert(prog)
+        Perl_assert_aTHX; assert(prog)
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DEBUG_START_MATCH   \
-        assert(prog); assert(start); assert(end); assert(blurb); \
-        assert(start <= end)
+        Perl_assert_aTHX; assert(prog); assert(start); assert(end); \
+        assert(blurb); assert(start <= end)
 
 #   define PERL_ARGS_ASSERT_DUMP_EXEC_POS       \
-        assert(locinput); assert(scan); assert(loc_regeol); assert(loc_bostr); \
-        assert(loc_reg_starttry); assert(locinput <= loc_regeol)
+        Perl_assert_aTHX; assert(locinput); assert(scan); assert(loc_regeol); \
+        assert(loc_bostr); assert(loc_reg_starttry); \
+        assert(locinput <= loc_regeol)
 
 #   define PERL_ARGS_ASSERT_RE_EXEC_INDENTF     \
-        assert(fmt)
+        Perl_assert_aTHX; assert(fmt)
 
 # endif /* defined(DEBUGGING) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
@@ -11935,13 +12357,13 @@ Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_CAPTURE_CLEAR       \
-        assert(rex); assert(str)
+        Perl_assert_aTHX; assert(rex); assert(str)
 
 #   define PERL_ARGS_ASSERT_FOLDEQ_LATIN1_S2_FOLDED \
-        assert(s1); assert(s2)
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 #   define PERL_ARGS_ASSERT_UNWIND_PAREN        \
-        assert(rex)
+        Perl_assert_aTHX; assert(rex)
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE void
@@ -11964,26 +12386,26 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
 #if defined(PERL_IN_REGEX_ENGINE)
 
 # define PERL_ARGS_ASSERT_REGPROP               \
-        assert(sv); assert(o)
+        Perl_assert_aTHX; assert(sv); assert(o)
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DEBUG_PEEP          \
-        assert(str); assert(pRExC_state)
+        Perl_assert_aTHX; assert(str); assert(pRExC_state)
 
 #   define PERL_ARGS_ASSERT_DEBUG_SHOW_STUDY_FLAGS \
-        assert(open_str); assert(close_str)
+        Perl_assert_aTHX; assert(open_str); assert(close_str)
 
 #   define PERL_ARGS_ASSERT_DEBUG_STUDYDATA     \
-        assert(where)
+        Perl_assert_aTHX; assert(where)
 
 #   define PERL_ARGS_ASSERT_DUMPUNTIL           \
-        assert(r); assert(start); assert(node); assert(sv)
+        Perl_assert_aTHX; assert(r); assert(start); assert(node); assert(sv)
 
 #   define PERL_ARGS_ASSERT_RE_INDENTF          \
-        assert(fmt)
+        Perl_assert_aTHX; assert(fmt)
 
 #   define PERL_ARGS_ASSERT_RE_PRINTF           \
-        assert(fmt)
+        Perl_assert_aTHX; assert(fmt)
 
 # endif /* defined(DEBUGGING) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
@@ -12034,7 +12456,7 @@ Perl_re_printf(pTHX_ const char *fmt, ...)
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_EXT_RE_BUILD)
 #   define PERL_ARGS_ASSERT_GET_RE_GCLASS_AUX_DATA \
-        assert(node)
+        Perl_assert_aTHX; assert(node)
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
@@ -12045,7 +12467,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node
 #   endif
 # else /* if !defined(PERL_EXT_RE_BUILD) */
 #   define PERL_ARGS_ASSERT_GET_REGCLASS_AUX_DATA \
-        assert(node)
+        Perl_assert_aTHX; assert(node)
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
@@ -12060,19 +12482,22 @@ PERL_STATIC_INLINE bool
 Perl_check_regnode_after(pTHX_ const regnode *p, const STRLEN extra)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_CHECK_REGNODE_AFTER
+#   define PERL_ARGS_ASSERT_CHECK_REGNODE_AFTER \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE regnode *
 Perl_regnext(pTHX_ const regnode *p)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_REGNEXT
+#   define PERL_ARGS_ASSERT_REGNEXT             \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE regnode *
 Perl_regnode_after(pTHX_ const regnode *p, bool varies)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#   define PERL_ARGS_ASSERT_REGNODE_AFTER
+#   define PERL_ARGS_ASSERT_REGNODE_AFTER       \
+        Perl_assert_aTHX
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_REGEX_ENGINE) */
@@ -12080,14 +12505,15 @@ Perl_regnode_after(pTHX_ const regnode *p, bool varies)
 static void
 S_save_pushptri32ptr(pTHX_ void * const ptr1, const I32 i, void * const ptr2, const int type)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_PUSHPTRI32PTR
+# define PERL_ARGS_ASSERT_SAVE_PUSHPTRI32PTR    \
+        Perl_assert_aTHX
 
 static SV *
 S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SAVE_SCALAR_AT        \
-        assert(sptr)
+        Perl_assert_aTHX; assert(sptr)
 
 #endif /* defined(PERL_IN_SCOPE_C) */
 #if defined(PERL_IN_SV_C)
@@ -12104,7 +12530,7 @@ S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE    \
-        assert(gv); assert(cv); \
+        Perl_assert_aTHX; assert(gv); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static void
@@ -12113,7 +12539,7 @@ S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, S
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_ASSERT_UFT8_CACHE_COHERENT \
-        assert(func); assert(sv)
+        Perl_assert_aTHX; assert(func); assert(sv)
 
 static void
 S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
@@ -12121,14 +12547,14 @@ S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CROAK_SV_SETSV_FLAGS  \
-        assert(dsv); assert(ssv)
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 static bool
 S_curse(pTHX_ SV * const sv, const bool check_refcnt)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CURSE                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static STRLEN
 S_expect_number(pTHX_ const char ** const pattern)
@@ -12136,35 +12562,35 @@ S_expect_number(pTHX_ const char ** const pattern)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_EXPECT_NUMBER         \
-        assert(pattern)
+        Perl_assert_aTHX; assert(pattern)
 
 static SSize_t
 S_find_array_subscript(pTHX_ const AV * const av, const SV * const val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_ARRAY_SUBSCRIPT  \
-        assert(val)
+        Perl_assert_aTHX; assert(val)
 
 static SV *
 S_find_hash_subscript(pTHX_ const HV * const hv, const SV * const val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_HASH_SUBSCRIPT   \
-        assert(val)
+        Perl_assert_aTHX; assert(val)
 
 static SV *
 S_find_uninit_var(pTHX_ const OP * const obase, const SV * const uninit_sv, bool match, const char **desc_p)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_FIND_UNINIT_VAR       \
-        assert(desc_p)
+        Perl_assert_aTHX; assert(desc_p)
 
 static bool
 S_glob_2number(pTHX_ GV * const gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GLOB_2NUMBER          \
-        assert(gv)
+        Perl_assert_aTHX; assert(gv)
 
 static void
 S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype)
@@ -12172,21 +12598,21 @@ S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB      \
-        assert(dsv); assert(ssv)
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 static void
 S_not_a_number(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_A_NUMBER          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static void
 S_not_incrementable(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_INCREMENTABLE     \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static PTR_TBL_ENT_t *
 S_ptr_table_find(PTR_TBL_t * const tbl, const void * const sv)
@@ -12200,14 +12626,14 @@ S_sv_2iuv_common(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2IUV_COMMON        \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static void
 S_sv_add_arena(pTHX_ char * const ptr, const U32 size, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_ADD_ARENA          \
-        assert(ptr)
+        Perl_assert_aTHX; assert(ptr)
 
 static const char *
 S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size)
@@ -12215,14 +12641,14 @@ S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_DISPLAY            \
-        assert(sv); assert(tmpbuf)
+        Perl_assert_aTHX; assert(sv); assert(tmpbuf)
 
 static bool
 S_sv_numcmp_common(pTHX_ SV **sv1, SV **sv2, const U32 flags, int method, SV **result)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_SV_NUMCMP_COMMON      \
-        assert(result)
+        Perl_assert_aTHX; assert(result)
 
 static STRLEN
 S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 *end, STRLEN endu)
@@ -12231,8 +12657,8 @@ S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY     \
-        assert(s); assert(target); assert(end); assert(s <= target); \
-        assert(target <= end)
+        Perl_assert_aTHX; assert(s); assert(target); assert(end); \
+        assert(s <= target); assert(target <= end)
 
 static STRLEN
 S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const start, const U8 * const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0)
@@ -12242,7 +12668,7 @@ S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const st
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_CACHED     \
-        assert(sv); assert(mgp); assert(start); assert(send); \
+        Perl_assert_aTHX; assert(sv); assert(mgp); assert(start); assert(send); \
         assert(start < send)
 
 static STRLEN
@@ -12269,7 +12695,7 @@ S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_LEN_CACHE_UPDATE \
-        assert(sv); assert(mgp)
+        Perl_assert_aTHX; assert(sv); assert(mgp)
 
 static void
 S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN byte, const STRLEN utf8, const STRLEN blen)
@@ -12277,14 +12703,14 @@ S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_POS_CACHE_UPDATE \
-        assert(sv); assert(mgp)
+        Perl_assert_aTHX; assert(sv); assert(mgp)
 
 static SSize_t
 S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_VISIT                 \
-        assert(f)
+        Perl_assert_aTHX; assert(f)
 
 # if defined(DEBUGGING)
 static void
@@ -12292,19 +12718,21 @@ S_del_sv(pTHX_ SV *p)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_DEL_SV              \
-        assert(p)
+        Perl_assert_aTHX; assert(p)
 
 PERL_CALLCONV void
 Perl_sv_mark_arenas(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#   define PERL_ARGS_ASSERT_SV_MARK_ARENAS
+#   define PERL_ARGS_ASSERT_SV_MARK_ARENAS      \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_sweep_arenas(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-#   define PERL_ARGS_ASSERT_SV_SWEEP_ARENAS
+#   define PERL_ARGS_ASSERT_SV_SWEEP_ARENAS     \
+        Perl_assert_aTHX
 
 # endif /* defined(DEBUGGING) */
 # if !defined(NV_PRESERVES_UV)
@@ -12314,7 +12742,7 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #   else
 static int
@@ -12322,7 +12750,7 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 #   endif
 # endif /* !defined(NV_PRESERVES_UV) */
@@ -12332,7 +12760,7 @@ S_sv_buf_to_rw(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_BUF_TO_RW        \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -12341,7 +12769,7 @@ S_sv_unglob(pTHX_ SV * const sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_UNGLOB           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 # endif
 # if defined(USE_ITHREADS)
@@ -12352,7 +12780,7 @@ S_sv_dup_common(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_SV_DUP_COMMON       \
-        assert(ssv); assert(param)
+        Perl_assert_aTHX; assert(ssv); assert(param)
 
 static void
 S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param)
@@ -12361,7 +12789,7 @@ S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #   define PERL_ARGS_ASSERT_SV_DUP_HVAUX        \
-        assert(ssv); assert(dsv); assert(param)
+        Perl_assert_aTHX; assert(ssv); assert(dsv); assert(param)
 
 static SV **
 S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_PARAMS * const param)
@@ -12370,14 +12798,15 @@ S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 #   define PERL_ARGS_ASSERT_SV_DUP_INC_MULTIPLE \
-        assert(source); assert(dest); assert(param)
+        Perl_assert_aTHX; assert(source); assert(dest); assert(param)
 
 static void
 S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_UNREFERENCED_TO_TMP_STACK \
-        assert(unreferenced); assert(SvTYPE(unreferenced) == SVt_PVAV)
+        Perl_assert_aTHX; assert(unreferenced); \
+        assert(SvTYPE(unreferenced) == SVt_PVAV)
 
 # endif /* defined(USE_ITHREADS) */
 #endif /* defined(PERL_IN_SV_C) */
@@ -12385,12 +12814,14 @@ S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced)
 static int
 S_ao(pTHX_ int toketype)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_AO
+# define PERL_ARGS_ASSERT_AO                    \
+        Perl_assert_aTHX
 
 static void
 S_check_unary(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_CHECK_UNARY
+# define PERL_ARGS_ASSERT_CHECK_UNARY           \
+        Perl_assert_aTHX
 
 static void
 S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
@@ -12399,7 +12830,7 @@ S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CHECKCOMMA            \
-        assert(s); assert(name); assert(what)
+        Perl_assert_aTHX; assert(s); assert(name); assert(what)
 
 static char *
 S_filter_gets(pTHX_ SV *sv, STRLEN append)
@@ -12407,7 +12838,7 @@ S_filter_gets(pTHX_ SV *sv, STRLEN append)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FILTER_GETS           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static HV *
 S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
@@ -12415,45 +12846,47 @@ S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FIND_IN_MY_STASH      \
-        assert(pkgname)
+        Perl_assert_aTHX; assert(pkgname)
 
 static void
 S_force_ident(pTHX_ const char *s, int kind)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_IDENT           \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static void
 S_force_ident_maybe_lex(pTHX_ char pit)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_FORCE_IDENT_MAYBE_LEX
+# define PERL_ARGS_ASSERT_FORCE_IDENT_MAYBE_LEX \
+        Perl_assert_aTHX
 
 static void
 S_force_next(pTHX_ I32 type)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_FORCE_NEXT
+# define PERL_ARGS_ASSERT_FORCE_NEXT            \
+        Perl_assert_aTHX
 
 static char *
 S_force_strict_version(pTHX_ char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_STRICT_VERSION  \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static char *
 S_force_version(pTHX_ char *s, int guessing)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_VERSION         \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static char *
 S_force_word(pTHX_ char *start, int token, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_WORD            \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 static SV *
 S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const e)
@@ -12462,7 +12895,7 @@ S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME_WRAPPER \
-        assert(s); assert(e); assert(s <= e)
+        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e)
 
 static void
 S_incline(pTHX_ const char *s, const char *end)
@@ -12470,14 +12903,15 @@ S_incline(pTHX_ const char *s, const char *end)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INCLINE               \
-        assert(s); assert(end); assert(s <= end); assert(*end == '\0')
+        Perl_assert_aTHX; assert(s); assert(end); assert(s <= end); \
+        assert(*end == '\0')
 
 static int
 S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INTUIT_METHOD         \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 static int
 S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t caller_length)
@@ -12485,27 +12919,29 @@ S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INTUIT_MORE           \
-        assert(s); assert(e); assert(s <= e); assert(*e == '\0')
+        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e); \
+        assert(*e == '\0')
 
 static bool
 S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_EXISTING_IDENTIFIER \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static I32
 S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_LOP                   \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_STATIC_NO_RET void
 S_missingterm(pTHX_ char *s, STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
-# define PERL_ARGS_ASSERT_MISSINGTERM
+# define PERL_ARGS_ASSERT_MISSINGTERM           \
+        Perl_assert_aTHX
 
 static SV *
 S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, SV *sv, SV *pv, const char *type, STRLEN typelen, const char **error_msg)
@@ -12513,7 +12949,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, 
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_NEW_CONSTANT          \
-        assert(key); assert(sv)
+        Perl_assert_aTHX; assert(key); assert(sv)
 
 static char *
 S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * const e, bool is_utf8, HV **failure_details, U32 flags)
@@ -12523,8 +12959,8 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * co
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
-        assert(s); assert(s_end); assert(d); assert(*d); assert(e); \
-        assert(s <= s_end); assert(*d < e)
+        Perl_assert_aTHX; assert(s); assert(s_end); assert(d); assert(*d); \
+        assert(e); assert(s <= s_end); assert(*d < e)
 
 static char *
 S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf8, HV **failure_details, U32 flags)
@@ -12532,12 +12968,13 @@ S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSE_IDENT_NO_COPY   \
-        assert(s); assert(s_end); assert(s < s_end)
+        Perl_assert_aTHX; assert(s); assert(s_end); assert(s < s_end)
 
 static int
 S_pending_ident(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PENDING_IDENT
+# define PERL_ARGS_ASSERT_PENDING_IDENT         \
+        Perl_assert_aTHX
 
 static char *
 S_scan_const(pTHX_ char *start)
@@ -12545,7 +12982,7 @@ S_scan_const(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_CONST            \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 static char *
 S_scan_formline(pTHX_ char *s)
@@ -12553,7 +12990,7 @@ S_scan_formline(pTHX_ char *s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_FORMLINE         \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static char *
 S_scan_heredoc(pTHX_ char *s)
@@ -12561,7 +12998,7 @@ S_scan_heredoc(pTHX_ char *s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_HEREDOC          \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static char *
 S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
@@ -12570,7 +13007,8 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SCAN_IDENT            \
-        assert(s); assert(dest); assert(dest_end); assert(dest < dest_end)
+        Perl_assert_aTHX; assert(s); assert(dest); assert(dest_end); \
+        assert(dest < dest_end)
 
 static char *
 S_scan_inputsymbol(pTHX_ char *start)
@@ -12578,7 +13016,7 @@ S_scan_inputsymbol(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_INPUTSYMBOL      \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 static char *
 S_scan_pat(pTHX_ char *start, I32 type)
@@ -12586,7 +13024,7 @@ S_scan_pat(pTHX_ char *start, I32 type)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_PAT              \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 static char *
 S_scan_subst(pTHX_ char *start)
@@ -12594,7 +13032,7 @@ S_scan_subst(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_SUBST            \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 static char *
 S_scan_trans(pTHX_ char *start)
@@ -12602,25 +13040,28 @@ S_scan_trans(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_TRANS            \
-        assert(start)
+        Perl_assert_aTHX; assert(start)
 
 static I32
 S_sublex_done(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SUBLEX_DONE
+# define PERL_ARGS_ASSERT_SUBLEX_DONE           \
+        Perl_assert_aTHX
 
 static I32
 S_sublex_push(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SUBLEX_PUSH
+# define PERL_ARGS_ASSERT_SUBLEX_PUSH           \
+        Perl_assert_aTHX
 
 static I32
 S_sublex_start(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SUBLEX_START
+# define PERL_ARGS_ASSERT_SUBLEX_START          \
+        Perl_assert_aTHX
 
 static char *
 S_swallow_bom(pTHX_ U8 *s)
@@ -12628,7 +13069,7 @@ S_swallow_bom(pTHX_ U8 *s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SWALLOW_BOM           \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static char *
 S_tokenize_use(pTHX_ int is_use, char *s)
@@ -12636,40 +13077,41 @@ S_tokenize_use(pTHX_ int is_use, char *s)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOKENIZE_USE          \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static SV *
 S_tokeq(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_TOKEQ                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 static void
 S_update_debugger_info(pTHX_ SV *orig_sv, const char * const buf, STRLEN len)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_UPDATE_DEBUGGER_INFO
+# define PERL_ARGS_ASSERT_UPDATE_DEBUGGER_INFO  \
+        Perl_assert_aTHX
 
 static void
 S_warn_expect_operator(pTHX_ const char * const what, char *s, I32 pop_oldbufptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_EXPECT_OPERATOR  \
-        assert(what)
+        Perl_assert_aTHX; assert(what)
 
 static void
 S_yyerror_non_ascii_message(pTHX_ const U8 * const s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_YYERROR_NON_ASCII_MESSAGE \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static int
 S_yywarn(pTHX_ const char * const s, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_YYWARN                \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 # if defined(DEBUGGING)
 static void
@@ -12679,14 +13121,14 @@ S_printbuf(pTHX_ const char * const fmt, const char * const s)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_1,0);
 #   define PERL_ARGS_ASSERT_PRINTBUF            \
-        assert(fmt); assert(s)
+        Perl_assert_aTHX; assert(fmt); assert(s)
 
 static int
 S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOKEREPORT          \
-        assert(lvalp)
+        Perl_assert_aTHX; assert(lvalp)
 
 # endif /* defined(DEBUGGING) */
 # if !defined(PERL_NO_UTF16_FILTER)
@@ -12695,14 +13137,14 @@ S_add_utf16_textfilter(pTHX_ U8 * const s, bool reversed)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_ADD_UTF16_TEXTFILTER \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 static I32
 S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_UTF16_TEXTFILTER    \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 # endif /* !defined(PERL_NO_UTF16_FILTER) */
 #endif /* defined(PERL_IN_TOKE_C) */
@@ -12712,14 +13154,15 @@ S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flag
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_ISA_LOOKUP            \
-        assert(stash); assert(SvTYPE(stash) == SVt_PVHV); assert(namesv || name)
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        assert(namesv || name)
 
 static bool
 S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SVPVN \
-        assert(sv); assert(namesv || name)
+        Perl_assert_aTHX; assert(sv); assert(namesv || name)
 
 #endif /* defined(PERL_IN_UNIVERSAL_C) */
 #if defined(PERL_IN_UTF8_C)
@@ -12731,7 +13174,7 @@ S_check_locale_boundary_crossing(pTHX_ const U8 * const p, const UV result, U8 *
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_LOCALE_BOUNDARY_CROSSING \
-        assert(p); assert(ustrp); assert(lenp)
+        Perl_assert_aTHX; assert(p); assert(ustrp); assert(lenp)
 
 static HV *
 S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
@@ -12739,7 +13182,7 @@ S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_MSG_HV            \
-        assert(message)
+        Perl_assert_aTHX; assert(message)
 
 static UV
 S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Size_t *remaining_count, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal)
@@ -12748,7 +13191,7 @@ S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Si
         Perl_attribute_nonnull(pTHX_5)
         Perl_attribute_nonnull(pTHX_8);
 # define PERL_ARGS_ASSERT_TO_CASE_CP_LIST       \
-        assert(invlist); assert(invmap); assert(normal)
+        Perl_assert_aTHX; assert(invlist); assert(invmap); assert(normal)
 
 static U8
 S_to_lower_latin1(const U8 c, U8 *p, STRLEN *lenp, const char dummy)
@@ -12764,8 +13207,8 @@ S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, S
         Perl_attribute_nonnull(pTHX_6)
         Perl_attribute_nonnull(pTHX_9);
 # define PERL_ARGS_ASSERT_TO_UTF8_CASE_         \
-        assert(ustrp); assert(lenp); assert(invlist); assert(invmap); \
-        assert(normal)
+        Perl_assert_aTHX; assert(ustrp); assert(lenp); assert(invlist); \
+        assert(invmap); assert(normal)
 
 static UV
 S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
@@ -12775,7 +13218,8 @@ S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_FC             \
-        assert(p); assert(e); assert(ustrp); assert(lenp); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp); \
+        assert(p < e)
 
 static UV
 S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *lenp)
@@ -12785,7 +13229,8 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *le
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_LC             \
-        assert(p0); assert(e); assert(ustrp); assert(lenp); assert(p0 < e)
+        Perl_assert_aTHX; assert(p0); assert(e); assert(ustrp); assert(lenp); \
+        assert(p0 < e)
 
 static UV
 S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
@@ -12795,7 +13240,8 @@ S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_UC             \
-        assert(p); assert(e); assert(ustrp); assert(lenp); assert(p < e)
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp); \
+        assert(p < e)
 
 static char *
 S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, const STRLEN non_cont_byte_pos, const STRLEN expect_len)
@@ -12803,7 +13249,7 @@ S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, c
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UNEXPECTED_NON_CONTINUATION_TEXT \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 # if 0
 static void
@@ -12813,7 +13259,7 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category, const char * const name, cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_5);
 #   define PERL_ARGS_ASSERT_WARN_ON_FIRST_DEPRECATED_USE \
-        assert(name); assert(alternative); assert(file)
+        Perl_assert_aTHX; assert(name); assert(alternative); assert(file)
 
 # endif /* 0 */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -12845,26 +13291,28 @@ S_is_utf8_overlong(const U8 * const s, const STRLEN len)
 static bool
 S_ckwarn_common(pTHX_ U32 w)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_CKWARN_COMMON
+# define PERL_ARGS_ASSERT_CKWARN_COMMON         \
+        Perl_assert_aTHX
 
 static SV *
 S_mess_alloc(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_MESS_ALLOC
+# define PERL_ARGS_ASSERT_MESS_ALLOC            \
+        Perl_assert_aTHX
 
 static SV *
 S_with_queued_errors(pTHX_ SV *ex)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_WITH_QUEUED_ERRORS    \
-        assert(ex)
+        Perl_assert_aTHX; assert(ex)
 
 static void
 S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p, STRLEN xs_len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK  \
-        assert(xs_p)
+        Perl_assert_aTHX; assert(xs_p)
 
 # if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 static void
@@ -12880,7 +13328,8 @@ S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const cha
 static void
 S_pidgone(pTHX_ Pid_t pid, int status)
         Perl_attribute_nonnull_aTHX;
-#   define PERL_ARGS_ASSERT_PIDGONE
+#   define PERL_ARGS_ASSERT_PIDGONE             \
+        Perl_assert_aTHX
 
 # endif
 #endif /* defined(PERL_IN_UTIL_C) */
@@ -12932,7 +13381,7 @@ Perl_AvFILL_(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AVFILL_               \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE I32 *
 Perl_CvDEPTH(const CV * const sv)
@@ -12945,12 +13394,14 @@ Perl_CvGV(pTHX_ CV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CVGV                  \
-        assert(sv); assert(SvTYPE(sv) == SVt_PVCV || SvTYPE(sv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(sv); \
+        assert(SvTYPE(sv) == SVt_PVCV || SvTYPE(sv) == SVt_PVFM)
 
 PERL_STATIC_INLINE Stack_off_t
 Perl_POPMARK(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_POPMARK
+# define PERL_ARGS_ASSERT_POPMARK               \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE struct regexp *
 Perl_ReANY(const REGEXP * const re)
@@ -12975,35 +13426,35 @@ Perl_SvGETMAGIC(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVGETMAGIC            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE IV
 Perl_SvIV(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV                  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE IV
 Perl_SvIV_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV_NOMG             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE NV
 Perl_SvNV(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV                  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE NV
 Perl_SvNV_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV_NOMG             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_FORCE_INLINE bool
 Perl_SvPVXtrue(pTHX_ SV *sv)
@@ -13011,7 +13462,7 @@ Perl_SvPVXtrue(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPVXTRUE             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_FORCE_INLINE char *
 Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const PL_SvPVtype type, Perl_SvPV_helper_non_trivial_t non_trivial, const bool or_null, const U32 return_flags)
@@ -13020,24 +13471,26 @@ Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const 
         Perl_attribute_nonnull(pTHX_5)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPV_HELPER           \
-        assert(sv); assert(non_trivial)
+        Perl_assert_aTHX; assert(sv); assert(non_trivial)
 
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SVREFCNT_DEC
+# define PERL_ARGS_ASSERT_SVREFCNT_DEC          \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC_NN       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE SV *
 Perl_SvREFCNT_dec_ret_NULL(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SVREFCNT_DEC_RET_NULL
+# define PERL_ARGS_ASSERT_SVREFCNT_DEC_RET_NULL \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE SV *
 Perl_SvREFCNT_inc(SV *sv);
@@ -13056,45 +13509,48 @@ Perl_SvREFCNT_inc_void(SV *sv);
 PERL_STATIC_INLINE bool
 Perl_SvTRUE(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SVTRUE
+# define PERL_ARGS_ASSERT_SVTRUE                \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_NN             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_common(pTHX_ SV *sv, const bool sv_2bool_is_fallback)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_COMMON         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SVTRUE_NOMG
+# define PERL_ARGS_ASSERT_SVTRUE_NOMG           \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE UV
 Perl_SvUV(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV                  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE UV
 Perl_SvUV_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV_NOMG             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE Stack_off_t
 Perl_TOPMARK(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_TOPMARK
+# define PERL_ARGS_ASSERT_TOPMARK               \
+        Perl_assert_aTHX
 
 # define PERL_ARGS_ASSERT_APPEND_UTF8_FROM_NATIVE_BYTE \
         assert(dest)
@@ -13105,7 +13561,7 @@ Perl_av_count(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_COUNT              \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE SV **
 Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
@@ -13113,14 +13569,14 @@ Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_FETCH_SIMPLE       \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE AV *
 Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_NEW_ALLOC          \
-        assert(size > 0)
+        Perl_assert_aTHX; assert(size > 0)
 
 PERL_STATIC_INLINE void
 Perl_av_push_simple(pTHX_ AV *av, SV *val)
@@ -13128,21 +13584,22 @@ Perl_av_push_simple(pTHX_ AV *av, SV *val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_AV_PUSH_SIMPLE        \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(val)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        assert(val)
 
 PERL_STATIC_INLINE void
 Perl_av_remove_offset(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_REMOVE_OFFSET      \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE SV **
 Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_STORE_SIMPLE       \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
@@ -13150,7 +13607,7 @@ Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8         \
-        assert(s); assert(lenp)
+        Perl_assert_aTHX; assert(s); assert(lenp)
 
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
@@ -13158,14 +13615,14 @@ Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8_TEMP_PV \
-        assert(s); assert(lenp)
+        Perl_assert_aTHX; assert(s); assert(lenp)
 
 PERL_STATIC_INLINE void
 Perl_clear_defarray_simple(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_DEFARRAY_SIMPLE \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
@@ -13173,7 +13630,7 @@ Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ                \
-        assert(s1); assert(s2)
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
@@ -13181,7 +13638,7 @@ Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LATIN1         \
-        assert(s1); assert(s2)
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ_locale(pTHX_ const char *s1, const char *s2, I32 len)
@@ -13189,13 +13646,14 @@ Perl_foldEQ_locale(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LOCALE         \
-        assert(s1); assert(s2)
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_STATIC_INLINE MGVTBL *
 Perl_get_vtbl(pTHX_ int vtbl_id)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_GET_VTBL
+# define PERL_ARGS_ASSERT_GET_VTBL              \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE UV
 Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
@@ -13204,7 +13662,7 @@ Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximat
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_BIN              \
-        assert(start); assert(len_p); assert(flags)
+        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE UV
 Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
@@ -13213,7 +13671,7 @@ Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximat
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_HEX              \
-        assert(start); assert(len_p); assert(flags)
+        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE UV
 Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
@@ -13222,14 +13680,14 @@ Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximat
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_OCT              \
-        assert(start); assert(len_p); assert(flags)
+        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
 
 PERL_STATIC_INLINE void *
 Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32, const int action, SV *val, const U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN     \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
 
 PERL_STATIC_INLINE Size_t
 Perl_isC9_STRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
@@ -13277,7 +13735,7 @@ Perl_is_safe_syscall(pTHX_ const char *pv, STRLEN len, const char *what, const c
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_SAFE_SYSCALL       \
-        assert(pv); assert(what); assert(op_name)
+        Perl_assert_aTHX; assert(pv); assert(what); assert(op_name)
 
 PERL_STATIC_INLINE bool
 Perl_is_strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
@@ -13346,7 +13804,8 @@ PERL_STATIC_INLINE OP *
 Perl_newPADxVOP(pTHX_ I32 type, I32 flags, PADOFFSET padix)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWPADXVOP
+# define PERL_ARGS_ASSERT_NEWPADXVOP            \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE SV *
 Perl_newRV_noinc(pTHX_ SV * const tmpRef)
@@ -13354,26 +13813,29 @@ Perl_newRV_noinc(pTHX_ SV * const tmpRef)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWRV_NOINC           \
-        assert(tmpRef)
+        Perl_assert_aTHX; assert(tmpRef)
 
 PERL_STATIC_INLINE SV *
 Perl_newSV_type(pTHX_ const svtype type)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWSV_TYPE
+# define PERL_ARGS_ASSERT_NEWSV_TYPE            \
+        Perl_assert_aTHX
 
 PERL_STATIC_FORCE_INLINE SV *
 Perl_newSV_type_mortal(pTHX_ const svtype type)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__
         __attribute__always_inline__;
-# define PERL_ARGS_ASSERT_NEWSV_TYPE_MORTAL
+# define PERL_ARGS_ASSERT_NEWSV_TYPE_MORTAL     \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE SV *
 Perl_newSVsv_flags(pTHX_ SV * const old, I32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWSVSV_FLAGS
+# define PERL_ARGS_ASSERT_NEWSVSV_FLAGS         \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE SV *
 Perl_new_sv(pTHX_ const char *file, int line, const char *func)
@@ -13381,96 +13843,105 @@ Perl_new_sv(pTHX_ const char *file, int line, const char *func)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_NEW_SV                \
-        assert(file); assert(func)
+        Perl_assert_aTHX; assert(file); assert(func)
 
 PERL_STATIC_INLINE void
 Perl_pop_stackinfo(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_POP_STACKINFO
+# define PERL_ARGS_ASSERT_POP_STACKINFO         \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_push_stackinfo(pTHX_ I32 type, UV flags)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PUSH_STACKINFO
+# define PERL_ARGS_ASSERT_PUSH_STACKINFO        \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_context(pTHX_ SV **mark, U8 gimme, SSize_t extra)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_CONTEXT           \
-        assert(mark)
+        Perl_assert_aTHX; assert(mark)
 
 PERL_STATIC_INLINE void
 Perl_rpp_extend(pTHX_ SSize_t n)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_EXTEND
+# define PERL_ARGS_ASSERT_RPP_EXTEND            \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_invoke_xs(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_INVOKE_XS         \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE bool
 Perl_rpp_is_lone(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_IS_LONE           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE SV *
 Perl_rpp_pop_1_norc(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_POP_1_NORC
+# define PERL_ARGS_ASSERT_RPP_POP_1_NORC        \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_1(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_POPFREE_1
+# define PERL_ARGS_ASSERT_RPP_POPFREE_1         \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_1_NN(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_POPFREE_1_NN
+# define PERL_ARGS_ASSERT_RPP_POPFREE_1_NN      \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_2(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_POPFREE_2
+# define PERL_ARGS_ASSERT_RPP_POPFREE_2         \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_2_NN(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_POPFREE_2_NN
+# define PERL_ARGS_ASSERT_RPP_POPFREE_2_NN      \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_to(pTHX_ SV **sp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO        \
-        assert(sp)
+        Perl_assert_aTHX; assert(sp)
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_to_NN(pTHX_ SV **sp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO_NN     \
-        assert(sp)
+        Perl_assert_aTHX; assert(sp)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_1_norc(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1_NORC       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2)
@@ -13478,63 +13949,63 @@ Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_PUSH_2            \
-        assert(sv1); assert(sv2)
+        Perl_assert_aTHX; assert(sv1); assert(sv2)
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_IMM(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_IMM          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_1_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1_NN    \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_IMM_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_IMM_NN  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1_COMMON(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_COMMON \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_NN    \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_IMM_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_IMM_NN  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
@@ -13542,7 +14013,7 @@ Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT        \
-        assert(sp); assert(sv)
+        Perl_assert_aTHX; assert(sp); assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv)
@@ -13550,7 +14021,7 @@ Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NN     \
-        assert(sp); assert(sv)
+        Perl_assert_aTHX; assert(sp); assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv)
@@ -13558,7 +14029,7 @@ Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC   \
-        assert(sp); assert(sv)
+        Perl_assert_aTHX; assert(sp); assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_norc_NN(pTHX_ SV **sp, SV *sv)
@@ -13566,29 +14037,32 @@ Perl_rpp_replace_at_norc_NN(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC_NN \
-        assert(sp); assert(sv)
+        Perl_assert_aTHX; assert(sp); assert(sv)
 
 PERL_STATIC_INLINE bool
 Perl_rpp_stack_is_rc(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_STACK_IS_RC
+# define PERL_ARGS_ASSERT_RPP_STACK_IS_RC       \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE bool
 Perl_rpp_try_AMAGIC_1(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_1
+# define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_1      \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE bool
 Perl_rpp_try_AMAGIC_2(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_2
+# define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_2      \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_1           \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2)
@@ -13596,28 +14070,30 @@ Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_2           \
-        assert(sv1); assert(sv2)
+        Perl_assert_aTHX; assert(sv1); assert(sv2)
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_IMM(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_IMM         \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE char *
 Perl_savepv(pTHX_ const char *pv)
         Perl_attribute_nonnull_aTHX
         __attribute__malloc__
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SAVEPV
+# define PERL_ARGS_ASSERT_SAVEPV                \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE char *
 Perl_savepvn(pTHX_ const char *pv, Size_t len)
         Perl_attribute_nonnull_aTHX
         __attribute__malloc__
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SAVEPVN
+# define PERL_ARGS_ASSERT_SAVEPVN               \
+        Perl_assert_aTHX
 
 PERL_STATIC_INLINE char *
 Perl_savesharedsvpv(pTHX_ SV *sv)
@@ -13626,7 +14102,7 @@ Perl_savesharedsvpv(pTHX_ SV *sv)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVESHAREDSVPV        \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE char *
 Perl_savesvpv(pTHX_ SV *sv)
@@ -13635,7 +14111,7 @@ Perl_savesvpv(pTHX_ SV *sv)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVESVPV              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE unsigned
 Perl_single_1bit_pos32(U32 word)
@@ -13650,28 +14126,28 @@ Perl_sv_pvbyten_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE_WRAPPER \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE char *
 Perl_sv_pvutf8n_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE_WRAPPER \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE char  *
 Perl_sv_setpv_freshbuf(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_SETPV_FRESHBUF     \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_STATIC_INLINE void
 Perl_switch_argstack(pTHX_ AV *to)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SWITCH_ARGSTACK       \
-        assert(to); assert(SvTYPE(to) == SVt_PVAV)
+        Perl_assert_aTHX; assert(to); assert(SvTYPE(to) == SVt_PVAV)
 
 PERL_STATIC_INLINE IV
 Perl_utf8_distance(pTHX_ const U8 *a, const U8 *b)
@@ -13680,7 +14156,7 @@ Perl_utf8_distance(pTHX_ const U8 *a, const U8 *b)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_DISTANCE         \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop(const U8 *s, SSize_t off)
@@ -13722,7 +14198,7 @@ Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void **free_me)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_NEW_PV  \
-        assert(s_ptr); assert(lenp); assert(free_me)
+        Perl_assert_aTHX; assert(s_ptr); assert(lenp); assert(free_me)
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
@@ -13730,7 +14206,7 @@ Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_OVERWRITE \
-        assert(s_ptr); assert(lenp)
+        Perl_assert_aTHX; assert(s_ptr); assert(lenp)
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
@@ -13738,7 +14214,7 @@ Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_TEMP_PV \
-        assert(s_ptr); assert(lenp)
+        Perl_assert_aTHX; assert(s_ptr); assert(lenp)
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs)
@@ -13761,7 +14237,7 @@ Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR_BUF     \
-        assert(s); assert(send); assert(s <= send)
+        Perl_assert_aTHX; assert(s); assert(send); assert(s <= send)
 
 PERL_STATIC_INLINE UV
 Perl_utf8n_to_uvchr_msgs(const U8 * const s0, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors, AV **msgs)
@@ -13774,14 +14250,14 @@ Perl_uv_to_utf8(pTHX_ U8 *d, UV uv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8            \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_STATIC_INLINE U8 *
 Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8_FLAGS      \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_STATIC_INLINE UV
 Perl_valid_utf8_to_uv(const U8 *s, STRLEN *retlen)
@@ -13800,77 +14276,77 @@ Perl_cx_popblock(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPBLOCK           \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popeval(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPEVAL            \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popformat(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPFORMAT          \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popgiven(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPGIVEN           \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPLOOP            \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB             \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub_args(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_ARGS        \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_COMMON      \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_popwhen(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPWHEN            \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE PERL_CONTEXT *
 Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV **sp, I32 saveix)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CX_PUSHBLOCK          \
-        assert(sp)
+        Perl_assert_aTHX; assert(sp)
 
 PERL_STATIC_INLINE void
 Perl_cx_pusheval(pTHX_ PERL_CONTEXT *cx, OP *retop, SV *namesv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHEVAL           \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
@@ -13878,7 +14354,7 @@ Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHFORMAT         \
-        assert(cx); assert(cv); \
+        Perl_assert_aTHX; assert(cx); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE void
@@ -13886,7 +14362,7 @@ Perl_cx_pushgiven(pTHX_ PERL_CONTEXT *cx, SV *orig_defsv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHGIVEN          \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave)
@@ -13894,14 +14370,14 @@ Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_FOR       \
-        assert(cx); assert(itervarp)
+        Perl_assert_aTHX; assert(cx); assert(itervarp)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushloop_plain(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_PLAIN     \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
@@ -13909,7 +14385,7 @@ Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHSUB            \
-        assert(cx); assert(cv); \
+        Perl_assert_aTHX; assert(cx); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE void
@@ -13917,26 +14393,27 @@ Perl_cx_pushtry(pTHX_ PERL_CONTEXT *cx, OP *retop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHTRY            \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_pushwhen(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHWHEN           \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE void
 Perl_cx_topblock(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_TOPBLOCK           \
-        assert(cx)
+        Perl_assert_aTHX; assert(cx)
 
 PERL_STATIC_INLINE U8
 Perl_gimme_V(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GIMME_V
+# define PERL_ARGS_ASSERT_GIMME_V               \
+        Perl_assert_aTHX
 
 # if !defined(HAS_STRLCAT)
 PERL_STATIC_INLINE Size_t
@@ -13964,7 +14441,7 @@ S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_OR_PV_POS_U2B    \
-        assert(sv); assert(pv)
+        Perl_assert_aTHX; assert(sv); assert(pv)
 
 PERL_STATIC_INLINE Size_t
 S_variant_under_utf8_count(const U8 * const s, const U8 * const e)
@@ -14060,16 +14537,17 @@ S_get_regex_charset_name(const U32 flags, STRLEN * const lenp)
            defined(PERL_IN_UTF8_C) */
 # if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY)
-#   define PERL_ARGS_ASSERT_ADD_CP_TO_INVLIST
+#   define PERL_ARGS_ASSERT_ADD_CP_TO_INVLIST   \
+        Perl_assert_aTHX
 
 #   define PERL_ARGS_ASSERT_INVLIST_EXTEND      \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 #   define PERL_ARGS_ASSERT_INVLIST_HIGHEST     \
         assert(invlist)
 
 #   define PERL_ARGS_ASSERT_INVLIST_SET_LEN     \
-        assert(invlist)
+        Perl_assert_aTHX; assert(invlist)
 
 # endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) ||
            defined(PERL_IN_REGCOMP_ANY) */
@@ -14151,7 +14629,7 @@ Perl_cop_file_avn(pTHX_ const COP *cop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_COP_FILE_AVN        \
-        assert(cop)
+        Perl_assert_aTHX; assert(cop)
 
 # endif
 # if !defined(WIN32)
@@ -14164,12 +14642,13 @@ Perl_get_context(void)
 #endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #if defined(PERL_RC_STACK)
 # define PERL_ARGS_ASSERT_PP_WRAP               \
-        assert(real_pp_fn)
+        Perl_assert_aTHX; assert(real_pp_fn)
 
 PERL_CALLCONV int
 Perl_runops_wrap(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_RUNOPS_WRAP
+# define PERL_ARGS_ASSERT_RUNOPS_WRAP           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
@@ -14177,7 +14656,7 @@ Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_XS_WRAP               \
-        assert(xsub); assert(cv); \
+        Perl_assert_aTHX; assert(xsub); assert(cv); \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
@@ -14217,7 +14696,7 @@ Perl_unlnk(pTHX_ const char *f)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UNLNK                 \
-        assert(f)
+        Perl_assert_aTHX; assert(f)
 
 #endif
 #if defined(USE_C_BACKTRACE)
@@ -14226,31 +14705,35 @@ Perl_dump_c_backtrace(pTHX_ PerlIO *fp, int max_depth, int skip)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_C_BACKTRACE      \
-        assert(fp)
+        Perl_assert_aTHX; assert(fp)
 
 PERL_CALLCONV Perl_c_backtrace *
 Perl_get_c_backtrace(pTHX_ int max_depth, int skip)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_GET_C_BACKTRACE
+# define PERL_ARGS_ASSERT_GET_C_BACKTRACE       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_get_c_backtrace_dump(pTHX_ int max_depth, int skip)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GET_C_BACKTRACE_DUMP
+# define PERL_ARGS_ASSERT_GET_C_BACKTRACE_DUMP  \
+        Perl_assert_aTHX
 
 #endif /* defined(USE_C_BACKTRACE) */
 #if defined(USE_DTRACE)
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_CALL     \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+        Perl_assert_aTHX; assert(cv); \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_LOAD     \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_OP       \
-        assert(op)
+        Perl_assert_aTHX; assert(op)
 
-# define PERL_ARGS_ASSERT_DTRACE_PROBE_PHASE
+# define PERL_ARGS_ASSERT_DTRACE_PROBE_PHASE    \
+        Perl_assert_aTHX
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
@@ -14276,7 +14759,7 @@ Perl_alloccopstash(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_ALLOCCOPSTASH         \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void *
 Perl_any_dup(pTHX_ void *v, const PerlInterpreter *proto_perl)
@@ -14284,7 +14767,7 @@ Perl_any_dup(pTHX_ void *v, const PerlInterpreter *proto_perl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ANY_DUP               \
-        assert(proto_perl)
+        Perl_assert_aTHX; assert(proto_perl)
 
 PERL_CALLCONV void
 Perl_clone_params_del(CLONE_PARAMS *param)
@@ -14306,7 +14789,7 @@ Perl_cx_dup(pTHX_ PERL_CONTEXT *cx, I32 ix, I32 max, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CX_DUP                \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV DIR *
 Perl_dirp_dup(pTHX_ DIR * const dp, CLONE_PARAMS * const param)
@@ -14314,14 +14797,14 @@ Perl_dirp_dup(pTHX_ DIR * const dp, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DIRP_DUP              \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV PerlIO *
 Perl_fp_dup(pTHX_ PerlIO * const fp, const char type, CLONE_PARAMS * const param)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_FP_DUP                \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV GP *
 Perl_gp_dup(pTHX_ GP * const gp, CLONE_PARAMS * const param)
@@ -14329,7 +14812,7 @@ Perl_gp_dup(pTHX_ GP * const gp, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GP_DUP                \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV HE *
 Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS *param)
@@ -14337,7 +14820,7 @@ Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HE_DUP                \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV HEK *
 Perl_hek_dup(pTHX_ HEK *e, CLONE_PARAMS *param)
@@ -14345,7 +14828,7 @@ Perl_hek_dup(pTHX_ HEK *e, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HEK_DUP               \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV MAGIC *
 Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS * const param)
@@ -14353,7 +14836,7 @@ Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MG_DUP                \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV struct mro_meta *
 Perl_mro_meta_dup(pTHX_ struct mro_meta *smeta, CLONE_PARAMS *param)
@@ -14362,7 +14845,7 @@ Perl_mro_meta_dup(pTHX_ struct mro_meta *smeta, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MRO_META_DUP          \
-        assert(smeta); assert(param)
+        Perl_assert_aTHX; assert(smeta); assert(param)
 
 PERL_CALLCONV OP *
 Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
@@ -14370,7 +14853,7 @@ Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWPADOP              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV PADLIST *
 Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
@@ -14380,7 +14863,7 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADLIST_DUP           \
-        assert(srcpad); assert(param)
+        Perl_assert_aTHX; assert(srcpad); assert(param)
 
 PERL_CALLCONV PADNAME *
 Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
@@ -14390,7 +14873,7 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADNAME_DUP           \
-        assert(src); assert(param)
+        Perl_assert_aTHX; assert(src); assert(param)
 
 PERL_CALLCONV PADNAMELIST *
 Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
@@ -14399,14 +14882,14 @@ Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADNAMELIST_DUP       \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV yy_parser *
 Perl_parser_dup(pTHX_ const yy_parser * const proto, CLONE_PARAMS * const param)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSER_DUP            \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV PerlInterpreter *
 perl_clone(PerlInterpreter *proto_perl, UV flags)
@@ -14421,7 +14904,7 @@ Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_RE_DUP_GUTS           \
-        assert(sstr); assert(dstr); assert(param)
+        Perl_assert_aTHX; assert(sstr); assert(dstr); assert(param)
 
 PERL_CALLCONV void *
 Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
@@ -14429,7 +14912,7 @@ Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_REGDUPE_INTERNAL      \
-        assert(rx); assert(param)
+        Perl_assert_aTHX; assert(rx); assert(param)
 
 PERL_CALLCONV void
 Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const param)
@@ -14438,7 +14921,7 @@ Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const p
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_RVPV_DUP              \
-        assert(dsv); assert(ssv); assert(param)
+        Perl_assert_aTHX; assert(dsv); assert(ssv); assert(param)
 
 PERL_CALLCONV PERL_SI *
 Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS *param)
@@ -14446,7 +14929,7 @@ Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SI_DUP                \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV ANY *
 Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS *param)
@@ -14455,7 +14938,7 @@ Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SS_DUP                \
-        assert(proto_perl); assert(param)
+        Perl_assert_aTHX; assert(proto_perl); assert(param)
 
 PERL_CALLCONV SV *
 Perl_sv_dup(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
@@ -14463,7 +14946,7 @@ Perl_sv_dup(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP                \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 PERL_CALLCONV SV *
 Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
@@ -14471,7 +14954,7 @@ Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP_INC            \
-        assert(param)
+        Perl_assert_aTHX; assert(param)
 
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV void
@@ -14481,7 +14964,7 @@ Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_OP_RELOCATE_SV      \
-        assert(svp); assert(targp)
+        Perl_assert_aTHX; assert(svp); assert(targp)
 
 # endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #else /* if !defined(USE_ITHREADS) */
@@ -14493,7 +14976,7 @@ Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_COPFILEGV_SET       \
-        assert(c); assert(gv)
+        Perl_assert_aTHX; assert(c); assert(gv)
 
 # endif
 #endif /* !defined(USE_ITHREADS) */
@@ -14505,7 +14988,7 @@ Perl_magic_freecollxfrm(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_FREECOLLXFRM    \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
@@ -14514,10 +14997,10 @@ Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_SETCOLLXFRM     \
-        assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(sv); assert(mg)
 
 # define PERL_ARGS_ASSERT_STRXFRM               \
-        assert(src)
+        Perl_assert_aTHX; assert(src)
 
 PERL_CALLCONV char *
 Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
@@ -14525,7 +15008,7 @@ Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_COLLXFRM_FLAGS     \
-        assert(sv); assert(nxp)
+        Perl_assert_aTHX; assert(sv); assert(nxp)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
@@ -14545,7 +15028,7 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string, STRLEN len, STRLEN *xlen, boo
 # if defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
      defined(PERL_IN_SV_C)
 #   define PERL_ARGS_ASSERT_MEM_COLLXFRM_       \
-        assert(input_string); assert(xlen)
+        Perl_assert_aTHX; assert(input_string); assert(xlen)
 
 # endif
 # if defined(USE_THREADS)
@@ -14555,7 +15038,7 @@ Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_COLLXFRM         \
-        assert(sv); assert(nxp)
+        Perl_assert_aTHX; assert(sv); assert(nxp)
 
 # endif
 #endif /* defined(USE_LOCALE_COLLATE) */
@@ -14569,140 +15052,162 @@ Perl_warn_problematic_locale(void);
 PERL_CALLCONV void
 Perl_PerlIO_clearerr(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_CLEARERR
+# define PERL_ARGS_ASSERT_PERLIO_CLEARERR       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlIO_close(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_CLOSE
+# define PERL_ARGS_ASSERT_PERLIO_CLOSE          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlIO_eof(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_EOF
+# define PERL_ARGS_ASSERT_PERLIO_EOF            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlIO_error(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_ERROR
+# define PERL_ARGS_ASSERT_PERLIO_ERROR          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlIO_fileno(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_FILENO
+# define PERL_ARGS_ASSERT_PERLIO_FILENO         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlIO_fill(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_FILL
+# define PERL_ARGS_ASSERT_PERLIO_FILL           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlIO_flush(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_FLUSH
+# define PERL_ARGS_ASSERT_PERLIO_FLUSH          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV STDCHAR *
 Perl_PerlIO_get_base(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_GET_BASE
+# define PERL_ARGS_ASSERT_PERLIO_GET_BASE       \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_get_bufsiz(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_PERLIO_GET_BUFSIZ
+# define PERL_ARGS_ASSERT_PERLIO_GET_BUFSIZ     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_get_cnt(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_PERLIO_GET_CNT
+# define PERL_ARGS_ASSERT_PERLIO_GET_CNT        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV STDCHAR *
 Perl_PerlIO_get_ptr(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_GET_PTR
+# define PERL_ARGS_ASSERT_PERLIO_GET_PTR        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_read(pTHX_ PerlIO *f, void *vbuf, Size_t count)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_READ           \
-        assert(vbuf)
+        Perl_assert_aTHX; assert(vbuf)
 
 PERL_CALLCONV void
 Perl_PerlIO_restore_errno(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_RESTORE_ERRNO
+# define PERL_ARGS_ASSERT_PERLIO_RESTORE_ERRNO  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_PerlIO_save_errno(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_SAVE_ERRNO
+# define PERL_ARGS_ASSERT_PERLIO_SAVE_ERRNO     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV int
 Perl_PerlIO_seek(pTHX_ PerlIO *f, Off_t offset, int whence)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_SEEK
+# define PERL_ARGS_ASSERT_PERLIO_SEEK           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_PerlIO_set_cnt(pTHX_ PerlIO *f, SSize_t cnt)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_SET_CNT
+# define PERL_ARGS_ASSERT_PERLIO_SET_CNT        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_PerlIO_set_ptrcnt(pTHX_ PerlIO *f, STDCHAR *ptr, SSize_t cnt)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_SET_PTRCNT
+# define PERL_ARGS_ASSERT_PERLIO_SET_PTRCNT     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_PerlIO_setlinebuf(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_SETLINEBUF
+# define PERL_ARGS_ASSERT_PERLIO_SETLINEBUF     \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stderr(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_PERLIO_STDERR
+# define PERL_ARGS_ASSERT_PERLIO_STDERR         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stdin(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_PERLIO_STDIN
+# define PERL_ARGS_ASSERT_PERLIO_STDIN          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stdout(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_PERLIO_STDOUT
+# define PERL_ARGS_ASSERT_PERLIO_STDOUT         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV Off_t
 Perl_PerlIO_tell(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PERLIO_TELL
+# define PERL_ARGS_ASSERT_PERLIO_TELL           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_unread(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_UNREAD         \
-        assert(vbuf)
+        Perl_assert_aTHX; assert(vbuf)
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_WRITE          \
-        assert(vbuf)
+        Perl_assert_aTHX; assert(vbuf)
 
 #endif /* defined(USE_PERLIO) */
 #if defined(USE_PERL_SWITCH_LOCALE_CONTEXT)
 PERL_CALLCONV void
 Perl_switch_locale_context(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SWITCH_LOCALE_CONTEXT
+# define PERL_ARGS_ASSERT_SWITCH_LOCALE_CONTEXT \
+        Perl_assert_aTHX
 
 #endif
 #if defined(USE_QUADMATH)
@@ -14725,7 +15230,8 @@ Perl_quadmath_format_valid(const char *format)
 PERL_CALLCONV void
 Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SVREFCNT_DEC_SET_NULL
+# define PERL_ARGS_ASSERT_SVREFCNT_DEC_SET_NULL \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
@@ -14741,7 +15247,7 @@ Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, i
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_OPEN               \
-        assert(gv); assert(name)
+        Perl_assert_aTHX; assert(gv); assert(name)
 
 PERL_CALLCONV Size_t
 Perl_expected_size(UV size);
@@ -14761,27 +15267,31 @@ Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_FOLDEQ_UTF8           \
-        assert(s1); assert(s2)
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_CALLCONV GV *
 Perl_gv_AVadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_AVADD
+# define PERL_ARGS_ASSERT_GV_AVADD              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV GV *
 Perl_gv_HVadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_HVADD
+# define PERL_ARGS_ASSERT_GV_HVADD              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV GV *
 Perl_gv_IOadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_IOADD
+# define PERL_ARGS_ASSERT_GV_IOADD              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV GV *
 Perl_gv_SVadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_SVADD
+# define PERL_ARGS_ASSERT_GV_SVADD              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
@@ -14789,21 +15299,21 @@ Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GV_EFULLNAME3         \
-        assert(sv); assert(gv)
+        Perl_assert_aTHX; assert(sv); assert(gv)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GV_FETCHMETH          \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GV_FETCHMETH_AUTOLOAD \
-        assert(name)
+        Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name)
@@ -14811,7 +15321,7 @@ Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GV_FETCHMETHOD        \
-        assert(stash); assert(name)
+        Perl_assert_aTHX; assert(stash); assert(name)
 
 PERL_CALLCONV void
 Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
@@ -14819,7 +15329,7 @@ Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GV_FULLNAME3          \
-        assert(sv); assert(gv)
+        Perl_assert_aTHX; assert(sv); assert(gv)
 
 PERL_CALLCONV void
 Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
@@ -14827,21 +15337,22 @@ Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GV_INIT               \
-        assert(gv); assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
+        Perl_assert_aTHX; assert(gv); \
+        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV SV *
 Perl_hv_delete(pTHX_ HV *hv, const char *key, I32 klen, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_DELETE             \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
 
 PERL_CALLCONV SV *
 Perl_hv_delete_ent(pTHX_ HV *hv, SV *keysv, I32 flags, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_DELETE_ENT         \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
 
 PERL_CALLCONV bool
 Perl_hv_exists(pTHX_ HV *hv, const char *key, I32 klen)
@@ -14849,7 +15360,7 @@ Perl_hv_exists(pTHX_ HV *hv, const char *key, I32 klen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HV_EXISTS             \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
 
 PERL_CALLCONV bool
 Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
@@ -14857,21 +15368,21 @@ Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HV_EXISTS_ENT         \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
 
 PERL_CALLCONV SV **
 Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_FETCH              \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
 
 PERL_CALLCONV HE *
 Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_FETCH_ENT          \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
 
 PERL_CALLCONV HE *
 Perl_hv_iternext(pTHX_ HV *hv)
@@ -14879,38 +15390,38 @@ Perl_hv_iternext(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HV_ITERNEXT           \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_magic(pTHX_ HV *hv, GV *gv, int how)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_MAGIC              \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV **
 Perl_hv_store(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_HV_STORE              \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV HE *
 Perl_hv_store_ent(pTHX_ HV *hv, SV *key, SV *val, U32 hash)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_HV_STORE_ENT          \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV SV **
 Perl_hv_store_flags(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash, int flags)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_HV_STORE_FLAGS        \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_hv_undef(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_HV_UNDEF              \
-        assert(!hv || SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV I32
 Perl_ibcmp(pTHX_ const char *a, const char *b, I32 len)
@@ -14920,7 +15431,7 @@ Perl_ibcmp(pTHX_ const char *a, const char *b, I32 len)
         __attribute__warn_unused_result__
         __attribute__pure__;
 # define PERL_ARGS_ASSERT_IBCMP                 \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_CALLCONV I32
 Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
@@ -14930,7 +15441,7 @@ Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
         __attribute__warn_unused_result__
         __attribute__pure__;
 # define PERL_ARGS_ASSERT_IBCMP_LOCALE          \
-        assert(a); assert(b)
+        Perl_assert_aTHX; assert(a); assert(b)
 
 PERL_CALLCONV I32
 Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
@@ -14938,7 +15449,7 @@ Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_IBCMP_UTF8            \
-        assert(s1); assert(s2)
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_CALLCONV char *
 Perl_instr(const char *big, const char *little)
@@ -15029,97 +15540,110 @@ Perl_is_utf8_valid_partial_char(const U8 * const s0, const U8 * const e)
 PERL_CALLCONV CV *
 Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_NEWATTRSUB
+# define PERL_ARGS_ASSERT_NEWATTRSUB            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV AV *
 Perl_newAV(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV
+# define PERL_ARGS_ASSERT_NEWAV                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV AV *
 Perl_newAV_alloc_x(pTHX_ SSize_t size)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV_ALLOC_X
+# define PERL_ARGS_ASSERT_NEWAV_ALLOC_X         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV AV *
 Perl_newAV_alloc_xz(pTHX_ SSize_t size)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV_ALLOC_XZ
+# define PERL_ARGS_ASSERT_NEWAV_ALLOC_XZ        \
+        Perl_assert_aTHX
 
 PERL_CALLCONV AV *
 Perl_newAV_mortal(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV_MORTAL
+# define PERL_ARGS_ASSERT_NEWAV_MORTAL          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV GV *
 Perl_newGVgen(pTHX_ const char *pack)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_NEWGVGEN              \
-        assert(pack)
+        Perl_assert_aTHX; assert(pack)
 
 PERL_CALLCONV HV *
 Perl_newHV(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWHV
+# define PERL_ARGS_ASSERT_NEWHV                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV IO *
 Perl_newIO(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWIO
+# define PERL_ARGS_ASSERT_NEWIO                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV CV *
 Perl_newSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *block)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_NEWSUB
+# define PERL_ARGS_ASSERT_NEWSUB                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVsv(pTHX_ SV * const old)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWSVSV
+# define PERL_ARGS_ASSERT_NEWSVSV               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVsv_nomg(pTHX_ SV * const old)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWSVSV_NOMG
+# define PERL_ARGS_ASSERT_NEWSVSV_NOMG          \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_lvalue(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_OP_LVALUE
+# define PERL_ARGS_ASSERT_OP_LVALUE             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV const char *
 Perl_phase_name(pTHX_ enum perl_phase phase)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PHASE_NAME
+# define PERL_ARGS_ASSERT_PHASE_NAME            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_qerror(pTHX_ SV *err)
         Perl_attribute_nonnull_aTHX
         __attribute__deprecated__;
-# define PERL_ARGS_ASSERT_QERROR
+# define PERL_ARGS_ASSERT_QERROR                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_resume_compcv_and_save(pTHX_ struct suspended_compcv *buffer)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RESUME_COMPCV_AND_SAVE \
-        assert(buffer)
+        Perl_assert_aTHX; assert(buffer)
 
 PERL_CALLCONV void
 Perl_resume_compcv_final(pTHX_ struct suspended_compcv *buffer)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RESUME_COMPCV_FINAL   \
-        assert(buffer)
+        Perl_assert_aTHX; assert(buffer)
 
 PERL_CALLCONV void
 Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
@@ -15127,22 +15651,26 @@ Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SAVE_AELEM            \
-        assert(av); assert(SvTYPE(av) == SVt_PVAV); assert(sptr)
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_freeop(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_FREEOP
+# define PERL_ARGS_ASSERT_SAVE_FREEOP           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_freepv(pTHX_ char *pv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_FREEPV
+# define PERL_ARGS_ASSERT_SAVE_FREEPV           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_freesv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_FREESV
+# define PERL_ARGS_ASSERT_SAVE_FREESV           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
@@ -15151,19 +15679,21 @@ Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SAVE_HELEM            \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(sptr)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(key); assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_mortalizesv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SAVE_MORTALIZESV      \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_save_op(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_OP
+# define PERL_ARGS_ASSERT_SAVE_OP               \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
@@ -15178,21 +15708,21 @@ Perl_sv_2bool(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2BOOL              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV IV
 Perl_sv_2iv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2IV                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pv(pTHX_ SV *sv, STRLEN *lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2PV                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pv_nolen(pTHX_ SV *sv)
@@ -15200,14 +15730,14 @@ Perl_sv_2pv_nolen(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_2PV_NOLEN          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pvbyte(pTHX_ SV *sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2PVBYTE            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
@@ -15215,14 +15745,14 @@ Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_2PVBYTE_NOLEN      \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pvutf8(pTHX_ SV *sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2PVUTF8            \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
@@ -15230,14 +15760,14 @@ Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_2PVUTF8_NOLEN      \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV UV
 Perl_sv_2uv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2UV                \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
@@ -15245,7 +15775,7 @@ Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_CATPVN             \
-        assert(dsv); assert(sstr)
+        Perl_assert_aTHX; assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
 Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
@@ -15253,21 +15783,21 @@ Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_CATPVN_MG          \
-        assert(dsv); assert(sstr)
+        Perl_assert_aTHX; assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
 Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_CATSV              \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_CATSV_MG           \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
 Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv)
@@ -15275,7 +15805,7 @@ Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_COPYPV             \
-        assert(dsv); assert(ssv)
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 PERL_CALLCONV void
 Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv)
@@ -15283,19 +15813,20 @@ Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_COPYPV_NOMG        \
-        assert(dsv); assert(ssv)
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 PERL_CALLCONV I32
 Perl_sv_eq(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_EQ
+# define PERL_ARGS_ASSERT_SV_EQ                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_force_normal(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_FORCE_NORMAL       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char * const little, const STRLEN littlelen)
@@ -15303,48 +15834,56 @@ Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, c
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_SV_INSERT             \
-        assert(bigstr); assert(little)
+        Perl_assert_aTHX; assert(bigstr); assert(little)
 
 PERL_CALLCONV SV *
 Perl_sv_mortalcopy(pTHX_ SV * const oldsv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_MORTALCOPY
+# define PERL_ARGS_ASSERT_SV_MORTALCOPY         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_sv_numcmp(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMCMP
+# define PERL_ARGS_ASSERT_SV_NUMCMP             \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numeq(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMEQ
+# define PERL_ARGS_ASSERT_SV_NUMEQ              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numge(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMGE
+# define PERL_ARGS_ASSERT_SV_NUMGE              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numgt(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMGT
+# define PERL_ARGS_ASSERT_SV_NUMGT              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numle(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMLE
+# define PERL_ARGS_ASSERT_SV_NUMLE              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numlt(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMLT
+# define PERL_ARGS_ASSERT_SV_NUMLT              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV bool
 Perl_sv_numne(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMNE
+# define PERL_ARGS_ASSERT_SV_NUMNE              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_sv_pv(pTHX_ SV *sv)
@@ -15352,7 +15891,7 @@ Perl_sv_pv(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_PV                 \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_pvbyte(pTHX_ SV *sv)
@@ -15360,14 +15899,14 @@ Perl_sv_pvbyte(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_PVBYTE             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_pvn_force(pTHX_ SV *sv, STRLEN *lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVN_FORCE          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
 Perl_sv_pvutf8(pTHX_ SV *sv)
@@ -15375,82 +15914,83 @@ Perl_sv_pvutf8(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_PVUTF8             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_setsv(pTHX_ SV *dsv, SV *ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_SETSV              \
-        assert(dsv)
+        Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV bool
 Perl_sv_streq(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_STREQ
+# define PERL_ARGS_ASSERT_SV_STREQ              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_sv_taint(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_TAINT              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_unref(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_UNREF              \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_USEPVN             \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_USEPVN_MG          \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_utf8_downgrade(pTHX_ SV * const sv, const bool fail_ok)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE     \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_utf8_downgrade_nomg(pTHX_ SV * const sv, const bool fail_ok)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_NOMG \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE       \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_NOMG  \
-        assert(sv)
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV UV
 Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -15458,7 +15998,7 @@ Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_TO_UNI_FOLD           \
-        assert(p); assert(lenp)
+        Perl_assert_aTHX; assert(p); assert(lenp)
 
 PERL_CALLCONV U8 *
 Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
@@ -15527,35 +16067,35 @@ Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8_MSGS       \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UVCHR_TO_UTF8         \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS   \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS_MSGS \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_CALLCONV U8 *
 Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS \
-        assert(d)
+        Perl_assert_aTHX; assert(d)
 
 PERL_CALLCONV UV
 Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
@@ -15569,17 +16109,19 @@ Perl_whichsig(pTHX_ const char *sig)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_WHICHSIG              \
-        assert(sig)
+        Perl_assert_aTHX; assert(sig)
 
 PERL_CALLCONV void
 Perl_thread_locale_init(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT
+# define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT    \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_thread_locale_term(pTHX)
         Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM
+# define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM    \
+        Perl_assert_aTHX
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 /* PERL_CALLCONV U8 *
@@ -15608,21 +16150,21 @@ Perl_do_aspawn(pTHX_ SV *really, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_DO_ASPAWN             \
-        assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(mark); assert(sp)
 
 PERL_CALLCONV int
 Perl_do_spawn(pTHX_ char *cmd)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN              \
-        assert(cmd)
+        Perl_assert_aTHX; assert(cmd)
 
 PERL_CALLCONV int
 Perl_do_spawn_nowait(pTHX_ char *cmd)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN_NOWAIT       \
-        assert(cmd)
+        Perl_assert_aTHX; assert(cmd)
 
 #endif /* defined(VMS) || defined(WIN32) */
 #if defined(WIN32)
@@ -15635,7 +16177,8 @@ PERL_CALLCONV bool
 Perl_get_win32_message_utf8ness(pTHX_ const char *string)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_GET_WIN32_MESSAGE_UTF8NESS
+# define PERL_ARGS_ASSERT_GET_WIN32_MESSAGE_UTF8NESS \
+        Perl_assert_aTHX
 
 PERL_CALLCONV_NO_RET void
 win32_croak_not_implemented(const char *fname)
@@ -15651,7 +16194,7 @@ Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC3              \
-        assert(incmd)
+        Perl_assert_aTHX; assert(incmd)
 
 #endif /* !defined(WIN32) */
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4152,10 +4152,13 @@ sub generate_proto_h {
         $ret .= "$func(";
 
         if ($has_context) {
+
+            # Pretend there was an aTHX argument in the first position.
+            unshift $args->@*, "PerlInterpreter* aTHX NN";
             push @attrs, "Perl_attribute_nonnull_aTHX";
 
             $ret .= "pTHX";
-            $ret .= "_ " if $args->@*;
+            $ret .= "_ " if $args->@* > 1;
         }
 
         if (@$args) {
@@ -4221,7 +4224,7 @@ sub generate_proto_h {
                          . " an EPTR form, MPTR, SPTR), NULLOK, or NZ"
                                                if 0 + $nn + $nz + $nullok > 1;
 
-                    push( @nonnull, $n ) if $nn;
+                    push( @nonnull, $n - $has_context) if $nn;
 
                     # A non-pointer shouldn't have a pointer-related modifier.
                     # But typedefs may be pointers without our knowing it, so
@@ -4253,14 +4256,17 @@ sub generate_proto_h {
                         die_at_end "$func: $arg ($n) doesn't have a name\n";
                     }
                     my $argname = $1;
+                    my $is_aTHX = (   $has_context
+                                   && defined $argname
+                                   && $argname eq 'aTHX' && $n == 1);
 
-                    if (   defined $argname
+                    if (! $is_aTHX && defined $argname
                         && ($args_assert_line || $binarycompat))
                     {
                         if ($nn||$nz) {
                             push @asserts, "assert($argname)";
                             if ($nn) {
-                                my $string_n = $n;
+                                my $string_n = $n - $has_context;
                                 $string_n = "pTHX_$string_n" if $has_context;
                                 push @attrs,
                                      "Perl_attribute_nonnull($string_n)";
@@ -4432,6 +4438,7 @@ sub generate_proto_h {
                 }
             }
 
+            shift $args->@* if $has_context;    # Remove implicit aTHX arg
             $ret .= join ", ", @$args;
         }
         else {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4155,7 +4155,6 @@ sub generate_proto_h {
 
             # Pretend there was an aTHX argument in the first position.
             unshift $args->@*, "PerlInterpreter* aTHX NN";
-            push @attrs, "Perl_attribute_nonnull_aTHX";
 
             $ret .= "pTHX";
             $ret .= "_ " if $args->@* > 1;
@@ -4260,7 +4259,12 @@ sub generate_proto_h {
                                    && defined $argname
                                    && $argname eq 'aTHX' && $n == 1);
 
-                    if (! $is_aTHX && defined $argname
+                    if ($is_aTHX) {
+                        if ($nn) {
+                            push @attrs, "Perl_attribute_nonnull_aTHX";
+                        }
+                    }
+                    elsif (   defined $argname
                         && ($args_assert_line || $binarycompat))
                     {
                         if ($nn||$nz) {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4239,7 +4239,8 @@ sub generate_proto_h {
                     $temp_arg =~
                               s/ \s* \b ( struct | enum | union ) \b \s*/ /xg;
                     if ( ($temp_arg ne "...")
-                        && ($temp_arg !~ /\w+\s+(\w+)(?:\[\d+\])?\s*$/) ) {
+                        && ($temp_arg !~ /\w+\s+(\w+)(?:\[\d+\])?\s*$/) )
+                    {
                         die_at_end "$func: $arg ($n) doesn't have a name\n";
                     }
                     my $argname = $1;

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4030,7 +4030,6 @@ sub generate_proto_h {
 
         my @nonnull;
         my $has_depth = ( $flags =~ /W/ );
-        my $has_context = ( $flags !~ /T/ );
         my $never_returns = ( $flags =~ /r/ );
         my $binarycompat = ( $flags =~ /b/ );
         my $has_mflag = ( $flags =~ /m/ );
@@ -4056,6 +4055,11 @@ sub generate_proto_h {
             # gets generated.
             $need_longs{$plain_func} = $args_assert_line = 1;
         }
+
+        # Macros don't have a context parameter unless there is a Perl_ form
+        # generated for them.
+        my $has_context = ($flags !~ /T/ && (   $need_longs{$plain_func}
+                                             || ! $has_mflag));
 
         if (! $can_ignore && $ret_type eq 'void') {
             warn "It is nonsensical to require the return value of a void"

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4261,6 +4261,7 @@ sub generate_proto_h {
 
                     if ($is_aTHX) {
                         if ($nn) {
+                            push @asserts,  "Perl_assert_aTHX";
                             push @attrs, "Perl_attribute_nonnull_aTHX";
                         }
                     }
@@ -4585,9 +4586,11 @@ sub generate_proto_h {
         #endif
 
         #if defined(MULTIPLICITY)
-        #  define Perl_attribute_nonnull_aTHX  __attribute__nonnull__(1)
+          #  define Perl_assert_aTHX             assert(aTHX)
+          #  define Perl_attribute_nonnull_aTHX  __attribute__nonnull__(1)
         #else
-        #  define Perl_attribute_nonnull_aTHX
+          #  define Perl_assert_aTHX
+          #  define Perl_attribute_nonnull_aTHX
         #endif
 
         START_EXTERN_C

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4150,9 +4150,14 @@ sub generate_proto_h {
         $ret = "";
         $ret .= "$retval\n";
         $ret .= "$func(";
-        if ( $has_context ) {
-            $ret .= @$args ? "pTHX_ " : "pTHX";
+
+        if ($has_context) {
+            push @attrs, "Perl_attribute_nonnull_aTHX";
+
+            $ret .= "pTHX";
+            $ret .= "_ " if $args->@*;
         }
+
         if (@$args) {
             die_at_end
                     "$plain_func: n flag is contradicted by having arguments"
@@ -4498,8 +4503,6 @@ sub generate_proto_h {
             die_at_end "$plain_func: Function with '...' arguments must have"
                      . " f or F flag";
         }
-
-        unshift @attrs, "Perl_attribute_nonnull_aTHX" if $has_context;
 
         if ( @attrs ) {
             $ret .= "\n"

--- a/util.c
+++ b/util.c
@@ -3870,11 +3870,12 @@ Perl_report_evil_fh(pTHX_ const GV *gv)
 void
 Perl_init_tm(pTHX_ struct tm *ptm)	/* see mktime, strftime and asctime */
 {
+    PERL_ARGS_ASSERT_INIT_TM;
+    PERL_UNUSED_CONTEXT;
+
 #ifdef HAS_TM_TM_ZONE
     Time_t now;
     const struct tm* my_tm;
-    PERL_UNUSED_CONTEXT;
-    PERL_ARGS_ASSERT_INIT_TM;
     (void)time(&now);
 
     LOCALTIME_LOCK;
@@ -3883,8 +3884,6 @@ Perl_init_tm(pTHX_ struct tm *ptm)	/* see mktime, strftime and asctime */
         Copy(my_tm, ptm, 1, struct tm);
     LOCALTIME_UNLOCK;
 #else
-    PERL_UNUSED_CONTEXT;
-    PERL_ARGS_ASSERT_INIT_TM;
     PERL_UNUSED_ARG(ptm);
 #endif
 }


### PR DESCRIPTION
This is the part of #24257 that I think really should not be deferred.

Blead already has set `__attribute_nonnull__` on the aTHX arguments to every function for non-DEBUGGING builds.  I'm uncomfortable not having equivalent asserts for DEBUGGING

* This set of changes does not require a perldelta entry.
