### PR TITLE
Time::HiRes: make nanosleep.t more robust against busy systems

### DIFF
--- a/dist/Time-HiRes/Changes
+++ b/dist/Time-HiRes/Changes
@@ -20,6 +20,7 @@ Revision history for the Perl extension Time::HiRes.
  - don't try to suppress C++ compatibility warnings in C++ builds, since
    that warns.
  - Fix sleep's prototype to match CORE::sleep (;$).
+ - t/nanosleep.t: improve robustness on busy systems.
 
 1.9764 [2020-08-10]
  - Fix a bunch of repeated-word typos

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -50,7 +50,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  stat lstat utime
                 );
 
-our $VERSION = '1.9780';
+our $VERSION = '1.9781';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/dist/Time-HiRes/t/nanosleep.t
+++ b/dist/Time-HiRes/t/nanosleep.t
@@ -26,11 +26,23 @@ ok $one == $two || $two == $three
 
 SKIP: {
     skip "no gettimeofday", 2 unless &Time::HiRes::d_gettimeofday;
-    my $f = Time::HiRes::time();
-    Time::HiRes::nanosleep(500_000_000);
-    my $f2 = Time::HiRes::time();
-    my $d = $f2 - $f;
+    my $max_trials = 10;
+    my $trials = 0;
+    my $f;
+    my $f2;
+    my $d;
+    while ($trials++ < $max_trials) {
+        $f = Time::HiRes::time();
+        Time::HiRes::nanosleep(500_000_000);
+        $f2 = Time::HiRes::time();
+        $d = $f2 - $f;
+
+        # don't test the low-end, if this takes less than the low-end
+        # we have a real problem
+        last if $d < 0.9;
+
+        note "fail trial $trials/$max_trials d $d";
+    }
     cmp_ok $d, '>', 0.4, "nanosleep for more than 0.4 sec";
-    skip "flapping test - more than 0.9 sec could be necessary...", 1 if $ENV{CI};
     cmp_ok $d, '<', 0.9 or diag("# slept $d secs $f to $f2\n");
 }


### PR DESCRIPTION
This now does up to 10 trials see if a nanosleep takes something like the expected maximum limit of duration.

If any trial takes less than that limit the trials finish and falls through to the test checks.

If any trial takes less than the minimum expected by the test the test still fails, since I'd expect a busy system to extend the duration, not reduce it.

Fixes #24284

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
