### PR TITLE
cpan/Module-Metadata - Update to version 1.000039

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1723,22 +1723,22 @@ cpan/Module-Load-Conditional/t/to_load/NotX.pm			Module::Conditional tests
 cpan/Module-Load-Conditional/t/to_load/ToBeLoaded		Module::Conditional tests
 cpan/Module-Loaded/lib/Module/Loaded.pm	Module::Loaded
 cpan/Module-Loaded/t/01_Module-Loaded.t	Module::Loaded tests
-cpan/Module-Metadata/corpus/BOMTest/UTF16BE.pm
-cpan/Module-Metadata/corpus/BOMTest/UTF16LE.pm
-cpan/Module-Metadata/corpus/BOMTest/UTF8.pm
-cpan/Module-Metadata/lib/Module/Metadata.pm
-cpan/Module-Metadata/t/contains_pod.t
-cpan/Module-Metadata/t/encoding.t
-cpan/Module-Metadata/t/endpod.t
-cpan/Module-Metadata/t/extract-package.t
-cpan/Module-Metadata/t/extract-version.t
-cpan/Module-Metadata/t/lib/0_1/Foo.pm
-cpan/Module-Metadata/t/lib/0_2/Foo.pm
-cpan/Module-Metadata/t/lib/ENDPOD.pm
-cpan/Module-Metadata/t/lib/GeneratePackage.pm
-cpan/Module-Metadata/t/metadata.t
-cpan/Module-Metadata/t/taint.t
-cpan/Module-Metadata/t/version.t
+cpan/Module-Metadata/corpus/BOMTest/UTF16BE.pm	Module related to Module::Metadata
+cpan/Module-Metadata/corpus/BOMTest/UTF16LE.pm	Module related to Module::Metadata
+cpan/Module-Metadata/corpus/BOMTest/UTF8.pm	Module related to Module::Metadata
+cpan/Module-Metadata/lib/Module/Metadata.pm	Module related to Module::Metadata
+cpan/Module-Metadata/t/contains_pod.t		Test file related to Module::Metadata
+cpan/Module-Metadata/t/encoding.t		Test file related to Module::Metadata
+cpan/Module-Metadata/t/endpod.t			Test file related to Module::Metadata
+cpan/Module-Metadata/t/extract-package.t	Test file related to Module::Metadata
+cpan/Module-Metadata/t/extract-version.t	Test file related to Module::Metadata
+cpan/Module-Metadata/t/lib/0_1/Foo.pm		Module related to Module::Metadata
+cpan/Module-Metadata/t/lib/0_2/Foo.pm		Module related to Module::Metadata
+cpan/Module-Metadata/t/lib/ENDPOD.pm		Module related to Module::Metadata
+cpan/Module-Metadata/t/lib/GeneratePackage.pm	Module related to Module::Metadata
+cpan/Module-Metadata/t/metadata.t		Test file related to Module::Metadata
+cpan/Module-Metadata/t/taint.t			Test file related to Module::Metadata
+cpan/Module-Metadata/t/version.t		Test file related to Module::Metadata
 cpan/NEXT/lib/NEXT.pm				Pseudo-class NEXT for method redispatch
 cpan/NEXT/t/actual.t				NEXT
 cpan/NEXT/t/actuns.t				NEXT

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -865,7 +865,8 @@ our %Modules = (
     },
 
     'Module::Metadata' => {
-        'DISTRIBUTION' => 'ETHER/Module-Metadata-1.000038.tar.gz',
+        'DISTRIBUTION' => 'ETHER/Module-Metadata-1.000039.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Sun Apr  5 19:01:14 2026',
         'FILES'        => q[cpan/Module-Metadata],
         'EXCLUDED'     => [
             qw(t/00-report-prereqs.t),

--- a/cpan/Module-Metadata/lib/Module/Metadata.pm
+++ b/cpan/Module-Metadata/lib/Module/Metadata.pm
@@ -1,6 +1,6 @@
 # -*- mode: cperl; tab-width: 8; indent-tabs-mode: nil; basic-offset: 2 -*-
 # vim:ts=8:sw=2:et:sta:sts=2:tw=78
-package Module::Metadata; # git description: v1.000037-8-g92dec6c
+package Module::Metadata; # git description: v1.000038-5-g7f7baae
 # ABSTRACT: Gather package and POD information from perl module files
 
 # Adapted from Perl-licensed code originally distributed with
@@ -14,7 +14,7 @@ sub __clean_eval { eval $_[0] }
 use strict;
 use warnings;
 
-our $VERSION = '1.000038';
+our $VERSION = '1.000039';
 
 use Carp qw/croak/;
 use File::Spec;
@@ -87,7 +87,7 @@ my $CLASS_REGEXP = qr{  # match a class declaration (core since 5.38)
   \s*                   # optional whitespace
   ($V_NUM_REGEXP)?      # optional version number
   \s*                   # optional whitespace
-  [;\{]                 # semicolon line terminator or block start
+  [:;\{]                # attribute start, semicolon line terminator or block start
 }x;
 
 my $VARNAME_REGEXP = qr{ # match fully-qualified VERSION name
@@ -861,7 +861,7 @@ Module::Metadata - Gather package and POD information from perl module files
 
 =head1 VERSION
 
-version 1.000038
+version 1.000039
 
 =head1 SYNOPSIS
 
@@ -1072,6 +1072,14 @@ Returns a boolean indicating whether the package (if provided) or any package
 Note This only checks for valid C<package> declarations, and does not take any
 ownership information into account.
 
+=head1 GIVING THANKS
+
+=for stopwords MetaCPAN GitHub
+
+If you found this module to be useful, please show your appreciation by
+adding a +1 in L<MetaCPAN|https://metacpan.org/dist/Module-Metadata>
+and a star in L<GitHub|https://github.com/Perl-Toolchain-Gang/Module-Metadata>.
+
 =head1 SUPPORT
 
 Bugs may be submitted through L<the RT bug tracker|https://rt.cpan.org/Public/Dist/Display.html?Name=Module-Metadata>
@@ -1093,7 +1101,7 @@ assistance from David Golden (xdg) <dagolden@cpan.org>.
 
 =head1 CONTRIBUTORS
 
-=for stopwords Karen Etheridge David Golden Vincent Pit Matt S Trout Chris Nehren Graham Knop Olivier Mengué Tomas Doran Christian Walde Craig A. Berry Tatsuhiko Miyagawa tokuhirom 'BinGOs' Williams Mitchell Steinbrunner Edward Zborowski Gareth Harper James Raspass Jerry D. Hedden Josh Jore Kent Fredric Leon Timmermans Peter Rabbitson Steve Hay
+=for stopwords Karen Etheridge David Golden Vincent Pit Matt S Trout Chris Nehren Graham Knop Olivier Mengué Tomas Doran Christian Walde Craig A. Berry Tatsuhiko Miyagawa tokuhirom 'BinGOs' Williams Mitchell Steinbrunner Edward Zborowski Erik Huelsmann Gareth Harper James Raspass Jerry D. Hedden Josh Jore Kent Fredric Leon Timmermans Peter Rabbitson Steve Hay
 
 =over 4
 
@@ -1160,6 +1168,10 @@ David Steinbrunner <dsteinbrunner@pobox.com>
 =item *
 
 Edward Zborowski <ed@rubensteintech.com>
+
+=item *
+
+Erik Huelsmann <ehuels@gmail.com>
 
 =item *
 

--- a/cpan/Module-Metadata/t/extract-package.t
+++ b/cpan/Module-Metadata/t/extract-package.t
@@ -142,6 +142,14 @@ our $foo = 1;
 class Simple::Edward;
 ---
 },
+{
+  name => 'package and class declarations',
+  package => [ 'Ticket::Widget::Entry' ],
+  code => <<'---',
+package Ticket::Widget::Entry 0.36;
+class Ticket::Widget::Entry :strict(params) :isa(Tickit::Widget);
+---
+},
 );
 
 my $test_num = 0;

--- a/cpan/Module-Metadata/t/extract-version.t
+++ b/cpan/Module-Metadata/t/extract-version.t
@@ -387,6 +387,38 @@ our $VERSION = '1.23_00_00';
   all_versions => { Simple => 'v1.2_3' },
 },
 {
+  name => 'class NAME VERSION ATTRIBUTE',
+  code => <<'---',
+  class Simple 1.23 :isa(Complex);
+---
+  vers => '1.23',
+  all_versions => { Simple => '1.23' },
+},
+{
+  name => 'class NAME VERSION ATTRIBUTE',
+  code => <<'---',
+  class Simple 1.23_01 :isa(Complex);
+---
+  vers => '1.23_01',
+  all_versions => { Simple => '1.23_01' },
+},
+{
+  name => 'class NAME VERSION ATTRIBUTE',
+  code => <<'---',
+  class Simple v1.2.3 :isa(Complex);
+---
+  vers => 'v1.2.3',
+  all_versions => { Simple => 'v1.2.3' },
+},
+{
+  name => 'class NAME VERSION ATTRIBUTE',
+  code => <<'---',
+  class Simple v1.2_3 :isa(Complex);
+---
+  vers => 'v1.2_3',
+  all_versions => { Simple => 'v1.2_3' },
+},
+{
   name => 'trailing crud',
   code => <<'---',
   package Simple;
@@ -500,6 +532,46 @@ class Simple 1.23 {
   name => 'class NAME VERSION BLOCK (2)',
   code => <<'---',
 class Simple v1.2.3_4 {
+  1;
+}
+---
+  vers => 'v1.2.3_4',
+  all_versions => { Simple => 'v1.2.3_4' },
+},
+{
+  name => 'class NAME ATTRIBUTE BLOCK, undef $VERSION',
+  code => <<'---',
+class Simple :isa(Complex) {
+  our $VERSION;
+}
+---
+  vers => $undef,
+  all_versions => {},
+},
+{
+  name => 'class NAME ATTRIBUTE BLOCK, with $VERSION',
+  code => <<'---',
+class Simple :isa(Complex) {
+  our $VERSION = '1.23';
+}
+---
+  vers => '1.23',
+  all_versions => { Simple => '1.23' },
+},
+{
+  name => 'class NAME VERSION ATTRIBUTE BLOCK (1)',
+  code => <<'---',
+class Simple 1.23 :isa(Complex) {
+  1;
+}
+---
+  vers => '1.23',
+  all_versions => { Simple => '1.23' },
+},
+{
+  name => 'class NAME VERSION ATTRIBUTE BLOCK (2)',
+  code => <<'---',
+class Simple v1.2.3_4 :isa(Complex) {
   1;
 }
 ---


### PR DESCRIPTION
1.000039  2026-04-03 20:54:53Z
  - adds recognition of attributes in "class" declarations (Erik Huelsmann, #39)

**NOTE:** This distribution sailed through `Porting/sync-with-cpan`, but since we're in the final weeks before full program freeze and since it includes small changes to source code, I'm formulating this synchronization as a pull request.  PSC: please determine whether this can be merged to blead before April 20, or else slap a 'defer-next-dev' label on it. @ap @Leont @leonerd 