### PR TITLE
perlapi: Add heading text for the COP section

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -281,7 +281,15 @@ my %valid_sections = (
     $compiler_scn => {},
     $directives_scn => {},
     $concurrency_scn => {},
-    $COP_scn => {},
+    $COP_scn => {
+        header => <<~'EOT',
+            COP stands for "Current Operation".  It is the type used for
+            nextstate and dbstate ops, storing the filename and line number,
+            warning bits, hints bits, feature flags, I<etc>, and a sort of
+            incremental representation of the hints hash for the code that
+            follows.
+            EOT
+    },
     $CV_scn => {
         header => <<~'EOT',
             This section documents functions to manipulate CVs which are


### PR DESCRIPTION
This was extracted from https://github.com/Perl/perl5/pull/24251#issuecomment-4159637294.  Enhancements welcome!

* This set of changes does not require a perldelta entry.
