### PR TITLE
cpan/IO-Compress - Update to version 2.220

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -677,8 +677,8 @@ our %Modules = (
     },
 
     'IO-Compress' => {
-        'DISTRIBUTION' => 'PMQS/IO-Compress-2.219.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Wed Mar 11 22:56:57 2026',
+        'DISTRIBUTION' => 'PMQS/IO-Compress-2.220.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Sun May 17 07:54:14 2026',
         'MAIN_MODULE'  => 'IO::Compress::Base',
         'FILES'        => q[cpan/IO-Compress],
         'EXCLUDED'     => [

--- a/cpan/IO-Compress/Makefile.PL
+++ b/cpan/IO-Compress/Makefile.PL
@@ -3,7 +3,7 @@
 use strict ;
 require 5.006 ;
 
-$::VERSION = '2.219' ;
+$::VERSION = '2.220' ;
 $::DEP_VERSION = '2.218';
 
 use lib '.';

--- a/cpan/IO-Compress/bin/zipdetails
+++ b/cpan/IO-Compress/bin/zipdetails
@@ -29,7 +29,7 @@ use Encode;
 use Getopt::Long;
 use List::Util qw(min max);
 
-my $VERSION = '4.005' ;
+my $VERSION = '4.006' ;
 
 sub fatal_tryWalk;
 sub fatal_truncated ;
@@ -118,7 +118,7 @@ use constant ZIP_EXTRA_SUBFIELD_MAX_SIZE    => ZIP_EXTRA_MAX_SIZE -
                                                ZIP_EXTRA_SUBFIELD_HEADER_SIZE;
 
 use constant ZIP_EOCD_MIN_SIZE              => 22 ;
-
+use constant ZIP_CENTRAL_HDR_MIN_SIZE       => 46 ;
 
 use constant ZIP_LD_FILENAME_OFFSET         => 30;
 use constant ZIP_CD_FILENAME_OFFSET         => 46;
@@ -132,7 +132,7 @@ my %ZIP_CompressionMethods =
           4 => 'Reduced compression factor 3',
           5 => 'Reduced compression factor 4',
           6 => 'Imploded',
-          7 => 'Reserved for Tokenizing compression algorithm',
+          7 => 'Tokenized',
           8 => 'Deflated',
           9 => 'Deflate64',
          10 => 'PKWARE Data Compression Library Imploding',
@@ -145,7 +145,7 @@ my %ZIP_CompressionMethods =
          17 => 'Reserved by PKWARE',
          18 => 'IBM/TERSE or Xceed BWT', # APPNOTE has IBM/TERSE. Xceed reuses it unofficially
          19 => 'IBM LZ77 z Architecture (PFS)',
-         20 => 'Ipaq8', # see https://encode.su/threads/1048-info-zip-lpaq8
+         20 => 'Zstandard (Deprecated) or Ipaq8', # Deprecated ZStandard and see https://encode.su/threads/1048-info-zip-lpaq8
          92 => 'Reference', # Winzip Only from version 25
          93 => 'Zstandard',
          94 => 'MP3',
@@ -2127,7 +2127,7 @@ sub LocalHeader
     }
 
     # Defer test for directory payload until Central Header processing.
-    # Need to have external file attributes to deal with sme edge conditions.
+    # Need to have external file attributes to deal with some edge conditions.
     # # APPNOTE 6.3.10, sec 4.3.8
     # warning $FH->tell - $filenameLength, "Directory '$filename' must not have a payload"
     #     if ! $streaming && $filename =~ m#/$# && $localEntry->uncompressedSize ;
@@ -3363,7 +3363,7 @@ sub DataDescriptor
     }
 
     # Defer test for directory payload until central header processing.
-    # Need to have external file attributes to deal with sme edge conditions.
+    # Need to have external file attributes to deal with some edge conditions.
     # # APPNOTE 6.3.10, sec 4.3.8
     # my $filename = $localEntry->filename;
     # warning undef, "Directory '$filename' must not have a payload"
@@ -4049,7 +4049,7 @@ sub walkExtra
 
                 # Belt & Braces - should now be at $endExtraOffset
                 # error here means issue in an extra handler
-                # should noy happen, but just in case
+                # should not happen, but just in case
                 # TODO -- need tests for this
                 my $here = $FH->tell() ;
                 if ($here > $endExtraOffset)
