### PR TITLE
Document PERL_POISON, reflow affected text

### DIFF
--- a/handy.h
+++ b/handy.h
@@ -2984,10 +2984,10 @@ enum mem_log_type {
           (v = (MEM_WRAP_CHECK_(n,t) (c*)MEM_LOG_REALLOC(n,t,v,saferealloc((Malloc_t)(v),(MEM_SIZE)((n)*sizeof(t))))))
 
 #ifdef PERL_POISON
-#define Safefree(d) \
+#  define Safefree(d) \
   ((d) ? (void)(safefree(MEM_LOG_FREE((Malloc_t)(d))), Poison(&(d), 1, Malloc_t)) : (void) 0)
 #else
-#define Safefree(d)	safefree(MEM_LOG_FREE((Malloc_t)(d)))
+#  define Safefree(d)	safefree(MEM_LOG_FREE((Malloc_t)(d)))
 #endif
 
 /* assert that a valid ptr has been supplied - use this instead of assert(ptr)  *

--- a/handy.h
+++ b/handy.h
@@ -2814,6 +2814,7 @@ optimise.
 This is an architecture-independent macro that does a shallow copy of one
 structure to another.
 
+=for apidoc_section $debugging
 =for apidoc Am|void|PoisonWith|void* dest|int nitems|type|U8 byte
 
 Fill up memory with a byte pattern (a byte repeated over and over

--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -162,7 +162,7 @@ should use C<sv_gets> instead:
   Instead Of:                    Use:
 
   t* p = malloc(n)               Newx(p, n, t)
-  t* p = calloc(n, s)            Newxz(p, n, t)
+  t* p = calloc(n, s)            Newxz(p, n, t)   (But see [1] below)
   p = realloc(p, n)              Renew(p, n, t)
 
 It is not portable to try to allocate 0 bytes; allocating 1 or more is
@@ -178,26 +178,13 @@ occur, or subtle memory leaks or subtle heap corruption.
 Notice the different order of arguments to C<Copy> and C<Move> than used
 in C<memcpy> and C<memmove>.
 
-  memset(dst, 0, n * sizeof(t))  Zero(dst, n, t)
-  memzero(dst, 0)                Zero(dst, n, char)
+  memset(dst, 0, n * sizeof(t))  Zero(dst, n, t)      (But see [1] below)
+  memzero(dst, 0)                Zero(dst, n, char)   (But see [1] below)
   free(p)                        Safefree(p)
 
   strdup(p)                      savepv(p)
   strndup(p, n)                  savepvn(p, n) (Hey, strndup doesn't
                                                 exist!)
-
-Sometimes instead of zeroing the allocated heap by using Newxz() you
-should consider "poisoning" the data.  This means writing a bit
-pattern into it that should be illegal as pointers (and floating point
-numbers), and also hopefully surprising enough as integers, so that
-any code attempting to use the data without forethought will break
-sooner rather than later.  Poisoning can be done using the Poison()
-macros, which have similar arguments to Zero():
-
-  PoisonWith(dst, n, t, b)    scribble memory with byte b
-  PoisonNew(dst, n, t)        equal to PoisonWith(dst, n, t, 0xAB)
-  PoisonFree(dst, n, t)       equal to PoisonWith(dst, n, t, 0xEF)
-  Poison(dst, n, t)           equal to PoisonFree(dst, n, t)
 
   strstr(big, little)            instr(big, little)
   memmem(big, blen, little, len) ninstr(big, bigend, little, little_end)
@@ -244,6 +231,10 @@ create a string that isn't valid UTF-8 if the current underlying locale
 of the program is UTF-8.  What happens is that the C<%s> and its
 operand are simply skipped without any notice.
 L<https://sourceware.org/bugzilla/show_bug.cgi?id=6530>.
+
+[1] Sometimes instead of zeroing the allocated memory, you
+should consider "poisoning" the data to catch uninitialized uses of it.
+See L<perlhacktips/Catching hidden flaws>.
 
 =head2 Character Class Tests
 

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1,5 +1,5 @@
-
-=encoding utf8
+C<
+=>encoding utf8
 
 =for comment
 Consistent formatting of this file is achieved with:
@@ -1057,17 +1057,22 @@ calculate the length for you.  See L<perlapi/String Handling>.
 
 =head1 DEBUGGING
 
-You can compile a special debugging version of Perl, which allows you
-to use the C<-D> option of Perl to tell more about what Perl is doing.
-But sometimes there is no alternative than to dive in with a debugger,
-either to see the stack trace of a core dump (very useful in a bug
-report), or trying to figure out what went wrong before the core dump
-happened, or how did we end up having wrong or unexpected results.
+Most code won't work as intended the first time it is run, and so needs
+to be debugged and revised.  Scarier is code that seems to work but has
+hidden flaws that a hacker could use to perform malicious actions.
+There are ways to detect both types.
 
 =head2 Poking at Perl
 
-To really poke around with Perl, you'll probably want to build Perl for
-debugging, like this:
+We will start with the first kind.  You can compile a special debugging
+version of Perl, which enables many built-in checks that things are
+going as expected.  When one fails, the interpreter abruptly stops with
+a message as to what went wrong.  Many people always use this option
+during code development.  It also allows you to enable tracing of one or
+more specific areas of the execution, and to use a debugger much more
+conveniently.
+
+To create this kind of Perl, you will need to:
 
     ./Configure -d -DDEBUGGING
     make
@@ -1076,12 +1081,15 @@ C<-DDEBUGGING> turns on the C compiler's C<-g> flag to have it produce
 debugging information which will allow us to step through a running
 program, and to see in which C function we are at (without the
 debugging information we might see only the numerical addresses of the
-functions, which is not very helpful). It will also turn on the
-C<DEBUGGING> compilation symbol which enables all the internal
-debugging code in Perl. There are a whole bunch of things you can debug
-with this: L<perlrun|perlrun/-Dletters> lists them all, and the best
-way to find out about them is to play about with them.  The most useful
-options are probably
+functions, which is not very helpful).  See L</Using a source-level
+debugger> for more on this.
+
+C<-DDEBUGGING> also causes each compiled file to have the symbol
+C<DEBUGGING> #defined.  This enables all the internal debugging code in
+Perl, including the ability to trace a whole bunch of things.
+L<perlrun|perlrun/-Dletters> lists them all, and the best way to find
+out about them is to play about with them.  The most useful options for
+a general overview of what is going on are probably:
 
     l  Context (loop) stack processing
     s  Stack snapshots (with v, displays all stacks)
@@ -1112,10 +1120,45 @@ non-debugging perl by using XS modules:
 
 More details can be found in L<perlguts/Tracing the interpreter execution>.
 
+=head2 Catching hidden flaws
+
+Various tools exist to find hidden flaws in your code, but these
+typically cause an unacceptable slowdown, and so tend not to get used
+until a problem is found, which may be after a hacker has caused damage.
+See L</MEMORY DEBUGGERS> for more on these.
+
+But perl does have a compilation option that catches many instances of
+the important flaw of using uninitialized values, and slows things down by
+much less than these tools -- by around 5%.  To enable it, add this option
+to your F<Configure> call
+
+    ./Configure ... -Accflags=-DPERL_POISON
+    make
+
+=for apidoc_section $debugging
+=for apidoc Amnh||PERL_POISON
+
+This causes perl to set any created or freed memory to specific bit
+patterns that should be illegal as pointers (and floating point
+numbers), and also hopefully surprising enough as integers, so that any
+code attempting to use the data without forethought will break sooner
+rather than later.
+
+You may wish to always cause this to happen for particular memory
+allocations.  The following macros (which have similar arguments to
+Zero()) accomplish this:
+
+  PoisonWith(dst, n, t, b)    scribble memory with byte b
+  PoisonNew(dst, n, t)        equal to PoisonWith(dst, n, t, 0xAB)
+  PoisonFree(dst, n, t)       equal to PoisonWith(dst, n, t, 0xEF)
+  Poison(dst, n, t)           equal to PoisonFree(dst, n, t)
+
 =head2 Using a source-level debugger
 
-If the debugging output of C<-D> doesn't help you, it's time to step
-through perl's execution with a source-level debugger.
+If the debugging output of C<-D> doesn't help you, it's time to dive in
+with a source-level debugger, either to see the stack trace of a core
+dump (very useful in a bug report), or to try to figure out what went
+wrong before the core dump by stepping through perl's execution.
 
 =over 3
 
@@ -1521,6 +1564,8 @@ must be doing something that is quite unfriendly for memory debuggers.
 If you don't feel like waiting, you can simply kill the perl process.
 Roughly valgrind slows down execution by factor 10, AddressSanitizer by
 factor 2.
+
+(Also see L</Catching hidden flaws>.)
 
 B<NOTE 2>: To minimize the number of memory leak false alarms (see
 L</PERL_DESTRUCT_LEVEL> for more information), you have to set the

--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1100,7 +1100,9 @@ For example
     (-e:1)	add
         =>  NV(1)
 
-All the options are listed in L<perlrun/-Dletters>.
+All the options are listed in L<perlrun/-Dletters>.  Note that C<-DU> is
+reserved for your (temporary) use; you can add your own debugging
+statements controlled just by that switch.
 
 Some of the functionality of the debugging code can be achieved with a
 non-debugging perl by using XS modules:

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -500,11 +500,11 @@ S_rxres_free(pTHX_ void **rsp)
     if (p) {
         void *tmp = INT2PTR(char*,*p);
 #ifdef PERL_POISON
-#ifdef PERL_ANY_COW
+#  ifdef PERL_ANY_COW
         U32 i = 9 + p[1] * 2;
-#else
+#  else
         U32 i = 8 + p[1] * 2;
-#endif
+#  endif
 #endif
 
 #ifdef PERL_ANY_COW

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -6205,7 +6205,7 @@ Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int pass)
     while (PL_tmps_ix >= tmps_base) {
         SV* const sv = PL_tmps_stack[PL_tmps_ix--];
 #ifdef PERL_POISON
-        PoisonWith(PL_tmps_stack + PL_tmps_ix + 1, 1, SV *, 0xAB);
+        PoisonNew(PL_tmps_stack + PL_tmps_ix + 1, 1, SV *);
 #endif
         if (LIKELY(sv)) {
             SvTEMP_off(sv);


### PR DESCRIPTION
And it also replaces a macro expansion by the call to the macro.

* This set of changes does not require a perldelta entry.
