### PR TITLE
perlpacktut: fix variable name typo in an example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1320,6 +1320,7 @@ Sreeji K Das                   <sreeji_k@yahoo.com>
 Stan Ulbrych                   <89152624+StanFromIreland@users.noreply.github.com>
 Stanislaw Pusep                <stas@sysd.org>
 Stas Bekman                    <stas@stason.org>
+Stefan Adams                   <s1037989@gmail.com>
 Stefan Seifert                 <nine@detonation.org>
 Steffen Müller                 <smueller@cpan.org>
 Steffen Schwigon               <ss5@renormalist.net>

--- a/pod/perlpacktut.pod
+++ b/pod/perlpacktut.pod
@@ -966,7 +966,7 @@ we can draw memory maps, showing where the extra 4 bytes are hidden:
 
    0           +4          +8
    +--+--+--+--+--+--+--+--+
-   |     l     |  h  |c1|c2|
+   |     l     |  s  |c1|c2|
    +--+--+--+--+--+--+--+--+
    dense_t
 


### PR DESCRIPTION
Second item in the dense_t struct is `short s` but is represented as `h` in the memory map.