### PR TITLE
Storable.xs: Avoid signed int overflow when unpacking a list of hook data items

### DIFF
--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -5056,7 +5056,10 @@ static SV *retrieve_hook_common(pTHX_ stcxt_t *cxt, const char *cname, int large
         }
         else
             GETMARK(len3);
-        if (len3) {
+        if (len3 == I32_MAX)
+            /* If len3 is exactly I32_MAX it will upset av_extend below */
+            CROAK(("Invalid count of hook data items"));
+        else if (len3) {
             av = newAV();
             av_extend(av, len3 + 1);    /* Leave room for [0] */
             AvFILLp(av) = len3;         /* About to be filled anyway */

--- a/dist/Storable/lib/Storable.pm
+++ b/dist/Storable/lib/Storable.pm
@@ -30,7 +30,7 @@ our @EXPORT_OK = qw(
 our ($canonical, $forgive_me);
 
 BEGIN {
-    our $VERSION = '3.40';
+    our $VERSION = '3.41';
 }
 
 our $recursion_limit;


### PR DESCRIPTION
Otherwise, `av_extend` sees INT_MAX+1, which wraps around to negative maximum and gets upset.

* This set of changes does not require a perldelta entry.