### PR TITLE
testsuite.yml: use windows-2022 for MSVC

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -459,7 +459,7 @@ jobs:
 
   windows-msvc143:
     name: "Windows msvc143"
-    runs-on: windows-2025
+    runs-on: windows-2022
     timeout-minutes: 120
     needs: sanity_check
     if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_msvc143 == 'true'))


### PR DESCRIPTION
I've been seeing occasional MSVC run failures with the message:

The system cannot find the path specified.
'nmake' is not recognized as an internal or external command, operable program or batch file.
Error: Process completed with exit code 1.

from the build, and a notice:

NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by May 12, 2026

So use windows-2022, as suggested in runner-images/issues/14017 at least until 5.45 opens up.

This has been reported elsewhere:

https://github.com/actions/runner-images/issues/14004

According to:

https://github.com/actions/runner-images/issues/14017

"During this period your workflows will gradually switch over to the new image with Visual Studio 2026 as the default."

so we can expect this change to gradually become visible to all users over the coming weeks.

Example failures:

https://github.com/tonycoz/perl5/actions/runs/25704574120/job/75472975842 https://github.com/tonycoz/perl5/actions/runs/25702895051/job/75467985059

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
