### PR TITLE
File::Glob: Note use [!...] for negated char classes

### DIFF
--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -33,7 +33,7 @@ $EXPORT_TAGS{bsd_glob} = [@{$EXPORT_TAGS{glob}}];
 
 our @EXPORT_OK   = (@{$EXPORT_TAGS{'glob'}}, 'csh_glob');
 
-our $VERSION = '1.43';
+our $VERSION = '1.44';
 
 sub import {
     require Exporter;
@@ -127,6 +127,7 @@ under L</EXPORTS>, below.
 
   \       Quote the next metacharacter
   []      Character class
+  [!...]  Negated character class (not [^...])
   {}      Multiple pattern
   *       Match any string of characters
   ?       Match any single character


### PR DESCRIPTION
This works in sh, not Perl's [^...].

Fixes #21866


* This set of changes does not require a perldelta entry.
