### PR TITLE
Perl_regexec_flags - keep and reuse a spare *offs buffer once allocated

### DIFF
--- a/pod/perlreapi.pod
+++ b/pod/perlreapi.pod
@@ -688,6 +688,8 @@ values.
         U32 lastparen;           /* highest close paren matched ($+) */
         U32 lastcloseparen;      /* last close paren matched ($^N) */
         regexp_paren_pair *offs; /* Array of offsets for (@-) and (@+) */
+        regexp_paren_pair *offs_spare; /* To minimise allocation churn when this
+                                        * regex was the last successful match */
         char **recurse_locinput; /* used to detect infinite recursion, XXX: move to internal */
 
 
@@ -699,6 +701,9 @@ values.
         /* original flags used to compile the pattern, may differ from
          * extflags in various ways */
         PERL_BITFIELD32 compflags:9;
+
+        /* Is offs_spare already in use? */
+        PERL_BITFIELD32 offs_spare_used:1;
 
         /*---------------------------------------------------------------------- */
 

--- a/regcomp.c
+++ b/regcomp.c
@@ -13491,6 +13491,8 @@ Perl_pregfree2(pTHX_ REGEXP *rx)
     SvREFCNT_dec(r->saved_copy);
 #endif
     Safefree(RXp_OFFSp(r));
+    if (r->offs_spare)
+        Safefree(r->offs_spare);
     if (r->logical_to_parno) {
         Safefree(r->logical_to_parno);
         Safefree(r->parno_to_logical);
@@ -13601,6 +13603,11 @@ Perl_reg_temp_copy(pTHX_ REGEXP *dsv, REGEXP *ssv)
         const I32 npar = srx->nparens+1;
         NewCopy(RXp_OFFSp(srx), RXp_OFFSp(drx), npar, regexp_paren_pair);
     }
