### PR TITLE
Mention Crypt::SysRandom

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6692,6 +6692,8 @@ including:
 
 =over
 
+=item * L<Crypt::SysRandom>
+
 =item * L<Crypt::URandom>
 
 =item * L<Crypt::PRNG>

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -78,6 +78,7 @@ CPANPLUS
 crypt(3)
 Crypt::PRNG
 Crypt::URandom
+Crypt::SysRandom
 ctime(3)
 curl(1)
 Dancer


### PR DESCRIPTION
Crypt::SysRandom is an alternative to Crypt::URandom, and is developed by Leon Timmermans <fawaka@gmail.com> who has contributed to the Perl core and maintains many important tools.

It has a cleaner architecture and a separate XS module that can be installed for using system calls.

It's worth mentioning.