@@ -4179,7 +4179,7 @@ sub walk_Zip64_in_LD
 
     if ($assumeLengthsPresent || $assumeAllFieldsPresent || full32 $entry->std_uncompressedSize )
     {
-        # TODO defer a warning if in local header & central/local don't have std_uncompressedSizeset to 0xffffffff
+        # TODO defer a warning if in local header & central/local don't have std_uncompressedSize set to 0xffffffff
         my $fieldName = 'Uncompressed Size';
         if (length $zip64Extended < 8)
         {
@@ -4838,7 +4838,7 @@ sub decode_Minizip_Hash
     # 0x1a51 Minizip Hash
     # Definition in https://github.com/zlib-ng/minizip-ng/blob/master/doc/mz_extrafield.md#hash-0x1a51
 
-    # caller ckecks there are at least 4 bytes available
+    # caller checks there are at least 4 bytes available
     my $extraID = shift ;
     my $len = shift;
     my $entry = shift;
@@ -5080,13 +5080,21 @@ sub decode_Ux
     out_v "  GID";
 }
 
-sub decodeLitteEndian
+sub canDecodeLittleEndian
+{
+    my $value = shift;
+
+    state $valid = { 0 => 1, 1 => 1, 2 => 1, 4 => 2, 8 => 1} ;
+    return $valid->{$value};
+}
+
+sub decodeLittleEndian
 {
     my $value = shift ;
 
     if (length $value == 8)
     {
-        return unpackValueQ ($value)
+        return unpackValue_Q ($value)
     }
     elsif (length $value == 4)
     {
@@ -5102,7 +5110,7 @@ sub decodeLitteEndian
     }
     else {
         # TODO - fix this
-        internalFatal undef, "unsupported decodeLitteEndian length '" . length ($value) . "'";
+        internalFatal undef, "unsupported decodeLittleEndian length '" . length ($value) . "'";
     }
 }
 
@@ -5137,8 +5145,20 @@ sub decode_ux
         }
 
         myRead(my $data, $uidSize);
-        out2 $data, "UID", decodeLitteEndian($data);
+        if (canDecodeLittleEndian($uidSize))
+        {
+            out2 $data, "UID", decodeLittleEndian($data);
+        }
+        else
+        {
+            out2 $data, "UID", "Invalid UID Value: " . hexDump($data);
+            info $FH->tell() - $uidSize, extraFieldIdentifier($extraID) . ": UID value is not a valid value"
+        }
         $available -= $uidSize ;
+    }
+    else
+    {
+        info $FH->tell() - 1, extraFieldIdentifier($extraID) . ": 'UID Size' should not be zero"
     }
 
     if ($available < 1)
@@ -5163,8 +5183,20 @@ sub decode_ux
         }
 
         myRead(my $data, $gidSize);
-        out2 $data, "GID", decodeLitteEndian($data);
+        if (canDecodeLittleEndian($gidSize))
+        {
+            out2 $data, "GID", decodeLittleEndian($data);
+        }
+        else
+        {
+            out2 $data, "GID", "Invalid GID Value: " .hexDump($data);
+            info $FH->tell() - $gidSize, extraFieldIdentifier($extraID) . ":  GID value is not a valid value"
+        }
         $available -= $gidSize ;
+    }
+    else
+    {
+        info $FH->tell() - 1, extraFieldIdentifier($extraID) . ": 'GID Size' should not be zero"
     }
 
 }
@@ -5622,6 +5654,9 @@ sub peekAtOffset
     my $offset = shift;
     my $len = shift;
 
+    return undef
+        if $offset + $len > $FILELEN;
+
     my $here = $FH->tell();
 
     seekTo($offset) ;
@@ -5631,7 +5666,7 @@ sub peekAtOffset
     seekTo($here);
 
     length $buffer == $len
-        or return '';
+        or return undef;
 
     return $buffer;
 }
@@ -5677,7 +5712,7 @@ sub chckForAPKSigningBlock
     my $cdOffset = shift;
     my $cdSize = shift;
 
-    # APK Signing Block comes directy before the Central directory
+    # APK Signing Block comes directly before the Central directory
     # See https://source.android.com/security/apksigning/v2
 
     # If offset available is less than 44, it isn't an APK signing block
