### PR TITLE
perl.pod - move some tutorials to the tutorials section

### DIFF
--- a/pod/perl.pod
+++ b/pod/perl.pod
@@ -66,13 +66,16 @@ aux h2ph h2xs perlbug pl2pm pod2html pod2man splain xsubpp
 
     perlootut           Perl OO tutorial for beginners
 
-    perlperf            Perl Performance and Optimization Techniques
+    perlopentut         Perl open() tutorial
 
-    perlstyle           Perl style guide
+    perlpacktut         Perl pack() and unpack() tutorial
+
+    perldebtut          Perl debugging tutorial
 
     perlcheat           Perl cheat sheet
+    perlperf            Perl Performance and Optimization Techniques
+    perlstyle           Perl style guide
     perltrap            Perl traps for the unwary
-    perldebtut          Perl debugging tutorial
 
     perlfaq             Perl frequently asked questions
       perlfaq1          General Questions About Perl
@@ -92,8 +95,6 @@ aux h2ph h2xs perlbug pl2pm pod2html pod2man splain xsubpp
     perlop              Perl expressions: operators, precedence, string literals
     perlsub             Perl subroutines
     perlfunc            Perl built-in functions
-      perlopentut       Perl open() tutorial
-      perlpacktut       Perl pack() and unpack() tutorial
     perlpod             Perl plain old documentation
     perlpodspec         Perl plain old documentation format specification
     perldocstyle        Perl style guide for core docs
@@ -111,7 +112,7 @@ aux h2ph h2xs perlbug pl2pm pod2html pod2man splain xsubpp
     perlform            Perl formats
     perlobj             Perl objects
     perltie             Perl objects hidden behind simple variables
-      perldbmfilter     Perl DBM filters
+    perldbmfilter       Perl DBM filters
     perlclass           Perl class syntax
 
     perlipc             Perl interprocess communication


### PR DESCRIPTION
Three of the tutorials mentioned in the Reference Manual section are moved back into the Tutorials section, which seems a more natural home.

_perlunitut_ remains where it is, in a set of Unicode references, as that seems like a better fit - plus the contents of this tutorial should be reviewed prior to it being moved to what would arguably be a higher level of prominance in the Tutorials section.

_perlxstut_ also stays in the Internals and C Language Interface section.

Closes #17710

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
