### PR TITLE
S_cleanup_regmatch_info_aux - don't Safefree(NULL)

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -11528,7 +11528,8 @@ S_cleanup_regmatch_info_aux(pTHX_ void *arg)
     regmatch_info_aux_eval *eval_state =  aux->info_aux_eval;
     regmatch_slab *s;
 
-    Safefree(aux->poscache);
+    if (aux->poscache)
+        Safefree(aux->poscache);
 
     if (eval_state) {
 


### PR DESCRIPTION
One of the tasks of the `S_cleanup_regmatch_info_aux` destructor is to free any `aux->poscache` allocation.

However, many regular expressions - such as a simple TRIE - don't cause an allocation to occur. This commit adds a check to ensure that an unnecessary function call isn't made in those instances.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