+
+    /* If the copy needs offs_spare, it will lazily allocate it.*/
+    drx->offs_spare = NULL;
+    drx->offs_spare_used = FALSE;
+
     if (srx->substrs) {
         int i;
         Newx(drx->substrs, 1, struct reg_substr_data);
@@ -13805,6 +13812,10 @@ Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
 
     npar = r->nparens+1;
     NewCopy(RXp_OFFSp(r), RXp_OFFSp(ret), npar, regexp_paren_pair);
+
+    /* If the clone needs offs_spare, it will lazily allocate it.*/
+    ret->offs_spare = NULL;
+    ret->offs_spare_used = FALSE;
 
     if (ret->substrs) {
         /* Do it this way to avoid reading from *r after the StructCopy().

--- a/regexec.c
+++ b/regexec.c
@@ -3690,6 +3690,12 @@ S_reg_set_capture_string(pTHX_ REGEXP * const rx,
 
 
 
+static void S_clear_offs_spare(pTHX_ regexp *prog)
+{
+    PERL_UNUSED_CONTEXT;
+    prog->offs_spare_used = FALSE;
+}
+
 /*
  - regexec_flags - match a regexp against a string
  */
@@ -3723,6 +3729,7 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     regmatch_info reginfo_buf __attribute__uninitialized__;
     regmatch_info *const reginfo = &reginfo_buf;
     regexp_paren_pair *swap = NULL;
+    bool offs_spare_used = FALSE;
     I32 oldsave;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
@@ -3945,14 +3952,49 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
         /* We have to be careful. If the previous successful match
            was from this regex we don't want a subsequent partially
            successful match to clobber the old results.
-           So when we detect this possibility we add a swap buffer
-           to the re, and switch the buffer each match. If we fail,
-           we switch it back; otherwise we leave it swapped.
+
+           So when we detect this possibility we use a swap buffer
+           and revert back to the original buffer if the match fails.
         */
         swap = RXp_OFFSp(prog);
-        /* avoid leak if we die, or clean up anyway if match completes */
-        SAVEFREEPV(swap);
-        Newxz(RXp_OFFSp(prog), (prog->nparens + 1), regexp_paren_pair);
+        if (UNLIKELY(prog->offs_spare_used)) {
+            /* This regex is re-entering. The number of swap buffers needed
+             * is not statically determinable, so heap allocations are
+             * unavoidable. */
+            SAVEFREEPV(swap);
+            Newx(RXp_OFFSp(prog), (prog->nparens + 1), regexp_paren_pair);
+        } else {
+            /* This regex is not re-entering (at least, not yet), so
+             * only one swap buffer is needed and this is kept as a
+             * regex-local spare. This means that code like:
+             *     while ($x =~ /(.)/g) { ... }
+             * does not do a calloc+free in every loop iteration.*/
+            regexp_paren_pair * const old_offs_spare = prog->offs_spare;
+            prog->offs_spare = swap; /* Stash the successful match offs */
+            prog->offs_spare_used = TRUE;
+            offs_spare_used = TRUE;
+            SAVEDESTRUCTOR_X(S_clear_offs_spare, prog);
+
+            if (old_offs_spare) {
+                /* Nice! There is already a buffer ready to use. */
+                RXp_OFFSp(prog) = old_offs_spare;
+            } else {
+                /* Lazily allocate the per-regex spare buffer. */
+                Newx(RXp_OFFSp(prog), (prog->nparens + 1), regexp_paren_pair);
+            }
+        }
+
+        /* Initialize in the same way that S_regtry does it. */
+        if (prog->nparens) {
+            regexp_paren_pair *pp = RXp_OFFSp(prog);
+            I32 i;
+            for (i = prog->nparens; i > 0; i--) {
+                ++pp;
+                pp->start = -1;
+                pp->end = -1;
+            }
+        }
+
         DEBUG_BUFFERS_r(re_exec_indentf(
             "rex = 0x%" UVxf " saving  offs: orig = 0x%" UVxf " new = 0x%" UVxf "\n",
             0,
@@ -4360,19 +4402,28 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 
     if (swap) {
         /* we failed :-( roll it back.
-         * Since the swap buffer will be freed on scope exit which follows
-         * shortly, restore the old captures by copying 'swap's original
-         * data to the new offs buffer
+         * Restore the old captures by copying 'swap's original data to
+         * the new offs buffer. The regex-local offs_spare will be
+         * retained, any heap allocated swaps will be freed on scope
+         * exit which follows shortly.
          */
         DEBUG_BUFFERS_r(re_exec_indentf(
-            "rex = 0x%" UVxf " rolling back offs: 0x%" UVxf " will be freed; restoring data to =0x%" UVxf "\n",
+            "rex = 0x%" UVxf " rolling back offs: 0x%" UVxf " %s; restoring data to =0x%" UVxf "\n",
             0,
             PTR2UV(prog),
             PTR2UV(RXp_OFFSp(prog)),
+            offs_spare_used ? "kept as offs_spare" : "will be freed",
             PTR2UV(swap)
         ));
 
-        Copy(swap, RXp_OFFSp(prog), prog->nparens + 1, regexp_paren_pair);
+        if (offs_spare_used) {
+            prog->offs_spare = RXp_OFFSp(prog);
+            RXp_OFFSp(prog)  = swap;
+            prog->offs_spare_used = FALSE;
+        } else {
+            Copy(swap, RXp_OFFSp(prog), prog->nparens + 1, regexp_paren_pair);
+        }
+
     }
 
     /* clean up; this will trigger destructors that will free all slabs

--- a/regexp.h
+++ b/regexp.h
@@ -186,6 +186,8 @@ typedef struct regexp {
     U32 lastparen;           /* highest close paren matched ($+) */
     U32 lastcloseparen;      /* last close paren matched ($^N) */
     regexp_paren_pair *offs; /* Array of offsets for (@-) and (@+) */
+    regexp_paren_pair *offs_spare; /* To minimise allocation churn when this
+                                    * regex was the last successful match */
     char **recurse_locinput; /* used to detect infinite recursion, XXX: move to internal */
 
     /*---------------------------------------------------------------------- */
@@ -196,6 +198,9 @@ typedef struct regexp {
     /* original flags used to compile the pattern, may differ from
      * extflags in various ways */
     PERL_BITFIELD32 compflags:9;
+
+    /* Is offs_spare already in use? */
+    PERL_BITFIELD32 offs_spare_used:1;
 
     /*---------------------------------------------------------------------- */
 


### PR DESCRIPTION
When executing a regular expression that was the origin of the previous successful match, the results of that previous match must not be overwritten in case the current attempt at matching is unsuccessful.

(That is to say, `(PL_curpm && (PM_GETRE(PL_curpm) == rx))` and the contents of special punctuation variables such as `%+` and `$1` etc. must not be clobbered if the current regex fails to match.)

Perl does this by moving the the associated heap allocated `regexp_paren_pair‎` chunk to one side and working on an identically-sized `swap` chunk. Currently, the working chunk is allocated on each entry to `Perl_regexec_flags` and the previous chunk freed prior to exit. (If the current match is unsuccessful, the contents of the previous chunk are copied to the new chunk.)

To illustrate, every iteration of the following code snippet (after the first) will allocate and free a `regexp_paren_pair‎` chunk.

    while ($x =~ /(.)/g) { ... }

While allocation is unavoidable in (probably uncommon) cases where the regex is re-entrant, for common cases such as the above snippet, only two allocations are needed - the previous one and the current one - and the heap management overhead is undesirable.

This commit adds a lazily-allocated spare chunk when first needed, then keeps it around for future reuse. If additional chunks are needed, they will still be freshly allocated and then later freed as happens now.

The commit also changes chunk initialization: instead of zeroing it, the `start` and `end` members of each struct are set to `-1`, which matches up to what `S_regtry` does. (See the comments in that function beginning with `XXXX What this code is doing here?!!!` for context.)

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and one will be added when the next dev cycle begins.
