### PR TITLE
Perl_op_scope - don't null COP when ENTERSUB follows

### DIFF
--- a/op.c
+++ b/op.c
@@ -4641,12 +4641,31 @@ Perl_op_scope(pTHX_ OP *o)
             OpTYPE_set(o, OP_SCOPE);
             kid = cLISTOPo->op_first;
             if (OP_TYPE_IS_COP_NN(kid)) {
-                op_null(kid);
+                /* As a small micro-optimization, it might be possible
+                 * to null this COP without detrimental consequence.
+                 *
+                 * However, if a subroutine call immediately follows, any
+                 * use of caller() before the return will be operating on
+                 * whatever the previous COP was. This is most often
+                 * noticeable when caller() outputs an obviously inaccurate
+                 * caller line number. Hence the COP is preserved when
+                 * followed by an entersub.
+                 */
+                 OP *sib = OpSIBLING(kid);
+                 if (LIKELY(sib)) {
+                     if (sib->op_type != OP_ENTERSUB) {
+                         op_null(kid);
 
-                /* The following deals with things like 'do {1 for 1}' */
-                kid = OpSIBLING(kid);
-                if (kid && OP_TYPE_IS_COP_NN(kid))
-                    op_null(kid);
+                         /* The following deals with things like 'do {1 for 1}' */
+                         if (OP_TYPE_IS_COP_NN(sib)) {
+                             OP *sib2 = OpSIBLING(sib);
+                             if (!sib2 || sib2->op_type != OP_ENTERSUB)
+                                 op_null(sib);
+                         }
+                     }
+                 } else {
+                     op_null(kid);
+                 }
             }
         }
         else

--- a/t/op/caller.t
+++ b/t/op/caller.t
@@ -5,7 +5,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    plan( tests => 112 ); # some tests are run in a BEGIN block
+    plan( tests => 113 ); # some tests are run in a BEGIN block
 }
 
 my @c;
@@ -393,3 +393,14 @@ do './op/caller.pl' or die $@;
     }
     ->($a[0], 'B');
 }
+
+# Derived from GH #23175
+fresh_perl_is(<<'END', '4 at - line 1.', {},
+    sub bogocarp() { my ($fi, $pa, $line) = caller; die $line; }
+    my $x = 1;
+    if ($x) {
+       bogocarp();
+    }
+    print $x;
+END
+    'GH #23175 - caller line number in if-condition block');


### PR DESCRIPTION
Prior to this commit, `Perl_op_scope` would always nullify the initial COP as a micro-optimization. However, if the first statement in the scope is a subroutine call in which `caller()` is used to get the caller's line number - which it pulls out of the relevant COP - the line number returned will typically be incorrect.

This commit adds logic to check the type of the COP sibling, if any, and leaves the COP alone if the sibling is an `OP_ENTERSUB`.

Closes #23175

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry. I'll hopefully have 2-3 line number fixup PRs ready for 5.45.1 and will write a combined perldelta entry prior to that release.
