### PR TITLE
Revert "Reapply "op.c: re-enable coderef-in-stash optimization""

### DIFF
--- a/class.c
+++ b/class.c
@@ -717,13 +717,10 @@ S_class_cleanup_definition(pTHX_ HV *stash)
                 SvREFCNT_dec_NN(cv);
                 GvCV_set((GV*)entry, NULL);
             }
-            else if (SvROK(entry)) {
-                SV *sv = SvRV(entry);
-                if (SvTYPE(sv) == SVt_PVCV
-                         && (CvIsMETHOD((CV*)sv) || memEQs(kpv, klen, "new"))) {
-                    (void)hv_delete(stash, kpv, HeUTF8(he) ? -(I32)klen : (I32)klen,
-                                    G_DISCARD);
-                }
+            else if (SvTYPE(entry) == SVt_PVCV
+                     && (CvIsMETHOD((CV*)entry) || memEQs(kpv, klen, "new"))) {
+                (void)hv_delete(stash, kpv, HeUTF8(he) ? -(I32)klen : (I32)klen,
+                                G_DISCARD);
             }
         }
         ++PL_sub_generation;

--- a/op.c
+++ b/op.c
@@ -11565,9 +11565,12 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
            Also, we may be called from load_module at run time, so
            PL_curstash (which sets CvSTASH) may not point to the stash the
            sub is stored in.  */
+        /* XXX This optimization is currently disabled for packages other
+               than main, since there was too much CPAN breakage.  */
         const I32 flags =
            ec ? GV_NOADD_NOINIT
               :   (IN_PERL_RUNTIME && PL_curstash != CopSTASH(PL_curcop))
+               || PL_curstash != PL_defstash
                || memchr(name, ':', namlen) || memchr(name, '\'', namlen)
                     ? gv_fetch_flags
                     : GV_ADDMULTI | GV_NOINIT | GV_NOTQUAL;

--- a/t/op/sub.t
+++ b/t/op/sub.t
@@ -398,7 +398,10 @@ is ref($main::{rt_129916}), 'CODE', 'simple sub stored as CV in stash (main::)';
     package RT129916;
     sub foo { 42 }
 }
-is ref($RT129916::{foo}), 'CODE', 'simple sub stored as CV in stash (non-main::)';
+{
+    local $::TODO = "disabled for now";
+    is ref($RT129916::{foo}), 'CODE', 'simple sub stored as CV in stash (non-main::)';
+}
 
 # Calling xsub via ampersand syntax when @_ has holes
 SKIP: {


### PR DESCRIPTION
This reverts commit c0053197fb3c4bbe8d0582fb502ab99e6edc1881.

```
commit c0053197fb3c4bbe8d0582fb502ab99e6edc1881
Author:     Lukas Mai <lukasmai.403@gmail.com>
AuthorDate: Tue Jul 29 08:16:11 2025 +0200
Commit:     Tony Cook <tony@develop-help.com>
CommitDate: Thu Jul 31 09:48:21 2025 +1000

    Reapply "op.c: re-enable coderef-in-stash optimization"
    
    When seeing 'sub foo { ... }', perl does not need to allocate a full
    typeglob (with the subroutine being stored in the CODE slot). Instead,
    it can just store a coderef directly in the stash.
```

  `make test_harness` passes, but impact on CPAN not assessed.