### PR TITLE
Fix rrwo@cpan.org email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -767,6 +767,7 @@ Rick Delaney <rick@consumercontact.com> <rick.delaney@home.com>
 Rick Delaney <rick@consumercontact.com> <rick.delaney@rogers.com>
 Rick Delaney <rick@consumercontact.com> Rick Delaney <rick@bort.ca>
 Robert May <robertmay@cpan.org> <rob@themayfamily.me.uk>
+Robert Rothenberg <perl@rhizomnic.com> Robert Rothenberg <rrwo@cpan.org>
 Roberto C. Sanchez <roberto@connexer.com> Roberto C. S�nchez <roberto@connexer.com>
 Robin Barker <rmbarker@cpan.org> Robin Barker (via RT) <perlbug-followup@perl.org>
 Robin Barker <rmbarker@cpan.org> Robin Barker <r.m.barker@btinternet.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1225,7 +1225,7 @@ Rob Napier                     <rnapier@employees.org>
 Robert May                     <robertmay@cpan.org>
 Robert Millan                  <rmh@debian.org>
 Robert Partington              <rjp@riffraff.plig.net>
-Robert Rothenberg              <rrwo@cpan.org>
+Robert Rothenberg              <perl@rhizomnic.com>
 Robert Sanders                 <Robert.Sanders@linux.org>
 Robert Sebastian Gerus         <arachnist@gmail.com>
 Robert Spier                   <rspier@pobox.com>


### PR DESCRIPTION
Since cpan.org email forwarding is down permanently, change the address to what is now on PAUSE.

Also add a couple of additional aliases that might leak in the future.

Edit: @haarg asked me to fix this at PTS