### PR TITLE
perlhacktips: Fix =encoding directive

### DIFF
--- a/pod/perlhacktips.pod
+++ b/pod/perlhacktips.pod
@@ -1,5 +1,4 @@
-C<
-=>encoding utf8
+=encoding utf8
 
 =for comment
 Consistent formatting of this file is achieved with:


### PR DESCRIPTION
Commit 0dc87bc7621 added a C<> around the = of the encoding directive, thus making it ineffective.

There aren't actually any non-ASCII characters in the file, so it's not a live bug.

------
* This set of changes does not require a perldelta entry.
