### PR TITLE
cpan/IO-Socket-IP - Update to version 0.44

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -696,8 +696,8 @@ our %Modules = (
     },
 
     'IO::Socket::IP' => {
-        'DISTRIBUTION' => 'PEVANS/IO-Socket-IP-0.43.tar.gz',
-        'SYNCINFO'     => 'tib on Wed Dec  4 17:32:19 2024',
+        'DISTRIBUTION' => 'PEVANS/IO-Socket-IP-0.44.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Fri May 15 06:56:20 2026',
         'FILES'        => q[cpan/IO-Socket-IP],
         'EXCLUDED'     => [
             qr{^examples/},

--- a/cpan/IO-Socket-IP/lib/IO/Socket/IP.pm
+++ b/cpan/IO-Socket-IP/lib/IO/Socket/IP.pm
@@ -3,12 +3,12 @@
 #
 #  (C) Paul Evans, 2010-2024 -- leonerd@leonerd.org.uk
 
-package IO::Socket::IP 0.43;
+package IO::Socket::IP 0.44;
 
 use v5.14;
 use warnings;
 
-use base qw( IO::Socket );
+use parent qw( IO::Socket );
 
 use Carp;
 
@@ -1199,7 +1199,7 @@ sub join_addr
 
 package # hide from indexer
    IO::Socket::IP::_ForINET;
-use base qw( IO::Socket::IP );
+use parent qw( IO::Socket::IP );
 
 sub configure
 {
@@ -1213,7 +1213,7 @@ sub configure
 
 package # hide from indexer
    IO::Socket::IP::_ForINET6;
-use base qw( IO::Socket::IP );
+use parent qw( IO::Socket::IP );
 
 sub configure
 {


### PR DESCRIPTION
```
0.44    2026-05-13
        [CHANGES]
         * Can `use parent` rather than `use base` (thanks James Raspass)
           (RT177570)
```

* This set of changes does not require a perldelta entry.
