### PR TITLE
pp_unstack - set PL_curcop for better condition line number accuracy

### DIFF
--- a/pp_hot.c
+++ b/pp_hot.c
@@ -529,6 +529,11 @@ PP(pp_unstack)
     if (!(PL_op->op_flags & OPf_SPECIAL)) {
         assert(CxTYPE(cx) == CXt_BLOCK || CxTYPE_is_LOOP(cx));
         CX_LEAVE_SCOPE(cx);
+        /* PL_curcop points somewhere inside this loop body.
+         * Unless it is reset, any warnings, errors, or caller()
+         * lookups inside the loop condition will display a
+         * misleading line number. */
+        PL_curcop = cx->blk_oldcop;
     }
     return NORMAL;
 }

--- a/t/lib/warnings/9uninit
+++ b/t/lib/warnings/9uninit
@@ -1464,7 +1464,7 @@ EXPECT
 Use of uninitialized value $undef in numeric eq (==) at - line 4.
 Use of uninitialized value $undef in numeric eq (==) at - line 5.
 ########
-# TODO long standing bug - conditions of while loops
+# NAME conditions of while loops
 use warnings;
 
 my $c;
@@ -1480,7 +1480,7 @@ EXPECT
 Use of uninitialized value $c in numeric eq (==) at - line 5.
 Use of uninitialized value $c in numeric eq (==) at - line 5.
 ########
-# TODO long standing bug - conditions of until loops
+# NAME conditions of until loops
 use warnings;
 
 my $c;
@@ -1496,7 +1496,7 @@ EXPECT
 Use of uninitialized value $c in numeric eq (==) at - line 5.
 Use of uninitialized value $c in numeric eq (==) at - line 5.
 ########
-# TODO long standing bug - conditions of for loops
+# NAME conditions of for loops
 use warnings;
 
 my $c;

--- a/t/run/switches.t
+++ b/t/run/switches.t
@@ -692,7 +692,7 @@ while (<>) {
 print "ok\n";
 CODE
         $code =~ s/tmpinplace/$tmpinplace/;
-        fresh_perl_like($code, qr/^Cannot complete in-place edit of \Q$tmpinplace\E\/foo: .* - line 5, <> line \d+\./, { },
+        fresh_perl_like($code, qr/^Cannot complete in-place edit of \Q$tmpinplace\E\/foo: .* - line 3, <> line \d+\./, { },
                        "chdir while in-place editing (no at-functions)");
     }
 


### PR DESCRIPTION
Diagnostic messages triggered by the contents of a loop condition have tended to show inaccurate line numbers, as the COP in effect usually pertains to a statement inside the loop body. Sometimes deep inside the loop body.

This long-standing example would warn about `Use of uninitialized value $c in numeric eq (==) at - line 10.`, when the correct location is line 5:
```
use warnings;

my $c;
my $d = 1;
while ($c == 0 && $d) {
  # a
  # few
  # blank
  # lines
  undef $d;
}
```

This commit tweaks `pp_unstack` to set `PL_curcop` to the last valid COP prior to loop entry, which is usually going to have a line number closer to where the loop condition exists in the source code.

No new tests added, as the three TODO tests that now pass seem ample.

Closes #15589
Closes #16574

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry. I'll hopefully have 2-3 line number fixup PRs ready for 5.45.1 and will write a combined perldelta entry prior to that release.
