### PR TITLE
Revert "SelfLoader: don't mix buffered and unbuffered I/O"

### DIFF
--- a/dist/SelfLoader/lib/SelfLoader.pm
+++ b/dist/SelfLoader/lib/SelfLoader.pm
@@ -98,7 +98,7 @@ sub _load_stubs {
     croak("$callpack doesn't contain an __DATA__ token")
         unless defined fileno($fh);
     # Protect: fork() shares the file pointer between the parent and the kid
-    if(seek($fh, tell($fh), 0)) {
+    if(sysseek($fh, tell($fh), 0)) {
       open my $nfh, '<&', $fh or croak "reopen: $!";# dup() the fd
       close $fh or die "close: $!";                 # autocloses, but be
                                                     # paranoid


### PR DESCRIPTION
This reverts commit 7a6d188450d90f682310727be3a10c944e8153fb.

This fixed some smoke failures but introduced others, go back to the old state.

Fixes #24407

An alternative to #24409

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
