### PR TITLE
pod: Truncate trailing spaces

### DIFF
--- a/pod/perl5004delta.pod
+++ b/pod/perl5004delta.pod
@@ -349,7 +349,7 @@ The new conversions in Perl's sprintf() are:
    %i	a synonym for %d
    %p	a pointer (the address of the Perl value, in hexadecimal)
    %n	special: *stores* the number of characters output so far
-        into the next variable in the parameter list 
+        into the next variable in the parameter list
 
 The new flags that go between the C<%> and the conversion are:
 
@@ -761,7 +761,7 @@ details on how to get started with building this port.
 
 There is also support for building perl under the Cygwin32 environment.
 Cygwin32 is a set of GNU tools that make it possible to compile and run
-many Unix programs under Windows NT by providing a mostly Unix-like 
+many Unix programs under Windows NT by providing a mostly Unix-like
 interface for compilation and execution.  See F<README.cygwin32> in the
 perl distribution for more details on this port and how to obtain the
 Cygwin32 toolkit.

--- a/pod/perl5005delta.pod
+++ b/pod/perl5005delta.pod
@@ -232,12 +232,12 @@ Note that only the major bug fixes are listed here.  See F<Changes> for others.
 	Backtracking might not restore start of $3.
 	No feedback if max count for * or + on "complex" subexpression
 	    was reached, similarly (but at compile time) for {3,34567}
-	Primitive restrictions on max count introduced to decrease a 
+	Primitive restrictions on max count introduced to decrease a
 	    possibility of a segfault;
 	(ZERO-LENGTH)* could segfault;
 	(ZERO-LENGTH)* was prohibited;
 	Long REs were not allowed;
-	/RE/g could skip matches at the same position after a 
+	/RE/g could skip matches at the same position after a
 	  zero-length match;
 
 =item New regular expression constructs
@@ -504,14 +504,14 @@ the command-line arguments used in F<config.sh>.
 
 BeOS is now supported.  See F<README.beos>.
 
-DOS is now supported under the DJGPP tools.  See F<README.dos> (installed 
+DOS is now supported under the DJGPP tools.  See F<README.dos> (installed
 as L<perldos> on some systems).
 
 MiNT is now supported.  See F<README.mint>.
 
 MPE/iX is now supported.  See README.mpeix.
 
-MVS (aka OS390, aka Open Edition) is now supported.  See F<README.os390> 
+MVS (aka OS390, aka Open Edition) is now supported.  See F<README.os390>
 (installed as L<perlos390> on some systems).
 
 Stratus VOS is now supported.  See F<README.vos>.
@@ -522,7 +522,7 @@ Win32 support has been vastly enhanced.  Support for Perl Object, a C++
 encapsulation of Perl.  GCC and EGCS are now supported on Win32.
 See F<README.win32>, aka L<perlwin32>.
 
-VMS configuration system has been rewritten.  See F<README.vms> (installed 
+VMS configuration system has been rewritten.  See F<README.vms> (installed
 as F<README_vms> on some systems).
 
 The hints files for most Unix platforms have seen incremental improvements.
@@ -691,7 +691,7 @@ Config.pm now has a glossary of variables.
 F<Porting/patching.pod> has detailed instructions on how to create and
 submit patches for perl.
 
-L<perlport> specifies guidelines on how to write portably. 
+L<perlport> specifies guidelines on how to write portably.
 
 L<perlmodinstall> describes how to fetch and install modules from C<CPAN>
 sites.
@@ -872,7 +872,7 @@ method.  Probably indicates an unintended loop in your inheritance hierarchy.
 
 (W) You gave a single reference where Perl was expecting a list with
 an even number of elements (for assignment to a hash). This
-usually means that you used the anon hash constructor when you meant 
+usually means that you used the anon hash constructor when you meant
 to use parens. In any case, a hash requires key/value B<pairs>.
 
     %hash = { one => 1, two => 2, };   # WRONG

--- a/pod/perl5100delta.pod
+++ b/pod/perl5100delta.pod
@@ -246,7 +246,7 @@ overriding the lexical declaration with C<our $_>. (Rafael Garcia-Suarez)
 
 A new prototype character has been added. C<_> is equivalent to C<$> but
 defaults to C<$_> if the corresponding argument isn't supplied (both C<$>
-and C<_> denote a scalar). Due to the optional nature of the argument, 
+and C<_> denote a scalar). Due to the optional nature of the argument,
 you can only use it at the end of a prototype, or before a semicolon.
 
 This has a small incompatible consequence: the prototype() function has
@@ -652,7 +652,7 @@ Assume the following code:
   main calls Foo::Bar::baz()
   Foo::Bar inherits from Foo::Base
   Foo::Bar::baz() calls Foo::Base::_bazbaz()
