### PR TITLE
Store `ObjectFIELDS()` in `sv_u` union

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -1179,9 +1179,9 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
                     .xmg_stash = NULL, .xmg_u = {.xmg_magic = NULL},
                     .xobject_maxfield = -1,
                     .xobject_iter_sv_at = 0,
-                    .xobject_fields = NULL,
                 };
                 *((XPVOBJ*) SvANY(sv)) = pvo;
+                ObjectFIELDS(sv) = NULL;
             }
             break;
         default:

--- a/sv.h
+++ b/sv.h
@@ -227,6 +227,7 @@ typedef struct hek HEK;
         HE**	svu_hash;		\
         GP*	svu_gp;			\
         PerlIO *svu_fp;			\
+        SV**    svu_fields;             \
     }	sv_u				\
     SV_HEAD_DEBUG_
 
@@ -723,12 +724,11 @@ struct xobject {
     union xmgu_ xmg_u;
     SSize_t     xobject_maxfield;
     SSize_t     xobject_iter_sv_at; /* this is only used by Perl_sv_clear() */
-    SV**        xobject_fields;
 };
 
+#define ObjectFIELDS(inst)    ((inst)->sv_u.svu_fields)
 #define ObjectMAXFIELD(inst)  ((XPVOBJ *)SvANY(inst))->xobject_maxfield
 #define ObjectITERSVAT(inst)  ((XPVOBJ *)SvANY(inst))->xobject_iter_sv_at
-#define ObjectFIELDS(inst)    ((XPVOBJ *)SvANY(inst))->xobject_fields
 
 /* The following macros define implementation-independent predicates on SVs. */
 

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -291,7 +291,7 @@ static const struct body_details bodies_by_type[] = {
       FIT_ARENA(24, sizeof(ALIGNED_TYPE_NAME(XPVIO))) },
 
     { sizeof(ALIGNED_TYPE_NAME(XPVOBJ)),
-      copy_length(XPVOBJ, xobject_fields),
+      copy_length(XPVOBJ, xobject_iter_sv_at),
       0,
       SVt_PVOBJ, TRUE, NONV, HASARENA,
       FIT_ARENA(0, sizeof(ALIGNED_TYPE_NAME(XPVOBJ))) },


### PR DESCRIPTION
When I originally created the object system I forgot about the `sv_u` union, where e.g. AVs store the actual array pointer. This would have been a good place to store the fields array, rather than in the XPVOBJ extension structure.

Moving it there may make a tiny performance improvement (because of fewer indirect pointer accesses), but more importantly will reduce the memory size of all object instances by one pointer storage.

* This set of changes does not require a perldelta entry.