### PR TITLE
Perl_closest_cop - traverse LOGOPs for more accurate line numbers

### DIFF
--- a/t/op/caller.t
+++ b/t/op/caller.t
@@ -5,7 +5,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    plan( tests => 112 ); # some tests are run in a BEGIN block
+    plan( tests => 114 ); # some tests are run in a BEGIN block
 }
 
 my @c;
@@ -393,3 +393,37 @@ do './op/caller.pl' or die $@;
     }
     ->($a[0], 'B');
 }
+
+# Derived from GH #16872
+
+fresh_perl_is(<<'END', 'HERE WE ARE at - line 16.', {},
+    use strict; use warnings;
+    sub u(_) { defined($_[0]) ? $_[0] : "undef" }
+    sub f { warn((join ", ", map{u} (caller(0))), "\n"); }
+
+    use Carp;
+    my $bad = 1;
+    if (0) {
+    #
+    #
+    # millions of lines of spagetti code
+    #
+    #
+    }
+    elsif ($bad) {
+      # my $x; #un-comment and the problem goes away
+      confess("HERE WE ARE");
+    }
+END
+    'GH #16872 - caller line number: elsif($bad) {confess()}');
+
+# Derived from GH #23175
+fresh_perl_is(<<'END', '4 at - line 1.', {},
+    sub bogocarp() { my ($fi, $pa, $line) = caller; die $line; }
+    my $x = 1;
+    if ($x) {
+       bogocarp();
+    }
+    print $x;
+END
+    'GH #23175 - caller line number: if($x) { bogocarp() }');

--- a/t/op/caller.t
+++ b/t/op/caller.t
@@ -5,7 +5,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    plan( tests => 114 ); # some tests are run in a BEGIN block
+    plan( tests => 115 ); # some tests are run in a BEGIN block
 }
 
 my @c;
@@ -427,3 +427,23 @@ fresh_perl_is(<<'END', '4 at - line 1.', {},
     print $x;
 END
     'GH #23175 - caller line number: if($x) { bogocarp() }');
+
+# Derived from muddle.pl in GH #16872
+fresh_perl_is <<'END', "t3 at - line 7.\n\tmain::t3() called at - line 13", {},
+use strict;
+use warnings;
+use Carp;
+
+sub t1 {}
+sub t2 {}
+sub t3 { Carp::confess("t3"); }
+
+if (t1) {
+
+} elsif (t2) {
+
+} elsif (t3) {
+
+}
+END
+    'GH #16872 (part) - caller line number if (t1) {} elsif (t2) {}';

--- a/util.c
+++ b/util.c
@@ -1531,6 +1531,35 @@ Perl_mess(pTHX_ const char *pat, ...)
     return retval;
 }
 
+/*
+=for apidoc closest_cop
+
+Returns the closest COP to the current OP (C<curop>), given the last COP
+seen (C<cop>), a starting OP (C<o>), and a traversal option (C<opnext>).
+
+The function walks the optree from the starting OP, calling itself
+recursively if required, until the walk is exhausted. The best candidate
+COP should then be returned.
+
+This function is typically used by C<Perl_sv_mess> to find the correct
+source code file name and line number to emit in a warning or fatal
+message, or by C<pp_caller> to populate its return values.
+
+The most recently seen COP (C<cop>) is unsuitable in situations such as:
+
+=over
+
+=item *
+C<caller()> needs the most recent COP in a sub I<caller's> context.
+
+=item *
+A closer COP existed, but was nulled out during compilation.
+
+=back
+
+=cut
+*/
+
 const COP*
 Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop,
                        bool opnext)
@@ -1541,10 +1570,36 @@ Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop,
     /* opnext means that curop is actually the ->op_next of the op we are
        seeking. */
 
-    if (!o || !curop || (
-        opnext ? o->op_next == curop && o->op_type != OP_SCOPE : o == curop
-    ))
+    if (!o || !curop || (!opnext && o == curop) )
         return cop;
+
+    if (opnext && o->op_next == curop) {
+        /* COPs in branches of LOGOPs are frequently nulled out during
+         * compilation/optimization, so these branches should definitely
+         * be checked to pick up any relevent such COP, as otherwise it's
+         * easy for the returned cop to refer to a line in source code
+         * far away from the line where PL_op came from.
+         *
+         * For example, consider the elsif branch here:
+         *     if ($condition) {
+         *         # Many lines
+         *     } elsif ($other) {
+         *         warn "Boop";
+         *     }
+         *
+         * cop is likely to be the OP_NEXTSTATE prior to the this optree.
+         * o is likely to be an OP_NULL with a LOGOP kid. The elsif
+         * branch will start with an OP_SCOPE, and the first OP_NEXTSTATE
+         * inside it will have been nulled out and is an ex-nextstate.
+         * */
+        if (! ( (o->op_flags & OPf_KIDS) && (
+                     o->op_type  == OP_NULL
+                  || o->op_type  == OP_SCOPE
+                  || OP_CLASS(o) == OA_LOGOP
+            )))
+            return cop;
+    }
+
 
     if (o->op_flags & OPf_KIDS) {
         const OP *kid;

--- a/util.c
+++ b/util.c
@@ -1595,6 +1595,7 @@ Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop,
         if (! ( (o->op_flags & OPf_KIDS) && (
                      o->op_type  == OP_NULL
                   || o->op_type  == OP_SCOPE
+                  || o->op_type  == OP_LINESEQ
                   || OP_CLASS(o) == OA_LOGOP
             )))
             return cop;


### PR DESCRIPTION
`Perl_closest_cop` attempts to find the COP closest to a supplied OP*, from which source code file name and line number information is typically retrieved. Other than recursive calls to itself, this function's main callers are `pp_caller` and `Perl_mess_sv`.

The function checks for `ex-nextstate` COPs that are more relevant than the supplied live COP, but prior to this commit it returned early rather than walking common LOGOP optrees. Branches within those trees that don't have a full OP_ENTER/OP_LEAVE scoping pair will instead have an OP_SCOPE followed by an OP_NEXTSTATE - and that COP gets nulled out during compilation.

This is one reason why wildly inaccurate line numbers might be returned in warnings or error messages, as in this example adapted from GH #16872:

```
    use strict; use warnings;
    sub u(_) { defined($_[0]) ? $_[0] : "undef" }
    sub f { warn((join ", ", map{u} (caller(0))), "\n"); }

    use Carp;
    my $bad = 1;
    if (0) {     # <-- The live COP is around here
    #
    #
    # millions of lines of spagetti code
    #
    #
    }
    elsif ($bad) {
      # <-- The ex-nextstate COP is around here
      # my $x; #un-comment and the problem goes away
      confess("HERE WE ARE");
    }
```
Closes #16872
Closes #23175

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry. I'll hopefully have 2-3 line number fixup PRs ready for 5.45.1 and will write a combined perldelta entry prior to that release.