### PR TITLE
github: re-instate and update detect-conflicts workflow

### DIFF
--- a/.github/workflows/detect-conflicts.yml
+++ b/.github/workflows/detect-conflicts.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - blead
+permissions: {}
+jobs:
+  conflicts:
+    permissions:
+      pull-requests: write # to add labels to pull requests
+
+    runs-on: ubuntu-latest
+    if: ( github.event.pull_request.head.repo.full_name == 'Perl/perl5' || github.repository == 'Perl/perl5' )
+    steps:
+      # improve the chance that the mergeable status is computed
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "hasConflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 600 # 600 * 10 sec => 100 minutes
+          WAIT_MS: 10000 # 10 sec


### PR DESCRIPTION
This originally used a customized workflow at
https://github.com/atoomic/auto-label-merge-conflicts/tree/custom which included
https://github.com/mschilde/auto-label-merge-conflicts/pull/43 which was merged in 2020.

Recently this custom version has been failing due to a bug that has been fixed upstream in
https://github.com/mschilde/auto-label-merge-conflicts/pull/67

Unfortunately this workflow only runs on the blead branch, so we can only see if it works by merging it.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.

This isn't a change to perl itself.