### PR TITLE
Note (yyl_leftcurly) & restore (newATTRSUB_x) line numbers for anon subs

### DIFF
--- a/lib/perl5db.t
+++ b/lib/perl5db.t
@@ -3527,9 +3527,9 @@ EOS
     # https://github.com/Perl/perl5/issues/799
     my $prog = <<'EOS';
 sub problem {
-    $SIG{__DIE__} = sub {
+    $SIG{__DIE__} = sub { # The break point _should_ be set here.
         die "<b problem> will set a break point here.\n";
-    };    # The break point _should_ be set here.
+    };
     warn "This line will run even if you enter <c problem>.\n";
 }
 &problem;
@@ -3612,9 +3612,9 @@ EOS
 print "1\n";
 eval <<'EOC';
 sub problem {
-    $SIG{__DIE__} = sub {
+    $SIG{__DIE__} = sub {  # The break point _should_ be set here.
         die "<b problem> will set a break point here.\n";
-    };    # The break point _should_ be set here.
+    };
     warn "This line will run even if you enter <c problem>.\n";
 }
 EOC

--- a/op.c
+++ b/op.c
@@ -4790,7 +4790,15 @@ Perl_block_end(pTHX_ I32 floor, OP *seq)
     /* XXX Is the null PL_parser check necessary here? */
     assert(PL_parser); /* Let’s find out under debugging builds.  */
     if (PL_parser && PL_parser->parsed_sub) {
+
+        /* If this is an anonymous sub, it might have been declared in the
+         * middle of a statement. To avoid messing up the line numbering of
+         * that statement, note the copline prior to the newSTATEOP call
+         * and restore it straight afterwards. */
+        const line_t saved_copline = PL_parser->copline;
         o = newSTATEOP(0, NULL, NULL);
+        PL_parser->copline = saved_copline;
+
         op_null(o);
         retval = op_append_elem(OP_LINESEQ, retval, o);
     }
@@ -11779,6 +11787,13 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
     bool name_is_utf8 = o && !o_is_gv && SvUTF8(cSVOPo->op_sv);
     bool evanescent = FALSE;
     bool isBEGIN = FALSE;
+
+    /* If this is an anonymous sub, it might have been declared in the
+     * middle of a statement. To avoid messing up the line numbering of
+     * that statement, note the copline now and restore it later. */
+    const line_t note_copline = (!o && !o_is_gv)
+                                ? PL_parser->copline : NOLINE;
+
     OP *start = NULL;
 #ifdef PERL_DEBUG_READONLY_OPS
     OPSLAB *slab = NULL;
@@ -12245,7 +12260,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
   done:
     assert(!cv || evanescent || SvREFCNT((SV*)cv) != 0);
     if (PL_parser)
-        PL_parser->copline = NOLINE;
+        PL_parser->copline = note_copline;
     LEAVE_SCOPE(floor);
 
     assert(!cv || evanescent || SvREFCNT((SV*)cv) != 0);

--- a/t/op/caller.t
+++ b/t/op/caller.t
@@ -315,10 +315,8 @@ sub dbdie {
 END
     "caller should not SEGV for eval '' stack frames";
 
-TODO: {
-    local $::TODO = 'RT #7165: line number should be consistent for multiline subroutine calls';
-    fresh_perl_is(<<'EOP', "6\n9\n", {}, 'RT #7165: line number should be consistent for multiline subroutine calls');
-      sub tagCall {
+fresh_perl_is(<<'EOP', "6\n9\n", {}, 'RT #7165: line number should be consistent for multiline subroutine calls');
+    sub tagCall {
         my ($package, $file, $line) = caller;
         print "$line\n";
       }
@@ -329,7 +327,6 @@ TODO: {
       tagCall
       sub {};
 EOP
-}
 
 $::testing_caller = 1;
 

--- a/toke.c
+++ b/toke.c
@@ -7052,7 +7052,13 @@ yyl_leftcurly(pTHX_ char *s, const U8 formbrack)
         break;
     }
 
-    pl_yylval.ival = CopLINE(PL_curcop);
+    /* PL_copline contains the line number of the last-seen COP.
+     * CopLINE(PL_curcop) could have advanced past that. We
+     * likely want to save PL_curcop where possible to get
+     * more accurate line numbering for diagnostics/caller. */
+    pl_yylval.ival = (PL_copline == NOLINE)
+                     ? CopLINE(PL_curcop) : PL_copline;
+
     PL_copline = NOLINE;   /* invalidate current command line number */
     TOKEN(formbrack ? PERLY_EQUAL_SIGN : PERLY_BRACE_OPEN);
 }


### PR DESCRIPTION
Declaring an anonymous subroutine in the middle of a statement is likely to result in an inaccurate line number being stored in the COP preceding the statement. This is because line number information is discarded during parsing and creation of the anonymous subroutine.

This commit attempts to store and restore a more accurate line number for the COP. This will improve the accuracy of line numbers emitted by diagnostic messages and `caller()`. **_Tests containing hardcoded line numbers may require updating as a result of this commit._**

This (previously) TODO test from _caller.t_ shows the difference:

```
    sub tagCall {
        my ($package, $file, $line) = caller;
        print "$line\n";
      }

      tagCall    # Line number 6 correctly reported before & after
      "abc";

      tagCall    # Line number 9 correctly reported with this commit
      sub {};    # Line number 10 incorrectly reported previously
```

Changes in line numbering could also affect where breaking on a function occurs in the perl debugger. This can be seen in the included change to _perl5db.t_, where breaking on entry to `problem()` now occurs at the start of the subroutine, rather than after the anonymous subroutine declaration:

```
sub problem {
    $SIG{__DIE__} = sub {  # Breaking on problem() now lands here
        die "<b problem> will set a break point here.\n";
    };    # Breaking on problem() used to land here
```

Closes #4125

-------------------------------------------------------------------------------

* This set of changes requires a perldelta entry. I'll hopefully have 2-3 line number fixup PRs ready for 5.45.1 and will write a combined perldelta entry prior to that release.
