### PR TITLE
regen/regcharclass.pl: add 'bool' support

### DIFF
--- a/regcharclass.h
+++ b/regcharclass.h
@@ -3975,6 +3975,6 @@
  * e3ac360c03d18779fea6d6497fbbe53798135da55e3764d3c9f90a79bbf7e8b5 lib/unicore/mktables
  * 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
- * 852a8a7814f08a155d79fead2656fe2b4450ab17a2bce8a1127016119c9c3bc3 regen/regcharclass.pl
+ * be914e28ced65e0730a18740bf3188c02a60bf94b68a2a3120d172ec7b56e17e regen/regcharclass.pl
  * b2f896452d2b30da3e04800f478c60c1fd0b03d6b668689b020f1e3cf1f1cdd9 regen/regcharclass_multi_char_folds.pl
  * ex: set ro ft=c: */

--- a/regen/regcharclass.pl
+++ b/regen/regcharclass.pl
@@ -573,6 +573,8 @@ sub _optree {
             $else= $self->{strs}{ $trie->{''} }{cp}[0] unless defined $else;
             $else= $self->val_fmt($else) if $else > 9;
             $else= "len=$depth, $else";
+        } elsif ( $ret_type eq 'bool' ) {
+            $else= 1;
         }
     }
     # extract the meaningful keys from the trie, filter out '' as
@@ -1441,7 +1443,7 @@ sub render {
 # Opts are:
 # type             : 'cp', 'cp_high', 'generic', 'high', 'low', 'latin1',
 #                    'utf8', 'LATIN1', 'UTF8' 'backwards_UTF8'
-# ret_type         : 'cp' or 'len'
+# ret_type         : 'cp', 'len', or 'bool'
 # safe             : don't assume is well-formed UTF-8, so don't skip any range
 #                    checks, and add length guards to macro
 # no_length_checks : like safe, but don't add length guards.
@@ -1476,6 +1478,11 @@ sub make_macro {
         }
     }
     my $ret_type= $opts{ret_type} || ( $opts{type} =~ /^cp/ ? 'cp' : 'len' );
+    # 'bool' combined with 'cp' is invalid: 'cp' macros already return
+    # a boolean-like result and can be used directly in boolean context.
+    if ($ret_type eq 'bool' && $type =~ /^cp/) {
+        die "Can't do a 'bool' ret_type on 'cp' type macro '$self->{op}'"
+    }
     my $method;
     if ( $opts{safe} ) {
         $method= 'length_optree';
@@ -1734,6 +1741,10 @@ EOF
 #               list, which is a pointer as to where to store the number of
 #               bytes matched, while also returning the code point.  The macro
 #               name is changed to 'what_len_BASE...'.  See pod for caveats
+# Appending '-bool' causes the macro to return a boolean rather than a
+#               length.  The macro name retains the 'is_' prefix.  Use this
+#               when the byte length of the match is not needed, as it can
+#               produce simpler generated code.
 #
 # Valid modifiers:
 #   safe        The input string is not necessarily valid UTF-8.  In


### PR DESCRIPTION
Add a new `'bool'` return type for generated macros. Unlike the default `'len'` return type which returns the byte length of the match, `'bool'` macros return a simple true/false result, which can produce simpler generated code when the match length is not needed.

The 'bool' type can be requested by appending `'-bool'` to a type specifier in the __DATA__ section (e.g. `'UTF8-bool'`).

The `'is_'` prefix is retained for bool macros, making it more accurate than for `'len'` macros which also use it.