### PR TITLE
Test SvUTF8 on Win32 wrappers under UTF-8 ACP

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -457,6 +457,67 @@ jobs:
   # \ V  V / | ' \/ _` / _ \ V  V (_-<
   #  \_/\_/|_|_||_\__,_\___/\_/\_//__/
 
+  windows-msvc143-utf8acp:
+    name: "Windows msvc143 (UTF-8 ACP)"
+    runs-on: windows-2025
+    timeout-minutes: 120
+    needs: sanity_check
+    if: (! cancelled() && needs.sanity_check.outputs.run_all_jobs == 'true')
+
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+      - name: Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cd win32
+          nmake CCTYPE=MSVC143 CFG=Debug
+      # Embed the per-process UTF-8 ACP opt-in (Windows 10 1903+) into
+      # the freshly-built perl.exe so the rest of the job runs as if
+      # the system code page were CP_UTF8. External .manifest files
+      # are ignored when an embedded one is present, so we rewrite it
+      # with mt.exe.  t/win32/cp_utf8_acp.t skips on legacy ACP and
+      # runs under TODO on UTF-8 ACP — failures there document the
+      # bug without breaking the build.
+      - name: Enable UTF-8 ACP for perl.exe
+        shell: pwsh
+        run: |
+          $perl = "$pwd\perl.exe"
+          if (-not (Test-Path $perl)) { throw "perl.exe not found at $perl" }
+          $manifest = @'
+          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+            <application xmlns="urn:schemas-microsoft-com:asm.v3">
+              <windowsSettings>
+                <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+              </windowsSettings>
+            </application>
+          </assembly>
+          '@
+          Set-Content -Path perl-utf8.manifest -Value $manifest -Encoding UTF8
+          $before = (& $perl -e 'require Win32; print Win32::GetACP()')
+          Write-Host "GetACP() before manifest patch: $before"
+          $mt = Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\bin' -Recurse -Filter mt.exe -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match 'x64\\mt\.exe$' } |
+                Select-Object -First 1
+          if (-not $mt) { throw 'mt.exe not found' }
+          & $mt.FullName -manifest perl-utf8.manifest "-outputresource:${perl};1"
+          $after = (& $perl -e 'require Win32; print Win32::GetACP()')
+          Write-Host "GetACP() after manifest patch:  $after"
+          if ($after -ne '65001') { throw "GetACP() returned $after; expected 65001" }
+      - name: Show Config
+        shell: cmd
+        run: |
+          .\perl.exe -V
+          .\perl.exe -e "use Config; print Config::config_sh"
+      - name: Run Tests
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cd win32
+          nmake CCTYPE=MSVC143 CFG=Debug test
+
   windows-msvc143:
     name: "Windows msvc143"
     runs-on: windows-2025

--- a/MANIFEST
+++ b/MANIFEST
@@ -6760,6 +6760,7 @@ t/uni/universal.t			See if Unicode in calls to UNIVERSAL works
 t/uni/upper.t				See if Unicode casing works
 t/uni/variables.t			See that the rules for variable names work
 t/uni/write.t				See if Unicode formats work
+t/win32/cp_utf8_acp.t			Test SvUTF8 flag on Win32 wrappers under CP_UTF8 ACP
 t/win32/crypt.t				Test Win32 crypt for compatibility
 t/win32/fs.t				Test Win32 link for compatibility
 t/win32/popen.t				Test for stdout races in backticks, etc

--- a/t/win32/cp_utf8_acp.t
+++ b/t/win32/cp_utf8_acp.t
@@ -113,4 +113,37 @@ note("GetACP() = $acp");
     }
 }
 
+# Cwd::getdcwd (Win32-only XS sub, separate _getdcwd CRT call)
+{
+    my $dcwd = Cwd::getdcwd();
+    TODO: {
+        local our $TODO = '_getdcwd does not set SvUTF8 under CP_UTF8 ACP';
+        ok(defined $dcwd && utf8::is_utf8($dcwd),
+           "Cwd::getdcwd() has SvUTF8 flag");
+    }
+}
+
+# readlink — needs an actual symlink. Symlink creation on Windows
+# requires Developer Mode or admin; skip cleanly when symlink() fails.
+{
+    my $home = Cwd::getcwd();
+    my $tmp  = tempdir(CLEANUP => 1);
+    chdir $tmp or die "chdir $tmp: $!";
+    open(my $fh, '>', 'target.txt') or die "open target: $!";
+    close $fh;
+    my $made = eval { symlink('target.txt', 'link') } ? 1 : 0;
+    SKIP: {
+        skip 'symlink not allowed (need developer mode or admin)', 1
+            unless $made;
+        my $value = readlink 'link';
+        TODO: {
+            local our $TODO = 'win32_readlink does not set SvUTF8 under CP_UTF8 ACP';
+            ok(defined $value && utf8::is_utf8($value),
+               "readlink() has SvUTF8 flag (got: "
+               . (defined $value ? "'$value'" : 'undef') . ')');
+        }
+    }
+    chdir $home;
+}
+
 done_testing();

