### PR TITLE
The \a character means 'alert', not 'alarm'

### DIFF
--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -1654,7 +1654,7 @@ X<\o{}>
     \r                  return            (CR)
     \f                  form feed         (FF)
     \b                  backspace         (BS)
-    \a                  alarm (bell)      (BEL)
+    \a                  alert (bell)      (BEL)
     \e                  escape            (ESC)
     \x{263A}     [1,8]  hex char          (example shown: SMILEY)
     \x{ 263A }          Same, but shows optional blanks inside and

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1005,7 +1005,7 @@ also work:
  \n          newline               (LF, NL)
  \r          return                (CR)
  \f          form feed             (FF)
- \a          alarm (bell)          (BEL)
+ \a          alert (bell)          (BEL)
  \e          escape (think troff)  (ESC)
  \cK         control char          (example: VT)
  \x{}, \x00  character whose ordinal is the given hexadecimal number

--- a/pod/perlrebackslash.pod
+++ b/pod/perlrebackslash.pod
@@ -64,7 +64,7 @@ as C<Not in [].>
 
  \000              Octal escape sequence.  See also \o{}.
  \1                Absolute backreference.  Not in [].
- \a                Alarm or bell.
+ \a                Alert or bell.
  \A                Beginning of string.  Not in [].
  \b{}, \b          Boundary. (\b is a backspace in []).
  \B{}, \B          Not a boundary.  Not in [].
@@ -121,7 +121,7 @@ description.  (For EBCDIC platforms, see L<perlebcdic/OPERATOR DIFFERENCES>.)
 
  Seq.  Code Point  ASCII   Cntrl   Description.
        Dec    Hex
-  \a     7     07    BEL    \cG    alarm or bell
+  \a     7     07    BEL    \cG    alert or bell
   \b     8     08     BS    \cH    backspace [1]
   \e    27     1B    ESC    \c[    escape character
   \f    12     0C     FF    \cL    form feed

--- a/pod/perlreref.pod
+++ b/pod/perlreref.pod
@@ -90,7 +90,7 @@ delimiters can be used.  Must be reset with reset().
 
 These work as in normal strings.
 
-   \a       Alarm (beep)
+   \a       Alert (beep)
    \e       Escape
    \f       Formfeed
    \n       Newline


### PR DESCRIPTION
These pods used the wrong name.  The C standard calls it 'alert'


* This set of changes does not require a perldelta entry.
