### PR TITLE
op.c: don't warn on 'open my $fh, $file;'

### DIFF
--- a/op.c
+++ b/op.c
@@ -4975,28 +4975,37 @@ Perl_localize(pTHX_ OP *o, I32 lex)
             }
             if (sigil && (*s == ';' || *s == '=')) {
                 bool should_warn = TRUE;
-                if (PL_parser->last_lop_op == OP_OPEN || PL_parser->last_lop_op == OP_OPEN_DIR) {
-                    /* horrible hack on top of a horrible hack: avoid warning
-                     * on 'open my $foo, $bar;' and 'opendir my $foo, $bar;' */
-                    const char *t = PL_parser->last_lop, *stop = PL_parser->bufend;
+                switch (PL_parser->last_lop_op) {
+                    case OP_OPEN:
+                    case OP_OPEN_DIR:
+                    case OP_SOCKET:
+                    case OP_ACCEPT:
+                    {
+                        /* horrible hack on top of a horrible hack: avoid warning
+                         * on 'open/opendir/socket/accept my $foo, $bar;'
+                         * [GH #4186] */
+                        const char *t = PL_parser->last_lop, *stop = PL_parser->bufend;
 
-                    /* optional whitespace */
-                    for (; t < stop && memCHRs(" \t\n", *t); t++) {}
-                    /* keyword 1: one of open, CORE::open, opendir, CORE::opendir */
-                    for (; t < stop && (isWORDCHAR(*t) || UTF8_IS_CONTINUED(*t) || *t == ':'); t++) {}
-                    /* whitespace */
-                    for (; t < stop && memCHRs(" \t\n", *t); t++) {}
-                    /* keyword 2: one of my, our, state, local */
-                    for (; t < stop && (isWORDCHAR(*t) || UTF8_IS_CONTINUED(*t) || *t == ':'); t++) {}
-                    /* optional whitespace */
-                    for (; t < stop && memCHRs(" \t\n", *t); t++) {
-                        if (t == PL_parser->oldoldbufptr) {
-                            break;
+                        /* optional whitespace */
+                        for (; t < stop && memCHRs(" \t\n", *t); t++) {}
+                        /* keyword 1: one of open, CORE::open, opendir, CORE::opendir */
+                        for (; t < stop && (isWORDCHAR(*t) || UTF8_IS_CONTINUED(*t) || *t == ':'); t++) {}
+                        /* whitespace */
+                        for (; t < stop && memCHRs(" \t\n", *t); t++) {}
+                        /* keyword 2: one of my, our, state, local */
+                        for (; t < stop && (isWORDCHAR(*t) || UTF8_IS_CONTINUED(*t) || *t == ':'); t++) {}
+                        /* optional whitespace */
+                        for (; t < stop && memCHRs(" \t\n", *t); t++) {
+                            if (t == PL_parser->oldoldbufptr) {
+                                break;
+                            }
                         }
-                    }
 
-                    if (t == PL_parser->oldoldbufptr) {
-                        should_warn = FALSE;
+                        if (t == PL_parser->oldoldbufptr) {
+                            should_warn = FALSE;
+                        }
+
+                        break;
                     }
                 }
                 if (should_warn) {

--- a/op.c
+++ b/op.c
@@ -4952,7 +4952,7 @@ Perl_localize(pTHX_ OP *o, I32 lex)
             && PL_parser->bufptr[-1] == ','
             && ckWARN(WARN_PARENTHESIS))
         {
-            char *s = PL_parser->bufptr;
+            const char *s = PL_parser->bufptr;
             bool sigil = FALSE;
 
             /* some heuristics to detect a potential error */
@@ -4974,15 +4974,42 @@ Perl_localize(pTHX_ OP *o, I32 lex)
                     break;
             }
             if (sigil && (*s == ';' || *s == '=')) {
-                warner(packWARN(WARN_PARENTHESIS),
-                       "Parentheses missing around \"%s\" list",
-                       lex
-                           ? (PL_parser->in_my == KEY_our
-                               ? "our"
-                               : PL_parser->in_my == KEY_state
-                                   ? "state"
-                                   : "my")
-                           : "local");
+                bool should_warn = TRUE;
+                if (PL_parser->last_lop_op == OP_OPEN || PL_parser->last_lop_op == OP_OPEN_DIR) {
+                    /* horrible hack on top of a horrible hack: avoid warning
+                     * on 'open my $foo, $bar;' and 'opendir my $foo, $bar;' */
+                    const char *t = PL_parser->last_lop, *stop = PL_parser->bufend;
+
+                    /* optional whitespace */
+                    for (; t < stop && memCHRs(" \t\n", *t); t++) {}
+                    /* keyword 1: one of open, CORE::open, opendir, CORE::opendir */
+                    for (; t < stop && (isWORDCHAR(*t) || UTF8_IS_CONTINUED(*t) || *t == ':'); t++) {}
+                    /* whitespace */
+                    for (; t < stop && memCHRs(" \t\n", *t); t++) {}
+                    /* keyword 2: one of my, our, state, local */
+                    for (; t < stop && (isWORDCHAR(*t) || UTF8_IS_CONTINUED(*t) || *t == ':'); t++) {}
+                    /* optional whitespace */
+                    for (; t < stop && memCHRs(" \t\n", *t); t++) {
+                        if (t == PL_parser->oldoldbufptr) {
+                            break;
+                        }
+                    }
+
+                    if (t == PL_parser->oldoldbufptr) {
+                        should_warn = FALSE;
+                    }
+                }
+                if (should_warn) {
+                    warner(packWARN(WARN_PARENTHESIS),
+                           "Parentheses missing around \"%s\" list",
+                           lex
+                               ? (PL_parser->in_my == KEY_our
+                                   ? "our"
+                                   : PL_parser->in_my == KEY_state
+                                       ? "state"
+                                       : "my")
+                               : "local");
+                }
             }
         }
     }

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -898,6 +898,38 @@ Parentheses missing around "local" list at - line 3.
 Parentheses missing around "local" list at - line 4.
 Parentheses missing around "local" list at - line 5.
 ########
+# NAME don't warn on 'open/opendir my $x, $y'
+# NOTE GH #4186
+# NOTE 'if (0)' because we only test parsing, not runtime behavior
+use warnings 'parenthesis';
+my $mode = '<';
+my ($file, $fh2, $dir);
+if (0) {
+    pipe my $fh1, $fh2;
+    open my $fh, $mode, $file;
+    opendir my $dh, $dir;
+    CORE::open CORE::my $fh, $mode, $file;
+    CORE::opendir CORE::my $dh, $dir;
+}
+if (0) {
+    pipe our $fh1, $fh2;
+    open our $fh, $mode, $file;
+    opendir our $dh, $dir;
+    CORE::open CORE::our $fh, $mode, $file;
+    CORE::opendir CORE::our $dh, $dir;
+}
+if (0) {
+    pipe local $fh1, $fh2;
+    open local $fh, $mode, $file;
+    opendir local $dh, $dir;
+    CORE::open CORE::local $fh, $mode, $file;
+    CORE::opendir CORE::local $dh, $dir;
+}
+EXPECT
+Parentheses missing around "my" list at - line 5.
+Parentheses missing around "our" list at - line 12.
+Parentheses missing around "local" list at - line 19.
+########
 # op.c
 use warnings 'bareword' ;
 print (ABC || 1) ;

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -930,6 +930,30 @@ Parentheses missing around "my" list at - line 5.
 Parentheses missing around "our" list at - line 12.
 Parentheses missing around "local" list at - line 19.
 ########
+# NAME don't warn on 'socket/accept my $x, $y'
+# NOTE GH #4186 reprise
+use warnings 'parenthesis';
+my ($domain, $type, $protocol);
+if (0) {
+    socket my $socket, $domain, $type, $protocol;
+    accept my $newsocket, $socket;
+    CORE::socket my $socket, $domain, $type, $protocol;
+    CORE::accept CORE::my $newsocket, $socket;
+}
+if (0) {
+    socket our $socket, $domain, $type, $protocol;
+    accept our $newsocket, $socket;
+    CORE::socket CORE::our $socket, $domain, $type, $protocol;
+    CORE::accept CORE::our $newsocket, $socket;
+}
+if (0) {
+    socket local $socket, $domain, $type, $protocol;
+    accept local $newsocket, $socket;
+    CORE::socket CORE::local $socket, $domain, $type, $protocol;
+    CORE::accept CORE::local $newsocket, $socket;
+}
+EXPECT
+########
 # op.c
 use warnings 'bareword' ;
 print (ABC || 1) ;


### PR DESCRIPTION
We have a hacky heuristic that complains about `Missing parentheses around "my" list` when it sees `my $x, $y;` or similar, assuming the programmer intended to declare both variables as local: `my ($x, $y);`.

However, this warning is inappropriate for open/opendir because `open my $fh, $mode, $file` or `opendir my $dh, $dir` can appear in perfectly correct code. Detecting this case is not easy because the warning is generated by inspecting the tokenizer state and manually reparsing parts of the input. This commit adds even more hackery and reparsing to avoid the inappropriate warning.

Fixes #4186.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