--- a/t/win32/cp_utf8_acp.t
+++ b/t/win32/cp_utf8_acp.t
@@ -1,0 +1,116 @@
+#!./perl
+
+# When the system code page is CP_UTF8 (set via "Use Unicode UTF-8 for
+# worldwide language support" or a per-process app manifest), several
+# CORE Win32 wrappers in win32/win32.c return UTF-8-encoded bytes
+# through char buffers and the resulting Perl SVs do not carry the
+# SvUTF8 flag.  Concatenation with a Unicode string then upgrades each
+# byte as Latin-1 and produces mojibake.
+#
+# The assertions below are FLAG-based so they hold regardless of system
+# locale.  Each is wrapped in TODO until win32.c calls SvUTF8_on (or
+# equivalent) at the relevant SV-construction sites.
+#
+# Test design:
+#   - Skip the whole file unless the active code page is CP_UTF8.
+#   - Each assertion runs under TODO so the suite stays green until
+#     someone lands the fix and removes the TODO marker.
+
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib';
+    require './test.pl';
+}
+
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use Cwd ();
+use POSIX ();
+
+if ($^O ne 'MSWin32') {
+    skip_all('Windows only');
+}
+
+require Win32;
+my $acp = Win32::GetACP();
+if ($acp != 65001) {
+    skip_all("requires GetACP() == 65001 (got $acp); embed an "
+             . "<activeCodePage>UTF-8</activeCodePage> manifest in "
+             . "perl.exe to enable");
+}
+
+note("GetACP() = $acp");
+
+# readdir entries
+{
+    my $home = Cwd::getcwd();
+    my $tmp  = tempdir(CLEANUP => 1);
+    chdir $tmp or die "chdir $tmp: $!";
+    open(my $fh, '>', 'marker.txt') or die "open: $!";
+    close $fh;
+    opendir(my $dh, '.') or die "opendir: $!";
+    my @entries = grep { !/^\./ } readdir $dh;
+    closedir $dh;
+    chdir $home;
+
+    TODO: {
+        local our $TODO = 'win32_readdir does not set SvUTF8 under CP_UTF8 ACP';
+        for my $e (@entries) {
+            ok(utf8::is_utf8($e), "readdir entry '$e' has SvUTF8 flag");
+        }
+    }
+}
+
+# $ENV{X}
+{
+    $ENV{T_CP_UTF8_ACP} = 'value';
+    TODO: {
+        local our $TODO = 'win32_getenv does not set SvUTF8 under CP_UTF8 ACP';
+        ok(utf8::is_utf8($ENV{T_CP_UTF8_ACP}), '$ENV{X} has SvUTF8 flag');
+    }
+    delete $ENV{T_CP_UTF8_ACP};
+}
+
+# $^E (formatted Windows error message)
+{
+    $! = 0;
+    open(my $fh, '<', "no-such-file-pid$$");  # expected to fail
+    my $err = "$^E";
+    TODO: {
+        local our $TODO = 'win32_str_os_error does not set SvUTF8 under CP_UTF8 ACP';
+        ok(utf8::is_utf8($err), '$^E has SvUTF8 flag');
+    }
+}
+
+# getlogin()
+{
+    my $login = getlogin();
+    TODO: {
+        local our $TODO = 'getlogin (GetUserName) does not set SvUTF8 under CP_UTF8 ACP';
+        ok(defined $login && utf8::is_utf8($login),
+           "getlogin() has SvUTF8 flag (got: " . (defined $login ? "'$login'" : 'undef') . ')');
+    }
+}
+
+# POSIX::uname() nodename
+{
+    my @uname = POSIX::uname();
+    TODO: {
+        local our $TODO = 'win32_uname does not set SvUTF8 under CP_UTF8 ACP';
+        ok(@uname && utf8::is_utf8($uname[1]),
+           "POSIX::uname()[1] has SvUTF8 flag (got: '$uname[1]')");
+    }
+}
+
+# Cwd::getcwd
+{
+    my $cwd = Cwd::getcwd();
+    TODO: {
+        local our $TODO = 'win32_get_childdir does not set SvUTF8 under CP_UTF8 ACP';
+        ok(defined $cwd && utf8::is_utf8($cwd),
+           "Cwd::getcwd() has SvUTF8 flag");
+    }
+}
+
+done_testing();


