### PR TITLE
Add a test for GH#4693, fixed at some point in the past

### DIFF
--- a/t/op/runlevel.t
+++ b/t/op/runlevel.t
@@ -366,3 +366,22 @@ print undef;
 
 EXPECT
 [TIE] Use of uninitialized value in print at - line 11.
+########
+# NAME GH #4693 LOGOP branch COP survives LOGOP constant folding
+if (0) {die "aa";}
+elsif (1) {die "bb";}
+EXPECT
+bb at - line 2.
+########
+# NAME LOGOP branch COP survives LOGOP constant folding (2)
+if (1) {die "aa";}
+elsif (0) {die "bb";}
+EXPECT
+aa at - line 1.
+########
+# NAME LOGOP branch COP survives LOGOP constant folding (3)
+if (0) {die "aa";}
+elsif (0) {die "bb";}
+else {die "cc";}
+EXPECT
+cc at - line 3.


### PR DESCRIPTION
This old ticket pertains to incorrect line numbers when a LOGOP condition can be evaluated at compile time.

```
if (0) {print "aa";}
elsif (1) {print "bb";}
```

The condition and untaken branch are freed during compilation. At some point, the surviving optree did not include a COP containing an accurate line number.

It does nowadays, but there doesn't seem to be a dedicated test for it. This commit adds one, plus tests for `if()` and `else()` variants.

Closes #4693

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
