### PR TITLE
Make sv_setsv_cow() visible everywhere

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -4394,8 +4394,8 @@ RTp	|MEM_SIZE|malloc_good_size					\
 				|size_t nbytes
 #endif
 #if defined(PERL_ANY_COW)
-: Used in regexec.c
-EXpx	|SV *	|sv_setsv_cow	|NULLOK SV *dsv 			\
+: Used in regexec.c, and unfortunately in cpan GH #23660
+Cpx	|SV *	|sv_setsv_cow	|NULLOK SV *dsv 			\
 				|NN SV *ssv
 #endif
 #if defined(PERL_CORE)

--- a/embed.h
+++ b/embed.h
@@ -915,6 +915,9 @@
 #   define utf8n_to_uvuni(a,b,c,d)              Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)
 #   define uvuni_to_utf8(a,b)                   Perl_uvuni_to_utf8(aTHX_ a,b)
 # endif
+# if defined(PERL_ANY_COW)
+#   define sv_setsv_cow(a,b)                    Perl_sv_setsv_cow(aTHX_ a,b)
+# endif
 # if defined(PERL_CORE)
 #   define PerlLIO_dup2_cloexec(a,b)            Perl_PerlLIO_dup2_cloexec(aTHX_ a,b)
 #   define PerlLIO_dup_cloexec(a)               Perl_PerlLIO_dup_cloexec(aTHX_ a)
@@ -1909,9 +1912,6 @@
 #   define variant_under_utf8_count             S_variant_under_utf8_count
 #   if !defined(HAS_MEMRCHR)
 #     define my_memrchr                         S_my_memrchr
-#   endif
-#   if defined(PERL_ANY_COW)
-#     define sv_setsv_cow(a,b)                  Perl_sv_setsv_cow(aTHX_ a,b)
 #   endif
 #   if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
        defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) || \

--- a/proto.h
+++ b/proto.h
@@ -7944,16 +7944,14 @@ Perl_ref(pTHX_ OP *o, I32 type)
 # endif
 #endif /* !defined(NO_MATHOMS) */
 #if defined(PERL_ANY_COW)
-# define PERL_ARGS_ASSERT_SV_SETSV_COW          \
-        Perl_assert_aTHX; assert(ssv)
-
-# if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
 Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
-# endif
-#endif /* defined(PERL_ANY_COW) */
+# define PERL_ARGS_ASSERT_SV_SETSV_COW          \
+        Perl_assert_aTHX; assert(ssv)
+
+#endif
 #if defined(PERL_CORE)
 PERL_CALLCONV void
 Perl_opslab_force_free(pTHX_ OPSLAB *slab)


### PR DESCRIPTION
See GH #23660.  A cpan module is using this function, and the function was not listed as externally visible.  Probably a new function needs to written to provide similar functionality.  But for now, simply let the current function be visible.  It already is marked as experimental.


* This set of changes does not require a perldelta entry.