-  Foo::Base::_bazbaz() calls: warnings::warnif('substr', 'some warning 
+  Foo::Base::_bazbaz() calls: warnings::warnif('substr', 'some warning
 message');
 
 On 5.8.x, the code warns when Foo::Bar contains C<use warnings;>
@@ -1187,7 +1187,7 @@ A new configuration variable, available as C<$Config{d_pseudofork}> in
 the L<Config> module, has been added, to distinguish real fork() support
 from fake pseudofork used on Windows platforms.
 
-A new configuration variable, C<d_printf_format_null>, has been added, 
+A new configuration variable, C<d_printf_format_null>, has been added,
 to see if printf-like formats are allowed to be NULL.
 
 =item Configure help

--- a/pod/perl5101delta.pod
+++ b/pod/perl5101delta.pod
@@ -1043,7 +1043,7 @@ F<win32/buildext.pl>.
 Removed F<libbsd> for AIX 5L and 6.1. Only flock() was used from F<libbsd>.
 
 Removed F<libgdbm> for AIX 5L and 6.1. The F<libgdbm> is delivered as an
-optional package with the AIX Toolbox. Unfortunately the 64 bit version 
+optional package with the AIX Toolbox. Unfortunately the 64 bit version
 is broken.
 
 Hints changes mean that AIX 4.2 should work again.
@@ -1288,7 +1288,7 @@ These have all been fixed.
 
 A 5.10.0 optimisation to clear the temporary stack within the implicit
 loop of C<s///ge> has been reverted, as it turned out to be the cause of
-obscure bugs in seemingly unrelated parts of the interpreter [commit 
+obscure bugs in seemingly unrelated parts of the interpreter [commit
 ef0d4e17921ee3de].
 
 =item *
@@ -1619,7 +1619,7 @@ Tests for the interaction of Unicode properties and threads.
 
 Test the tied methods of C<Tie::Hash::NamedCapture>.
 
-=item t/op/reg_posixcc.t 
+=item t/op/reg_posixcc.t
 
 Check that POSIX character classes behave consistently.
 

--- a/pod/perl5120delta.pod
+++ b/pod/perl5120delta.pod
@@ -496,7 +496,7 @@ longer be used as an attribute.
 =item *
 
 Perl's command-line switch "-P", which was deprecated in version 5.10.0, has
-now been removed. The CPAN module C<< Filter::cpp >> can be used as an 
+now been removed. The CPAN module C<< Filter::cpp >> can be used as an
 alternative.
 
 =back

--- a/pod/perl5121delta.pod
+++ b/pod/perl5121delta.pod
@@ -27,7 +27,7 @@ changes to the core language in this release.
 
 =head2 Pragmata Changes
 
-=over 
+=over
 
 =item *
 
@@ -42,7 +42,7 @@ just exports them directly as functions without the wrapper.
 
 =head2 Updated Modules
 
-=over 
+=over
 
 =item *
 
@@ -93,7 +93,7 @@ We updated the GitHub mirror link in L<perlrepository> to mirrors/perl, not gith
 
 We fixed a minor error in L<perl5114delta>.
 
-=item * 
+=item *
 
 We replaced a mention of the now-obsolete L<Switch> with F<given>/F<when>.
 
@@ -101,11 +101,11 @@ We replaced a mention of the now-obsolete L<Switch> with F<given>/F<when>.
 
 We improved documentation about F<$sitelibexp/sitecustomize.pl> in L<perlrun>.
 
-=item * 
+=item *
 
 We corrected L<perlmodlib> which had unintentionally omitted a number of modules.
 
-=item * 
+=item *
 
 We updated the documentation for 'require' in L<perlfunc> relating to putting Perl code in @INC.
 
@@ -125,7 +125,7 @@ We filled in a blank in L<perlport> with the release date of Perl 5.12.
 
 We fixed broken links in a number of perldelta files.
 
-=item * 
+=item *
 
 The documentation for L<Carp> incorrectly stated that the $Carp::Verbose
 variable makes cluck generate stack backtraces.
@@ -175,9 +175,9 @@ F<perl5db.t>: Fix for test failures when C<Term::ReadLine::Gnu> is installed.
 
 =head2 Configuration improvements
 
-=over 
+=over
 
-=item * 
+=item *
 
 We updated F<INSTALL> with notes about how to deal with broken F<dbm.h>
 on OpenSUSE (and possibly other platforms)
@@ -204,17 +204,17 @@ to the previous nextstate) and a label, the package declaration is now
 emitted first, because it is syntactically impermissible for a label to
 prefix a package declaration.
 
-=item * 
+=item *
 
 XSUB.h now correctly redefines fgets under PERL_IMPLICIT_SYS
 
 See also: L<http://rt.cpan.org/Public/Bug/Display.html?id=55049>
 
-=item * 
+=item *
 
 utf8::is_utf8 now respects GMAGIC (e.g. $1)
 
-=item * 
+=item *
 
 XS code using C<fputc()> or C<fputs()>: on Windows could cause an error
 due to their arguments being swapped.
@@ -226,7 +226,7 @@ See also: L<https://github.com/Perl/perl5/issues/10156>
 We fixed a small bug in lex_stuff_pvn() that caused spurious syntax errors
 in an obscure situation.  It happened when stuffing was performed on the
 last line of a file and the line ended with a statement that lacked a
-terminating semicolon.  
+terminating semicolon.
 
 See also: L<https://github.com/Perl/perl5/issues/10273>
 
@@ -265,7 +265,7 @@ See also: L<https://github.com/Perl/perl5/issues/10193>
 
 =head2 HP-UX
 
-=over 
+=over
 
 =item *
 
@@ -277,7 +277,7 @@ Perl now allows -Duse64bitint without promoting to use64bitall on HP-UX
 
 =over
 
-=item * 
+=item *
 
 Perl now builds on AIX 4.2
 
@@ -290,7 +290,7 @@ and limited support for POSIX C<sigaction()>.
 
 =over
 
-=item * 
+=item *
 
 FreeBSD 7 no longer contains F</usr/bin/objformat>. At build time,
 Perl now skips the F<objformat> check for versions 7 and higher and

--- a/pod/perl5125delta.pod
+++ b/pod/perl5125delta.pod
@@ -22,7 +22,7 @@ This problem has been corrected.  Bug reported by Robert Zacek.
 
 =head2 C<File::Glob::bsd_glob()> memory error with GLOB_ALTDIRFUNC (CVE-2011-2728)
 
-Calling C<File::Glob::bsd_glob> with the unsupported flag GLOB_ALTDIRFUNC would 
+Calling C<File::Glob::bsd_glob> with the unsupported flag GLOB_ALTDIRFUNC would
 cause an access violation / segfault.  A Perl program that accepts a flags value from
 an external source could expose itself to denial of service or arbitrary code
 execution attacks.  There are no known exploits in the wild.  The problem has been

--- a/pod/perl5140delta.pod
+++ b/pod/perl5140delta.pod
@@ -45,7 +45,7 @@ deprecation warning message unless such warnings are turned off.  The
 new name for U+0007 in Perl is C<ALERT>, which corresponds nicely
 with the existing shorthand sequence for it, C<"\a">.  C<\N{BEL}>
 means U+0007, with no warning given.  The character at U+1F514 has no
-name in 5.14, but can be referred to by C<\N{U+1F514}>. 
+name in 5.14, but can be referred to by C<\N{U+1F514}>.
 In Perl 5.16, C<\N{BELL}> will refer to U+1F514; all code
 that uses C<\N{BELL}> should be converted to use C<\N{ALERT}>,
 C<\N{BEL}>, or C<"\a"> before upgrading.
@@ -138,7 +138,7 @@ inconsistent and in places, incorrect.
 
 Unicode non-characters, some of which previously were erroneously
 considered illegal in places by Perl, contrary to the Unicode Standard,
-are now always legal internally.  Inputting or outputting them 
+are now always legal internally.  Inputting or outputting them
 works the same as with the non-legal Unicode code points, because the Unicode
 Standard says they are (only) illegal for "open interchange".
 
@@ -158,7 +158,7 @@ expression now means that the subexpression does not inherit surrounding
 modifiers such as C</i>, but reverts to the Perl defaults.  Any modifiers
 following the caret override the defaults.
 
-Stringification of regular expressions now uses this notation.  
+Stringification of regular expressions now uses this notation.
 For example, C<qr/hlagh/i> would previously be stringified as
 C<(?i-xsm:hlagh)>, but now it's stringified as C<(?^i:hlagh)>.
 
@@ -174,7 +174,7 @@ expressions with fixed strings containing C<?-xism>.
 Four new regular expression modifiers have been added.  These are mutually
 exclusive: one only can be turned on at a time.
 
-=over 
+=over
 
 =item *
 
@@ -207,7 +207,7 @@ For example,
     "k"     =~ /\N{KELVIN SIGN}/ai
     "\xDF" =~ /ss/ai
 
-match but 
+match but
 
     "k"    =~ /\N{KELVIN SIGN}/aai
     "\xDF" =~ /ss/aai
@@ -307,8 +307,8 @@ C<@{}> or C<%{}>:
   push @{$obj->tags}, $new_tag;  # old way
   push $obj->tags,    $new_tag;  # new way
 
-  for ( keys %{$hoh->{genres}{artists}} ) {...} # old way 
-  for ( keys $hoh->{genres}{artists}    ) {...} # new way 
+  for ( keys %{$hoh->{genres}{artists}} ) {...} # old way
+  for ( keys $hoh->{genres}{artists}    ) {...} # new way
 
 =head3 Single term prototype
 
@@ -321,7 +321,7 @@ force scalar context on the argument.  See L<perlsub/Prototypes>.
 A package declaration can now contain a code block, in which case the
 declaration is in scope inside that block only.  So C<package Foo { ... }>
 is precisely equivalent to C<{ package Foo; ... }>.  It also works with
-a version number in the declaration, as in C<package Foo 1.2 { ... }>, 
+a version number in the declaration, as in C<package Foo 1.2 { ... }>,
 which is its most attractive feature.  See L<perlfunc>.
 
 =head3 Statement labels can appear in more places
@@ -354,7 +354,7 @@ to how C<die>, C<warn>, and C<$@> behave.
 
 =over
 
-=item * 
+=item *
 
 When an exception is thrown inside an C<eval>, the exception is no
 longer at risk of being clobbered by destructor code running during unwinding.
@@ -384,7 +384,7 @@ always emitted as a warning, leaving the surrounding C<$@> untouched.
 In addition to object destructors, this also affects any function call
 run by XS code using the C<G_KEEPERR> flag.
 
-=item * 
+=item *
 
 Warnings for C<warn> can now be objects in the same way as exceptions
 for C<die>.  If an object-based warning gets the default handling
@@ -420,7 +420,7 @@ log the seed used for that run so this can later be used to produce the same res
 Perl's printf and sprintf operators, and Perl's internal printf replacement
 function, now understand the C90 size modifiers "hh" (C<char>), "z"
 (C<size_t>), and "t" (C<ptrdiff_t>).  Also, when compiled with a C99
-compiler, Perl now understands the size modifier "j" (C<intmax_t>) 
+compiler, Perl now understands the size modifier "j" (C<intmax_t>)
 (but this is not portable).
 
 So, for example, on any modern machine, C<sprintf("%hhd", 257)> returns "1".
@@ -612,9 +612,9 @@ has come to rely on the incorrect behaviour.
 =head3 Stringification of regexes has changed
 
 Default regular expression modifiers are now notated using
-C<(?^...)>.  Code relying on the old stringification will fail.  
+C<(?^...)>.  Code relying on the old stringification will fail.
 This is so that when new modifiers are added, such code won't
-have to keep changing each time this happens, because the stringification 
+have to keep changing each time this happens, because the stringification
 will automatically incorporate the new modifiers.
 
 Code that needs to work properly with both old- and new-style regexes
@@ -680,7 +680,7 @@ of an empty C<%hash> always returning false in scalar context.
 
 =head3 Clearing stashes
 
-Stash list assignment C<%foo:: = ()> used to make the stash temporarily 
+Stash list assignment C<%foo:: = ()> used to make the stash temporarily
 anonymous while it was being emptied.  Consequently, any of its
 subroutines referenced elsewhere would become anonymous,  showing up as
 "(unknown)" in C<caller>.  They now retain their package names such that
@@ -753,8 +753,8 @@ it as well.
 
 =head3 Parsing of package and variable names
 
-Parsing the names of packages and package variables has changed: 
-multiple adjacent pairs of colons, as in C<foo::::bar>, are now all 
+Parsing the names of packages and package variables has changed:
+multiple adjacent pairs of colons, as in C<foo::::bar>, are now all
 treated as package separators.
 
 Regardless of this change, the exact parsing of package separators has
@@ -956,7 +956,7 @@ course, do not generate the warning.
 =head2 List assignment to C<$[>
 
 Assignment to C<$[> was deprecated and started to give warnings in
-Perl version 5.12.0.  This version of Perl (5.14) now also emits a warning 
+Perl version 5.12.0.  This version of Perl (5.14) now also emits a warning
 when assigning to C<$[> in list context.  This fixes an oversight in 5.12.0.
 
 =head2 Use of qw(...) as parentheses
@@ -1168,7 +1168,7 @@ programs that do not use C<%+> or C<%->.
 
 The internal structures of threading now make fewer API calls and fewer
 allocations, resulting in noticeably smaller object code.  Additionally,
-many thread context checks have been deferred so they're done only 
+many thread context checks have been deferred so they're done only
 as needed (although this is only possible for non-debugging builds).
 
 =head2 Adjacent pairs of nextstate opcodes are now optimized away
@@ -1247,7 +1247,7 @@ a single location for easier maintenance.
 
 =item *
 
-The following modules were added by the L<Unicode::Collate> 
+The following modules were added by the L<Unicode::Collate>
 upgrade.  See below for details.
 
 L<Unicode::Collate::CJK::Big5>
@@ -1318,7 +1318,7 @@ archives to be uploaded to CPAN.
 
 =item *
 
-A new L<ptargrep(1)> utility for using regular expressions against 
+A new L<ptargrep(1)> utility for using regular expressions against
 the contents of files in a tar archive.
 
 =item *
@@ -1421,8 +1421,8 @@ errors" error that ensue if there has been a syntax error
 
 L<CGI> has been upgraded from version 3.48 to 3.52.
 
-This provides the following security fixes: the MIME boundary in 
-multipart_init() is now random and the handling of 
+This provides the following security fixes: the MIME boundary in
+multipart_init() is now random and the handling of
 newlines embedded in header values has been improved.
 
 =item *
@@ -1456,7 +1456,7 @@ Major highlights:
 
 =item * support for L<local::lib>
 
-=item * support for L<HTTP::Tiny> to reduce the dependency on FTP sites 
+=item * support for L<HTTP::Tiny> to reduce the dependency on FTP sites
 
 =item * automatic mirror selection
 
@@ -2088,21 +2088,21 @@ L<Unicode::Collate> has been upgraded from version 0.52_01 to 0.73.
 L<Unicode::Collate> has been updated to use Unicode 6.0.0.
 
 L<Unicode::Collate::Locale> now supports a plethora of new locales: I<ar, be,
-bg, de__phonebook, hu, hy, kk, mk, nso, om, tn, vi, hr, ig, ja, ko, ru, sq, 
+bg, de__phonebook, hu, hy, kk, mk, nso, om, tn, vi, hr, ig, ja, ko, ru, sq,
 se, sr, to, uk, zh, zh__big5han, zh__gb2312han, zh__pinyin>, and I<zh__stroke>.
 
 The following modules have been added:
 
-L<Unicode::Collate::CJK::Big5> for C<zh__big5han> which makes 
+L<Unicode::Collate::CJK::Big5> for C<zh__big5han> which makes
 tailoring of CJK Unified Ideographs in the order of CLDR's big5han ordering.
 
 L<Unicode::Collate::CJK::GB2312> for C<zh__gb2312han> which makes
 tailoring of CJK Unified Ideographs in the order of CLDR's gb2312han ordering.
 
-L<Unicode::Collate::CJK::JISX0208> which makes tailoring of 6355 kanji 
+L<Unicode::Collate::CJK::JISX0208> which makes tailoring of 6355 kanji
 (CJK Unified Ideographs) in the JIS X 0208 order.
 
-L<Unicode::Collate::CJK::Korean> which makes tailoring of CJK Unified Ideographs 
+L<Unicode::Collate::CJK::Korean> which makes tailoring of CJK Unified Ideographs
 in the order of CLDR's Korean ordering.
 
 L<Unicode::Collate::CJK::Pinyin> for C<zh__pinyin> which makes
@@ -2137,7 +2137,7 @@ This upgrade also includes several bug fixes:
 
 =item *
 
-It is now updated to Unicode Version 6.0.0 with I<Corrigendum #8>, 
+It is now updated to Unicode Version 6.0.0 with I<Corrigendum #8>,
 excepting that, just as with Perl 5.14, the code point at U+1F514 has no name.
 
 =item *
@@ -2387,7 +2387,7 @@ Several API functions that process optrees have been newly documented.
 =head3 L<perlvar> revamp
 
 L<perlvar> reorders the variables and groups them by topic.  Each variable
-introduced after Perl 5.000 notes the first version in which it is 
+introduced after Perl 5.000 notes the first version in which it is
 available.  L<perlvar> also has a new section for deprecated variables to
 note when they were removed.
 
@@ -2410,7 +2410,7 @@ is now much more straightforward and clear.
 The L<perlhack> document is now much shorter, and focuses on the Perl 5
 development process and submitting patches to Perl.  The technical content
 has been moved to several new documents, L<perlsource>, L<perlinterp>,
-L<perlhacktut>, and L<perlhacktips>.  This technical content has 
+L<perlhacktut>, and L<perlhacktips>.  This technical content has
 been only lightly edited.
 
 The perlrepository document has been renamed to L<perlgit>.  This new
@@ -2745,7 +2745,7 @@ Improved rebase behaviour
 
 If a DLL is updated on cygwin the old imagebase address is reused.
 This solves most rebase errors, especially when updating on core DLL's.
-See L<http://www.tishler.net/jason/software/rebase/rebase-2.4.2.README> 
+See L<http://www.tishler.net/jason/software/rebase/rebase-2.4.2.README>
 for more information.
 
 =item *
@@ -2762,7 +2762,7 @@ Updated build hints file
 
 =over
 
-=item * 
+=item *
 
 FreeBSD 7 no longer contains F</usr/bin/objformat>.  At build time,
 Perl now skips the F<objformat> check for versions 7 and higher and
@@ -2772,7 +2772,7 @@ assumes ELF (5.12.1).
 
 =head3 HP-UX
 
-=over 
+=over
 
 =item *
 
@@ -3117,7 +3117,7 @@ get-magic is processed.
   sv_collxfrm_flags
 
 In some of these cases, the non-C<_flags> functions have
-been replaced with wrappers around the new functions. 
+been replaced with wrappers around the new functions.
 
 =head3 pv/pvs/sv versions of existing functions
 
@@ -3719,7 +3719,7 @@ causing a memory leak [perl #75176].
 In addition, various other bugs related to typeglobs and stashes have been
 fixed:
 
-=over 
+=over
 
 =item *
 
@@ -4072,7 +4072,7 @@ C<@DB::args> has been fixed (5.12.2).
 
 =item *
 
-Perl no longer stomps on C<$DB::single>, C<$DB::trace>, and C<$DB::signal> 
+Perl no longer stomps on C<$DB::single>, C<$DB::trace>, and C<$DB::signal>
 if these variables already have values when C<$^P> is assigned to [perl #72422].
 
 =item *
@@ -4350,7 +4350,7 @@ sprintf() was ignoring locales when called with constant arguments
 =item *
 
 Combining the vector (C<%v>) flag and dynamic precision would
-cause C<sprintf> to confuse the order of its arguments, making it 
+cause C<sprintf> to confuse the order of its arguments, making it
 treat the string as the precision and vice-versa [perl #83194].
 
 =back

--- a/pod/perl5141delta.pod
+++ b/pod/perl5141delta.pod
@@ -134,7 +134,7 @@ on environment variables has been corrected and expanded.
 
 =head3 L<POSIX>
 
-=over 
+=over
 
 =item *
 
@@ -182,7 +182,7 @@ option, as used by some projects that include perl's header files.
 Some test failures in F<dist/Locale-Maketext/t/09_compile.t> that could
 occur depending on the environment have been fixed. [perl #89896]
 
-=item * 
+=item *
 
 A watchdog timer for F<t/re/re.t> was lengthened to accommodate SH-4 systems
 which were unable to complete the tests before the previous timer ran out.
@@ -204,7 +204,7 @@ None
 
 =head3 Solaris
 
-=over 
+=over
 
 =item *
 
@@ -217,12 +217,12 @@ Solaris 9 and Solaris 10 has been corrected.
 
 =over
 
-=item * 
+=item *
 
 The F<lib/locale.t> test script has been updated to work on the upcoming
 Lion release.
 
-=item * 
+=item *
 
 Mac OS X specific compilation instructions have been clarified.
 
@@ -230,7 +230,7 @@ Mac OS X specific compilation instructions have been clarified.
 
 =head3 Ubuntu Linux
 
-=over 
+=over
 
 =item *
 
@@ -241,7 +241,7 @@ paths on Ubuntu natty.
 
 =head1 Internal Changes
 
-=over 
+=over
 
 =item *
 
@@ -286,7 +286,7 @@ portion of the fold, plus some more.
 
 is one such case.  C<\xDF> folds to C<"ss">.
 
-=item * 
+=item *
 
 Several Unicode case-folding bugs have been fixed.
 

--- a/pod/perl5160delta.pod
+++ b/pod/perl5160delta.pod
@@ -57,7 +57,7 @@ traditionally enabled by default, before they could be turned off.
 
 C<< no feature >> now resets to the default feature set.  To disable all
 features (which is likely to be a pretty special-purpose request, since
-it presumably won't match any named set of semantics) you can now  
+it presumably won't match any named set of semantics) you can now
 write C<< no feature ':all' >>.
 
 C<$[> is now disabled under C<use v5.16>.  It is part of the default
@@ -185,7 +185,7 @@ has been deprecated in Perl since v5.14, and any use of it will raise a
 warning message (unless turned off).  The name "ALERT" is now the
 preferred name for this code point, with "BEL" an acceptable short
 form.  The name for the new cell phone character, at code point U+1F514,
-remains undefined in this version of Perl (hence we don't 
+remains undefined in this version of Perl (hence we don't
 implement quite all of Unicode 6.1), but starting in v5.18, BELL will mean
 this character, and not U+0007.
 
@@ -474,7 +474,7 @@ C<continue> to depend on it.
 
 The C<phase-change> probes will fire when the interpreter's phase
 changes, which tracks the C<${^GLOBAL_PHASE}> variable.  C<arg0> is
-the new phase name; C<arg1> is the old one.  This is useful 
+the new phase name; C<arg1> is the old one.  This is useful
 for limiting your instrumentation to one or more of: compile time,
 run time, or destruct time.
 
@@ -673,7 +673,7 @@ Unescaped literal C<< "{" >> in regular expressions.
 
 Starting with v5.20, it is planned to require a literal C<"{"> to be
 escaped, for example by preceding it with a backslash.  In v5.18, a
-deprecated warning message will be emitted for all such uses.  
+deprecated warning message will be emitted for all such uses.
 This affects only patterns that are to match a literal C<"{">.  Other
 uses of this character, such as part of a quantifier or sequence as in
 those below, are completely unaffected:
@@ -3497,7 +3497,7 @@ return value of C<substr> is referenced and later assigned to.
 
 Passing a substring of a read-only value or a typeglob to a function
 (potential lvalue context) no longer causes an immediate "Can't coerce"
-or "Modification of a read-only value" error.  That error occurs only 
+or "Modification of a read-only value" error.  That error occurs only
 if the passed value is assigned to.
 
 The same thing happens with the "substr outside of string" error.  If
@@ -4192,8 +4192,8 @@ because the optimizer optimizes away some of Configure's tests.  A
 workaround is to omit the C<-flto> flag when running Configure, but add
 it back in while actually building, something like
 
-    sh Configure -Doptimize=-O2                                             
-    make OPTIMIZE='-O2 -flto'                                               
+    sh Configure -Doptimize=-O2
+    make OPTIMIZE='-O2 -flto'
 
 =item *
 

--- a/pod/perl5200delta.pod
+++ b/pod/perl5200delta.pod
@@ -2975,7 +2975,7 @@ stringification of the decimal point. [perl #108378] [perl #115800]
 
 There have been several fixes related to Perl's handling of locales.  perl
 #38193 was described above in L</Internal Changes>.
-Also fixed is 
+Also fixed is
 #118197, where the radix (decimal point) character had to be an ASCII
 character (which doesn't work for some non-Western languages);
 and #115808, in which C<POSIX::setlocale()> on failure returned an

--- a/pod/perl5201delta.pod
+++ b/pod/perl5201delta.pod
@@ -335,7 +335,7 @@ leaving C<$!> as C<ENOENT>.
 
 =item *
 
-Many issues have been detected by L<Coverity|http://www.coverity.com/> and 
+Many issues have been detected by L<Coverity|http://www.coverity.com/> and
 fixed.
 
 =back

--- a/pod/perl5260delta.pod
+++ b/pod/perl5260delta.pod
@@ -3220,7 +3220,7 @@ that if you specify very small values using the hexadecimal floating
 point format, like C<0x1.fffffffffffffp-1022>, they become zeros.
 L<[GH #15990]|https://github.com/Perl/perl5/issues/15990>
 
-=back 
+=back
 
 =head1 Errata From Previous Releases
 

--- a/pod/perl5280delta.pod
+++ b/pod/perl5280delta.pod
@@ -390,7 +390,7 @@ unescaped left brace is one where we have no intention of repurposing
 C<"{"> to be something other than itself.
 
 That exception is now generalized to include various other such cases
-where the C<"{"> will not be repurposed. 
+where the C<"{"> will not be repurposed.
 
 Note that these uses continue to raise a deprecation message.
 
@@ -2292,7 +2292,7 @@ The C<printf> format specifier C<%.0f> no longer rounds incorrectly
 L<[GH #9125]|https://github.com/Perl/perl5/issues/9125>,
 and now shows the correct sign for a negative zero.
 
-=item * 
+=item *
 
 Fixed an issue where the error C<< Scalar value @arrayname[0] better
 written as $arrayname >> would give an error C<< Cannot printf Inf with 'c' >>

--- a/pod/perl5300delta.pod
+++ b/pod/perl5300delta.pod
@@ -254,7 +254,7 @@ L<[GH #16769]|https://github.com/Perl/perl5/issues/16769>.
 =item *
 
 Improvements based on LGTM analysis and recommendation.
-(L<https://lgtm.com/projects/g/Perl/perl5/alerts/?mode=tree>). 
+(L<https://lgtm.com/projects/g/Perl/perl5/alerts/?mode=tree>).
 L<[GH #16765]|https://github.com/Perl/perl5/issues/16765>.
 L<[GH #16773]|https://github.com/Perl/perl5/issues/16773>.
 
@@ -772,7 +772,7 @@ Clarification of the syntax of /(?(cond)yes)/.
 =item *
 
 There are actually two slightly different types of UTF-8 locales: one for Turkic
-languages and one for everything else. Starting in Perl v5.30, Perl seamlessly 
+languages and one for everything else. Starting in Perl v5.30, Perl seamlessly
 handles both types.
 
 =back

--- a/pod/perl5320delta.pod
+++ b/pod/perl5320delta.pod
@@ -665,7 +665,7 @@ L<XS::APItest> has been upgraded from version 1.00 to 1.09.
 =item *
 
 Pod::Parser has been removed from the core distribution.
-It still is available for download from CPAN. This resolves 
+It still is available for download from CPAN. This resolves
 [L<#13194|https://github.com/Perl/perl5/issues/13194>].
 
 =back
@@ -1724,7 +1724,7 @@ C<[GH #17045]|https://github.com/Perl/perl5/issues/17045>]
 Extraordinarily large (over 2GB) floating point format widths could
 cause an integer overflow in the underlying call to snprintf(),
 resulting in an assertion. Formatted floating point widths are now
-limited to the range of int, the return value of snprintf(). 
+limited to the range of int, the return value of snprintf().
 [L<#16881|https://github.com/Perl/perl5/issues/16881>]
 
 =item *
@@ -1759,7 +1759,7 @@ L<[GH #16847]|https://github.com/Perl/perl5/issues/16847>
 =item *
 
 Incomplete hex and binary literals like C<0x> and C<0b> are now
-treated as if the C<x> or C<b> is part of the next token. 
+treated as if the C<x> or C<b> is part of the next token.
 [L<#17010|https://github.com/Perl/perl5/issues/17010>]
 
 =item *

--- a/pod/perl5341delta.pod
+++ b/pod/perl5341delta.pod
@@ -77,7 +77,7 @@ Support for compiling perl on Windows using Microsoft Visual Studio 2022
 B::Deparse now correctly handles try/catch blocks with more complex scopes.
 [L<GH #18874|https://github.com/Perl/perl5/issues/18874>]
 
-=item * 
+=item *
 
 try/catch now correctly returns the last evaluated expression when the catch
 block has more than one statement. [L<GH #18855|https://github.com/Perl/perl5/issues/18855>]

--- a/pod/perl5362delta.pod
+++ b/pod/perl5362delta.pod
@@ -14,7 +14,7 @@ L<perl5361delta>, which describes differences between 5.36.0 and 5.36.1.
 
 =head1 Security
 
-This release fixes the following security issues. 
+This release fixes the following security issues.
 
 =head2 CVE-2023-47038 - Write past buffer end via illegal user-defined Unicode property
 

--- a/pod/perl5363delta.pod
+++ b/pod/perl5363delta.pod
@@ -15,7 +15,7 @@ L<perl5361delta>, which describes differences between 5.36.0 and 5.36.1.
 
 =head1 Security
 
-This release fixes the following security issues. 
+This release fixes the following security issues.
 
 =head2 CVE-2023-47038 - Write past buffer end via illegal user-defined Unicode property
 

--- a/pod/perl5380delta.pod
+++ b/pod/perl5380delta.pod
@@ -366,7 +366,7 @@ supplement the features have come and gone.
 
 In v5.38.0, we are declaring the experiment a failure.  Some future system may
 take the conceptual place of smartmatch, but it has not yet been designed or
-built.  
+built.
 
 These features will be entirely removed from perl in v5.42.0.
 

--- a/pod/perl5381delta.pod
+++ b/pod/perl5381delta.pod
@@ -14,7 +14,7 @@ L<perl5380delta>, which describes differences between 5.36.0 and 5.38.0.
 
 =head1 Security
 
-This release fixes the following security issues. 
+This release fixes the following security issues.
 
 =head2 CVE-2023-47038 - Write past buffer end via illegal user-defined Unicode property
 

--- a/pod/perl5382delta.pod
+++ b/pod/perl5382delta.pod
@@ -15,7 +15,7 @@ L<perl5380delta>, which describes differences between 5.37.0 and 5.38.0.
 
 =head1 Security
 
-This release fixes the following security issues. 
+This release fixes the following security issues.
 
 =head2 CVE-2023-47038 - Write past buffer end via illegal user-defined Unicode property
 

--- a/pod/perl5433delta.pod
+++ b/pod/perl5433delta.pod
@@ -133,7 +133,7 @@ L<XS::APItest> has been upgraded from version 1.44 to 1.46.
 =item *
 
 L<perlapi> now contains information about how to find what release of
-Perl first contained an API element 
+Perl first contained an API element
 
 =back
 

--- a/pod/perl561delta.pod
+++ b/pod/perl561delta.pod
@@ -66,7 +66,7 @@ Infinity is now recognized as a number.
 
 In Perl 5.6.0, qw(a\\b) produced a string with two backslashes instead
 of one, in a departure from the behavior in previous versions.  The
-older behavior has been reinstated.  
+older behavior has been reinstated.
 
 =item caller()
 
@@ -110,7 +110,7 @@ Autovivification of symbolic references of special variables described
 in L<perlvar> (as in C<${$num}>) was accidentally disabled.  This works
 again now.
 
-=item Lexical warnings 
+=item Lexical warnings
 
 Lexical warnings now propagate correctly into C<eval "...">.
 
@@ -827,7 +827,7 @@ is able to use "quads" (64-bit integers) as follows:
 
 =item *
 
-constants (decimal, hexadecimal, octal, binary) in the code 
+constants (decimal, hexadecimal, octal, binary) in the code
 
 =item *
 
@@ -852,7 +852,7 @@ of the integer values may produce surprising results)
 
 =item *
 
-in bit arithmetics: & | ^ ~ << >> (NOTE: these used to be forced 
+in bit arithmetics: & | ^ ~ << >> (NOTE: these used to be forced
 to be 32 bits wide but now operate on the full native width.)
 
 =item *
@@ -954,7 +954,7 @@ Perl subroutines with a prototype of C<($$)>, and XSUBs in general, can
 now be used as sort subroutines.  In either case, the two elements to
 be compared are passed as normal parameters in @_.  See L<perlfunc/sort>.
 
-For unprototyped sort subroutines, the historical behavior of passing 
+For unprototyped sort subroutines, the historical behavior of passing
 the elements to be compared as the global variables $a and $b remains
 unchanged.
 
@@ -1037,7 +1037,7 @@ templates.
 =head2 Weak references
 
 In previous versions of Perl, you couldn't cache objects so as
-to allow them to be deleted if the last reference from outside 
+to allow them to be deleted if the last reference from outside
 the cache is deleted.  The reference in the cache would hold a
 reference count on the object and the objects would never be
 destroyed.
@@ -1056,7 +1056,7 @@ automatically undef-ed.
 To use this feature, you need the Devel::WeakRef package from CPAN, which
 contains additional documentation.
 
-    NOTE: This is an experimental feature.  Details are subject to change.  
+    NOTE: This is an experimental feature.  Details are subject to change.
 
 =head2 Binary numbers supported
 
@@ -1107,7 +1107,7 @@ it.  The array element at that position returns to its uninitialized
 state, so that testing for the same element with exists() will return
 false.  If the element happens to be the one at the end, the size of
 the array also shrinks up to the highest element that tests true for
-exists(), or 0 if none such is found.  If the array is tied, the DELETE() 
+exists(), or 0 if none such is found.  If the array is tied, the DELETE()
 method in the corresponding tied package will be invoked.
 
 See L<perlfunc/exists> and L<perlfunc/delete> for examples.
@@ -1303,7 +1303,7 @@ See L<perlsub/Prototypes>.
 =head2 C<require> and C<do> may be overridden
 
 C<require> and C<do 'file'> operations may be overridden locally
-by importing subroutines of the same name into the current package 
+by importing subroutines of the same name into the current package
 (or globally by importing them into the CORE::GLOBAL:: namespace).
 Overriding C<require> will also affect C<use>, provided the override
 is visible at compile-time.
@@ -1420,10 +1420,10 @@ go to achieve production quality compiled executables.
 =item Benchmark
 
 Overall, Benchmark results exhibit lower average error and better timing
-accuracy.  
+accuracy.
 
 You can now run tests for I<n> seconds instead of guessing the right
-number of tests to run: e.g., timethese(-5, ...) will run each 
+number of tests to run: e.g., timethese(-5, ...) will run each
 code for at least 5 CPU seconds.  Zero as the "number of repetitions"
 means "for at least 3 CPU seconds".  The output format has also
 changed.  For example:
@@ -1652,7 +1652,7 @@ A bug that prevented the non-option call-back <> from being
 specified as the first argument has been fixed.
 
 To specify the characters < and > as option starters, use ><. Note,
-however, that changing option starters is strongly deprecated. 
+however, that changing option starters is strongly deprecated.
 
 =item IO
 
@@ -1806,7 +1806,7 @@ fixed.
 =item Sys::Syslog
 
 Sys::Syslog now uses XSUBs to access facilities from syslog.h so it
-no longer requires syslog.ph to exist. 
+no longer requires syslog.ph to exist.
 
 =item Sys::Hostname
 
@@ -2111,7 +2111,7 @@ Some platforms support system APIs that are capable of handling large files
 (typically, files larger than two gigabytes).  Perl will try to use these
 APIs if you ask for -Duselargefiles.
 
-See L</"Large file support"> for more information. 
+See L</"Large file support"> for more information.
 
 =head2 installusrbinperl
 
@@ -2336,7 +2336,7 @@ been fixed.
 
 =head2 All compilation errors are true errors
 
-Some "errors" encountered at compile time were by necessity 
+Some "errors" encountered at compile time were by necessity
 generated as warnings followed by eventual termination of the
 program.  This enabled more such errors to be reported in a
 single run, rather than causing a hard stop at the first error
@@ -2446,7 +2446,7 @@ run in compile-only mode.  Since this is typically not the expected
 behavior, END blocks are not executed anymore when the C<-c> switch
 is used, or if compilation fails.
 
-See L</"Support for CHECK blocks"> for how to run things when the compile 
+See L</"Support for CHECK blocks"> for how to run things when the compile
 phase ends.
 
 =head2 Potential to leak DATA filehandles
@@ -2672,7 +2672,7 @@ from the CRTL's internal environment array and discovered the array was
 missing.  You need to figure out where your CRTL misplaced its environ
 or define F<PERL_ENV_TABLES> (see L<perlvms>) so that environ is not searched.
 
-=item Can't remove %s: %s, skipping file 
+=item Can't remove %s: %s, skipping file
 
 (S) You requested an inplace edit without creating a backup file.  Perl
 was unable to remove the original file to replace it with the modified
@@ -2725,13 +2725,13 @@ C<overload> or C<charnames> pragma?  See L<charnames> and L<overload>.
 
 (D) defined() is not usually useful on arrays because it checks for an
 undefined I<scalar> value.  If you want to see if the array is empty,
-just use C<if (@array) { # not empty }> for example.  
+just use C<if (@array) { # not empty }> for example.
 
 =item defined(%hash) is deprecated
 
 (D) defined() is not usually useful on hashes because it checks for an
 undefined I<scalar> value.  If you want to see if the hash is empty,
-just use C<if (%hash) { # not empty }> for example.  
+just use C<if (%hash) { # not empty }> for example.
 
 =item Did not produce a valid header
 
@@ -2944,7 +2944,7 @@ Remember that "my", "our", and "local" bind tighter than comma.
 
 (W ambiguous) It used to be that Perl would try to guess whether you
 wanted an array interpolated or a literal @.  It no longer does this;
-arrays are now I<always> interpolated into strings.  This means that 
+arrays are now I<always> interpolated into strings.  This means that
 if you try something like:
 
         print "fred@example.com";
@@ -3308,7 +3308,7 @@ See L</"More functional bareword prototype (*)">.
 =item Semantics of bit operators may have changed on 64-bit platforms
 
 If your platform is either natively 64-bit or if Perl has been
-configured to used 64-bit integers, i.e., $Config{ivsize} is 8, 
+configured to used 64-bit integers, i.e., $Config{ivsize} is 8,
 there may be a potential incompatibility in the behavior of bitwise
 numeric operators (& | ^ ~ << >>).  These operators used to strictly
 operate on the lower 32 bits of integers in previous versions, but now
@@ -3558,7 +3558,7 @@ include the following:
 
 =item The DB module
 
-=item The regular expression code constructs: 
+=item The regular expression code constructs:
 
 C<(?{ code })> and C<(??{ code })>
 

--- a/pod/perl56delta.pod
+++ b/pod/perl56delta.pod
@@ -229,7 +229,7 @@ is able to use "quads" (64-bit integers) as follows:
 
 =item *
 
-constants (decimal, hexadecimal, octal, binary) in the code 
+constants (decimal, hexadecimal, octal, binary) in the code
 
 =item *
 
@@ -254,7 +254,7 @@ of the integer values may produce surprising results)
 
 =item *
 
-in bit arithmetics: & | ^ ~ << >> (NOTE: these used to be forced 
+in bit arithmetics: & | ^ ~ << >> (NOTE: these used to be forced
 to be 32 bits wide but now operate on the full native width.)
 
 =item *
@@ -356,7 +356,7 @@ Perl subroutines with a prototype of C<($$)>, and XSUBs in general, can
 now be used as sort subroutines.  In either case, the two elements to
 be compared are passed as normal parameters in @_.  See L<perlfunc/sort>.
 
-For unprototyped sort subroutines, the historical behavior of passing 
+For unprototyped sort subroutines, the historical behavior of passing
 the elements to be compared as the global variables $a and $b remains
 unchanged.
 
@@ -439,7 +439,7 @@ templates.
 =head2 Weak references
 
 In previous versions of Perl, you couldn't cache objects so as
-to allow them to be deleted if the last reference from outside 
+to allow them to be deleted if the last reference from outside
 the cache is deleted.  The reference in the cache would hold a
 reference count on the object and the objects would never be
 destroyed.
@@ -458,7 +458,7 @@ automatically undef-ed.
 To use this feature, you need the Devel::WeakRef package from CPAN, which
 contains additional documentation.
 
-    NOTE: This is an experimental feature.  Details are subject to change.  
+    NOTE: This is an experimental feature.  Details are subject to change.
 
 =head2 Binary numbers supported
 
@@ -509,7 +509,7 @@ it.  The array element at that position returns to its uninitialized
 state, so that testing for the same element with exists() will return
 false.  If the element happens to be the one at the end, the size of
 the array also shrinks up to the highest element that tests true for
-exists(), or 0 if none such is found.  If the array is tied, the DELETE() 
+exists(), or 0 if none such is found.  If the array is tied, the DELETE()
 method in the corresponding tied package will be invoked.
 
 See L<perlfunc/exists> and L<perlfunc/delete> for examples.
@@ -705,7 +705,7 @@ See L<perlsub/Prototypes>.
 =head2 C<require> and C<do> may be overridden
 
 C<require> and C<do 'file'> operations may be overridden locally
-by importing subroutines of the same name into the current package 
+by importing subroutines of the same name into the current package
 (or globally by importing them into the CORE::GLOBAL:: namespace).
 Overriding C<require> will also affect C<use>, provided the override
 is visible at compile-time.
@@ -822,10 +822,10 @@ go to achieve production quality compiled executables.
 =item Benchmark
 
 Overall, Benchmark results exhibit lower average error and better timing
-accuracy.  
+accuracy.
 
 You can now run tests for I<n> seconds instead of guessing the right
-number of tests to run: e.g., timethese(-5, ...) will run each 
+number of tests to run: e.g., timethese(-5, ...) will run each
 code for at least 5 CPU seconds.  Zero as the "number of repetitions"
 means "for at least 3 CPU seconds".  The output format has also
 changed.  For example:
@@ -1054,7 +1054,7 @@ A bug that prevented the non-option call-back <> from being
 specified as the first argument has been fixed.
 
 To specify the characters < and > as option starters, use ><. Note,
-however, that changing option starters is strongly deprecated. 
+however, that changing option starters is strongly deprecated.
 
 =item IO
 
@@ -1208,7 +1208,7 @@ fixed.
 =item Sys::Syslog
 
 Sys::Syslog now uses XSUBs to access facilities from syslog.h so it
-no longer requires syslog.ph to exist. 
+no longer requires syslog.ph to exist.
 
 =item Sys::Hostname
 
@@ -1513,7 +1513,7 @@ Some platforms support system APIs that are capable of handling large files
 (typically, files larger than two gigabytes).  Perl will try to use these
 APIs if you ask for -Duselargefiles.
 
-See L</"Large file support"> for more information. 
+See L</"Large file support"> for more information.
 
 =head2 installusrbinperl
 
@@ -1731,7 +1731,7 @@ been fixed.
 
 =head2 All compilation errors are true errors
 
-Some "errors" encountered at compile time were by necessity 
+Some "errors" encountered at compile time were by necessity
 generated as warnings followed by eventual termination of the
 program.  This enabled more such errors to be reported in a
 single run, rather than causing a hard stop at the first error
@@ -1841,7 +1841,7 @@ run in compile-only mode.  Since this is typically not the expected
 behavior, END blocks are not executed anymore when the C<-c> switch
 is used, or if compilation fails.
 
-See L</"Support for CHECK blocks"> for how to run things when the compile 
+See L</"Support for CHECK blocks"> for how to run things when the compile
 phase ends.
 
 =head2 Potential to leak DATA filehandles
@@ -2067,7 +2067,7 @@ from the CRTL's internal environment array and discovered the array was
 missing.  You need to figure out where your CRTL misplaced its environ
 or define F<PERL_ENV_TABLES> (see L<perlvms>) so that environ is not searched.
 
-=item Can't remove %s: %s, skipping file 
+=item Can't remove %s: %s, skipping file
 
 (S) You requested an inplace edit without creating a backup file.  Perl
 was unable to remove the original file to replace it with the modified
@@ -2120,13 +2120,13 @@ C<overload> or C<charnames> pragma?  See L<charnames> and L<overload>.
 
 (D) defined() is not usually useful on arrays because it checks for an
 undefined I<scalar> value.  If you want to see if the array is empty,
-just use C<if (@array) { # not empty }> for example.  
+just use C<if (@array) { # not empty }> for example.
 
 =item defined(%hash) is deprecated
 
 (D) defined() is not usually useful on hashes because it checks for an
 undefined I<scalar> value.  If you want to see if the hash is empty,
-just use C<if (%hash) { # not empty }> for example.  
+just use C<if (%hash) { # not empty }> for example.
 
 =item Did not produce a valid header
 
@@ -2339,7 +2339,7 @@ Remember that "my", "our", and "local" bind tighter than comma.
 
 (W ambiguous) It used to be that Perl would try to guess whether you
 wanted an array interpolated or a literal @.  It no longer does this;
-arrays are now I<always> interpolated into strings.  This means that 
+arrays are now I<always> interpolated into strings.  This means that
 if you try something like:
 
         print "fred@example.com";
@@ -2703,7 +2703,7 @@ See L</"More functional bareword prototype (*)">.
 =item Semantics of bit operators may have changed on 64-bit platforms
 
 If your platform is either natively 64-bit or if Perl has been
-configured to used 64-bit integers, i.e., $Config{ivsize} is 8, 
+configured to used 64-bit integers, i.e., $Config{ivsize} is 8,
 there may be a potential incompatibility in the behavior of bitwise
 numeric operators (& | ^ ~ << >>).  These operators used to strictly
 operate on the lower 32 bits of integers in previous versions, but now
@@ -2920,7 +2920,7 @@ include the following:
 
 =item The DB module
 
-=item The regular expression code constructs: 
+=item The regular expression code constructs:
 
 C<(?{ code })> and C<(??{ code })>
 

--- a/pod/perl581delta.pod
+++ b/pod/perl581delta.pod
@@ -663,7 +663,7 @@ now uses the vendor-supplied function if detected.
 A rare access violation at Perl start-up could occur if the Perl image was
 installed with privileges or if there was an identifier with the
 subsystem attribute set in the process's rightslist.  Either of these
-circumstances triggered tainting code that contained a pointer bug. 
+circumstances triggered tainting code that contained a pointer bug.
 The faulty pointer arithmetic has been fixed.
 
 =item *

--- a/pod/perl582delta.pod
+++ b/pod/perl582delta.pod
@@ -93,7 +93,7 @@ correctly by the parser.
 
 Interpreter initialization is more complete when -DMULTIPLICITY is off.
 This should resolve problems with initializing and destroying the Perl
-interpreter more than once in a single process.                      
+interpreter more than once in a single process.
 
 =head1 Platform Specific Problems
 

--- a/pod/perl583delta.pod
+++ b/pod/perl583delta.pod
@@ -156,7 +156,7 @@ and consider upgrading their glibc.
 
 =head1 Known Problems
 
-Detached threads aren't supported on Windows yet, as they may lead to 
+Detached threads aren't supported on Windows yet, as they may lead to
 memory access violation problems.
 
 There is a known race condition opening scripts in C<suidperl>. C<suidperl>

--- a/pod/perl585delta.pod
+++ b/pod/perl585delta.pod
@@ -186,7 +186,7 @@ Perl -V has several improvements
 correctly outputs local patch names that contain embedded code snippets
 or other characters that used to confuse it.
 
-=item * 
+=item *
 
 arguments to -V that look like regexps will give multiple lines of output.
 

--- a/pod/perl587delta.pod
+++ b/pod/perl587delta.pod
@@ -287,7 +287,7 @@ C<pack> C<Z0> used to destroy the preceding character.
 
 =item *
 
-C<P>/C<p> C<pack> formats used to only recognise literal C<undef> 
+C<P>/C<p> C<pack> formats used to only recognise literal C<undef>
 
 =back
 

--- a/pod/perl588delta.pod
+++ b/pod/perl588delta.pod
@@ -1541,7 +1541,7 @@ select(), instead of a bitmask.
     # Wrong, will now warn
     $rin = fileno(STDIN);
     ($nfound,$timeleft) = select($rout=$rin, undef, undef, $timeout);
-    
+
     # Should be
     $rin = '';
     vec($rin,fileno(STDIN),1) = 1;

--- a/pod/perl589delta.pod
+++ b/pod/perl589delta.pod
@@ -108,7 +108,7 @@ basic exception handling in XS modules. You can use these macros if you call
 code that may C<croak>, but you need to do some cleanup before giving control
 back to Perl. See L<perlguts/Exception Handling> for more details.
 
-=head2 -D option enhancements 
+=head2 -D option enhancements
 
 =over
 
@@ -173,7 +173,7 @@ MirOS BSD
 
 =item *
 
-RISC OS 
+RISC OS
 
 =item *
 
@@ -202,7 +202,7 @@ indicated in C<$]>. The bundled version is 2.17
 C<Win32API::File> now available in core on Microsoft Windows. The bundled
 version is 0.1001_01
 
-=item * 
+=item *
 
 C<Devel::InnerPackage> finds all the packages defined by a single file. It is
 part of the C<Module::Pluggable> distribution. The bundled version is 0.3
@@ -638,7 +638,7 @@ C<Filter::Util::Call> upgraded to version 1.07
 
 C<Filter::Simple> upgraded to version 0.83
 
-=item * 
+=item *
 
 C<FindBin> upgraded to version 1.49
 
@@ -801,7 +801,7 @@ C<Pod::Html> upgraded to version 1.09
 
 C<Pod::Parser> upgraded to version 1.35
 
-=item * 
+=item *
 
 C<Pod::Usage> upgraded to version 1.35
 
@@ -1010,7 +1010,7 @@ C<Time::Local> upgraded to version 1.1901
 
 =item *
 
-C<Time::HiRes> upgraded to version 1.9715 with various build improvements 
+C<Time::HiRes> upgraded to version 1.9715 with various build improvements
 (including VMS) and minor platform-specific bug fixes (including
 for HP-UX 11 ia64).
 
@@ -1182,7 +1182,7 @@ terminology and how to correctly handle Unicode in Perl scripts.
 L<perlunicode> is updated in section user defined properties.
 
 L<perluniintro> has been updated in the example of detecting data that is not
-valid in particular encoding. 
+valid in particular encoding.
 
 L<perlcommunity> provides an overview of the Perl Community along with further
 resources.
@@ -1213,7 +1213,7 @@ L<perlfunc>:
 
 =item *
 
-Documentation is fixed in section C<caller> and C<pop>. 
+Documentation is fixed in section C<caller> and C<pop>.
 
 =item *
 
@@ -1236,7 +1236,7 @@ L<perllocale> documentation is adjusted for number localization and
 C<POSIX::setlocale> to fix Debian bug #379463.
 
 L<perlmodlib> is updated with C<CPAN::API::HOWTO> and
-C<Sys::Syslog::win32::Win32> 
+C<Sys::Syslog::win32::Win32>
 
 L<perlre> documentation updated to reflect the differences between
 C<[[:xxxxx:]]> and C<\p{IsXxxxx}> matches. Also added section on C</g> and
@@ -1256,7 +1256,7 @@ information in options C<-x> and C<-u>.
 
 L<perlsub> example is updated to use a lexical variable for C<opendir> syntax.
 
-L<perlvar> fixes confusion about real GID C<$(> and effective GID C<$)>. 
+L<perlvar> fixes confusion about real GID C<$(> and effective GID C<$)>.
 
 Perl thread tutorial example is fixed in section
 L<perlthrtut/Queues: Passing Data Around> and L<perlthrtut>.
@@ -1321,7 +1321,7 @@ correct C89 value - the length of the formatted string. Previously we could
 not rely on the return value of C<sprintf()>, because on some ancient but
 extant platforms it still returns C<char *>.
 
-=item * 
+=item *
 
 C<index> is now faster if the search string is stored in UTF-8 but only contains
 characters in the Latin-1 range.
@@ -1452,7 +1452,7 @@ Record IEEE usage in C<config.h>
 
 Help older VMS compilers by using C<ccflags> when building C<munchconfig.exe>.
 
-=item * 
+=item *
 
 Don't try to build old C<Thread> extension on VMS when C<-Duseithreads> has
 been chosen.
@@ -1485,9 +1485,9 @@ build of perl.
 Various improvements to the win32 build process, including support for Visual
 C++ 2005 Express Edition (aka Visual C++ 8.x).
 
-=item * 
+=item *
 
-F<perl.exe> will now have an icon if built with MinGW or Borland. 
+F<perl.exe> will now have an icon if built with MinGW or Borland.
 
 =item *
 
@@ -1636,7 +1636,7 @@ doesn't C<undef> the lexical.
 
 =item *
 
-The C<encoding> pragma now correctly ignores anything following an C<@> 
+The C<encoding> pragma now correctly ignores anything following an C<@>
 character in the C<LC_ALL> and C<LANG> environment variables. [RT # 49646]
 
 =item *
@@ -1840,7 +1840,7 @@ On VMS, escaped dots will be preserved when converted to Unix syntax.
 
 C<keys %+> no longer throws an C<'ambiguous'> warning.
 
-=item * 
+=item *
 
 Using C<#!perl -d> could trigger an assertion, which has been fixed.
 
@@ -2002,7 +2002,7 @@ Two new macros C<mPUSHs()> and C<mXPUSHs()> are added, to make it easier to
 push mortal SVs onto the stack. They were then used to fix several bugs where
 values on the stack had not been mortalised.
 
-A C<Perl_signbit()> function was added to test the sign of an C<NV>. It 
+A C<Perl_signbit()> function was added to test the sign of an C<NV>. It
 maps to the system one when available.
 
 C<Perl_av_reify()>, C<Perl_lex_end()>, C<Perl_mod()>, C<Perl_op_clear()>,
@@ -2211,7 +2211,7 @@ filename if the long name is outside the current codepage (Jan Dubois).
 C<Win32> upgraded to version 0.38. Now has a documented 'WinVista' response
 from C<GetOSName> and support for Vista's privilege elevation in C<IsAdminUser>.
 Support for Unicode characters in path names. Improved cygwin and Win64
-compatibility. 
+compatibility.
 
 =item *
 

--- a/pod/perlapio.pod
+++ b/pod/perlapio.pod
@@ -242,7 +242,7 @@ it is the last character that was read from the handle.
 =item B<PerlIO_unread(f,buf,count)>
 
 This allows one to unget more than a single byte.
-It effectively unshifts C<count> bytes onto the beginning of the buffer 
+It effectively unshifts C<count> bytes onto the beginning of the buffer
 C<buf>, so that the next read operation(s) will return them before
 anything else that was in the buffer.
 

--- a/pod/perlcall.pod
+++ b/pod/perlcall.pod
@@ -1987,7 +1987,7 @@ L<perlxs>, L<perlguts>, L<perlembed>
 
 =head1 AUTHOR
 
-Paul Marquess 
+Paul Marquess
 
 Special thanks to the following people who assisted in the creation of
 the document.

--- a/pod/perldata.pod
+++ b/pod/perldata.pod
@@ -8,11 +8,11 @@ perldata - Perl data types
 X<variable, name> X<variable name> X<data type> X<type>
 
 Perl has three built-in data types: scalars, arrays of scalars, and
-associative arrays of scalars, known as "hashes".  A scalar is a 
+associative arrays of scalars, known as "hashes".  A scalar is a
 single string (of any size, limited only by the available memory),
 number, or a reference to something (which will be discussed
 in L<perlref>).  Normal arrays are ordered lists of scalars indexed
-by number, starting with 0.  Hashes are unordered collections of scalar 
+by number, starting with 0.  Hashes are unordered collections of scalar
 values indexed by their associated string key.
 
 Values are usually referred to by name, or through a named reference.
@@ -283,7 +283,7 @@ assignment to an array or hash evaluates the righthand side in list
 context.  Assignment to a list (or slice, which is just a list
 anyway) also evaluates the right-hand side in list context.
 
-When you use the C<use warnings> pragma or Perl's B<-w> command-line 
+When you use the C<use warnings> pragma or Perl's B<-w> command-line
 option, you may see warnings
 about useless uses of constants or functions in "void context".
 Void context just means the value has been discarded, such as a
@@ -325,7 +325,7 @@ X<boolean> X<bool>
 A scalar value is interpreted as FALSE in the Boolean sense
 if it is undefined, the null string or the number 0 (or its
 string equivalent, "0"), and TRUE if it is anything else.  The
-Boolean context is just a special kind of scalar context where no 
+Boolean context is just a special kind of scalar context where no
 conversion to a string or a number is ever performed.
 Negation of a true value by C<!> or C<not> returns a special false value.
 When evaluated as a string it is treated as C<"">, but as a number, it
@@ -349,7 +349,7 @@ X<defined> X<undefined> X<undef> X<null> X<string, null>
 
 To find out whether a given string is a valid non-zero number, it's
 sometimes enough to test it against both numeric 0 and also lexical
-"0" (although this will cause noises if warnings are on).  That's 
+"0" (although this will cause noises if warnings are on).  That's
 because strings that aren't numbers count as 0, just as they do in B<awk>:
 
     if ($str == 0 && $str ne "0")  {
@@ -399,7 +399,7 @@ X<array, length>
 
     scalar(@whatever) == $#whatever + 1;
 
-Some programmers choose to use an explicit conversion so as to 
+Some programmers choose to use an explicit conversion so as to
 leave nothing to doubt:
 
     $element_count = scalar(@whatever);
@@ -805,7 +805,7 @@ A word that has no other interpretation in the grammar will
 be treated as if it were a quoted string.  These are known as
 "barewords".  As with filehandles and labels, a bareword that consists
 entirely of lowercase letters risks conflict with future reserved
-words, and if you use the C<use warnings> pragma or the B<-w> switch, 
+words, and if you use the C<use warnings> pragma or the B<-w> switch,
 Perl will warn you about any such words.  Perl limits barewords (like
 identifiers) to about 250 characters.  Future versions of Perl are likely
 to eliminate these arbitrary limitations.
@@ -825,7 +825,7 @@ X<array, interpolation> X<interpolation, array> X<$">
 
 Arrays and slices are interpolated into double-quoted strings
 by joining the elements with the delimiter specified in the C<$">
-variable (C<$LIST_SEPARATOR> if "use English;" is specified), 
+variable (C<$LIST_SEPARATOR> if "use English;" is specified),
 space by default.  The following are equivalent:
 
     $temp = join($", @ARGV);
@@ -901,7 +901,7 @@ identity in a LIST--the list
     (@foo,@bar,&SomeSub,%glarch)
 
 contains all the elements of @foo followed by all the elements of @bar,
-followed by all the elements returned by the subroutine named SomeSub 
+followed by all the elements returned by the subroutine named SomeSub
 called in list context, followed by the key/value pairs of %glarch.
 To make a list reference that does I<NOT> interpolate, see L<perlref>.
 
@@ -1118,14 +1118,14 @@ square brackets.  For example:
     @myarray = (5, 50, 500, 5000);
     print "The Third Element is", $myarray[2], "\n";
 
-The array indices start with 0.  A negative subscript retrieves its 
-value from the end.  In our example, C<$myarray[-1]> would have been 
+The array indices start with 0.  A negative subscript retrieves its
+value from the end.  In our example, C<$myarray[-1]> would have been
 5000, and C<$myarray[-2]> would have been 500.
 
 Hash subscripts are similar, only instead of square brackets curly brackets
 are used.  For example:
 
-    %scientists = 
+    %scientists =
     (
         "Newton" => "Isaac",
         "Einstein" => "Albert",
@@ -1170,7 +1170,7 @@ Since you can assign to a list of variables, you can also assign to
 an array or hash slice.
 
     @days[3..5]    = qw/Wed Thu Fri/;
-    @colors{'red','blue','green'} 
+    @colors{'red','blue','green'}
                    = (0xff0000, 0x0000ff, 0x00ff00);
     @folks[0, -1]  = @folks[-1, 0];
 
@@ -1185,7 +1185,7 @@ Since changing a slice changes the original array or hash that it's
 slicing, a C<foreach> construct will alter some--or even all--of the
 values of the array or hash.
 
-    foreach (@array[ 4 .. 10 ]) { s/peter/paul/ } 
+    foreach (@array[ 4 .. 10 ]) { s/peter/paul/ }
 
     foreach (@hash{qw[key1 key2]}) {
         s/^\s+//;                       # trim leading whitespace
@@ -1270,7 +1270,7 @@ Perl uses an internal type called a I<typeglob> to hold an entire
 symbol table entry.  The type prefix of a typeglob is a C<*>, because
 it represents all types.  This used to be the preferred way to
 pass arrays and hashes by reference into a function, but now that
-we have real references, this is seldom needed.  
+we have real references, this is seldom needed.
 
 The main use of typeglobs in modern Perl is to create symbol table aliases.
 This assignment:

--- a/pod/perldbmfilter.pod
+++ b/pod/perldbmfilter.pod
@@ -98,7 +98,7 @@ fix very easily.
     # Install DBM Filters
     $db->filter_fetch_key  ( sub { s/\0$//    } );
     $db->filter_store_key  ( sub { $_ .= "\0" } );
-    $db->filter_fetch_value( 
+    $db->filter_fetch_value(
         sub { no warnings 'uninitialized'; s/\0$// } );
     $db->filter_store_value( sub { $_ .= "\0" } );
 

--- a/pod/perldebguts.pod
+++ b/pod/perldebguts.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-perldebguts - Guts of Perl debugging 
+perldebguts - Guts of Perl debugging
 
 =head1 DESCRIPTION
 
@@ -54,7 +54,7 @@ Each hash C<%{"_<$filename"}> contains breakpoints and actions keyed
 by line number.  Individual entries (as opposed to the whole hash)
 are settable.  Perl only cares about Boolean true here, although
 the values used by F<perl5db.pl> have the form
-C<"$break_condition\0$action">.  
+C<"$break_condition\0$action">.
 
 The same holds for evaluated strings that contain subroutines, or
 which are currently being executed.  The $filename for C<eval>ed strings
@@ -94,7 +94,7 @@ When the execution of your program reaches a point that can hold a
 breakpoint, the C<DB::DB()> subroutine is called if any of the variables
 C<$DB::trace>, C<$DB::single>, or C<$DB::signal> is true.  These variables
 are not C<local>izable.  This feature is disabled when executing
-inside C<DB::DB()>, including functions called from it 
+inside C<DB::DB()>, including functions called from it
 unless C<< $^D & (1<<30) >> is true.
 
 =item *
@@ -238,12 +238,12 @@ convenient as arguments to C<< < >>, C<< << >> commands.
 =back
 
 Note that any variables and functions that are not documented in
-this manpages (or in L<perldebug>) are considered for internal   
+this manpages (or in L<perldebug>) are considered for internal
 use only, and as such are subject to change without notice.
 
 =head1 Frame Listing Output Examples
 
-The C<frame> option can be used to control the output of frame 
+The C<frame> option can be used to control the output of frame
 information.  For example, contrast this expression trace:
 
  $ perl -de 42
@@ -459,13 +459,13 @@ The debugging output at compile time looks like this:
     42: EXACT <k>(44)
     44: EOL(45)
     45: END(0)
-  anchored 'de' at 1 floating 'gh' at 3..2147483647 (checking floating) 
-        stclass 'ANYOF[bc]' minlen 7 
+  anchored 'de' at 1 floating 'gh' at 3..2147483647 (checking floating)
+        stclass 'ANYOF[bc]' minlen 7
   Offsets: [45]
   	1[4] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 5[1]
   	0[0] 12[1] 0[0] 6[1] 0[0] 7[1] 0[0] 9[1] 8[1] 0[0] 10[1] 0[0]
   	11[1] 0[0] 12[0] 12[0] 13[1] 0[0] 14[4] 0[0] 0[0] 0[0] 0[0]
-  	0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 18[1] 0[0] 19[1] 20[0]  
+  	0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 18[1] 0[0] 19[1] 20[0]
   Omitting $` $& $' support.
 
 The first line shows the pre-compiled form of the regex.  The second
@@ -474,19 +474,19 @@ shows the size of the compiled form (in arbitrary units, usually
 offset/length table, usually 4+C<size>*8.  The next line shows the
 label I<id> of the first node that does a match.
 
-The 
+The
 
-  anchored 'de' at 1 floating 'gh' at 3..2147483647 (checking floating) 
-        stclass 'ANYOF[bc]' minlen 7 
+  anchored 'de' at 1 floating 'gh' at 3..2147483647 (checking floating)
+        stclass 'ANYOF[bc]' minlen 7
 
 line (split into two lines above) contains optimizer
-information.  In the example shown, the optimizer found that the match 
+information.  In the example shown, the optimizer found that the match
 should contain a substring C<de> at offset 1, plus substring C<gh>
 at some offset between 3 and infinity.  Moreover, when checking for
 these substrings (to abandon impossible matches quickly), Perl will check
 for the substring C<gh> before checking for the substring C<de>.  The
 optimizer may also use the knowledge that the match starts (at the
-C<first> I<id>) with a character class, and no string 
+C<first> I<id>) with a character class, and no string
 shorter than 7 characters can possibly match.
 
 The fields of interest which may appear in this line are
@@ -525,7 +525,7 @@ all.
 
 Set if the pattern contains C<\G>.
 
-=item C<plus> 
+=item C<plus>
 
 Set if the pattern starts with a repeated char (as in C<x+y>).
 
@@ -533,7 +533,7 @@ Set if the pattern starts with a repeated char (as in C<x+y>).
 
 Set if the pattern starts with C<.*>.
 
-=item C<with eval> 
+=item C<with eval>
 
 Set if the pattern contain eval-groups, such as C<(?{ code })> and
 C<(??{ code })>.
@@ -554,7 +554,7 @@ is set, a call to the regex engine may be avoided even when the optimizer
 found an appropriate place for the match.
 
 Above the optimizer section is the list of I<nodes> of the compiled
-form of the regex.  Each line has format 
+form of the regex.  Each line has format
 
 C<   >I<id>: I<TYPE> I<OPTIONAL-INFO> (I<next-id>)
 
@@ -892,7 +892,7 @@ table, here split across several lines:
   	1[4] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 5[1]
   	0[0] 12[1] 0[0] 6[1] 0[0] 7[1] 0[0] 9[1] 8[1] 0[0] 10[1] 0[0]
   	11[1] 0[0] 12[0] 12[0] 13[1] 0[0] 14[4] 0[0] 0[0] 0[0] 0[0]
-  	0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 18[1] 0[0] 19[1] 20[0]  
+  	0[0] 0[0] 0[0] 0[0] 0[0] 0[0] 18[1] 0[0] 19[1] 20[0]
 
 The first line here indicates that the offset/length table contains 45
 entries.  Each entry is a pair of integers, denoted by C<offset[length]>.
@@ -900,11 +900,11 @@ Entries are numbered starting with 1, so entry #1 here is C<1[4]> and
 entry #12 is C<5[1]>.  C<1[4]> indicates that the node labeled C<1:>
 (the C<1: ANYOF[bc]>) begins at character position 1 in the
 pre-compiled form of the regex, and has a length of 4 characters.
-C<5[1]> in position 12 
+C<5[1]> in position 12
 indicates that the node labeled C<12:>
 (the C<< 12: EXACT <d> >>) begins at character position 5 in the
 pre-compiled form of the regex, and has a length of 1 character.
-C<12[1]> in position 14 
+C<12[1]> in position 14
 indicates that the node labeled C<14:>
 (the C<< 14: CURLYX[0] {1,32767} >>) begins at character position 12 in the
 pre-compiled form of the regex, and has a length of 1 character---that

--- a/pod/perldebtut.pod
+++ b/pod/perldebtut.pod
@@ -6,12 +6,12 @@ perldebtut - Perl debugging tutorial
 
 A (very) lightweight introduction in the use of the perl debugger, and a
 pointer to existing, deeper sources of information on the subject of debugging
-perl programs.  
+perl programs.
 
 There's an extraordinary number of people out there who don't appear to know
 anything about using the perl debugger, though they use the language every
-day.  
-This is for them.  
+day.
+This is for them.
 
 
 =head1 use strict
@@ -26,7 +26,7 @@ a problem:
 	$var1 = 'Hello World'; # always wanted to do that :-)
 	$var2 = "$varl\n";
 
-	print $var2; 
+	print $var2;
 	exit;
 
 While this compiles and runs happily, it probably won't do what's expected,
@@ -51,7 +51,7 @@ get four error messages because one variable is referenced twice:
  Global symbol "$var2" requires explicit package name at ./t1 line 5.
  Global symbol "$varl" requires explicit package name at ./t1 line 5.
  Global symbol "$var2" requires explicit package name at ./t1 line 7.
- Execution of ./hello aborted due to compilation errors.     
+ Execution of ./hello aborted due to compilation errors.
 
 Luvverly! and to fix this we declare all variables explicitly and now our
 script looks like this:	
@@ -63,13 +63,13 @@ script looks like this:
 	my $varl = undef;
 	my $var2 = "$varl\n";
 
-	print $var2; 
+	print $var2;
 	exit;
 
 We then do (always a good idea) a syntax check before we try to run it again:
 
 	> perl -c hello
-	hello syntax OK 
+	hello syntax OK
 
 And now when we run it, we get "\n" still, but at least we know why.  Just
 getting this script to compile has exposed the '$varl' (with the letter 'l')
@@ -81,12 +81,12 @@ variable, and simply changing $varl to $var1 solves the problem.
 Ok, but how about when you want to really see your data, what's in that
 dynamic variable, just before using it?
 
-	#!/usr/bin/perl 
+	#!/usr/bin/perl
 	use strict;
 
 	my $key = 'welcome';
 	my %data = (
-		'this' => qw(that), 
+		'this' => qw(that),
 		'tom' => qw(and jerry),
 		'welcome' => q(Hello World),
 		'zip' => q(welcome),
@@ -94,7 +94,7 @@ dynamic variable, just before using it?
 	my @data = keys %data;
 
 	print "$data{$key}\n";
-	exit;                               
+	exit;
 
 Looks OK, after it's been through the syntax check (perl -c scriptname), we
 run it and all we get is a blank line again!  Hmmmm.
@@ -110,7 +110,7 @@ after:
 And try again:
 
 	> perl data
-	All OK     
+	All OK
 
 	done: ''
 
@@ -119,7 +119,7 @@ trees for some time, we get a cup of coffee and try another approach.  That
 is, we bring in the cavalry by giving perl the 'B<-d>' switch on the command
 line:
 
-	> perl -d data 
+	> perl -d data
 	Default die handler restored.
 
 	Loading DB routines from perl5db.pl version 1.07
@@ -127,7 +127,7 @@ line:
 
 	Enter h or `h h' for help, or `man perldebug' for more help.
 
-	main::(./data:4):     my $key = 'welcome';   
+	main::(./data:4):     my $key = 'welcome';
 
 Now, what we've done here is to launch the built-in perl debugger on our
 script.  It's stopped at the first line of executable code and is waiting for
@@ -144,10 +144,10 @@ That's it, you're back on home turf again.
 
 =head1 help
 
-Fire the debugger up again on your script and we'll look at the help menu. 
-There's a couple of ways of calling help: a simple 'B<h>' will get the summary 
-help list, 'B<|h>' (pipe-h) will pipe the help through your pager (which is 
-(probably 'more' or 'less'), and finally, 'B<h h>' (h-space-h) will give you 
+Fire the debugger up again on your script and we'll look at the help menu.
+There's a couple of ways of calling help: a simple 'B<h>' will get the summary
+help list, 'B<|h>' (pipe-h) will pipe the help through your pager (which is
+(probably 'more' or 'less'), and finally, 'B<h h>' (h-space-h) will give you
 the entire help screen.  Here is the summary page:
 
 DB<1>h
@@ -190,32 +190,32 @@ DB<1>h
                                                                !pattern.
   X [Vars]       Same as "V current_package [Vars]".
   y [n [Vars]]   List lexicals in higher scope <n>.  Vars same as V.
- For more help, type h cmd_letter, or run man perldebug for all docs. 
+ For more help, type h cmd_letter, or run man perldebug for all docs.
 
 More confusing options than you can shake a big stick at!  It's not as bad as
 it looks and it's very useful to know more about all of it, and fun too!
 
 There's a couple of useful ones to know about straight away.  You wouldn't
 think we're using any libraries at all at the moment, but 'B<M>' will show
-which modules are currently loaded, and their version number, while 'B<m>' 
-will show the methods, and 'B<S>' shows all subroutines (by pattern) as 
-shown below.  'B<V>' and 'B<X>' show variables in the program by package 
-scope and can be constrained by pattern. 
+which modules are currently loaded, and their version number, while 'B<m>'
+will show the methods, and 'B<S>' shows all subroutines (by pattern) as
+shown below.  'B<V>' and 'B<X>' show variables in the program by package
+scope and can be constrained by pattern.
 
-	DB<2>S str 
+	DB<2>S str
 	dumpvar::stringify
 	strict::bits
 	strict::import
-	strict::unimport  
+	strict::unimport
 
 Using 'X' and cousins requires you not to use the type identifiers ($@%), just
 the 'name':
 
 	DM<3>X ~err
-	FileHandle(stderr) => fileno(2)    
+	FileHandle(stderr) => fileno(2)
 
 Remember we're in our tiny program with a problem, we should have a look at
-where we are, and what our data looks like. First of all let's view some code 
+where we are, and what our data looks like. First of all let's view some code
 at our present position (the first line of code in this case), via 'B<v>':
 
 	DB<4> v
@@ -228,7 +228,7 @@ at our present position (the first line of code in this case), via 'B<v>':
 	7               'tom' => qw(and jerry),
 	8               'welcome' => q(Hello World),
 	9               'zip' => q(welcome),
-	10      );                                 
+	10      );
 
 At line number 4 is a helpful pointer, that tells you where you are now.  To
 see more code, type 'v' again:
@@ -241,7 +241,7 @@ see more code, type 'v' again:
 	12:     print "All OK\n" if grep($key, keys %data);
 	13:     print "$data{$key}\n";
 	14:     print "done: '$data{$key}'\n";
-	15:     exit;      
+	15:     exit;
 
 And if you wanted to list line 5 again, type 'l 5', (note the space):
 
@@ -253,7 +253,7 @@ stuff to wade through, and 'l' can be very useful.  To reset your view to the
 line we're about to execute, type a lone period '.':
 
 	DB<5> .
-	main::(./data_a:4):     my $key = 'welcome';  
+	main::(./data_a:4):     my $key = 'welcome';
 
 The line shown is the one that is about to be executed B<next>, it hasn't
 happened yet.  So while we can print a variable with the letter 'B<p>', at
@@ -266,12 +266,12 @@ do is to step through the next executable statement with an 'B<s>':
 	main::(./data_a:7):             'tom' => qw(and jerry),
 	main::(./data_a:8):             'welcome' => q(Hello World),
 	main::(./data_a:9):             'zip' => q(welcome),
-	main::(./data_a:10):    );   
+	main::(./data_a:10):    );
 
 Now we can have a look at that first ($key) variable:
 
-	DB<7> p $key 
-	welcome 
+	DB<7> p $key
+	welcome
 
 line 13 is where the action is, so let's continue down to there via the letter
 'B<c>', which by the way, inserts a 'one-time-only' breakpoint at the given
@@ -290,10 +290,10 @@ to see what is happening:
 Not much in there, let's have a look at our hash:
 
 	DB<10> p %data
-	Hello Worldziptomandwelcomejerrywelcomethisthat 
+	Hello Worldziptomandwelcomejerrywelcomethisthat
 
 	DB<11> p keys %data
-	Hello Worldtomwelcomejerrythis  
+	Hello Worldtomwelcomejerrythis
 
 Well, this isn't very easy to read, and using the helpful manual (B<h h>), the
 'B<x>' command looks promising:
@@ -308,7 +308,7 @@ Well, this isn't very easy to read, and using the helpful manual (B<h h>), the
 	6  'jerry'
 	7  'welcome'
 	8  'this'
-	9  'that'     
+	9  'that'
 
 That's not much help, a couple of welcomes in there, but no indication of
 which are keys, and which are values, it's just a listed array dump and, in
@@ -321,18 +321,18 @@ to the data structure:
 	   'jerry' => 'welcome'
 	   'this' => 'that'
 	   'tom' => 'and'
-	   'welcome' => undef  
+	   'welcome' => undef
 
-The reference is truly dumped and we can finally see what we're dealing with. 
+The reference is truly dumped and we can finally see what we're dealing with.
 Our quoting was perfectly valid but wrong for our purposes, with 'and jerry'
 being treated as 2 separate words rather than a phrase, thus throwing the
 evenly paired hash structure out of alignment.
 
 The 'B<-w>' switch would have told us about this, had we used it at the start,
-and saved us a lot of trouble: 
+and saved us a lot of trouble:
 
 	> perl -w data
-	Odd number of elements in hash assignment at ./data line 5.    
+	Odd number of elements in hash assignment at ./data line 5.
 
 We fix our quoting: 'tom' => q(and jerry), and run it again, this time we get
 our expected output:
@@ -374,7 +374,7 @@ And let's have a look at it:
          	0  'this'
          	1  'that'
          	2  'etc'
-   		'unique_id' => 123       
+   		'unique_id' => 123
   	DB<3>
 
 Useful, huh?  You can eval nearly anything in there, and experiment with bits
@@ -475,7 +475,7 @@ little messy, to leave in production code.
 
 	my ($in, $out) = ($num, $num);
 	$DB::single=2; # insert at line 9!
-	if ($deg eq 'c') 
+	if ($deg eq 'c')
 		...
 
 	> perl -d temp -f33.3
@@ -486,12 +486,12 @@ little messy, to leave in production code.
 
 	Enter h or `h h' for help, or `man perldebug' for more help.
 
-	main::(temp:4): my $arg = $ARGV[0] || '-c100';     
+	main::(temp:4): my $arg = $ARGV[0] || '-c100';
 
 We'll simply continue down to our pre-set breakpoint with a 'B<c>':
 
   	DB<1> c
-	main::(temp:10):                if ($deg eq 'c') {   
+	main::(temp:10):                if ($deg eq 'c') {
 
 Followed by a view command to see where we are:
 
@@ -505,7 +505,7 @@ Followed by a view command to see where we are:
 	13              } else {
 	14:                     $deg = 'c';
 	15:                     $out = &f2c($num);
-	16              }                             
+	16              }
 
 And a print to show what values we're currently using:
 
@@ -524,7 +524,7 @@ using the list 'L' command:
 	DB<3> L
 	temp:
  		17:            print "$out $deg\n";
-   		break if (1)     
+   		break if (1)
 
 Note that to delete a breakpoint you use 'B'.
 
@@ -532,19 +532,19 @@ Now we'll continue down into our subroutine, this time rather than by line
 number, we'll use the subroutine name, followed by the now familiar 'v':
 
 	DB<3> c f2c
-	main::f2c(temp:30):             my $f = shift;  
+	main::f2c(temp:30):             my $f = shift;
 
 	DB<4> v
 	24:     exit;
 	25
 	26      sub f2c {
 	27==>           my $f = shift;
-	28:             my $c = 5 * $f - 32 / 9; 
+	28:             my $c = 5 * $f - 32 / 9;
 	29:             return $c;
 	30      }
 	31
 	32      sub c2f {
-	33:             my $c = shift;   
+	33:             my $c = shift;
 
 
 Note that if there was a subroutine call between us and line 29, and we wanted
@@ -552,7 +552,7 @@ to B<single-step> through it, we could use the 'B<s>' command, and to step
 over it we would use 'B<n>' which would execute the sub, but not descend into
 it for inspection.  In this case though, we simply continue down to line 29:
 
-	DB<4> c 29  
+	DB<4> c 29
 	main::f2c(temp:29):             return $c;
 
 And have a look at the return value:
@@ -567,7 +567,7 @@ possibilities with our sum:
 	DB<6> p (5 * $f - 32 / 9)
 	162.944444444444
 
-	DB<7> p 5 * $f - (32 / 9) 
+	DB<7> p 5 * $f - (32 / 9)
 	162.944444444444
 
 	DB<8> p (5 * $f) - 32 / 9
@@ -587,10 +587,10 @@ return out of the sub with an 'r':
 Looks good, let's just continue off the end of the script:
 
 	DB<12> c
-	0.72 c 
+	0.72 c
 	Debugged program terminated.  Use q to quit or R to restart,
   	use O inhibit_exit to avoid stopping after program termination,
-  	h q, h R or h O to get additional info.   
+  	h q, h R or h O to get additional info.
 
 A quick fix to the offending line (insert the missing parentheses) in the
 actual program and we're finished.
@@ -600,11 +600,11 @@ actual program and we're finished.
 
 Actions, watch variables, stack traces etc.: on the TODO list.
 
-	a 
+	a
 
-	w 
+	w
 
-	t 
+	t
 
 	T
 
@@ -670,7 +670,7 @@ Just a quick hint here for all those CGI programmers who can't figure out how
 on earth to get past that 'waiting for input' prompt, when running their CGI
 script from the command-line, try something like this:
 
-	> perl -d my_cgi.pl -nodebug 
+	> perl -d my_cgi.pl -nodebug
 
 Of course L<CGI> and L<perlfaq9> will tell you more.
 
@@ -678,7 +678,7 @@ Of course L<CGI> and L<perlfaq9> will tell you more.
 =head1 GUIs
 
 The command line interface is tightly integrated with an B<emacs> extension
-and there's a B<vi> interface too.  
+and there's a B<vi> interface too.
 
 You don't have to do this all on the command line, though, there are a few GUI
 options out there.  The nice thing about these is you can wave a mouse over a
@@ -703,18 +703,18 @@ B<-w>.  We can run the perl debugger B<perl -d scriptname> to inspect your
 data from within the perl debugger with the B<p> and B<x> commands.  You can
 walk through your code, set breakpoints with B<b> and step through that code
 with B<s> or B<n>, continue with B<c> and return from a sub with B<r>.  Fairly
-intuitive stuff when you get down to it.  
+intuitive stuff when you get down to it.
 
 There is of course lots more to find out about, this has just scratched the
 surface.  The best way to learn more is to use perldoc to find out more about
 the language, to read the on-line help (L<perldebug> is probably the next
-place to go), and of course, experiment.  
+place to go), and of course, experiment.
 
 
 =head1 SEE ALSO
 
-L<perldebug>, 
-L<perldebguts>, 
+L<perldebug>,
+L<perldebguts>,
 L<perl5db.pl>,
 L<perldiag>,
 L<perlrun>

--- a/pod/perldebug.pod
+++ b/pod/perldebug.pod
@@ -70,7 +70,7 @@ There are several ways to call the debugger:
 
 On the given program identified by C<program_name>.
 
-=item perl -d -e 0 
+=item perl -d -e 0
 
 Interactively supply an arbitrary C<expression> using C<-e>.
 
@@ -381,7 +381,7 @@ X<breakpoint>
 X<debugger command, disable>
 X<disable>
 
-Disable the breakpoint so it won't stop the execution of the program. 
+Disable the breakpoint so it won't stop the execution of the program.
 Breakpoints are enabled by default and can be re-enabled using the C<enable>
 command.
 
@@ -390,7 +390,7 @@ X<breakpoint>
 X<debugger command, disable>
 X<disable>
 
-Disable the breakpoint so it won't stop the execution of the program. 
+Disable the breakpoint so it won't stop the execution of the program.
 Breakpoints are enabled by default and can be re-enabled using the C<enable>
 command.
 
@@ -401,14 +401,14 @@ X<breakpoint>
 X<debugger command, disable>
 X<disable>
 
-Enable the breakpoint so it will stop the execution of the program. 
+Enable the breakpoint so it will stop the execution of the program.
 
 =item enable [line]
 X<breakpoint>
 X<debugger command, disable>
 X<disable>
 
-Enable the breakpoint so it will stop the execution of the program. 
+Enable the breakpoint so it will stop the execution of the program.
 
 This is done for a breakpoint in the current file.
 

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -399,7 +399,7 @@ points>, those can be delimiters.
 =head3 Attributes C<< :locked >> and C<< :unique >>
 
 The attributes C<< :locked >> (on code references) and C<< :unique >>
-(on array, hash and scalar references) have had no effect since 
+(on array, hash and scalar references) have had no effect since
 Perl 5.005 and Perl 5.8.8 respectively. Their use has been deprecated
 since.
 
@@ -505,7 +505,7 @@ throws a fatal error as of Perl 5.28.
 =head3 C<< B::OP::terse >>
 
 This method, which just calls C<< B::Concise::b_terse >>, has been
-deprecated, and disappeared in Perl 5.28. Please use 
+deprecated, and disappeared in Perl 5.28. Please use
 L<B::Concise> instead.
 
 
@@ -567,7 +567,7 @@ rectify this have been scrapped, as users found that rewriting a
 pending exception is actually a useful feature, and not a bug.
 
 Perl never issued a deprecation warning for this; the deprecation
-was by documentation policy only. But this deprecation has been 
+was by documentation policy only. But this deprecation has been
 lifted as of Perl 5.26.
 
 
@@ -590,7 +590,7 @@ became fatal in Perl 5.26.
 =head3 Use of C<< *glob{FILEHANDLE} >>
 
 The use of C<< *glob{FILEHANDLE} >> was deprecated in Perl 5.8.
-The intention was to use C<< *glob{IO} >> instead, for which 
+The intention was to use C<< *glob{IO} >> instead, for which
 C<< *glob{FILEHANDLE} >> is an alias.
 
 However, this feature was undeprecated in Perl 5.24.
@@ -598,8 +598,8 @@ However, this feature was undeprecated in Perl 5.24.
 =head3 Calling POSIX::%s() is deprecated
 
 The following functions in the C<POSIX> module are no longer available:
-C<isalnum>, C<isalpha>, C<iscntrl>, C<isdigit>, C<isgraph>, C<islower>,  
-C<isprint>, C<ispunct>, C<isspace>, C<isupper>, and C<isxdigit>.  The 
+C<isalnum>, C<isalpha>, C<iscntrl>, C<isdigit>, C<isgraph>, C<islower>,
+C<isprint>, C<ispunct>, C<isspace>, C<isupper>, and C<isxdigit>.  The
 functions are buggy and don't work on UTF-8 encoded strings.  See their
 entries in L<POSIX> for more information.
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -2600,7 +2600,7 @@ as a return, a goto, or a loop control statement.
 
 (F) The type of a reference given to L<builtin/export_lexically> did not
 match the sigil of the preceding name, or the value was not a reference at
-all. 
+all.
 
 =item Expecting close bracket in regex; marked by S<<-- HERE> in m/%s/
 
@@ -2875,9 +2875,9 @@ of C<input>, C<output> or C<detail>, followed by a boolean.
 =item Global symbol "%s" requires explicit package name (did you forget to
 declare "my %s"?)
 
-(F) You've said "use strict" or "use strict vars", which indicates 
-that all variables must either be lexically scoped (using "my" or "state"), 
-declared beforehand using "our", or explicitly qualified to say 
+(F) You've said "use strict" or "use strict vars", which indicates
+that all variables must either be lexically scoped (using "my" or "state"),
+declared beforehand using "our", or explicitly qualified to say
 which package the global variable is in (using "::").
 
 =item glob failed (%s)
@@ -2934,7 +2934,7 @@ unspecified destination.  See L<perlfunc/goto>.
 the indicated subroutine hasn't been defined, or if it was, it
 has since been undefined.
 
-=item Group name must start with a non-digit word character in regex; marked by 
+=item Group name must start with a non-digit word character in regex; marked by
 S<<-- HERE> in m/%s/
 
 (F) Group names must follow the rules for Perl identifiers, meaning
@@ -3181,7 +3181,7 @@ expression inside the construct was completely empty, or if there are
 too many or few operands for the number of operators.  Perl is not smart
 enough to give you a more precise indication as to what is wrong.
 
-=item Inconsistent hierarchy during C3 merge of class '%s': merging failed on 
+=item Inconsistent hierarchy during C3 merge of class '%s': merging failed on
 parent '%s'
 
 (F) The method resolution order (MRO) of the given class is not
@@ -3882,7 +3882,7 @@ wrong date.
 =item Lookbehind longer than %d not implemented in regex m/%s/
 
 (F) There is currently a limit on the length of string which lookbehind can
-handle.  This restriction may be eased in a future release. 
+handle.  This restriction may be eased in a future release.
 
 =item Lost precision when %s %f by 1
 
@@ -4511,7 +4511,7 @@ scope before it could possibly have been used.
 real method in a real package, and it could not find such a context.
 See L<mro>.
 
-=item \N in a character class must be a named character: \N{...} in regex; 
+=item \N in a character class must be a named character: \N{...} in regex;
 marked by S<<-- HERE> in m/%s/
 
 (F) The new (as of Perl 5.12) meaning of C<\N> as C<[^\n]> is not valid in a
@@ -5592,7 +5592,7 @@ expression the problem was discovered.  See L<perlre>.
 If the specification of the class was not completely valid, the message
 indicates that.
 
-=item POSIX syntax [. .] is reserved for future extensions in regex; marked by 
+=item POSIX syntax [. .] is reserved for future extensions in regex; marked by
 S<<-- HERE> in m/%s/
 
 (F) Within regular expression character classes ([]) the syntax beginning
@@ -5602,7 +5602,7 @@ character class, just escape the square brackets with the backslash: "\[."
 and ".\]".  The S<<-- HERE> shows whereabouts in the regular expression the
 problem was discovered.  See L<perlre>.
 
-=item POSIX syntax [= =] is reserved for future extensions in regex; marked by 
+=item POSIX syntax [= =] is reserved for future extensions in regex; marked by
 S<<-- HERE> in m/%s/
 
 (F) Within regular expression character classes ([]) the syntax beginning
@@ -5768,7 +5768,7 @@ The regex C<m/foo$\s+bar/m> translates to: match the word 'foo', the output
 record separator (see L<perlvar/$\>) and the letter 's' (one time or more)
 followed by the word 'bar'.
 
-If this is what you intended then you can silence the warning by using 
+If this is what you intended then you can silence the warning by using
 C<m/${\}/> (for example: C<m/foo${\}s+bar/>).
 
 If instead you intended to match the word 'foo' at the end of the line
@@ -6054,7 +6054,7 @@ by S<<-- HERE> in m/%s/
 (F) The regular expression pattern had too many occurrences
 of the specified modifier.  Remove the extraneous ones.
 
-=item Regexp modifier "%c" may not appear after the "-" in regex; marked by <-- 
+=item Regexp modifier "%c" may not appear after the "-" in regex; marked by <--
 HERE in m/%s/
 
 (F) Turning off the given modifier has the side effect of turning on
@@ -6631,7 +6631,7 @@ assignment or as a subroutine argument for example).
 (P) Perl tried to force the upgrade of an SV to a type which was actually
 inferior to its current type.
 
-=item Switch (?(condition)... contains too many branches in regex; marked by 
+=item Switch (?(condition)... contains too many branches in regex; marked by
 S<<-- HERE> in m/%s/
 
 (F) A (?(condition)if-clause|else-clause) construct can have at most
@@ -7564,7 +7564,7 @@ S<<-- HERE> in m/%s/
 recognized by Perl inside character classes.  This is a fatal
 error when the character class is used within C<(?[ ])>.
 
-=item Unrecognized escape \%c in character class passed through in regex; 
+=item Unrecognized escape \%c in character class passed through in regex;
 marked by S<<-- HERE> in m/%s/
 
 (W regexp) You used a backslash-character combination which is not
@@ -8183,7 +8183,7 @@ or if you meant this
 
 You need to add either braces or blanks to disambiguate.
 
-=item Using just the first character returned by \N{} in character class in 
+=item Using just the first character returned by \N{} in character class in
 regex; marked by S<<-- HERE> in m/%s/
 
 (W regexp) Named Unicode character escapes C<(\N{...})> may return
@@ -8401,15 +8401,15 @@ are automatically rebound to the current values of such variables.
 with alpha parts.
 
 =item Verb pattern '%s' has a mandatory argument in regex; marked by
-S<<-- HERE> in m/%s/ 
+S<<-- HERE> in m/%s/
 
 (F) You used a verb pattern that requires an argument.  Supply an
 argument or check that you are using the right verb.
 
 =item Verb pattern '%s' may not have an argument in regex; marked by
-S<<-- HERE> in m/%s/ 
+S<<-- HERE> in m/%s/
 
-(F) You used a verb pattern that is not allowed an argument.  Remove the 
+(F) You used a verb pattern that is not allowed an argument.  Remove the
 argument or check that you are using the right verb.
 
 =item Version control conflict marker

--- a/pod/perldocstyle.pod
+++ b/pod/perldocstyle.pod
@@ -409,7 +409,7 @@ allows nested text formats, and you should use this feature as needed.
 Here is an example sentence that mentions Perl's C<say> function, with a
 link to its documentation section within the C<perlfunc> man page:
 
-    In version 5.10, Perl added support for the 
+    In version 5.10, Perl added support for the
     L<C<say>|perlfunc/say FILEHANDLE LIST> function.
 
 Note the use of the vertical pipe ("C<|>") to separate how the link will
@@ -461,7 +461,7 @@ explanation's clarity without adding to its complexity.
 Like any other kind of source code, Pod lets you insert comments visible
 only to other people reading the source directly, and ignored by the
 formatting programs that transform Pod into various human-friendly
-output formats (such as HTML or PDF). 
+output formats (such as HTML or PDF).
 
 To comment Pod text, use the C<=for> and C<=begin> / C<=end> Pod
 directives, aiming them at a (notional) formatter called "C<comment>". A
@@ -549,7 +549,7 @@ argument, might have an entry in perlfunc shaped like this:
 
     =item myfunc
 
-    =for Pod::Functions demonstrate a function's perlfunc section 
+    =for Pod::Functions demonstrate a function's perlfunc section
 
     [ Main part of function definition goes here, with examples ]
 
@@ -878,7 +878,7 @@ after thoroughly documenting and demonstrating how it works in the
 common case. Furthermore, while engaging in this demonstration, the
 C<open> documentation does not burden the reader right away with detailed
 explanations about calling C<open> via any route other than the
-best-practice, three-argument style. 
+best-practice, three-argument style.
 
 =head3 Show the lesser ways when needed
 
@@ -997,7 +997,7 @@ reader. Should a sentence exist mainly to make a wry joke that doesn't
 further the reader's knowledge of Perl, set it aside, and consider
 recasting it into a personal blog post or other article instead.
 
-Write with a light heart, and a miserly hand. 
+Write with a light heart, and a miserly hand.
 
 =head1 INDEX OF PREFERRED TERMS
 

--- a/pod/perlebcdic.pod
+++ b/pod/perlebcdic.pod
@@ -248,35 +248,35 @@ abbreviations to the ones used by Unicode (and hence Perl):
  IBM       ASCII        IBM name
  abbr.    mapping
 
- BYP/INP    IND         Bypass, Inhibit Presentation 
- CSP        PLD         Control Sequence Prefix 
- CU1        SS3         Customer Use One 
- CU3        CSI         Customer Use Three 
- DS         PAD         Digit Select 
+ BYP/INP    IND         Bypass, Inhibit Presentation
+ CSP        PLD         Control Sequence Prefix
+ CU1        SS3         Customer Use One
+ CU3        CSI         Customer Use Three
+ DS         PAD         Digit Select
  EO         APC         Eight Ones
  FS/FDS     BPH         Field Separator
- GE         EPA         Graphic Escape 
- IR         STS         Index Return 
- IT         SGC         Indent Tab 
- MFA        PLU         Modify Field Attribute 
- NBS        SPA         Numeric Backspace 
- NL         NEL         New Line 
- POC        ESA         Program Operator Communication 
- PP         CCH         Presentation Position 
- RES/ENP    OSC         Restore, Enable Presentation 
- RFF        SCI         Required Form Feed 
- RNL        SSA         Required New Line 
- RPT        SS2         Repeat 
- SA         HTS         Set Attribute 
- SBS        SOS         Subscript 
- SEL        ST          Select 
- SFE        HTJ         Start Field Extended 
- SM/SW      VTS         Set Mode, Switch 
- SOS        HOP         Start of Significance 
- SPS        RI          Superscript 
- TRN        MW          Transparent 
- UBS        PU2         Unit Backspace 
- WUS        NBH         Word Underscore 
+ GE         EPA         Graphic Escape
+ IR         STS         Index Return
+ IT         SGC         Indent Tab
+ MFA        PLU         Modify Field Attribute
+ NBS        SPA         Numeric Backspace
+ NL         NEL         New Line
+ POC        ESA         Program Operator Communication
+ PP         CCH         Presentation Position
+ RES/ENP    OSC         Restore, Enable Presentation
+ RFF        SCI         Required Form Feed
+ RNL        SSA         Required New Line
+ RPT        SS2         Repeat
+ SA         HTS         Set Attribute
+ SBS        SOS         Subscript
+ SEL        ST          Select
+ SFE        HTJ         Start Field Extended
+ SM/SW      VTS         Set Mode, Switch
+ SOS        HOP         Start of Significance
+ SPS        RI          Superscript
+ TRN        MW          Transparent
+ UBS        PU2         Unit Backspace
+ WUS        NBH         Word Underscore
 
 And the inverse ones:
 
@@ -285,33 +285,33 @@ And the inverse ones:
 
  EO         APC         Eight Ones
  FS/FDS     BPH         Field Separator
- PP         CCH         Presentation Position 
- CU3        CSI         Customer Use Three 
- GE         EPA         Graphic Escape 
- POC        ESA         Program Operator Communication 
- SOS        HOP         Start of Significance 
- SFE        HTJ         Start Field Extended 
- SA         HTS         Set Attribute 
- BYP/INP    IND         Bypass, Inhibit Presentation 
- TRN        MW          Transparent 
- WUS        NBH         Word Underscore 
- NL         NEL         New Line 
- RES/ENP    OSC         Restore, Enable Presentation 
- DS         PAD         Digit Select 
- CSP        PLD         Control Sequence Prefix 
- MFA        PLU         Modify Field Attribute 
- UBS        PU2         Unit Backspace 
- SPS        RI          Superscript 
- RFF        SCI         Required Form Feed 
- IT         SGC         Indent Tab 
- SBS        SOS         Subscript 
- NBS        SPA         Numeric Backspace 
- RPT        SS2         Repeat 
- CU1        SS3         Customer Use One 
- RNL        SSA         Required New Line 
- SEL        ST          Select 
- IR         STS         Index Return 
- SM/SW      VTS         Set Mode, Switch 
+ PP         CCH         Presentation Position
+ CU3        CSI         Customer Use Three
+ GE         EPA         Graphic Escape
+ POC        ESA         Program Operator Communication
+ SOS        HOP         Start of Significance
+ SFE        HTJ         Start Field Extended
+ SA         HTS         Set Attribute
+ BYP/INP    IND         Bypass, Inhibit Presentation
+ TRN        MW          Transparent
+ WUS        NBH         Word Underscore
+ NL         NEL         New Line
+ RES/ENP    OSC         Restore, Enable Presentation
+ DS         PAD         Digit Select
+ CSP        PLD         Control Sequence Prefix
+ MFA        PLU         Modify Field Attribute
+ UBS        PU2         Unit Backspace
+ SPS        RI          Superscript
+ RFF        SCI         Required Form Feed
+ IT         SGC         Indent Tab
+ SBS        SOS         Subscript
+ NBS        SPA         Numeric Backspace
+ RPT        SS2         Repeat
+ CU1        SS3         Customer Use One
+ RNL        SSA         Required New Line
+ SEL        ST          Select
+ IR         STS         Index Return
+ SM/SW      VTS         Set Mode, Switch
 
 =head2 Unicode and UTF
 

--- a/pod/perlform.pod
+++ b/pod/perlform.pod
@@ -31,8 +31,8 @@ Output record formats are declared as follows:
     FORMLIST
     .
 
-If the name is omitted, format "STDOUT" is defined. A single "." in 
-column 1 is used to terminate a format.  FORMLIST consists of a sequence 
+If the name is omitted, format "STDOUT" is defined. A single "." in
+column 1 is used to terminate a format.  FORMLIST consists of a sequence
 of lines, each of which may be one of three types:
 
 =over 4
@@ -84,13 +84,13 @@ the various possibilities in detail.
 =head2 Text Fields
 X<format, text field>
 
-The length of the field is supplied by padding out the field with multiple 
+The length of the field is supplied by padding out the field with multiple
 "E<lt>", "E<gt>", or "|" characters to specify a non-numeric field with,
-respectively, left justification, right justification, or centering. 
+respectively, left justification, right justification, or centering.
 For a regular field, the value (up to the first newline) is taken and
 printed according to the selected justification, truncating excess characters.
 If you terminate a text field with "...", three dots will be shown if
-the value is truncated. A special text field may be used to do rudimentary 
+the value is truncated. A special text field may be used to do rudimentary
 multi-line text block filling; see L</Using Fill Mode> for details.
 
    Example:
@@ -133,10 +133,10 @@ line feed is chomped off, but all other characters are emitted verbatim.
 =head2 The Field ^* for Variable-Width One-line-at-a-time Text
 X<^*>
 
-Like "@*", this is a variable-width field. The value supplied must be a 
-scalar variable. Perl puts the first line (up to the first "\n") of the 
-text into the field, and then chops off the front of the string so that 
-the next time the variable is referenced, more of the text can be printed. 
+Like "@*", this is a variable-width field. The value supplied must be a
+scalar variable. Perl puts the first line (up to the first "\n") of the
+text into the field, and then chops off the front of the string so that
+the next time the variable is referenced, more of the text can be printed.
 The variable will I<not> be restored.
 
    Example:
@@ -183,15 +183,15 @@ the variable is referenced, more of the text can be printed.  (Yes, this
 means that the variable itself is altered during execution of the write()
 call, and is not restored.)  The next portion of text is determined by
 a crude line-breaking algorithm. You may use the carriage return character
-(C<\r>) to force a line break. You can change which characters are legal 
-to break on by changing the variable C<$:> (that's 
-$FORMAT_LINE_BREAK_CHARACTERS if you're using the English module) to a 
+(C<\r>) to force a line break. You can change which characters are legal
+to break on by changing the variable C<$:> (that's
+$FORMAT_LINE_BREAK_CHARACTERS if you're using the English module) to a
 list of the desired characters.
 
-Normally you would use a sequence of fields in a vertical stack associated 
-with the same scalar variable to print out a block of text. You might wish 
-to end the final field with the text "...", which will appear in the output 
-if the text was too long to appear in its entirety.  
+Normally you would use a sequence of fields in a vertical stack associated
+with the same scalar variable to print out a block of text. You might wish
+to end the final field with the text "...", which will appear in the output
+if the text was too long to appear in its entirety.
 
 
 =head2 Suppressing Lines Where All Fields Are Void
@@ -211,7 +211,7 @@ the line will be repeated until all the fields on the line are exhausted,
 i.e. undefined. For special (caret) text fields this will occur sooner or
 later, but if you use a text field of the at variety, the  expression you
 supply had better not give the same value every time forever! (C<shift(@f)>
-is a simple example that would work.)  Don't use a regular (at) numeric 
+is a simple example that would work.)  Don't use a regular (at) numeric
 field in such lines, because it will never go blank.
 
 

--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -296,7 +296,7 @@ current scope.
 =for Pod::Functions =Namespace
 
 L<C<caller>|/caller EXPR>,
-L<C<class>|/class NAMESPACE>, 
+L<C<class>|/class NAMESPACE>,
 L<C<field>|/field VARNAME>,
 L<C<import>|/import LIST>,
 L<C<local>|/local EXPR>,

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -816,7 +816,7 @@ C<SV*>.  To access the scalar value, you must first dereference the return
 value.  However, you should check to make sure that the return value is
 not NULL before dereferencing it.
 
-The first of these two functions checks if a hash table entry exists, and the 
+The first of these two functions checks if a hash table entry exists, and the
 second deletes it.
 
     bool  hv_exists(HV*, const char* key, U32 klen);
@@ -3613,7 +3613,7 @@ you if a string contains only valid UTF-8 characters, and the chances
 of a non-UTF-8 string looking like valid UTF-8 become very small very
 quickly with increasing string length.  On a character-by-character
 basis, C<isUTF8_CHAR>
-will tell you whether the current character in a string is valid UTF-8. 
+will tell you whether the current character in a string is valid UTF-8.
 
 =head2 How does UTF-8 represent Unicode characters?
 

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1933,7 +1933,7 @@ A F<gdb> session on a threaded perl might look something like this:
     Unmarked SV: 0xaf24c8: IV(3)
     Unmarked SV: 0xace6c8: PV("AV()"\0)
     Unmarked SV: 0xace848: PV("IV(1)"\0)
-    (gdb) 
+    (gdb)
 
 Here, at the start of the first call to pp_entereval(), all existing SVs
 are marked. Then at the start of the second call, we list all the SVs

--- a/pod/perlinterp.pod
+++ b/pod/perlinterp.pod
@@ -734,7 +734,7 @@ And here is the function from F<op.c>:
      2 Perl_ck_readline(pTHX_ OP *o)
      3 {
      4     PERL_ARGS_ASSERT_CK_READLINE;
-     5 
+     5
      6     if (o->op_flags & OPf_KIDS) {
      7          OP *kid = cLISTOPo->op_first;
      8          if (kid->op_type == OP_RV2GV)

--- a/pod/perliol.pod
+++ b/pod/perliol.pod
@@ -882,7 +882,7 @@ The following table summarizes the behaviour:
                 and return -1 (for numeric return values) or NULL (for
                 pointers)
  INHERITED      Inherited from the layer below
- SUCCESS        Return 0 (for numeric return values) or a pointer 
+ SUCCESS        Return 0 (for numeric return values) or a pointer
 
 =head2 Core Layers
 

--- a/pod/perllocale.pod
+++ b/pod/perllocale.pod
@@ -562,7 +562,7 @@ from using thread-safe locales.
 C<${^SAFE_LOCALES}> will be 0 on systems that turn off the thread-safe
 operations.
 
-Normally on unthreaded builds, Perl uses the traditional C<setlocale()> 
+Normally on unthreaded builds, Perl uses the traditional C<setlocale()>
 to change the locale, and not the alternate POSIX 2008 thread-safe
 locale-changing functions.  You can force the use of these on systems
 that have them by adding the C<-Accflags='-DUSE_THREAD_SAFE_LOCALE'> to

--- a/pod/perlmod.pod
+++ b/pod/perlmod.pod
@@ -107,7 +107,7 @@ even when used for other purposes than their built-in ones.  If you
 have a package called C<m>, C<s>, or C<y>, then you can't use the
 qualified form of an identifier because it would be instead interpreted
 as a pattern match, a substitution, or a transliteration.
-X<variable, punctuation> 
+X<variable, punctuation>
 
 Variables beginning with underscore used to be forced into package
 main, but we decided it was more useful for package writers to be able

--- a/pod/perlmodstyle.pod
+++ b/pod/perlmodstyle.pod
@@ -5,15 +5,15 @@ perlmodstyle - Perl module style guide
 =head1 INTRODUCTION
 
 This document attempts to describe the Perl Community's "best practice"
-for writing Perl modules.  It extends the recommendations found in 
+for writing Perl modules.  It extends the recommendations found in
 L<perlstyle> , which should be considered required reading
 before reading this document.
 
 While this document is intended to be useful to all module authors, it is
 particularly aimed at authors who wish to publish their modules on CPAN.
 
-The focus is on elements of style which are visible to the users of a 
-module, rather than those parts which are only seen by the module's 
+The focus is on elements of style which are visible to the users of a
+module, rather than those parts which are only seen by the module's
 developers.  However, many of the guidelines presented in this document
 can be extrapolated and applied successfully to a module's internals.
 
@@ -21,7 +21,7 @@ This document differs from L<perlnewmod> in that it is a style guide
 rather than a tutorial on creating CPAN modules.  It provides a
 checklist against which modules can be compared to determine whether
 they conform to best practice, without necessarily describing in detail
-how to achieve this.  
+how to achieve this.
 
 All the advice contained in this document has been gleaned from
 extensive conversations with experienced CPAN authors and users.  Every
@@ -29,9 +29,9 @@ piece of advice given here is the result of previous mistakes.  This
 information is here to help you avoid the same mistakes and the extra
 work that would inevitably be required to fix them.
 
-The first section of this document provides an itemized checklist; 
-subsequent sections provide a more detailed discussion of the items on 
-the list.  The final section, "Common Pitfalls", describes some of the 
+The first section of this document provides an itemized checklist;
+subsequent sections provide a more detailed discussion of the items on
+the list.  The final section, "Common Pitfalls", describes some of the
 most popular mistakes made by CPAN authors.
 
 =head1 QUICK CHECKLIST
@@ -177,8 +177,8 @@ amount of effort later on.
 
 =head2 Has it been done before?
 
-You may not even need to write the module.  Check whether it's already 
-been done in Perl, and avoid re-inventing the wheel unless you have a 
+You may not even need to write the module.  Check whether it's already
+been done in Perl, and avoid re-inventing the wheel unless you have a
 good reason.
 
 Good places to look for pre-existing modules include
@@ -228,7 +228,7 @@ When naming your module, consider the following:
 
 Be descriptive (i.e. accurately describes the purpose of the module).
 
-=item * 
+=item *
 
 Be consistent with existing modules.
 
@@ -258,8 +258,8 @@ Considerations for module design and coding:
 
 =head2 To OO or not to OO?
 
-Your module may be object oriented (OO) or not, or it may have both kinds 
-of interfaces available.  There are pros and cons of each technique, which 
+Your module may be object oriented (OO) or not, or it may have both kinds
+of interfaces available.  There are pros and cons of each technique, which
 should be considered when you design your API.
 
 In I<Perl Best Practices> (copyright 2004, Published by O'Reilly Media, Inc.),
@@ -323,7 +323,7 @@ difficult for the average module user to understand or use.
 
 =head2 Designing your API
 
-Your interfaces should be understandable by an average Perl programmer.  
+Your interfaces should be understandable by an average Perl programmer.
 The following guidelines may help you judge whether your API is
 sufficiently straightforward:
 
@@ -336,9 +336,9 @@ If your routine changes its behaviour significantly based on its
 arguments, it's a sign that you should have two (or more) separate
 routines.
 
-=item Separate functionality from output.  
+=item Separate functionality from output.
 
-Return your results in the most generic form possible and allow the user 
+Return your results in the most generic form possible and allow the user
 to choose how to use them.  The most generic form possible is usually a
 Perl data structure which can then be used to generate a text report,
 HTML, XML, a database query, or whatever else your users require.
@@ -346,17 +346,17 @@ HTML, XML, a database query, or whatever else your users require.
 If your routine iterates through some kind of list (such as a list of
 files, or records in a database) you may consider providing a callback
 so that users can manipulate each element of the list in turn.
-File::Find provides an example of this with its 
+File::Find provides an example of this with its
 C<find(\&wanted, $dir)> syntax.
 
 =item Provide sensible shortcuts and defaults.
 
 Don't require every module user to jump through the same hoops to achieve a
-simple result.  You can always include optional parameters or routines for 
+simple result.  You can always include optional parameters or routines for
 more complex or non-standard behaviour.  If most of your users have to
 type a few almost identical lines of code when they start using your
 module, it's a sign that you should have made that behaviour a default.
-Another good indicator that you should use defaults is if most of your 
+Another good indicator that you should use defaults is if most of your
 users call your routines with the same arguments.
 
 =item Naming conventions
@@ -404,9 +404,9 @@ Provide sensible defaults for parameters which have them.  Don't make
 your users specify parameters which will almost always be the same.
 
 The issue of whether to pass the arguments in a hash or a hashref is
-largely a matter of personal style. 
+largely a matter of personal style.
 
-The use of hash keys starting with a hyphen (C<-name>) or entirely in 
+The use of hash keys starting with a hyphen (C<-name>) or entirely in
 upper case (C<NAME>) is a relic of older versions of Perl in which
 ordinary lower case strings were not handled correctly by the C<=E<gt>>
 operator.  While some modules retain uppercase or hyphenated argument
@@ -419,7 +419,7 @@ consistent!
 =head2 Strictness and warnings
 
 Your module should run successfully under the strict pragma and should
-run without generating any warnings.  Your module should also handle 
+run without generating any warnings.  Your module should also handle
 taint-checking where appropriate, though this can cause difficulties in
 many cases.
 
@@ -447,19 +447,19 @@ document it clearly).
 
 =item *
 
-C<warn()> or C<carp()> a message to STDERR.  
+C<warn()> or C<carp()> a message to STDERR.
 
 =item *
 
 C<croak()> only when your module absolutely cannot figure out what to
-do.  (C<croak()> is a better version of C<die()> for use within 
-modules, which reports its errors from the perspective of the caller.  
+do.  (C<croak()> is a better version of C<die()> for use within
+modules, which reports its errors from the perspective of the caller.
 See L<Carp> for details of C<croak()>, C<carp()> and other useful
 routines.)
 
 =item *
 
-As an alternative to the above, you may prefer to throw exceptions using 
+As an alternative to the above, you may prefer to throw exceptions using
 the Error module.
 
 =back
@@ -475,9 +475,9 @@ to the commonest use.
 =head2 POD
 
 Your module should include documentation aimed at Perl developers.
-You should use Perl's "plain old documentation" (POD) for your general 
+You should use Perl's "plain old documentation" (POD) for your general
 technical documentation, though you may wish to write additional
-documentation (white papers, tutorials, etc) in some other format.  
+documentation (white papers, tutorials, etc) in some other format.
 You need to cover the following subjects:
 
 =over 4
@@ -515,7 +515,7 @@ minimal example of use (perhaps as little as one line of code; skip the
 unusual use cases or anything not needed by most users); the
 DESCRIPTION should describe your module in broad terms, generally in
 just a few paragraphs; more detail of the module's routines or methods,
-lengthy code examples, or other in-depth material should be given in 
+lengthy code examples, or other in-depth material should be given in
 subsequent sections.
 
 Ideally, someone who's slightly familiar with your module should be able
@@ -527,7 +527,7 @@ The recommended order of sections in Perl module documentation is:
 
 =over 4
 
-=item * 
+=item *
 
 NAME
 
@@ -541,7 +541,7 @@ DESCRIPTION
 
 =item *
 
-One or more sections or subsections giving greater detail of available 
+One or more sections or subsections giving greater detail of available
 methods and routines and any other relevant information.
 
 =item *
@@ -563,7 +563,7 @@ COPYRIGHT and LICENSE
 =back
 
 Keep your documentation near the code it documents ("inline"
-documentation).  Include POD for a given method right above that 
+documentation).  Include POD for a given method right above that
 method's subroutine.  This makes it easier to keep the documentation up
 to date, and avoids having to document each piece of code twice (once in
 POD and once in comments).
@@ -571,9 +571,9 @@ POD and once in comments).
 =head2 README, INSTALL, release notes, changelogs
 
 Your module should also include a README file describing the module and
-giving pointers to further information (website, author email).  
+giving pointers to further information (website, author email).
 
-An INSTALL file should be included, and should contain simple installation 
+An INSTALL file should be included, and should contain simple installation
 instructions.  When using ExtUtils::MakeMaker this will usually be:
 
 =over 4
@@ -627,8 +627,8 @@ The most common CPAN version numbering scheme looks like this:
 
     1.00, 1.10, 1.11, 1.20, 1.30, 1.31, 1.32
 
-A correct CPAN version number is a floating point number with at least 
-2 digits after the decimal.  You can test whether it conforms to CPAN by 
+A correct CPAN version number is a floating point number with at least
+2 digits after the decimal.  You can test whether it conforms to CPAN by
 using
 
     perl -MExtUtils::MakeMaker -le 'print MM->parse_version(shift)' \
@@ -668,7 +668,7 @@ Module authors should carefully consider whether to rely on other
 modules, and which modules to rely on.
 
 Most importantly, choose modules which are as stable as possible.  In
-order of preference: 
+order of preference:
 
 =over 4
 
@@ -700,17 +700,17 @@ L<C<use VERSION>|perlfunc/use VERSION> for details.
 =head2 Testing
 
 All modules should be tested before distribution (using "make disttest"),
-and the tests should also be available to people installing the modules 
-(using "make test").  
+and the tests should also be available to people installing the modules
+(using "make test").
 For Module::Build you would use the C<make test> equivalent C<perl Build test>.
 
-The importance of these tests is proportional to the alleged stability of a 
+The importance of these tests is proportional to the alleged stability of a
 module.  A module which purports to be
-stable or which hopes to achieve wide 
+stable or which hopes to achieve wide
 use should adhere to as strict a testing regime as possible.
 
-Useful modules to help you write tests (with minimum impact on your 
-development process or your time) include Test::Simple, Carp::Assert 
+Useful modules to help you write tests (with minimum impact on your
+development process or your time) include Test::Simple, Carp::Assert
 and Test::Inline.
 For more sophisticated test suites there are Test::More and Test::MockObject.
 
@@ -755,15 +755,15 @@ building blocks.
 =head2 Inappropriate documentation
 
 Don't fall into the trap of writing for the wrong audience.  Your
-primary audience is a reasonably experienced developer with at least 
-a moderate understanding of your module's application domain, who's just 
+primary audience is a reasonably experienced developer with at least
+a moderate understanding of your module's application domain, who's just
 downloaded your module and wants to start using it as quickly as possible.
 
-Tutorials, end-user documentation, research papers, FAQs etc are not 
-appropriate in a module's main documentation.  If you really want to 
+Tutorials, end-user documentation, research papers, FAQs etc are not
+appropriate in a module's main documentation.  If you really want to
 write these, include them as sub-documents such as C<My::Module::Tutorial> or
 C<My::Module::FAQ> and provide a link in the SEE ALSO section of the
-main documentation.  
+main documentation.
 
 =head1 SEE ALSO
 

--- a/pod/perlmroapi.pod
+++ b/pod/perlmroapi.pod
@@ -101,7 +101,7 @@ C<S_mro_get_linear_isa_dfs()> in F<mro_core.c>
 =head1 AUTHORS
 
 The implementation of the C3 MRO and switchable MROs within the perl core was
-written by Brandon L Black. Nicholas Clark created the pluggable interface, 
+written by Brandon L Black. Nicholas Clark created the pluggable interface,
 refactored Brandon's implementation to work with it, and wrote this document.
 
 =cut

--- a/pod/perlnewmod.pod
+++ b/pod/perlnewmod.pod
@@ -137,11 +137,11 @@ the command line, thus:
 If you do not wish to install the L<Module::Starter|Module::Starter>
 package from CPAN, F<h2xs> is an older tool, originally intended for the
 development of XS modules, which comes packaged with the Perl
-distribution. 
+distribution.
 
 A typical invocation of L<h2xs|h2xs> for a pure Perl module is:
 
-    h2xs -AX --skip-exporter --use-new-tests -n Foo::Bar 
+    h2xs -AX --skip-exporter --use-new-tests -n Foo::Bar
 
 The C<-A> omits the Autoloader code, C<-X> omits XS elements,
 C<--skip-exporter> omits the Exporter code, C<--use-new-tests> sets up a

--- a/pod/perlobj.pod
+++ b/pod/perlobj.pod
@@ -751,7 +751,7 @@ appending C<::> to it, like we saw earlier:
 
   my $file = new File:: $path, $data;
 
-Indirect object syntax is only available when the 
+Indirect object syntax is only available when the
 L<C<"indirect">|feature/The 'indirect' feature> named feature is enabled.
 This is enabled by default, but can be disabled if requested.  This
 feature is present in older feature version bundles, but was removed

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -3077,7 +3077,7 @@ delimiter) will be preserved:
      This text is indented with two spaces
 		This line is indented with two tabs, though those may
                 have been converted to spaces by various filters by
-                the time you read this. 
+                the time you read this.
    EOF
 
 =back

--- a/pod/perlpacktut.pod
+++ b/pod/perlpacktut.pod
@@ -6,8 +6,8 @@ perlpacktut - tutorial on C<pack> and C<unpack>
 
 C<pack> and C<unpack> are two functions for transforming data according
 to a user-defined template, between the guarded way Perl stores values
-and some well-defined representation as might be required in the 
-environment of a Perl program. Unfortunately, they're also two of 
+and some well-defined representation as might be required in the
+environment of a Perl program. Unfortunately, they're also two of
 the most misunderstood and most often overlooked functions that Perl
 provides. This tutorial will demystify them for you.
 
@@ -26,7 +26,7 @@ excellent alternative. The C<pack> function converts values to a byte
 sequence containing representations according to a given specification,
 the so-called "template" argument. C<unpack> is the reverse process,
 deriving some values from the contents of a string of bytes. (Be cautioned,
-however, that not all that has been packed together can be neatly unpacked - 
+however, that not all that has been packed together can be neatly unpacked -
 a very common experience as seasoned travellers are likely to confirm.)
 
 Why, you may ask, would you need a chunk of memory containing some values
@@ -35,8 +35,8 @@ some file, a device, or a network connection, whereby this binary
 representation is either forced on you or will give you some benefit
 in processing. Another cause is passing data to some system call that
 is not available as a Perl function: C<syscall> requires you to provide
-parameters stored in the way it happens in a C program. Even text processing 
-(as shown in the next section) may be simplified with judicious usage 
+parameters stored in the way it happens in a C program. Even text processing
+(as shown in the next section) may be simplified with judicious usage
 of these two functions.
 
 To see how (un)packing works, we'll start with a simple template
@@ -44,7 +44,7 @@ code where the conversion is in low gear: between the contents of a byte
 sequence and a string of hexadecimal digits. Let's use C<unpack>,
 since this may remind you of a hex dump or a crash message emitted by
 a program just before it fails. Assuming that the variable C<$mem> holds
-a sequence of bytes that we'd like to inspect without assuming anything 
+a sequence of bytes that we'd like to inspect without assuming anything
 about its meaning, we can write
 
    my( $hex ) = unpack( 'H*', $mem );
@@ -92,7 +92,7 @@ How do we do it? You might think first to use C<split>; however, since
 C<split> collapses blank fields, you'll never know whether a record was
 income or expenditure. Oops. Well, you could always use C<substr>:
 
-    while (<>) { 
+    while (<>) {
         my $date   = substr($_,  0, 11);
         my $desc   = substr($_, 12, 27);
         my $income = substr($_, 40,  7);
@@ -108,8 +108,8 @@ as horribly unfriendly.
 
 Or maybe we could use regular expressions:
 
-    while (<>) { 
-        my($date, $desc, $income, $expend) = 
+    while (<>) {
+        my($date, $desc, $income, $expend) =
             m|(\d\d/\d\d/\d{4}) (.{27}) (.{7})(.*)|;
         ...
     }
@@ -122,18 +122,18 @@ if you use the right tools. C<pack> and C<unpack> are designed to help
 you out when dealing with fixed-width data like the above. Let's have a
 look at a solution with C<unpack>:
 
-    while (<>) { 
+    while (<>) {
         my($date, $desc, $income, $expend) = unpack("A10xA27xA7A*", $_);
         ...
     }
 
 That looks a bit nicer; but we've got to take apart that weird template.
-Where did I pull that out of? 
+Where did I pull that out of?
 
 OK, let's have a look at some of our data again; in fact, we'll include
 the headers, and a handy ruler so we can keep track of where we are.
 
-             1         2         3         4         5        
+             1         2         3         4         5
     1234567890123456789012345678901234567890123456789012345678
     Date      |Description                | Income|Expenditure
     01/28/2001 Flea spray                                24.99
@@ -190,10 +190,10 @@ how much we've spent:
         $tot_expend += $expend;
     }
 
-    $tot_income = sprintf("%.2f", $tot_income); # Get them into 
+    $tot_income = sprintf("%.2f", $tot_income); # Get them into
     $tot_expend = sprintf("%.2f", $tot_expend); # "financial" format
 
-    $date = POSIX::strftime("%m/%d/%Y", localtime); 
+    $date = POSIX::strftime("%m/%d/%Y", localtime);
 
     # OK, let's go:
 
@@ -215,7 +215,7 @@ we? Shouldn't it skip forward? Let's look at what L<perlfunc/pack> says:
 Urgh. No wonder. There's a big difference between "a null byte",
 character zero, and "a space", character 32. Perl's put something
 between the date and the description - but unfortunately, we can't see
-it! 
+it!
 
 What we actually need to do is expand the width of the fields. The C<A>
 format pads any non-existent characters with spaces, so we can use the
@@ -238,9 +238,9 @@ be moved further over. There's an easy way to fix this up:
 unfortunately, we can't get C<pack> to right-justify our fields, but we
 can get C<sprintf> to do it:
 
-    $tot_income = sprintf("%.2f", $tot_income); 
+    $tot_income = sprintf("%.2f", $tot_income);
     $tot_expend = sprintf("%12.2f", $tot_expend);
-    $date = POSIX::strftime("%m/%d/%Y", localtime); 
+    $date = POSIX::strftime("%m/%d/%Y", localtime);
     print pack("A11 A28 A8 A*", $date, "Totals",
         $tot_income, $tot_expend);
 
@@ -259,7 +259,7 @@ we've seen of C<pack> and C<unpack> so far:
 
 Use C<pack> to go from several pieces of data to one fixed-width
 version; use C<unpack> to turn a fixed-width-format string into several
-pieces of data. 
+pieces of data.
 
 =item *
 
@@ -282,7 +282,7 @@ C<x6> means "skip 6 bytes" or "character 0, 6 times".
 =item *
 
 Instead of a number, you can use C<*> to mean "consume everything else
-left". 
+left".
 
 B<Warning>: when packing multiple pieces of data, C<*> only means
 "consume all of the current piece of data". That's to say
@@ -334,7 +334,7 @@ computer's representation you write
 
    my $ps = pack( 's', 20302 );
 
-Again, the result is a string, now containing 2 bytes. If you print 
+Again, the result is a string, now containing 2 bytes. If you print
 this string (which is, generally, not recommended) you might see
 C<ON> or C<NO> (depending on your system's byte ordering) - or something
 entirely different if your computer doesn't use ASCII character encoding.
@@ -353,15 +353,15 @@ getting set, and unpacking this will smartly return a negative value.
 for signed and unsigned 32-bit integers. And if this is not enough and
 your system supports 64 bit integers you can push the limits much closer
 to infinity with pack codes C<q> and C<Q>. A notable exception is provided
-by pack codes C<i> and C<I> for signed and unsigned integers of the 
+by pack codes C<i> and C<I> for signed and unsigned integers of the
 "local custom" variety: Such an integer will take up as many bytes as
 a local C compiler returns for C<sizeof(int)>, but it'll use I<at least>
 32 bits.
 
 Each of the integer pack codes C<sSlLqQ> results in a fixed number of bytes,
-no matter where you execute your program. This may be useful for some 
-applications, but it does not provide for a portable way to pass data 
-structures between Perl and C programs (bound to happen when you call 
+no matter where you execute your program. This may be useful for some
+applications, but it does not provide for a portable way to pass data
+structures between Perl and C programs (bound to happen when you call
 XS extensions or the Perl function C<syscall>), or when you read or
 write binary files. What you'll need in this case are template codes that
 depend on what your local C compiler compiles when you code C<short> or
@@ -372,7 +372,7 @@ values may vary, and that's why the values are given as expressions in
 C and Perl. (If you'd like to use values from C<%Config> in your program
 you have to import it with C<use Config>.)
 
-   signed unsigned  byte length in C   byte length in Perl       
+   signed unsigned  byte length in C   byte length in Perl
      s!     S!      sizeof(short)      $Config{shortsize}
      i!     I!      sizeof(int)        $Config{intsize}
      l!     L!      sizeof(long)       $Config{longsize}
@@ -422,11 +422,11 @@ together, we may now write:
 
    my( $ip, $cs,
        $flags,$fl,$fh,
-       $ax,$al,$ah, $bx,$bl,$bh, $cx,$cl,$ch, $dx,$dl,$dh, 
+       $ax,$al,$ah, $bx,$bl,$bh, $cx,$cl,$ch, $dx,$dl,$dh,
        $si, $di, $bp, $ds, $es ) =
    unpack( 'v2' . ('vXXCC' x 5) . 'v5', $frame );
 
-(The clumsy construction of the template can be avoided - just read on!)  
+(The clumsy construction of the template can be avoided - just read on!)
 
 We've taken some pains to construct the template so that it matches
 the contents of our frame buffer. Otherwise we'd either get undefined values,
@@ -542,7 +542,7 @@ string codes:
 It is not possible to pack or unpack bit fields - just integral bytes.
 C<pack> always starts at the next byte boundary and "rounds up" to the
 next multiple of 8 by adding zero bits as required. (If you do want bit
-fields, there is L<perlfunc/vec>. Or you could implement bit field 
+fields, there is L<perlfunc/vec>. Or you could implement bit field
 handling at the character string level, using split, substr, and
 concatenation on unpacked bit strings.)
 
@@ -554,7 +554,7 @@ status register (a "-" stands for a "reserved" bit):
    +-----------------+-----------------+
     MSB           LSB MSB           LSB
 
-Converting these two bytes to a string can be done with the unpack 
+Converting these two bytes to a string can be done with the unpack
 template C<'b16'>. To obtain the individual bit values from the bit
 string we use C<split> with the "empty" separator pattern which dissects
 into individual characters. Bit values from the "reserved" positions are
@@ -566,7 +566,7 @@ this goes".
       split( //, unpack( 'b16', $status ) );
 
 We could have used an unpack template C<'b12'> just as well, since the
-last 4 bits can be ignored anyway. 
+last 4 bits can be ignored anyway.
 
 
 =head2 Uuencoding
@@ -575,10 +575,10 @@ Another odd-man-out in the template alphabet is C<u>, which packs a
 "uuencoded string". ("uu" is short for Unix-to-Unix.) Chances are that
 you won't ever need this encoding technique which was invented to overcome
 the shortcomings of old-fashioned transmission mediums that do not support
-other than simple ASCII data. The essential recipe is simple: Take three 
-bytes, or 24 bits. Split them into 4 six-packs, adding a space (0x20) to 
-each. Repeat until all of the data is blended. Fold groups of 4 bytes into 
-lines no longer than 60 and garnish them in front with the original byte count 
+other than simple ASCII data. The essential recipe is simple: Take three
+bytes, or 24 bits. Split them into 4 six-packs, adding a space (0x20) to
+each. Repeat until all of the data is blended. Fold groups of 4 bytes into
+lines no longer than 60 and garnish them in front with the original byte count
 (incremented by 0x20) and a C<"\n"> at the end. - The C<pack> chef will
 prepare this for you, a la minute, when you select pack code C<u> on the menu:
 
@@ -592,11 +592,11 @@ the repeat count.
 
 =head2 Doing Sums
 
-An even stranger template code is C<%>E<lt>I<number>E<gt>. First, because 
+An even stranger template code is C<%>E<lt>I<number>E<gt>. First, because
 it's used as a prefix to some other template code. Second, because it
 cannot be used in C<pack> at all, and third, in C<unpack>, doesn't return the
 data as defined by the template code it precedes. Instead it'll give you an
-integer of I<number> bits that is computed from the data value by 
+integer of I<number> bits that is computed from the data value by
 doing sums. For numeric unpack codes, no big feat is achieved:
 
     my $buf = pack( 'iii', 100, 20, 3 );
@@ -745,7 +745,7 @@ endian shorts and packing them in the reverse byte order:
 
 In the previous section we've seen a network message that was constructed
 by prefixing the binary message length to the actual message. You'll find
-that packing a length followed by so many bytes of data is a 
+that packing a length followed by so many bytes of data is a
 frequently used recipe since appending a null byte won't work
 if a null byte may be part of the data. Here is an example where both
 techniques are used: after two null terminated strings with source and
@@ -783,7 +783,7 @@ Combining two pack codes with a slash (C</>) associates them with a single
 value from the argument list. In C<pack>, the length of the argument is
 taken and packed according to the first code while the argument itself
 is added after being converted with the template code after the slash.
-This saves us the trouble of inserting the C<length> call, but it is 
+This saves us the trouble of inserting the C<length> call, but it is
 in C<unpack> where we really score: The value of the length byte marks the
 end of the string to be taken from the buffer. Since this combination
 doesn't make sense except when the second pack code isn't C<a*>, C<A*>
@@ -842,7 +842,7 @@ in the buffer before we can let C<unpack> rip it apart:
    my %env = map( split( /=/, $_ ), unpack( "(Z*)$n", $env ) );
 
 The C<tr> counts the null bytes. The C<unpack> call returns a list of
-name-value pairs each of which is taken apart in the C<map> block. 
+name-value pairs each of which is taken apart in the C<map> block.
 
 
 =head2 Counting Repetitions
@@ -879,7 +879,7 @@ complement sum of the preceding bytes. Example: C<:0300300002337A1E>.
 
 The first step of processing such a line is the conversion, to binary,
 of the hexadecimal data, to obtain the four fields, while checking the
-checksum. No surprise here: we'll start with a simple C<pack> call to 
+checksum. No surprise here: we'll start with a simple C<pack> call to
 convert everything to binary:
 
    my $binrec = pack( 'H*', substr( $hexrec, 1 ) );
@@ -897,7 +897,7 @@ of the data in the first field as a length for the data field? Here
 the codes C<x> and C<X> come to the rescue, as they permit jumping
 back and forth in the string to unpack.
 
-   my( $addr, $type, $data ) = unpack( "x n C X4 C x3 /a", $bin ); 
+   my( $addr, $type, $data ) = unpack( "x n C X4 C x3 /a", $bin );
 
 Code C<x> skips a byte, since we don't need the count yet. Code C<n> takes
 care of the 16-bit big-endian integer address, and C<C> unpacks the
@@ -929,7 +929,7 @@ In the consideration of speed against memory requirements the balance
 has been tilted in favor of faster execution. This has influenced the
 way C compilers allocate memory for structures: On architectures
 where a 16-bit or 32-bit operand can be moved faster between places in
-memory, or to or from a CPU register, if it is aligned at an even or 
+memory, or to or from a CPU register, if it is aligned at an even or
 multiple-of-four or even at a multiple-of eight address, a C compiler
 will give you this speed benefit by stuffing extra bytes into structures.
 If you don't cross the C shoreline this is not likely to cause you any
@@ -982,7 +982,7 @@ the amount of fill bytes cannot be derived from the alignment of the next
 item alone.
 
 OK, so let's bite the bullet. Here's one way to get the alignment right
-by inserting template codes C<x>, which don't take a corresponding item 
+by inserting template codes C<x>, which don't take a corresponding item
 from the list:
 
   my $gappy = pack( 'cxs cxxx l!', $c1, $s, $c2, $l );
@@ -993,7 +993,7 @@ work for the platforms where the compiler aligns things as above.
 And somebody somewhere has a platform where it doesn't.
 [Probably a Cray, where C<short>s, C<int>s and C<long>s are all 8 bytes. :-)]
 
-Counting bytes and watching alignments in lengthy structures is bound to 
+Counting bytes and watching alignments in lengthy structures is bound to
 be a drag. Isn't there a way we can create the template with a simple
 program? Here's a C program that does the trick:
 
@@ -1022,11 +1022,11 @@ The output line can be used as a template in a C<pack> or C<unpack> call:
 
   my $gappy = pack( '@0c @2s! @4c @8l!', $c1, $s, $c2, $l );
 
-Gee, yet another template code - as if we hadn't plenty. But 
+Gee, yet another template code - as if we hadn't plenty. But
 C<@> saves our day by enabling us to specify the offset from the beginning
 of the pack buffer to the next item: This is just the value
 the C<offsetof> macro (defined in C<E<lt>stddef.hE<gt>>) returns when
-given a C<struct> type and one of its field names ("member-designator" in 
+given a C<struct> type and one of its field names ("member-designator" in
 C standardese).
 
 Neither using offsets nor adding C<x>'s to bridge the gaps is satisfactory.
@@ -1092,7 +1092,7 @@ like this:
    pack( 's!a' x @buffer,
          map{ ( $_->{count}, $_->{glyph} ) } @buffer );
 
-This packs C<3*@buffer> bytes, but it turns out that the size of 
+This packs C<3*@buffer> bytes, but it turns out that the size of
 C<buffer_t> is four times C<BUFLEN>! The moral of the story is that
 the required alignment of a structure or array is propagated to the
 next higher level where we have to consider padding I<at the end>
@@ -1165,7 +1165,7 @@ This is neither a specimen of simplicity nor a paragon of portability but
 it illustrates the point: We are able to sneak behind the scenes and
 access Perl's otherwise well-guarded memory! (Important note: Perl's
 C<syscall> does I<not> require you to construct pointers in this roundabout
-way. You simply pass a string variable, and Perl forwards the address.) 
+way. You simply pass a string variable, and Perl forwards the address.)
 
 How does C<unpack> with C<P> work? Imagine some pointer in the buffer
 about to be unpacked: If it isn't the null pointer (which will smartly
@@ -1180,7 +1180,7 @@ As a consequence, C<pack> ignores any number or C<*> after C<P>.
 
 
 Now that we have seen C<P> at work, we might as well give C<p> a whirl.
-Why do we need a second template code for packing pointers at all? The 
+Why do we need a second template code for packing pointers at all? The
 answer lies behind the simple fact that an C<unpack> with C<p> promises
 a null-terminated string starting at the address taken from the buffer,
 and that implies a length for the data item to be returned:
@@ -1192,29 +1192,29 @@ and that implies a length for the data item to be returned:
 
 Albeit this is apt to be confusing: As a consequence of the length being
 implied by the string's length, a number after pack code C<p> is a repeat
-count, not a length as after C<P>. 
+count, not a length as after C<P>.
 
 
 Using C<pack(..., $x)> with C<P> or C<p> to get the address where C<$x> is
 actually stored must be used with circumspection. Perl's internal machinery
-considers the relation between a variable and that address as its very own 
+considers the relation between a variable and that address as its very own
 private matter and doesn't really care that we have obtained a copy. Therefore:
 
 =over 4
 
-=item * 
+=item *
 
 Do not use C<pack> with C<p> or C<P> to obtain the address of variable
 that's bound to go out of scope (and thereby freeing its memory) before you
 are done with using the memory at that address.
 
-=item * 
+=item *
 
 Be very careful with Perl operations that change the value of the
 variable. Appending something to the variable, for instance, might require
 reallocation of its storage, leaving you with a pointer into no-man's land.
 
-=item * 
+=item *
 
 Don't think that you can get the address of a Perl variable
 when it is stored as an integer or double number! C<pack('P', $x)> will
@@ -1234,7 +1234,7 @@ Here are a collection of (possibly) useful canned recipes for C<pack>
 and C<unpack>:
 
     # Convert IP address for socket functions
-    pack( "C4", split /\./, "123.4.5.6" ); 
+    pack( "C4", split /\./, "123.4.5.6" );
 
     # Count the bits in a chunk of memory (e.g. a select vector)
     unpack( '%32b*', $mask );
@@ -1249,7 +1249,7 @@ and C<unpack>:
     # Prepare argument for the nanosleep system call
     my $timespec = pack( 'L!L!', $secs, $nanosecs );
 
-For a simple memory dump we unpack some bytes into just as 
+For a simple memory dump we unpack some bytes into just as
 many pairs of hex digits, and use C<map> to handle the traditional
 spacing - 16 bytes to a line:
 

--- a/pod/perlpod.pod
+++ b/pod/perlpod.pod
@@ -18,7 +18,7 @@ like plain text, HTML, man pages, and more.
 
 Pod markup consists of three basic kinds of paragraphs:
 L<ordinary|/"Ordinary Paragraph">,
-L<verbatim|/"Verbatim Paragraph">, and 
+L<verbatim|/"Verbatim Paragraph">, and
 L<command|/"Command Paragraph">.
 
 
@@ -28,7 +28,7 @@ X<POD, ordinary paragraph>
 Most paragraphs in your documentation will be ordinary blocks
 of text, like this one.  You can simply type in your text without
 any markup whatsoever, and with just a blank line before and
-after.  When it gets formatted, it will undergo minimal formatting, 
+after.  When it gets formatted, it will undergo minimal formatting,
 like being rewrapped, probably put into a proportionally spaced
 font, and maybe even justified.
 
@@ -239,7 +239,7 @@ called I<formatname>.  For example,
 
 The command "=for I<formatname> I<text...>"
 specifies that the remainder of just this paragraph (starting
-right after I<formatname>) is in that special format.  
+right after I<formatname>) is in that special format.
 
   =for html <hr> <img src="thang.png">
   <p> This is a raw HTML paragraph </p>
@@ -538,7 +538,7 @@ X<F> X<< FZ<><> >> X<POD, formatting code, filename> X<filename>
 Typically displayed in italics.  Example: "C<FE<lt>.cshrcE<gt>>"
 
 =item C<SE<lt>textE<gt>> -- text contains non-breaking spaces
-X<S> X<< SZ<><> >> X<POD, formatting code, non-breaking space> 
+X<S> X<< SZ<><> >> X<POD, formatting code, non-breaking space>
 X<non-breaking space>
 
 This means that the words in I<text> should not be broken

--- a/pod/perlpodspec.pod
+++ b/pod/perlpodspec.pod
@@ -277,7 +277,7 @@ below.  Examples:
 
   =item *
 
-  =item      *    
+  =item      *
 
   =item 14
 
@@ -352,7 +352,7 @@ before any non-US-ASCII data!), declares that this document is
 encoded in the encoding I<encodingname>, which must be
 an encoding name that L<Encode> recognizes.  (Encode's list
 of supported encodings, in L<Encode::Supported>, is useful here.)
-If the Pod parser cannot decode the declared encoding, it 
+If the Pod parser cannot decode the declared encoding, it
 should emit a warning and may abort parsing the document
 altogether.
 
@@ -555,7 +555,7 @@ would parse as equivalent to this:
 
     C<$foo-E<gt>bar>
 
-instead of as equivalent to a "C" formatting code containing 
+instead of as equivalent to a "C" formatting code containing
 only "$foo-", and then a "bar>" outside the "C" formatting code.  This
 problem has since been solved by the addition of syntaxes like this:
 
@@ -1462,7 +1462,7 @@ match just C<m/\A=item\s*\z/>.
 =item *
 
 An "=over" ... "=back" region containing no "=item" paragraphs at
-all, and containing only some number of 
+all, and containing only some number of
 ordinary/verbatim paragraphs, and possibly also some nested "=over"
 ... "=back" regions, "=for..." paragraphs, and "=begin"..."=end"
 regions.  Such an itemless "=over" ... "=back" region in Pod is
@@ -1472,7 +1472,7 @@ HTML.
 =back
 
 Note that with all the above cases, you can determine which type of
-"=over" ... "=back" you have, by examining the first (non-"=cut", 
+"=over" ... "=back" you have, by examining the first (non-"=cut",
 non-"=pod") Pod paragraph after the "=over" command.
 
 =item *
@@ -1546,7 +1546,7 @@ Authors of Pod formatters should note that this construct:
 
   =item Quisquam Est
 
-  Qui dolorem ipsum quia dolor sit amet, consectetur, adipisci 
+  Qui dolorem ipsum quia dolor sit amet, consectetur, adipisci
   velit, sed quia non numquam eius modi tempora incidunt ut
   labore et dolore magnam aliquam quaerat voluptatem.
 
@@ -1776,7 +1776,7 @@ The contents of the above "=begin :yetanotherformat" ...
 "=end :yetanotherformat" region I<aren't> data paragraphs, because
 the immediately containing region's identifier (":yetanotherformat")
 begins with a colon.  In practice, most regions that contain
-data paragraphs will contain I<only> data paragraphs; however, 
+data paragraphs will contain I<only> data paragraphs; however,
 the above nesting is syntactically valid as Pod, even if it is
 rare.  However, the handlers for some formats, like "html",
 will accept only data paragraphs, not nested regions; and they may
@@ -1830,7 +1830,7 @@ the content of the above "=begin html"..."=end html" I<may> be stored
 as two data paragraphs (one consisting of
 "<img src='wirth_spokesmodeling_book.png'>\n"
 and another consisting of "<hr>\n"), but I<should> be stored as
-a single data paragraph (consisting of 
+a single data paragraph (consisting of
 "<img src='wirth_spokesmodeling_book.png'>\n\n<hr>\n").
 
 Pod processors should tolerate empty

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -498,12 +498,12 @@ may be easier to grasp than the squashed equivalents
     /[d-eg-i3-7]/
     /[!@"#$%^&*()=?<>']/
 
-Starting in Perl v5.44, the experimental feature 
+Starting in Perl v5.44, the experimental feature
 
  use feature 'enhanced_xx';
 
 changes the behavior of C</xx> to allow your bracketed classes to extend
-over multiple lines and to contain comments.  
+over multiple lines and to contain comments.
 
 Without this feature being enabled, a C<#> inside a character class is
 still just a literal C<#>; but with it, the C<#> introduces a comment,

--- a/pod/perlsec.pod
+++ b/pod/perlsec.pod
@@ -325,7 +325,7 @@ doing something it shouldn't.
 Here's a way to do backticks reasonably safely.  Notice how the C<exec> is
 not called with a string that the shell could expand.  This is by far the
 best way to call something that might be subjected to shell escapes: just
-never call the shell at all.  
+never call the shell at all.
 
         use English;
         die "Can't fork: $!" unless defined($pid = open(KID, "-|"));
@@ -449,7 +449,7 @@ First of all, however, you I<can't> take away read permission, because
 the source code has to be readable in order to be compiled and
 interpreted.  (That doesn't mean that a CGI script's source is
 readable by people on the web, though.)  So you have to leave the
-permissions at the socially friendly 0755 level.  This lets 
+permissions at the socially friendly 0755 level.  This lets
 people on your local system only see your source.
 
 Some people mistakenly regard this as a security problem.  If your program does

--- a/pod/perlsecpolicy.pod
+++ b/pod/perlsecpolicy.pod
@@ -409,8 +409,8 @@ on private systems during the pre-release L</Embargo Period>.
 =head3 Release of fixes and announcements
 
 The L</Embargo Period> ends when the security fixes are committed to Perl's
-public git repository. Announcements will be sent to the 
-L<perl5-porters|https://lists.perl.org/list/perl5-porters.html> and 
+public git repository. Announcements will be sent to the
+L<perl5-porters|https://lists.perl.org/list/perl5-porters.html> and
 L<oss-security|https://oss-security.openwall.org/wiki/mailing-lists/oss-security>
 mailing lists.
 
@@ -507,10 +507,10 @@ issue is being addressed.
 Embargo lengths can vary depending on the complexity of the issue and the
 time required to develop a fix. The security team will communicate
 the expected duration of the embargo to the reporter and any other
-parties involved in the process. 
+parties involved in the process.
 
 As a goal, the security team aims to keep the total embargo period to less
-than 60 days. This may be extended due to the following factors: 
+than 60 days. This may be extended due to the following factors:
 
 =over 4
 

--- a/pod/perltie.pod
+++ b/pod/perltie.pod
@@ -326,7 +326,7 @@ Sets the total number of items in the tied array associated with
 object I<this> to be I<count>. If this makes the array larger then
 class's mapping of C<undef> should be returned for new positions.
 If the array becomes smaller then entries beyond count should be
-deleted. 
+deleted.
 
 In our example, 'undef' is really an element containing
 C<$self-E<gt>{ELEMSIZE}> number of spaces.  Observe:
@@ -357,7 +357,7 @@ where there is the possibility of having the allocated size of the array
 be larger than is visible to a perl programmer inspecting the size of the
 array. Many tied array implementations will have no reason to implement it.
 
-    sub EXTEND {   
+    sub EXTEND {
       my $self  = shift;
       my $count = shift;
       # nothing to see here, move along.
@@ -409,18 +409,18 @@ object I<this>.  For example:
       return $self->{ARRAY} = [];
     }
 
-=item PUSH this, LIST 
+=item PUSH this, LIST
 X<PUSH>
 
 Append elements of I<LIST> to the array.  For example:
 
-    sub PUSH {  
+    sub PUSH {
       my $self = shift;
       my @list = @_;
       my $last = $self->FETCHSIZE();
       $self->STORE( $last + $_, $list[$_] ) foreach 0 .. $#list;
       return $self->FETCHSIZE();
-    }   
+    }
 
 =item POP this
 X<POP>
@@ -443,7 +443,7 @@ and return it.  For example:
       return shift $self->{ARRAY}->@*;
     }
 
-=item UNSHIFT this, LIST 
+=item UNSHIFT this, LIST
 X<UNSHIFT>
 
 Insert LIST elements at the beginning of the array, moving existing elements
@@ -462,10 +462,10 @@ up to make room.  For example:
 =item SPLICE this, offset, length, LIST
 X<SPLICE>
 
-Perform the equivalent of C<splice> on the array. 
+Perform the equivalent of C<splice> on the array.
 
-I<offset> is optional and defaults to zero, negative values count back 
-from the end of the array. 
+I<offset> is optional and defaults to zero, negative values count back
+from the end of the array.
 
 I<length> is optional and defaults to rest of the array.
 
@@ -479,7 +479,7 @@ In our example, we'll use a little shortcut if there is a I<LIST>:
       my $self   = shift;
       my $offset = shift || 0;
       my $length = shift || $self->FETCHSIZE() - $offset;
-      my @list   = (); 
+      my @list   = ();
       if ( @_ ) {
         tie @list, __PACKAGE__, $self->{ELEMSIZE};
         @list   = @_;
@@ -511,7 +511,7 @@ the constructor.  FETCH and STORE access the key and value pairs.  EXISTS
 reports whether a key is present in the hash, and DELETE deletes one.
 CLEAR empties the hash by deleting all the key and value pairs.  FIRSTKEY
 and NEXTKEY implement the keys() and each() functions to iterate over all
-the keys. SCALAR is triggered when the tied hash is evaluated in scalar 
+the keys. SCALAR is triggered when the tied hash is evaluated in scalar
 context, and in 5.28 onwards, by C<keys> in boolean context. UNTIE is
 called when C<untie> happens, and DESTROY is called when the tied variable
 is garbage collected.
@@ -828,10 +828,10 @@ the hash is inside an iteration. If this isn't the case, FIRSTKEY is
 called, and the result will be a false value if FIRSTKEY returns the empty
 list, true otherwise.
 
-However, you should B<not> blindly rely on perl always doing the right 
-thing. Particularly, perl will mistakenly return true when you clear the 
-hash by repeatedly calling DELETE until it is empty. You are therefore 
-advised to supply your own SCALAR method when you want to be absolutely 
+However, you should B<not> blindly rely on perl always doing the right
+thing. Particularly, perl will mistakenly return true when you clear the
+hash by repeatedly calling DELETE until it is empty. You are therefore
+advised to supply your own SCALAR method when you want to be absolutely
 sure that your hash behaves nicely in scalar context.
 
 In our example we can just call C<scalar> on the underlying hash
@@ -890,14 +890,14 @@ OPEN, EOF, FILENO, SEEK, TELL - if the corresponding perl operators are
 used on the handle.
 
 When STDERR is tied, its PRINT method will be called to issue warnings
-and error messages.  This feature is temporarily disabled during the call, 
+and error messages.  This feature is temporarily disabled during the call,
 which means you can use C<warn()> inside PRINT without starting a recursive
 loop.  And just like C<__WARN__> and C<__DIE__> handlers, STDERR's PRINT
-method may be called to report parser errors, so the caveats mentioned under 
+method may be called to report parser errors, so the caveats mentioned under
 L<perlvar/%SIG> apply.
 
-All of this is especially useful when perl is embedded in some other 
-program, where output to STDOUT and STDERR may have to be redirected 
+All of this is especially useful when perl is embedded in some other
+program, where output to STDOUT and STDERR may have to be redirected
 in some special way.  See nvi and the Apache module for examples.
 
 When tying a handle, the first argument to C<tie> should begin with an

--- a/pod/perlunicode.pod
+++ b/pod/perlunicode.pod
@@ -1960,7 +1960,7 @@ available API elements for working with it.  UTF-8 is how Unicode
 strings are currently stored internally by the interpreter.  You B<need>
 to be using functions in the C<utf8_to_uv> family when parsing a string
 encoded in UTF-8.  This avoids the pitfalls of earlier API functions,
-whose names contained C<to_uvchr> instead of plain C<to_uv>.  
+whose names contained C<to_uvchr> instead of plain C<to_uv>.
 
 =item Illegal code points
 

--- a/pod/perlunifaq.pod
+++ b/pod/perlunifaq.pod
@@ -144,7 +144,7 @@ Here's what happens: when Perl reads in a string literal, it sticks to 8 bit
 encoding as long as it can. (But perhaps originally it was internally encoded
 as UTF-8, when you dumped it.) When it has to give that up because other
 characters are added to the text string, it silently upgrades the string to
-UTF-8. 
+UTF-8.
 
 If you properly encode your strings for output, none of this is of your
 concern, and you can just C<eval> dumped data as always.

--- a/pod/perlunitut.pod
+++ b/pod/perlunitut.pod
@@ -12,7 +12,7 @@ it right.
 
 There's a lot to know about character sets, and text encodings. It's probably
 best to spend a full day learning all this, but the basics can be learned in
-minutes. 
+minutes.
 
 These are not the very basics, though. It is assumed that you already
 know the difference between bytes and characters, and realise (and accept!)
@@ -53,7 +53,7 @@ store a single code point, or simply: character.
 
 B<UTF-8> is a Unicode encoding. Many people think that Unicode and UTF-8 are
 the same thing, but they're not. There are more Unicode encodings, but much of
-the world has standardized on UTF-8. 
+the world has standardized on UTF-8.
 
 UTF-8 treats the first 128 codepoints, 0..127, the same as ASCII. They take
 only one byte per character. All other characters are encoded as two to

--- a/pod/perlutil.pod
+++ b/pod/perlutil.pod
@@ -23,7 +23,7 @@ The main interface to Perl's documentation is F<perldoc>, although
 if you're reading this, it's more than likely that you've already found
 it. F<perldoc> will extract and format the documentation from any file
 in the current directory, any Perl module installed on the system, or
-any of the standard documentation pages, such as this one. Use 
+any of the standard documentation pages, such as this one. Use
 C<perldoc E<lt>nameE<gt>> to get information on any of the utilities
 described in this document.
 
@@ -99,7 +99,7 @@ and its libraries have been installed correctly.
 
 =head2 Development
 
-There are a set of utilities which help you in developing Perl programs, 
+There are a set of utilities which help you in developing Perl programs,
 and in particular, extending Perl with C.
 
 =over 3
@@ -196,7 +196,7 @@ with perl, but is available from the CPAN.)
 
 =item L<ptargrep>
 
-F<ptargrep> is a utility to apply pattern matching to the contents of files 
+F<ptargrep> is a utility to apply pattern matching to the contents of files
 in a tar archive.
 
 =item L<shasum>

--- a/pod/perlvms.pod
+++ b/pod/perlvms.pod
@@ -4,25 +4,25 @@ perlvms - VMS-specific documentation for Perl
 
 =head1 DESCRIPTION
 
-Gathered below are notes describing details of Perl 5's 
-behavior on VMS.  They are a supplement to the regular Perl 5 
-documentation, so we have focussed on the ways in which Perl 
-5 functions differently under VMS than it does under Unix, 
-and on the interactions between Perl and the rest of the 
-operating system.  We haven't tried to duplicate complete 
-descriptions of Perl features from the main Perl 
-documentation, which can be found in the F<[.pod]> 
+Gathered below are notes describing details of Perl 5's
+behavior on VMS.  They are a supplement to the regular Perl 5
+documentation, so we have focussed on the ways in which Perl
+5 functions differently under VMS than it does under Unix,
+and on the interactions between Perl and the rest of the
+operating system.  We haven't tried to duplicate complete
+descriptions of Perl features from the main Perl
+documentation, which can be found in the F<[.pod]>
 subdirectory of the Perl distribution.
 
-We hope these notes will save you from confusion and lost 
-sleep when writing Perl scripts on VMS.  If you find we've 
-missed something you think should appear here, please don't 
+We hope these notes will save you from confusion and lost
+sleep when writing Perl scripts on VMS.  If you find we've
+missed something you think should appear here, please don't
 hesitate to drop a line to vmsperl@perl.org.
 
 =head1 Installation
 
-Directions for building and installing Perl 5 can be found in 
-the file F<README.vms> in the main source directory of the 
+Directions for building and installing Perl 5 can be found in
+the file F<README.vms> in the main source directory of the
 Perl distribution.
 
 =head1 Organization of Perl Images
@@ -245,7 +245,7 @@ not the C<$^O> variable.
 
 When built on an ODS-5 volume with symbolic links enabled, Perl by
 default supports symbolic links when the requisite support is available
-in the filesystem and CRTL (generally 64-bit OpenVMS v8.3 and later). 
+in the filesystem and CRTL (generally 64-bit OpenVMS v8.3 and later).
 There are a number of limitations and caveats to be aware of when
 working with symbolic links on VMS.  Most notably, the target of a valid
 symbolic link must be expressed as a Unix-style path and it must exist
@@ -256,10 +256,10 @@ v8.3 or later.
 
 =head2 Wildcard expansion
 
-File specifications containing wildcards are allowed both on 
+File specifications containing wildcards are allowed both on
 the command line and within Perl globs (e.g. C<E<lt>*.cE<gt>>).  If
-the wildcard filespec uses VMS syntax, the resultant 
-filespecs will follow VMS syntax; if a Unix-style filespec is 
+the wildcard filespec uses VMS syntax, the resultant
+filespecs will follow VMS syntax; if a Unix-style filespec is
 passed in, Unix-style filespecs will be returned.
 Similar to the behavior of wildcard globbing for a Unix shell,
 one can escape command line wildcards with double quotation
@@ -280,18 +280,18 @@ in the following triple quoted manner:
 In both the case of unquoted command line arguments or in calls
 to C<glob()> VMS wildcard expansion is performed. (csh-style
 wildcard expansion is available if you use C<File::Glob::glob>.)
-If the wildcard filespec contains a device or directory 
-specification, then the resultant filespecs will also contain 
-a device and directory; otherwise, device and directory 
-information are removed.  VMS-style resultant filespecs will 
-contain a full device and directory, while Unix-style 
-resultant filespecs will contain only as much of a directory 
-path as was present in the input filespec.  For example, if 
-your default directory is Perl_Root:[000000], the expansion 
-of C<[.t]*.*> will yield filespecs  like 
-"perl_root:[t]base.dir", while the expansion of C<t/*/*> will 
-yield filespecs like "t/base.dir".  (This is done to match 
-the behavior of glob expansion performed by Unix shells.) 
+If the wildcard filespec contains a device or directory
+specification, then the resultant filespecs will also contain
+a device and directory; otherwise, device and directory
+information are removed.  VMS-style resultant filespecs will
+contain a full device and directory, while Unix-style
+resultant filespecs will contain only as much of a directory
+path as was present in the input filespec.  For example, if
+your default directory is Perl_Root:[000000], the expansion
+of C<[.t]*.*> will yield filespecs  like
+"perl_root:[t]base.dir", while the expansion of C<t/*/*> will
+yield filespecs like "t/base.dir".  (This is done to match
+the behavior of glob expansion performed by Unix shells.)
 
 Similarly, the resultant filespec will contain the file version
 only if one was present in the input filespec.
@@ -299,24 +299,24 @@ only if one was present in the input filespec.
 
 =head2 Pipes
 
-Input and output pipes to Perl filehandles are supported; the 
-"file name" is passed to lib$spawn() for asynchronous 
-execution.  You should be careful to close any pipes you have 
-opened in a Perl script, lest you leave any "orphaned" 
-subprocesses around when Perl exits. 
+Input and output pipes to Perl filehandles are supported; the
+"file name" is passed to lib$spawn() for asynchronous
+execution.  You should be careful to close any pipes you have
+opened in a Perl script, lest you leave any "orphaned"
+subprocesses around when Perl exits.
 
-You may also use backticks to invoke a DCL subprocess, whose 
-output is used as the return value of the expression.  The 
+You may also use backticks to invoke a DCL subprocess, whose
+output is used as the return value of the expression.  The
 string between the backticks is handled as if it were the
 argument to the C<system> operator (see below).  In this case,
-Perl will wait for the subprocess to complete before continuing. 
+Perl will wait for the subprocess to complete before continuing.
 
 The mailbox (MBX) that perl can create to communicate with a pipe
 defaults to a buffer size of 8192 on 64-bit systems, 512 on VAX.  The
 default buffer size is adjustable via the logical name PERL_MBX_SIZE
 provided that the value falls between 128 and the SYSGEN parameter
 MAXBUF inclusive.  For example, to set the mailbox size to 32767 use
-C<$ENV{'PERL_MBX_SIZE'} = 32767;> and then open and use pipe constructs. 
+C<$ENV{'PERL_MBX_SIZE'} = 32767;> and then open and use pipe constructs.
 An alternative would be to issue the command:
 
     $ Define PERL_MBX_SIZE 32767
@@ -393,7 +393,7 @@ This logical name must be defined before Perl is started.
 
 =head2 I/O redirection and backgrounding
 
-Perl for VMS supports redirection of input and output on the 
+Perl for VMS supports redirection of input and output on the
 command line, using a subset of Bourne shell syntax:
 
 =over 4
@@ -424,13 +424,13 @@ C<< 2>&1 >> redirects stderr to stdout.
 
 =back
 
-In addition, output may be piped to a subprocess, using the  
-character '|'.  Anything after this character on the command 
-line is passed to a subprocess for execution; the subprocess 
+In addition, output may be piped to a subprocess, using the
+character '|'.  Anything after this character on the command
+line is passed to a subprocess for execution; the subprocess
 takes the output of Perl as its input.
 
-Finally, if the command line ends with '&', the entire 
-command is run in the background as an asynchronous 
+Finally, if the command line ends with '&', the entire
+command is run in the background as an asynchronous
 subprocess.
 
 =head2 Command line switches
@@ -476,14 +476,14 @@ run.  It does not create a core dump file.
 
 =head1 Perl functions
 
-As of the time this document was last revised, the following 
-Perl functions were implemented in the VMS port of Perl 
+As of the time this document was last revised, the following
+Perl functions were implemented in the VMS port of Perl
 (functions marked with * are discussed in more detail below):
 
     file tests*, abs, alarm, atan, backticks*, binmode*, bless,
     caller, chdir, chmod, chown, chomp, chop, chr,
-    close, closedir, cos, crypt*, defined, delete, die, do, dump*, 
-    each, endgrent, endpwent, eof, eval, exec*, exists, exit, exp, 
+    close, closedir, cos, crypt*, defined, delete, die, do, dump*,
+    each, endgrent, endpwent, eof, eval, exec*, exists, exit, exp,
     fileno, flock  getc, getgrent*, getgrgid*, getgrnam, getlogin,
     getppid, getpwent*, getpwnam*, getpwuid*, glob, gmtime*, goto,
     grep, hex, ioctl, import, index, int, join, keys, kill*,
@@ -500,11 +500,11 @@ Perl functions were implemented in the VMS port of Perl
     undef, unlink*, unpack, untie, unshift, use, utime*,
     values, vec, wait, waitpid*, wantarray, warn, write, y///
 
-The following functions were not implemented in the VMS port, 
-and calling them produces a fatal error (usually) or 
+The following functions were not implemented in the VMS port,
+and calling them produces a fatal error (usually) or
 undefined behavior (rarely, we hope):
 
-    chroot, dbmclose, dbmopen, fork*, getpgrp, getpriority,  
+    chroot, dbmclose, dbmopen, fork*, getpgrp, getpriority,
     msgctl, msgget, msgsend, msgrcv, semctl,
     semget, semop, setpgrp, setpriority, shmctl, shmget,
     shmread, shmwrite, syscall
@@ -519,8 +519,8 @@ greater:
 
     fcntl (without locking)
 
-The following functions may or may not be implemented, 
-depending on what type of socket support you've built into 
+The following functions may or may not be implemented,
+depending on what type of socket support you've built into
 your copy of Perl:
 
     accept, bind, connect, getpeername,
@@ -548,7 +548,7 @@ v7.3-2, and better configuration support could detect this.
    setgrent, ttyname
 
 The following functions are available on Perls built on 64 bit OpenVMS v8.2
-and later.  
+and later.
 
    statvfs, socketpair
 
@@ -664,7 +664,7 @@ value with a severity level of ERROR.  This is to be compatible with
 how the VMS C library encodes these values.
 
 The minimum severity level set by C<die> in C<PERL_VMS_POSIX_EXIT> mode
-may be changed to be ERROR or higher in the future depending on the 
+may be changed to be ERROR or higher in the future depending on the
 results of testing and further review.
 
 See L</"$?"> for a description of the encoding of the Unix value to
@@ -772,9 +772,9 @@ though, so caveat scriptor.
 
 =item system LIST
 
-The C<system> operator creates a subprocess, and passes its 
-arguments to the subprocess for execution as a DCL command.  
-Since the subprocess is created directly via C<lib$spawn()>, any 
+The C<system> operator creates a subprocess, and passes its
+arguments to the subprocess for execution as a DCL command.
+Since the subprocess is created directly via C<lib$spawn()>, any
 valid DCL command string may be specified.  If the string begins with
 '@', it is treated as a DCL command unconditionally.  Otherwise, if
 the first token contains a character used as a delimiter in file
@@ -796,8 +796,8 @@ Perl waits for the subprocess to complete before continuing
 execution in the current process.  As described in L<perlfunc>,
 the return value of C<system> is a fake "status" which follows
 POSIX semantics unless the pragma C<use vmsish 'status'> is in
-effect; see the description of C<$?> in this document for more 
-detail.  
+effect; see the description of C<$?> in this document for more
+detail.
 
 =item time
 
@@ -807,12 +807,12 @@ to make life easier for code coming in from the POSIX/Unix world.
 
 =item times
 
-The array returned by the C<times> operator is divided up 
-according to the same rules the CRTL C<times()> routine.  
-Therefore, the "system time" elements will always be 0, since 
-there is no difference between "user time" and "system" time 
-under VMS, and the time accumulated by a subprocess may or may 
-not appear separately in the "child time" field, depending on 
+The array returned by the C<times> operator is divided up
+according to the same rules the CRTL C<times()> routine.
+Therefore, the "system time" elements will always be 0, since
+there is no difference between "user time" and "system" time
+under VMS, and the time accumulated by a subprocess may or may
+not appear separately in the "child time" field, depending on
 whether C<times()> keeps track of subprocesses separately.  Note
 especially that the VAXCRTL (at least) keeps track only of
 subprocesses spawned using C<fork()> and C<exec()>; it will not
@@ -862,14 +862,14 @@ and not traditional VMS behavior.
 
 =item utime LIST
 
-This operator changes only the modification time of the file (VMS 
-revision date) on ODS-2 volumes and ODS-5 volumes without access 
-dates enabled. On ODS-5 volumes with access dates enabled, the 
+This operator changes only the modification time of the file (VMS
+revision date) on ODS-2 volumes and ODS-5 volumes without access
+dates enabled. On ODS-5 volumes with access dates enabled, the
 true access time is modified.
 
 =item waitpid PID,FLAGS
 
-If PID is a subprocess started by a piped C<open()> (see L<open>), 
+If PID is a subprocess started by a piped C<open()> (see L<open>),
 C<waitpid> will wait for that subprocess, and return its final status
 value in C<$?>.  If PID is a subprocess created in some other way (e.g.
 SPAWNed before Perl was invoked), C<waitpid> will simply check once per
@@ -891,7 +891,7 @@ takes precedence.
 
 =over 4
 
-=item %ENV 
+=item %ENV
 
 The operation of the C<%ENV> array depends on the translation
 of the logical name F<PERL_ENV_TABLES>.  If defined, it should
@@ -1127,7 +1127,7 @@ generic failure status SS$_ABORT.  See also L<perlport/exit>.
 
 With the C<PERL_VMS_POSIX_EXIT> logical name defined as "ENABLE",
 setting C<$?> will cause the new value to be encoded into C<$^E>
-so that either the original parent or child exit status values 
+so that either the original parent or child exit status values
  0 to 255 can be automatically recovered by C programs expecting
 _POSIX_EXIT behavior.  If both a parent and a child exit value are
 non-zero, then it will be assumed that this is actually a VMS native
@@ -1138,8 +1138,8 @@ this way as it is known to not be a valid native VMS status value.
 It is recommended that only values in the range of normal Unix parent or
 child status numbers, 0 to 255 are used.
 
-The pragma C<use vmsish 'status'> makes C<$?> reflect the actual 
-VMS exit status instead of the default emulation of POSIX status 
+The pragma C<use vmsish 'status'> makes C<$?> reflect the actual
+VMS exit status instead of the default emulation of POSIX status
 described above.  This pragma also disables the conversion of
 non-zero values to SS$_ABORT when setting C<$?> in an END
 block (but zero will still be converted to SS$_NORMAL).
@@ -1154,7 +1154,7 @@ will be available in the exit status for DCL scripts or other native VMS tools,
 and will give the expected information for Posix programs.  It has not been
 made the default in order to preserve backward compatibility.
 
-N.B. Setting C<DECC$FILENAME_UNIX_REPORT> implicitly enables 
+N.B. Setting C<DECC$FILENAME_UNIX_REPORT> implicitly enables
 C<PERL_VMS_POSIX_EXIT>.
 
 =item $|


### PR DESCRIPTION
Fixes #13743 

This ticket got dropped without explanation.  I've updated the patch that was furnished with it.

* This set of changes does not require a perldelta entry.
