### PR TITLE
t/op/sselect.t: fix Time::HiRes typo

### DIFF
--- a/t/op/sselect.t
+++ b/t/op/sselect.t
@@ -7,7 +7,7 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('.', '../lib');
-    $hires = eval 'use Time::HiResx "time"; 1';
+    $hires = eval 'use Time::HiRes "time"; 1';
 }
 
 skip_all("Win32 miniperl has no socket select")


### PR DESCRIPTION
Fix a long-standing typo in `t/op/sselect.t`: the test tried to load `Time::HiResx`, so the high-resolution timing path never ran.

This PR is intentionally scoped to the typo only. The earlier version also proposed changing sub-microsecond `select()` timeout handling, but review feedback made it clear that changing that behavior needs separate evidence and discussion. The Fixer report that originally surfaced the investigation remains useful as busy-poll evidence, but it does not by itself prove that Perl should change `select()` semantics.

Validation performed locally against `blead`:

- `TMPDIR=/home/kom/tmp make test TEST_FILES=op/sselect.t`

The test passed with `tests=23`.
