### PR TITLE
pp_pack.c: Avoid ssize_t overflow when calculating the size of a structure

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5160,6 +5160,12 @@ mixed-case attribute name, instead.  See L<attributes>.
 (F) You can't specify a repeat count so large that it overflows your
 signed integers.  See L<perlfunc/pack>.
 
+=item Pack template structure size is too large
+
+(F) You called C<pack> or C<unpack> to operate on a structure, whose
+computed size is too large to fit in memory.  This usually happens as a
+result of embedding a large number as the repeat count for an item.
+
 =item page overflow
 
 (W io) A single call to write() produced more lines than can fit on a

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -543,12 +543,12 @@ S_measure_struct(pTHX_ tempsym_t* symptr)
                 break;
             case 'B':
             case 'b':
-                len = (len + 7)/8;
+                len = (len / 8) + !!(len % 8);
                 size = 1;
                 break;
             case 'H':
             case 'h':
-                len = (len + 1)/2;
+                len = (len / 2) + !!(len % 2);
                 size = 1;
                 break;
 

--- a/pp_pack.c
+++ b/pp_pack.c
@@ -558,6 +558,10 @@ S_measure_struct(pTHX_ tempsym_t* symptr)
                 break;
             }
         }
+        if ((size > 0) &&
+                ((len > SSize_t_MAX / size) ||         /* detect overflow of len * size */
+                 (len * size > SSize_t_MAX - total)))  /* detect overflow of total + len * size */
+            croak("Pack template structure size is too large");
         total += len * size;
     }
     return total;


### PR DESCRIPTION
If the user has requested a size that would overflow a SSize_t, then the only sensible thing to do is throw an exception, because the structure this implies couldn't possibly fit into memory anyway.

* This set of changes does not require a perldelta entry.