### PR TITLE
SelfLoader: try harder to not confuse PERLIO=stdio

### DIFF
--- a/dist/SelfLoader/lib/SelfLoader.pm
+++ b/dist/SelfLoader/lib/SelfLoader.pm
@@ -2,7 +2,8 @@ package SelfLoader;
 use 5.008;
 use strict;
 use IO::Handle;
-our $VERSION = "1.29";
+use Fcntl qw(SEEK_CUR SEEK_SET);
+our $VERSION = "1.30";
 
 # The following bit of eval-magic is necessary to make this work on
 # perls < 5.009005.
@@ -98,14 +99,30 @@ sub _load_stubs {
     croak("$callpack doesn't contain an __DATA__ token")
         unless defined fileno($fh);
     # Protect: fork() shares the file pointer between the parent and the kid
-    if(sysseek($fh, tell($fh), 0)) {
-      open my $nfh, '<&', $fh or croak "reopen: $!";# dup() the fd
-      close $fh or die "close: $!";                 # autocloses, but be
-                                                    # paranoid
-      open $fh, '<&', $nfh or croak "reopen2: $!";  # dup() the fd "back"
-      close $nfh or die "close after reopen: $!";   # autocloses, but be
-                                                    # paranoid
-      $fh->untaint;
+    # but the buffer isn't shared
+    #
+    # glibc fclose() might try to commit the fd position plus buffer
+    # offset into the fd position, and moving the fd position can
+    # confuse that.
+    #
+    # Fetch the raw position, this will only be used to check
+    # the file is seekable.
+    my $fdpos = sysseek($fh, 0, SEEK_CUR);
+    if ($fdpos && sysseek($fh, $fdpos, SEEK_SET)) {
+        # It's seekable, so fetch the position as adjusted for any
+        # buffered data
+        my $realpos = tell($fh);
+        open my $nfh, '<&', $fh or croak "reopen: $!";# dup() the fd
+        close $fh or die "close: $!";                 # autocloses, but be
+                                                      # paranoid
+        open $fh, '<&', $nfh or croak "reopen2: $!";  # dup() the fd "back"
+        close $nfh or die "close after reopen: $!";   # autocloses, but be
+                                                      # paranoid
+        $fh->untaint;
+        # the new handle should have no buffered data, so a raw seek should
+        # be safe
+        sysseek($fh, $realpos, SEEK_SET)
+          or croak "Cannot see cloned handle to original position: $!";
     }
     $Cache{"${currpack}::<DATA"} = 1;   # indicate package is cached
 


### PR DESCRIPTION
The previous change was failing on some FreeBSD and Linux.

Fixes #24407

The two smokers that started failing are 

freebsd 14.3-RELEASE-p8
FAIL in blead https://perl.develop-help.com/db/5530532
SUCCESS in [branch](https://perl.develop-help.com/?b=smoke-me/tonyc/selfloader-mixed-io-again) https://perl.develop-help.com/db/5530604

linux 6.12.74+deb13+1-amd64 [Debian GNU/Linux 13.4 (trixie)]
FAIL in blead https://perl.develop-help.com/db/5530533
SUCCESS in [branch](https://perl.develop-help.com/?b=smoke-me/tonyc/selfloader-mixed-io-again) https://perl.develop-help.com/db/5530606

The only other failures post 7a6d188450d90f682310727be3a10c944e8153fb in blead or in the selfloader-mixed-io-again branch are:

https://perl.develop-help.com/db/5530547 - [tib testing skiptest](https://github.com/Perl/perl5/pull/24404#issuecomment-4385459110)

https://perl.develop-help.com/db/5530603 - [this smoker seems to be a bit flaky](https://perl.develop-help.com/#os=rpi) or [here for a more comprehensive list](https://perl.develop-help.com/db/5530603/similar)


<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.

Edit: update perldev links now /similar is live, and perldev is down to discourage the bots