### PR TITLE
perlintern: Document two invlist functions

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -524,6 +524,7 @@ my %initial_file_section = (
                             'gv.h' => $GV_scn,
                             'hv.h' => $HV_scn,
                             'INTERN.h' => $global_definitions_scn,
+                            'invlist_inline.h' => $unicode_scn,
                             'locale.c' => $locale_scn,
                             'malloc.c' => $memory_scn,
                             'numeric.c' => $numeric_scn,

--- a/embed.fnc
+++ b/embed.fnc
@@ -5522,11 +5522,11 @@ ERp	|SV *	|get_ANYOFM_contents					\
 ERi	|SV *	|invlist_contents					\
 				|NN SV * const invlist			\
 				|const bool traditional_style
-ERTix	|UV	|invlist_highest_range_start				\
+ERTdi	|UV	|invlist_highest_range_start				\
 				|NN SV * const invlist
 ERTi	|bool	|invlist_is_iterating					\
 				|NN const SV * const invlist
-ERTix	|UV	|invlist_lowest |NN SV * const invlist
+ERTdi	|UV	|invlist_lowest |NN SV * const invlist
 Ep	|U32	|join_exact	|NN RExC_state_t *pRExC_state		\
 				|NN regnode *scan			\
 				|NN UV *min_subtract			\

--- a/invlist_inline.h
+++ b/invlist_inline.h
@@ -175,11 +175,18 @@ S_invlist_highest_range_start(SV* const invlist)
 {
     PERL_ARGS_ASSERT_INVLIST_HIGHEST_RANGE_START;
 
-    /* Returns the lowest code point of the highest range in the inversion
-     * list parameter.  This API has an ambiguity: it returns 0 either when
-     * the lowest such point is actually 0 or when the list is empty.  If this
-     * distinction matters to you, check for emptiness before calling this
-     * function. */
+/*
+=for apidoc invlist_highest_range_start
+
+Returns the lowest code point of the highest range in the inversion list
+given by its parameter.
+
+This API has an ambiguity: it returns 0 either when the lowest such
+point is actually 0 or when the list is empty.  If this distinction matters to
+you, check for emptiness before calling this function.
+
+=cut
+*/
 
     UV len = invlist_len_(invlist);
     UV *array;
@@ -360,10 +367,17 @@ S_invlist_lowest(SV* const invlist)
 {
     PERL_ARGS_ASSERT_INVLIST_LOWEST;
 
-    /* Returns the lowest code point that matches an inversion list.  This API
-     * has an ambiguity, as it returns 0 under either the lowest is actually
-     * 0, or if the list is empty.  If this distinction matters to you, check
-     * for emptiness before calling this function */
+/*
+=for apidoc invlist_lowest
+
+Returns the lowest code point that matches an inversion list.
+
+This API has an ambiguity, as it returns 0 under either the lowest is actually
+0, or if the list is empty.  If this distinction matters to you, check for
+emptiness before calling this function
+
+=cut
+*/
 
     UV len = invlist_len_(invlist);
     UV *array;


### PR DESCRIPTION
And remove their experimental status.  These are invlist_lowest() and invlist_highest_start()

* This set of changes does not require a perldelta entry.
