### PR TITLE
Add new Core Team members

### DIFF
--- a/Porting/core-team.json
+++ b/Porting/core-team.json
@@ -8,6 +8,7 @@
     "xdg@xdg.me"
   ],
   "active": [
+    "andk@cpan.org",
     "chris@bingosnet.co.uk",
     "cpan@corion.net",
     "craigberry@mac.com",
@@ -20,6 +21,7 @@
     "ilmari@ilmari.org",
     "jkeenan@pobox.com",
     "haarg@haarg.org",
+    "lukasmai.403+p5p@gmail.com",
     "perl@khwilliamson.com",
     "leonerd@leonerd.org.uk",
     "neilb@neilb.org",
@@ -31,6 +33,7 @@
     "rjbs@semiotic.systems",
     "steve.m.hay@googlemail.com",
     "stuart@perlfoundation.org",
+    "thibault.duponchelle@gmail.com",
     "toddr@cpanel.net",
     "tony@develop-help.com",
     "wolfsage@gmail.com"

--- a/pod/perlgov.pod
+++ b/pod/perlgov.pod
@@ -508,6 +508,8 @@ The current members of the Perl Core Team are:
 
 =over 4
 
+=item Andreas König <andk@cpan.org>
+
 =item Aristotle Pagaltzis <pagaltzis@gmx.de>
 
 =item Chad Granum <exodist7@gmail.com>
@@ -534,6 +536,8 @@ The current members of the Perl Core Team are:
 
 =item Leon Timmermans <fawaka@gmail.com>
 
+=item Lukas Mai <lukasmai.403+p5p@gmail.com>
+
 =item Matthew Horsfall <wolfsage@gmail.com>
 
 =item Max Maischein <cpan@corion.net>
@@ -542,7 +546,7 @@ The current members of the Perl Core Team are:
 
 =item Nicholas Clark <nick@ccl4.org>
 
-=item Nicolas R <atoomic@cpan.org>
+=item Nicolas R <nicolas@atoomic.org>
 
 =item Paul "LeoNerd" Evans <leonerd@leonerd.org.uk>
 
@@ -553,6 +557,8 @@ The current members of the Perl Core Team are:
 =item Steve Hay <steve.m.hay@googlemail.com>
 
 =item Stuart Mackintosh <stuart@perlfoundation.org>
+
+=item Thibault Duponchelle <thibault.duponchelle@gmail.com>
 
 =item Todd Rinaldo <toddr@cpanel.net>
 


### PR DESCRIPTION
After recent elections three new members are added to the Core Team:
* Andreas - ANDK
* Lukas - MAUKE
* Thibault - CONTRA