@@ -5840,7 +5875,7 @@ sub scanCentralDirectory
         if (! full32 $locHeaderOffset)
         {
             # Check for corrupt offset
-            # 1. ponting paset EOF
+            # 1. pointing paset EOF
             # 2. offset points forward in the file
             # 3. value at offset is not a CD record signature
 
@@ -6103,7 +6138,39 @@ sub findCentralDirectoryOffset
     if (needZip64EOCDLocator($diskNumber, $cdDiskNumber, $entriesOnThisDisk, $totalEntries, $centralDirOffset, $centralDirSize) &&
         ! emptyArchive($here, $diskNumber, $cdDiskNumber, $entriesOnThisDisk, $totalEntries, $centralDirOffset, $centralDirSize))
     {
+        # Possible/probable that need a zip64 record
+        # Must have if -- centralDirOffset > 0xFFFFFFFF or centralDirSize
+
+        my $want_zip64 = 0;
+
+        # Edge condition where centralDirOffset is exactly full32, but archive isn't a zip64 file
+        # Check if offset to central header is full32 and the central signature is not present
+        if (full32($centralDirOffset))
+        {
+            my $value = peekAtOffset($centralDirOffset, 4);
+            $want_zip64 = 1
+                if defined $value && unpack( "V",  $value) != ZIP_CENTRAL_HDR_SIG ;
+        }
+
+        # Already past point of no return?
+        $want_zip64 = 1
+            if $here > MAX32 + ZIP_EOCD_MIN_SIZE + ZIP_CENTRAL_HDR_MIN_SIZE;
+
+        # may look like there should be a zip64 entry, but not always the case
+        {
+            my $gotSig = peekAtOffset($here - ZIP64_END_CENTRAL_LOC_HDR_SIZE, 4) ;
+            if (defined $gotSig && unpack("V", $gotSig) != ZIP64_END_CENTRAL_LOC_HDR_SIG)
+            {
+                warning $$here - ZIP64_END_CENTRAL_LOC_HDR_SIZE - 4, sprintf("Expected signature for " . Signatures::nameAndHex(ZIP64_END_CENTRAL_LOC_HDR_SIG) . " not found, got 0x%X", $gotSig);
+            }
+            else
+            {
+                $want_zip64 = 1;
+            }
+        }
+
         ($centralDirOffset, $centralDirSize) = offsetFromZip64($fh, $here, ZIP_EOCD_MIN_SIZE + $commentLength + $trailingBytes)
+            if $want_zip64;
     }
     elsif ($is64bit)
     {
@@ -6236,7 +6303,7 @@ sub nibbles
 {
     package HeaderOffsetIndex;
 
-    # Store a list of header offsets recorded when scannning the central directory
+    # Store a list of header offsets recorded when scanning the central directory
 
     sub new
     {
@@ -7651,7 +7718,7 @@ at hand to help understand the output from this program.
 By default the program expects to be given a well-formed zip file.  It will
 navigate the zip file by first parsing the zip C<Central Directory> at the end
 of the file.  If the C<Central Directory> is found, it will then walk
-sequentally through the zip records starting at the beginning of the file.
+sequentially through the zip records starting at the beginning of the file.
 See L<Advanced Analysis> for other processing options.
 
 If the program finds any structural or portability issues with the zip file
@@ -7672,7 +7739,7 @@ C<--utc> option to display these fields in Coordinated Universal Time (UTC).
 =head3 Filenames & Comments
 
 Filenames and comments are decoded/encoded using the default system
-encoding of the host running C<zipdetails>. When the sytem encoding cannot
+encoding of the host running C<zipdetails>. When the system encoding cannot
 be determined C<cp437> will be used.
 
 The exceptions are
@@ -7710,7 +7777,7 @@ where the zip files contains sensitive data that cannot be shared.
 
 =item C<--scan>
 
-Pessimistically scan the zip file loking for possible zip records. Can be
+Pessimistically scan the zip file looking for possible zip records. Can be
 error-prone. For very large zip files this option is slow. Consider using
 the C<--walk> option first. See L<"Advanced Analysis Options">
 
@@ -8020,7 +8087,7 @@ any zip metadata that is still present in the file.
 When either of these options is enabled, this program will bypass the
 initial step of reading the C<Central Directory> at the end of the file and
 simply scan the zip file sequentially from the start of the file looking
-for zip metedata records. Although this can be error prone, for the most
+for zip metadata records. Although this can be error prone, for the most
 part it will find any zip file metadata that is still present in the file.
 
 The difference between the two options is how aggressive the sequential
@@ -8038,7 +8105,7 @@ record and display it.
 =head3 C<--walk>
 
 The C<--walk> option optimistically assumes that it has found a real zip
-metatada record and so starts the scan for the next record directly after
+metadata record and so starts the scan for the next record directly after
 the record it has just output.
 
 =head3 C<--scan>
@@ -8047,8 +8114,8 @@ The C<--scan> option is pessimistic and assumes the 4-byte signature
 sequence may have been a false-positive, so before starting the scan for
 the next resord, it will rewind to the location in the file directly after
 the 4-byte sequecce it just processed. This means it will rescan data that
-has already been processed.  For very lage zip files the C<--scan> option
-can be really realy slow, so trying the C<--walk> option first.
+has already been processed.  For very large zip files the C<--scan> option
+can be really really slow, so trying the C<--walk> option first.
 
 B<Important Note>: If the zip file being processed contains one or more
 nested zip files, and the outer zip file uses the C<STORE> compression
@@ -8099,7 +8166,7 @@ can display the filenames using the C<--encoding> option
 
 A less common variation of this is where the C<EFS> bit is set, signalling
 that the filename will be encoded in UTF-8, but the filename is not encoded
-in UTF-8. To deal with this scenarion, use the C<--no-language-encoding>
+in UTF-8. To deal with this scenario, use the C<--no-language-encoding>
 option along with the C<--encoding> option.
 
 

--- a/cpan/IO-Compress/lib/Compress/Zlib.pm
+++ b/cpan/IO-Compress/lib/Compress/Zlib.pm
@@ -7,17 +7,17 @@ use Carp ;
 use IO::Handle ;
 use Scalar::Util qw(dualvar);
 
-use IO::Compress::Base::Common 2.219 ;
+use IO::Compress::Base::Common 2.220 ;
 use Compress::Raw::Zlib 2.218 ;
-use IO::Compress::Gzip 2.219 ;
-use IO::Uncompress::Gunzip 2.219 ;
+use IO::Compress::Gzip 2.220 ;
+use IO::Uncompress::Gunzip 2.220 ;
 
 use strict ;
 use warnings ;
 use bytes ;
 our ($VERSION, $XS_VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -461,7 +461,7 @@ sub inflate
 
 package Compress::Zlib ;
 
-use IO::Compress::Gzip::Constants 2.219 ;
+use IO::Compress::Gzip::Constants 2.220 ;
 
 sub memGzip($)
 {

--- a/cpan/IO-Compress/lib/File/GlobMapper.pm
+++ b/cpan/IO-Compress/lib/File/GlobMapper.pm
@@ -29,6 +29,11 @@ our ($VERSION, @EXPORT_OK);
 $VERSION = '1.001';
 @EXPORT_OK = qw( globmap );
 
+our $BEGIN_DELIM = "\xFF";
+our $END_DELIM   = "\xFE";
+our $BACKSLASH_ESC = "\xFD";
+our $HASH_ESC = "\xFC";
+our $STAR_ESC = "\xFB";
 
 our ($noPreBS, $metachars, $matchMetaRE, %mapping, %wildCount);
 $noPreBS = '(?<!\\\)' ; # no preceding backslash
@@ -310,14 +315,23 @@ sub _parseOutputGlob
     }
 
     my $noPreBS = '(?<!\\\)' ; # no preceding backslash
-    #warn "noPreBS = '$noPreBS'\n";
+    my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
 
-    #$string =~ s/${noPreBS}\$(\d)/\${$1}/g;
-    $string =~ s/${noPreBS}#(\d)/\${$1}/g;
-    $string =~ s#${noPreBS}\*#\${inFile}#g;
-    $string = '"' . $string . '"';
+    # escape any use of the delimiter symbols
+    # $string =~ s/(${BEGIN_DELIM}|${END_DELIM}|${BACKSLASH_ESC})/$1$1/g;
 
-    #print "OUTPUT '$self->{OutputGlob}' => '$string'\n";
+    # escape \# and \*
+    $string =~ s/\\#/${HASH_ESC}/g;
+    $string =~ s/\\\*/${STAR_ESC}/g;
+
+    # Transform "#3" to BEGIN_DELIM 3 END_DELIM
+    $string =~ s/${noPreESC}#(\d)/${BEGIN_DELIM}${1}${END_DELIM}/g;
+
+    $string =~ s#\*#${BEGIN_DELIM}${END_DELIM}#g;
+
+    # print "INPUT  '$self->{InputPattern}'\n";
+    # print "OUTPUT '$self->{OutputGlob}' => '$string'\n";
+
     $self->{OutputPattern} = $string ;
 
     return 1 ;
@@ -335,11 +349,31 @@ sub _getFiles
         next if $inFiles{$inFile} ++ ;
 
         my $outFile = $inFile ;
+        my @matches ;
 
-        if ( $inFile =~ m/$self->{InputPattern}/ )
+        my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
+
+        if (@matches = ($inFile =~ m/$self->{InputPattern}/ ))
         {
-            no warnings 'uninitialized';
-            eval "\$outFile = $self->{OutputPattern};" ;
+            $outFile = $self->{OutputPattern};
+            my $ix = 1;
+
+            # get the filename glob
+            $outFile =~ s/${noPreESC}${BEGIN_DELIM}${END_DELIM}/$inFile/g;
+
+            # now each of the #1, #2,...
+            for my $pattern (@matches)
+            {
+                $outFile =~ s/${noPreESC}${BEGIN_DELIM}${ix}${END_DELIM}/$pattern/g;
+
+                ++ $ix;
+            }
+
+            # unescape
+            $outFile =~ s/${BEGIN_DELIM}${BEGIN_DELIM}/${BEGIN_DELIM}/g;
+            $outFile =~ s/${END_DELIM}${END_DELIM}/${END_DELIM}/g;
+            $outFile =~ s/${HASH_ESC}/#/g;
+            $outFile =~ s/${STAR_ESC}/*/g;
 
             if (defined $outInMapping{$outFile})
             {

--- a/cpan/IO-Compress/lib/IO/Compress.pm
+++ b/cpan/IO-Compress/lib/IO/Compress.pm
@@ -1,6 +1,6 @@
 package IO::Compress;
 
-our $VERSION = '2.219' ;
+our $VERSION = '2.220' ;
 
 =head1 NAME
 

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Bzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Bzip2.pm
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.219 qw(:Status);
+use IO::Compress::Base::Common  2.220 qw(:Status);
 
 use Compress::Raw::Bzip2  2.218 ;
 
 our ($VERSION);
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 sub mkCompObject
 {

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Deflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Deflate.pm
@@ -4,13 +4,13 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.219 qw(:Status);
+use IO::Compress::Base::Common 2.220 qw(:Status);
 use Compress::Raw::Zlib  2.218 qw( !crc32 !adler32 ) ;
 
 require Exporter;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, @EXPORT, %DEFLATE_CONSTANTS);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 @ISA = qw(Exporter);
 @EXPORT_OK = @Compress::Raw::Zlib::DEFLATE_CONSTANTS;
 %EXPORT_TAGS = %Compress::Raw::Zlib::DEFLATE_CONSTANTS;

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Identity.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Identity.pm
@@ -4,10 +4,10 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.219 qw(:Status);
+use IO::Compress::Base::Common  2.220 qw(:Status);
 our ($VERSION);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 sub mkCompObject
 {

--- a/cpan/IO-Compress/lib/IO/Compress/Base.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Base.pm
@@ -6,7 +6,7 @@ require 5.006 ;
 use strict ;
 use warnings;
 
-use IO::Compress::Base::Common 2.219 ;
+use IO::Compress::Base::Common 2.220 ;
 
 use IO::File ();
 use Scalar::Util ();
@@ -20,7 +20,7 @@ use Symbol();
 our (@ISA, $VERSION);
 @ISA    = qw(IO::File Exporter);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 #Can't locate object method "SWASHNEW" via package "utf8" (perhaps you forgot to load "utf8"?) at .../ext/Compress-Zlib/Gzip/blib/lib/Compress/Zlib/Common.pm line 16.
 

--- a/cpan/IO-Compress/lib/IO/Compress/Base/Common.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Base/Common.pm
@@ -11,7 +11,7 @@ use File::GlobMapper;
 require Exporter;
 our ($VERSION, @ISA, @EXPORT, %EXPORT_TAGS, $HAS_ENCODE);
 @ISA = qw(Exporter);
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 @EXPORT = qw( isaFilehandle isaFilename isaScalar
               whatIsInput whatIsOutput

--- a/cpan/IO-Compress/lib/IO/Compress/Bzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Bzip2.pm
@@ -5,16 +5,16 @@ use warnings;
 use bytes;
 require Exporter ;
 
-use IO::Compress::Base 2.219 ;
+use IO::Compress::Base 2.220 ;
 
-use IO::Compress::Base::Common  2.219 qw();
-use IO::Compress::Adapter::Bzip2 2.219 ;
+use IO::Compress::Base::Common  2.220 qw();
+use IO::Compress::Adapter::Bzip2 2.220 ;
 
 
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $Bzip2Error);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $Bzip2Error = '';
 
 @ISA    = qw(IO::Compress::Base Exporter);
@@ -51,7 +51,7 @@ sub getExtraParams
 {
     my $self = shift ;
 
-    use IO::Compress::Base::Common  2.219 qw(:Parse);
+    use IO::Compress::Base::Common  2.220 qw(:Parse);
 
     return (
             'blocksize100k' => [IO::Compress::Base::Common::Parse_unsigned,  1],

--- a/cpan/IO-Compress/lib/IO/Compress/Deflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Deflate.pm
@@ -8,16 +8,16 @@ use bytes;
 
 require Exporter ;
 
-use IO::Compress::RawDeflate 2.219 ();
-use IO::Compress::Adapter::Deflate 2.219 ;
+use IO::Compress::RawDeflate 2.220 ();
+use IO::Compress::Adapter::Deflate 2.220 ;
 
-use IO::Compress::Zlib::Constants 2.219 ;
-use IO::Compress::Base::Common  2.219 qw();
+use IO::Compress::Zlib::Constants 2.220 ;
+use IO::Compress::Base::Common  2.220 qw();
 
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $DeflateError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $DeflateError = '';
 
 @ISA    = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Gzip.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Gzip.pm
@@ -8,12 +8,12 @@ use bytes;
 
 require Exporter ;
 
-use IO::Compress::RawDeflate 2.219 () ;
-use IO::Compress::Adapter::Deflate 2.219 ;
+use IO::Compress::RawDeflate 2.220 () ;
+use IO::Compress::Adapter::Deflate 2.220 ;
 
-use IO::Compress::Base::Common  2.219 qw(:Status );
-use IO::Compress::Gzip::Constants 2.219 ;
-use IO::Compress::Zlib::Extra 2.219 ;
+use IO::Compress::Base::Common  2.220 qw(:Status );
+use IO::Compress::Gzip::Constants 2.220 ;
+use IO::Compress::Zlib::Extra 2.220 ;
 
 BEGIN
 {
@@ -25,7 +25,7 @@ BEGIN
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $GzipError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $GzipError = '' ;
 
 @ISA    = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Gzip/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Gzip/Constants.pm
@@ -9,7 +9,7 @@ require Exporter;
 our ($VERSION, @ISA, @EXPORT, %GZIP_OS_Names);
 our ($GZIP_FNAME_INVALID_CHAR_RE, $GZIP_FCOMMENT_INVALID_CHAR_RE);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/RawDeflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/RawDeflate.pm
@@ -6,16 +6,16 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base 2.219 ;
-use IO::Compress::Base::Common  2.219 qw(:Status :Parse);
-use IO::Compress::Adapter::Deflate 2.219 ;
+use IO::Compress::Base 2.220 ;
+use IO::Compress::Base::Common  2.220 qw(:Status :Parse);
+use IO::Compress::Adapter::Deflate 2.220 ;
 use Compress::Raw::Zlib  2.218 qw(Z_DEFLATED Z_DEFAULT_COMPRESSION Z_DEFAULT_STRATEGY);
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %DEFLATE_CONSTANTS, %EXPORT_TAGS, $RawDeflateError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $RawDeflateError = '';
 
 @ISA = qw(IO::Compress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Zip.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zip.pm
@@ -4,12 +4,12 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.219 qw(:Status );
-use IO::Compress::RawDeflate 2.219 ();
-use IO::Compress::Adapter::Deflate 2.219 ;
-use IO::Compress::Adapter::Identity 2.219 ;
-use IO::Compress::Zlib::Extra 2.219 ;
-use IO::Compress::Zip::Constants 2.219 ;
+use IO::Compress::Base::Common  2.220 qw(:Status );
+use IO::Compress::RawDeflate 2.220 ();
+use IO::Compress::Adapter::Deflate 2.220 ;
+use IO::Compress::Adapter::Identity 2.220 ;
+use IO::Compress::Zlib::Extra 2.220 ;
+use IO::Compress::Zip::Constants 2.220 ;
 
 use File::Spec();
 use Config;
@@ -47,7 +47,7 @@ require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $ZipError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $ZipError = '';
 
 @ISA = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Zip/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zip/Constants.pm
@@ -7,7 +7,7 @@ require Exporter;
 
 our ($VERSION, @ISA, @EXPORT, %ZIP_CM_MIN_VERSIONS);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/Zlib/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zlib/Constants.pm
@@ -9,7 +9,7 @@ require Exporter;
 
 our ($VERSION, @ISA, @EXPORT);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/Zlib/Extra.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zlib/Extra.pm
@@ -8,9 +8,9 @@ use bytes;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
-use IO::Compress::Gzip::Constants 2.219 ;
+use IO::Compress::Gzip::Constants 2.220 ;
 
 sub ExtraFieldError
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Bunzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Bunzip2.pm
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.219 qw(:Status);
+use IO::Compress::Base::Common 2.220 qw(:Status);
 
 use Compress::Raw::Bzip2 2.218 ;
 
 our ($VERSION, @ISA);
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 sub mkUncompObject
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Identity.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Identity.pm
@@ -4,12 +4,12 @@ use warnings;
 use strict;
 use bytes;
 
-use IO::Compress::Base::Common  2.219 qw(:Status);
+use IO::Compress::Base::Common  2.220 qw(:Status);
 use IO::Compress::Zip::Constants ;
 
 our ($VERSION);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 use Compress::Raw::Zlib  2.218 ();
 

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Inflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Inflate.pm
@@ -4,11 +4,11 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.219 qw(:Status);
+use IO::Compress::Base::Common  2.220 qw(:Status);
 use Compress::Raw::Zlib  2.218 qw(Z_OK Z_BUF_ERROR Z_STREAM_END Z_FINISH MAX_WBITS);
 
 our ($VERSION);
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 
 

--- a/cpan/IO-Compress/lib/IO/Uncompress/AnyInflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/AnyInflate.pm
@@ -6,22 +6,22 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.219 qw(:Parse);
+use IO::Compress::Base::Common 2.220 qw(:Parse);
 
-use IO::Uncompress::Adapter::Inflate  2.219 ();
+use IO::Uncompress::Adapter::Inflate  2.220 ();
 
 
-use IO::Uncompress::Base  2.219 ;
-use IO::Uncompress::Gunzip  2.219 ;
-use IO::Uncompress::Inflate  2.219 ;
-use IO::Uncompress::RawInflate  2.219 ;
-use IO::Uncompress::Unzip  2.219 ;
+use IO::Uncompress::Base  2.220 ;
+use IO::Uncompress::Gunzip  2.220 ;
+use IO::Uncompress::Inflate  2.220 ;
+use IO::Uncompress::RawInflate  2.220 ;
+use IO::Uncompress::Unzip  2.220 ;
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $AnyInflateError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $AnyInflateError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);
@@ -77,7 +77,7 @@ sub mkUncomp
 
      my @possible = qw( Inflate Gunzip Unzip );
      unshift @possible, 'RawInflate'
-        if 1 || $got->getValue('rawinflate');
+        if $got->getValue('rawinflate');
 
      my $magic = $self->ckMagic( @possible );
 

--- a/cpan/IO-Compress/lib/IO/Uncompress/AnyUncompress.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/AnyUncompress.pm
@@ -4,16 +4,16 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.219 ();
+use IO::Compress::Base::Common 2.220 ();
 
-use IO::Uncompress::Base 2.219 ;
+use IO::Uncompress::Base 2.220 ;
 
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $AnyUncompressError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $AnyUncompressError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);
@@ -33,8 +33,8 @@ BEGIN
    # Don't trigger any __DIE__ Hooks.
    local $SIG{__DIE__};
 
-   eval ' use IO::Uncompress::Adapter::Inflate 2.219 ;';
-   eval ' use IO::Uncompress::Adapter::Bunzip2 2.219 ;';
+   eval ' use IO::Uncompress::Adapter::Inflate 2.220 ;';
+   eval ' use IO::Uncompress::Adapter::Bunzip2 2.220 ;';
    eval ' use IO::Uncompress::Adapter::LZO 2.217 ;';
    eval ' use IO::Uncompress::Adapter::Lzf 2.217 ;';
    eval ' use IO::Uncompress::Adapter::UnLzma 2.217 ;';
@@ -42,12 +42,12 @@ BEGIN
    eval ' use IO::Uncompress::Adapter::UnZstd 2.217 ;';
    eval ' use IO::Uncompress::Adapter::UnLzip 2.217 ;';
 
-   eval ' use IO::Uncompress::Bunzip2 2.219 ;';
+   eval ' use IO::Uncompress::Bunzip2 2.220 ;';
    eval ' use IO::Uncompress::UnLzop 2.217 ;';
-   eval ' use IO::Uncompress::Gunzip 2.219 ;';
-   eval ' use IO::Uncompress::Inflate 2.219 ;';
-   eval ' use IO::Uncompress::RawInflate 2.219 ;';
-   eval ' use IO::Uncompress::Unzip 2.219 ;';
+   eval ' use IO::Uncompress::Gunzip 2.220 ;';
+   eval ' use IO::Uncompress::Inflate 2.220 ;';
+   eval ' use IO::Uncompress::RawInflate 2.220 ;';
+   eval ' use IO::Uncompress::Unzip 2.220 ;';
    eval ' use IO::Uncompress::UnLzf 2.217 ;';
    eval ' use IO::Uncompress::UnLzma 2.217 ;';
    eval ' use IO::Uncompress::UnXz 2.217 ;';

--- a/cpan/IO-Compress/lib/IO/Uncompress/Base.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Base.pm
@@ -9,12 +9,12 @@ our (@ISA, $VERSION, @EXPORT_OK, %EXPORT_TAGS);
 @ISA    = qw(IO::File Exporter);
 
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 use constant G_EOF => 0 ;
 use constant G_ERR => -1 ;
 
-use IO::Compress::Base::Common 2.219 ;
+use IO::Compress::Base::Common 2.220 ;
 
 use IO::File ;
 use Symbol;

--- a/cpan/IO-Compress/lib/IO/Uncompress/Bunzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Bunzip2.pm
@@ -4,15 +4,15 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.219 qw(:Status );
+use IO::Compress::Base::Common 2.220 qw(:Status );
 
-use IO::Uncompress::Base 2.219 ;
-use IO::Uncompress::Adapter::Bunzip2 2.219 ;
+use IO::Uncompress::Base 2.220 ;
+use IO::Uncompress::Adapter::Bunzip2 2.220 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $Bunzip2Error);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $Bunzip2Error = '';
 
 @ISA    = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/Gunzip.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Gunzip.pm
@@ -9,12 +9,12 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Uncompress::RawInflate 2.219 ;
+use IO::Uncompress::RawInflate 2.220 ;
 
 use Compress::Raw::Zlib 2.218 () ;
-use IO::Compress::Base::Common 2.219 qw(:Status );
-use IO::Compress::Gzip::Constants 2.219 ;
-use IO::Compress::Zlib::Extra 2.219 ;
+use IO::Compress::Base::Common 2.220 qw(:Status );
+use IO::Compress::Gzip::Constants 2.220 ;
+use IO::Compress::Zlib::Extra 2.220 ;
 
 require Exporter ;
 
@@ -28,7 +28,7 @@ Exporter::export_ok_tags('all');
 
 $GunzipError = '';
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 
 sub new
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Inflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Inflate.pm
@@ -5,15 +5,15 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.219 qw(:Status );
-use IO::Compress::Zlib::Constants 2.219 ;
+use IO::Compress::Base::Common  2.220 qw(:Status );
+use IO::Compress::Zlib::Constants 2.220 ;
 
-use IO::Uncompress::RawInflate  2.219 ;
+use IO::Uncompress::RawInflate  2.220 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $InflateError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $InflateError = '';
 
 @ISA    = qw(IO::Uncompress::RawInflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/RawInflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/RawInflate.pm
@@ -6,15 +6,15 @@ use warnings;
 use bytes;
 
 use Compress::Raw::Zlib  2.218 ;
-use IO::Compress::Base::Common  2.219 qw(:Status );
+use IO::Compress::Base::Common  2.220 qw(:Status );
 
-use IO::Uncompress::Base  2.219 ;
-use IO::Uncompress::Adapter::Inflate  2.219 ;
+use IO::Uncompress::Base  2.220 ;
+use IO::Uncompress::Adapter::Inflate  2.220 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $RawInflateError);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $RawInflateError = '';
 
 @ISA    = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
@@ -9,12 +9,12 @@ use warnings;
 use bytes;
 
 use IO::File;
-use IO::Uncompress::RawInflate  2.219 ;
-use IO::Compress::Base::Common  2.219 qw(:Status );
-use IO::Uncompress::Adapter::Inflate  2.219 ;
-use IO::Uncompress::Adapter::Identity 2.219 ;
-use IO::Compress::Zlib::Extra 2.219 ;
-use IO::Compress::Zip::Constants 2.219 ;
+use IO::Uncompress::RawInflate  2.220 ;
+use IO::Compress::Base::Common  2.220 qw(:Status );
+use IO::Uncompress::Adapter::Inflate  2.220 ;
+use IO::Uncompress::Adapter::Identity 2.220 ;
+use IO::Compress::Zlib::Extra 2.220 ;
+use IO::Compress::Zip::Constants 2.220 ;
 
 use Compress::Raw::Zlib  2.218 () ;
 
@@ -24,7 +24,7 @@ BEGIN
    local $SIG{__DIE__};
 
     eval{ require IO::Uncompress::Adapter::Bunzip2 ;
-          IO::Uncompress::Adapter::Bunzip2->VERSION(2.219) } ;
+          IO::Uncompress::Adapter::Bunzip2->VERSION(2.220) } ;
     eval{ require IO::Uncompress::Adapter::UnLzma ;
           IO::Uncompress::Adapter::UnLzma->VERSION(2.217) } ;
     eval{ require IO::Uncompress::Adapter::UnXz ;
@@ -38,7 +38,7 @@ require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $UnzipError, %headerLookup);
 
-$VERSION = '2.219';
+$VERSION = '2.220';
 $UnzipError = '';
 
 @ISA    = qw(IO::Uncompress::RawInflate Exporter);
@@ -157,8 +157,8 @@ sub fastForward
 
     while ($offset > 0)
     {
-        $c = length $offset
-            if length $offset < $c ;
+        $c = $offset
+            if $offset < $c ;
 
         $offset -= $c;
 

--- a/cpan/IO-Compress/t/globmapper.t
+++ b/cpan/IO-Compress/t/globmapper.t
@@ -24,7 +24,7 @@ Perl $]" )
     $extra = 1
         if eval { require Test::NoWarnings ;  Test::NoWarnings->import; 1 };
 
-    plan tests => 68 + $extra ;
+    plan tests => 76 + $extra ;
 
     use_ok('File::GlobMapper') ;
 }
@@ -287,6 +287,56 @@ Perl $]" )
         [ [map { "$tmpDir/$_" } qw(abc1.tmp X-c1-a-X)],
           [map { "$tmpDir/$_" } qw(abc2.tmp X-c2-a-X)],
           [map { "$tmpDir/$_" } qw(abc3.tmp X-c3-a-X)],
+        ], "  got mapping";
+}
+
+{
+    title "check escaping";
+
+    my $tmpDir ;#= 'td';
+    my $lex = LexDir->new( $tmpDir );
+
+    my $BEGIN_DELIM = "\xFF";
+    my $END_DELIM   = "\xFE";
+
+    #mkdir $tmpDir, 0777 ;
+
+    touch map { "$tmpDir/$_.tmp" } qw( abc1 abc2 abc3 ) ;
+
+    my $map = File::GlobMapper::globmap("$tmpDir/*b*.tmp", "$tmpDir/X-${BEGIN_DELIM}#2-#1${END_DELIM}-X");
+    ok $map, "  got map"
+        or diag $File::GlobMapper::Error ;
+
+    is @{ $map }, 3, "  returned 3 maps";
+    is_deeply $map,
+        [ [map { "$tmpDir/$_" } ("abc1.tmp", "X-${BEGIN_DELIM}c1-a${END_DELIM}-X")],
+          [map { "$tmpDir/$_" } ("abc2.tmp", "X-${BEGIN_DELIM}c2-a${END_DELIM}-X")],
+          [map { "$tmpDir/$_" } ("abc3.tmp", "X-${BEGIN_DELIM}c3-a${END_DELIM}-X")],
+        ], "  got mapping";
+}
+
+{
+    title "check backslash escaping";
+
+    my $tmpDir ;#= 'td';
+    my $lex = LexDir->new( $tmpDir );
+
+    my $BEGIN_DELIM = "\xFF";
+    my $END_DELIM   = "\xFE";
+
+    #mkdir $tmpDir, 0777 ;
+
+    touch map { "$tmpDir/$_.tmp" } qw( abc1 abc2 abc3 ) ;
+
+    my $map = File::GlobMapper::globmap("$tmpDir/*b*.tmp", $tmpDir . '/X-#2-\\#1\\*-X');
+    ok $map, "  got map"
+        or diag $File::GlobMapper::Error ;
+
+    is @{ $map }, 3, "  returned 3 maps";
+    is_deeply $map,
+        [ [map { "$tmpDir/$_" } ("abc1.tmp", "X-c1-#1*-X")],
+          [map { "$tmpDir/$_" } ("abc2.tmp", "X-c2-#1*-X")],
+          [map { "$tmpDir/$_" } ("abc3.tmp", "X-c3-#1*-X")],
         ], "  got mapping";
 }
 


### PR DESCRIPTION
  2.220 16 May 2026

    * remove use of eval in globmapper. #73 Sat May 16 17:48:34 2026 +0100 f2db247bf90d4cc7ee2710be384946081f3b4610

    * Update zipdetails to version 4.006. Sat May 16 13:43:12 2026 +0100 33c89d03d6e746ed2ead4f2f6570d47864c61bc7

    * Fix typo in fastForward #72 Fri May 15 23:18:39 2026 +0100 68db44076f4c1a86a2ffe53a958eac6cabaf72e2

    * Fix issue with "rawdeflate` option in AnyInflate. #71 Fri May 15 22:56:20 2026 +0100 fba3efe40208bd07034b6a3cf6bf9fc3b8b4f215

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
TODO: fill description here

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