### PR DESCRIPTION
Several CORE Win32 wrappers in `win32/win32.c` return UTF-8-encoded bytes through char buffers when the system code page is CP_UTF8 (set via "Use Unicode UTF-8 for worldwide language support" or a per-process app manifest), but the resulting Perl SVs do not carry the SvUTF8 flag. Concatenation with a Unicode string then upgrades each byte as Latin-1 and produces mojibake.

Affected wrappers and their SV-construction sites:

| Wrapper | SV-construction site | Perl-level surface |
|---|---|---|
| `win32_readdir` | `pp_sys.c` `pp_readdir` | `readdir($dh)` |
| `win32_getenv` | `hv.c` `%ENV` magic getter | `$ENV{X}` |
| `getlogin` (`GetUserName`) | `pp_sys.c` `pp_getlogin` | `getlogin()` |
| `win32_str_os_error` | `mg.c` `$^E` magic | `$^E` |
| `win32_uname` | `ext/POSIX/POSIX.xs` `uname` | `(POSIX::uname)[1]` |
| `win32_get_childdir` | `dist/PathTools/Cwd.xs` `getcwd_sv` | `Cwd::getcwd()` / `Cwd::cwd()` / `Cwd::fastcwd()` |
| `_getdcwd` (CRT) | `dist/PathTools/Cwd.xs` `getdcwd` | `Cwd::getdcwd()` |
| `win32_readlink` | `pp_sys.c` `pp_readlink` | `readlink($symlink)` |

This **draft** PR adds:

1. `t/win32/cp_utf8_acp.t` — flag-based assertions covering each leaky wrapper. The file skips unless `Win32::GetACP() == 65001`; under UTF-8 ACP each assertion runs inside `local our $TODO`, so failures document the bug without breaking the build. Once `win32.c` (and the Cwd / POSIX dual-life sites) call `SvUTF8_on` at the relevant SV-construction points, the assertions pass and the TODO markers can come off.

2. A `windows-msvc143-utf8acp` GHA job mirroring `windows-msvc143`, with a pwsh step that embeds an `<activeCodePage>UTF-8</activeCodePage>` manifest into the freshly-built `perl.exe` via `mt.exe`. The per-app manifest (Windows 10 1903+) is the only way to flip the active code page in a single CI step — the system-wide setting in Region / Administrative is a registry change that requires a reboot, which hosted runners cannot perform.

## Why this matters

On Unix, the kernel makes no encoding promise, so Perl returns OS bytes unflagged and the user decodes explicitly via `Encode::decode_utf8` or a `:encoding(UTF-8)` PerlIO layer. Windows is structurally different: `*A` ANSI APIs are a legacy compatibility shim over an intrinsically UTF-16 OS, and the UTF-8 ACP mode (`GetACP() == 65001`) is a guaranteed-valid-UTF-8 contract at that boundary. That contract is exactly the signal Perl needs to flag the SV correctly — Unix has no equivalent.

## Implementation pointer

The same SvUTF8-flag pattern is fixed for the matching XS surface in the CPAN `Win32` module at [perl-libwin32/win32 PR #56](https://github.com/perl-libwin32/win32/pull/56) (helpers `acp_bytes_to_sv` / `sv_setpv_acp`, plus a parallel `t/AcpUtf8.t`). That PR is the implementation template for the win32.c side: at each SV-construction point that wraps `*A` Windows API output, conditionally call `SvUTF8_on` when `GetACP() == CP_UTF8`.

## Verification

The test runs cleanly on Strawberry Perl 5.42 on a UTF-8-ACP Windows host. All 8 TODO assertions fire as expected; the TAP output stays a TODO-tolerated PASS.

Related: #17094 (umbrella Win32 Unicode meta-issue).

## Test plan

- [ ] CI's existing Windows jobs (`windows-msvc143`, `mingw64`) pass — the new test skips on legacy ACP, so they're unaffected.
- [ ] The new `windows-msvc143-utf8acp` job succeeds; its TAP output shows 8 TODO failures from `t/win32/cp_utf8_acp.t` documenting the bug.
- [ ] `GetACP() before manifest patch` and `GetACP() after manifest patch` lines in the job log show the runner's default (typically `1252`) flipping to `65001`.