### PR TITLE
Minimal changes to 5.44 to support z/OS

### DIFF
--- a/README.os390
+++ b/README.os390
@@ -15,315 +15,213 @@ on z/OS Unix System Services.
 
 =head1 DESCRIPTION
 
-This is a ported Perl for z/OS. It has been tested on z/OS 2.4 and
-should work fine with z/OS 2.5.
-It may work on other versions or releases, but those are
-the ones it has been tested on.
+Perl on z/OS has been tested on z/OS 3.1.
+It may work on other versions or releases.
 
-The native character set for z/OS is EBCDIC, but it can also run in ASCII mode.
-Perl can support either, but you have to compile it explicitly for one or the
-other.  You could have both an ASCII perl, and an EBCDIC perl on the same
-machine.  If you use ASCII mode and an ASCII perl, the Encode module shipped
-with perl can be used to translate files from various EBCDIC code pages for
-handling by perl, and then back on output
+The native character set for z/OS is EBCDIC (code page 1047 in North America),
+but recent OS releases have added the ability for individual processes to run
+in ASCII mode.  This mode works reasonably well, but there can be glitches.  It
+is under active development by IBM.
 
-This document describes how to build a 64-bit Dynamic Perl, either ASCII or
-EBCDIC.  You can interactively choose other configurations, as well as many
-other options in the Configure script that is run as part of the build
-process.  You may need to carry out some system configuration tasks before
-running Configure, as detailed below.
+For background on the ASCII vs EBCDIC modes, see
+L<https://makingdeveloperslivesbetter.wordpress.com/2022/01/07/is-z-os-ascii-or-ebcdic-yes/>
+
+Perl can support either mode, but you have to compile it explicitly for one or
+the other.  You could have both an ASCII perl, and an EBCDIC perl on the same
+machine.  If you use an ASCII perl, the Encode module shipped with perl can be
+used to translate files from various EBCDIC code pages for handling by perl,
+and then back on output.  The C<iconv> command in z/OS, may also be useful.
+
+z/OS has a native shell much like C<ksh> or C<bash>, and many commands that are
+similar to ones in Linux, such as C<sed>.  Available options for these may
+differ from the Linux ones.  But not many Open Source tools that a Linux user
+might be accustomed to using come with base z/OS.
+
+However, there is now an B<Open Source for z/OS> initiative to bring many such
+tools to z/OS users.  L<https://zopen-community> brings you to its landing
+page.  If an ASCII perl is sufficient for your needs, you should obtain it
+through them, at L<https://zopen-community/perlport>.
+
+There aren't any known 32-bit z/OS systems in existence anymore, so this
+document describes how to build a 64-bit EBCDIC Perl.
+
+Most CPAN modules have been written assuming ASCII.  They may or may not work
+on EBCDIC.  What we have found is that many do work, but may not appear to pass
+all their tests.  They can be used in the areas that they do work in.  Also the
+failure may not actually be a real failure, but a problem with the test.  This
+is because the typical test compares results with expected values which the
+test's author often hard-coded assuming ASCII.  For example, if you do a plain
+C<sort>, ASCII will have the digits first, uppercase letters next, and
+lowercase last.  EBCDIC sorts the opposite.  If your application really does
+need the ASCII ordering, the module won't give the proper results; but often
+you just need a consistent sorting, and for that purpose the module works
+perfectly well.
+
+Perl itself is shipped with some CPAN modules included.  Some of these do not
+work well on EBCDIC, and therefore testing of them is suppressed.  You can see
+which by examining F<t/TEST> and searching for EBCDIC.  Fixing these is under
+active development.
 
 =head2 Tools
 
-You will want to get GNU make 4.1 or later. GNU make can be downloaded from a
-port that Rocket Software provides.  You will need the z/OS c99 compiler from
-IBM (though xlc in c99 mode without optimization turned on works in EBCDIC).
+The tools required for building perl are available as:
 
-If you want the latest development version of Perl, you will need git.
-You can use git on another platform and transfer the result via sftp or ftp to
-z/OS.  But there is a z/OS native git client port available through Rocket
-Software.
+=over
 
-You may also need the gunzip client port that Rocket Software provides to unzip
-any zipped tarball you upload to z/OS.
+=item * native commands on z/OS
 
-=head2 Building a 64-bit Dynamic ASCII Perl
+z/OS has versions of many tools that come with the Linux OS.  Some of these
+don't have as many options as replacements available in the next group:
 
-For building from an official stable release of Perl, go to
-L<https://www.perl.org/get.html> and choose any one of the
-"Download latest stable source" buttons.  This will get you a tarball.  The
-name of that tarball will be something like 'perl-V.R.M,tar,gz', where V.R.M is
-the version/release/modification of the perl you are downloading. Do
+=item * through the zopen community
+
+C<gunzip> and C<clang> for example.  Also you can get C<bash> itself.
+
+=item * at no cost from IBM
+
+L<https://www.ibm.com/products/open-enterprise-foundation-zos>.  These
+include GNU make, which you will need.
+
+=back
+
+=head2 Building EBCDIC Perl on z/OS
+
+=head3 Getting perl source
+
+You'll first need a tarball.  At the moment this is written, there are no
+EBCDIC tarballs published, but it is easy to create one given that you have
+access to a system with any relatively modern perl.
+
+Then get an ASCII release tarball.  Choose one of the following:
+
+=over 4
+
+=item Official stable release
+
+Go to L<https://www.perl.org/get.html> and choose any one of the "Download
+latest Linuxy stable source" buttons.  The name of that tarball will be
+something like I<perl-V.R.M,tar,gz>, where V.R.M is the
+version/release/modification of the perl you are downloading.  Do
 
   gunzip perl-V.R.M.tar.gz
-
-Then one of:
-
-  tar -xvf perl-V.R.M.tar
-
   pax -r -f perl-V.R.M.tar
 
-Either of these will create the source directory.  You can rename it to
-whatever you like; for these instructions, 'perl' is assumed to be the name.
+This will create a directory named I<perl-V.R.M>, which you can rename to be
+whatever you want.  The instructions below assume you choose F<perl>.
 
-If instead you want the latest unstable development release, using the native
-git on z/OS, clone Perl:
+=item Development release
+
+If instead you want the latest unstable development release, clone Perl:
 
   git clone https://github.com/Perl/perl5.git perl
 
-Either way, once you have a 'perl' directory containing the source, cd into it,
-and tag all the code as ASCII:
+=back
+
+Either way, after getting the C<perl> directory populated, do
 
   cd perl
-  chtag -R -h -t -cISO8859-1 *
+  perl Porting/makerel -c -e
 
-Configure the build environment as 64-bit, Dynamic, ASCII, development,
-deploying it to F</usr/local/perl/ascii>:
+This will use whatever perl already is on the system to create an EBCDIC
+tarball named I<perl-V.R.M.tar.gz>.
 
-  export PATH=$PWD:$PATH
-  export LIBPATH=$PWD:$PATH
-  ./Configure -Dprefix=/usr/local/perl/ascii -des -Dusedevel \
-        -Duse64bitall -Dusedl
+Use C<scp> or C<sftp> to copy the tarball to the target z/OS system. Then, from
+the directory where it is located, do
 
-If you are building from a stable source, you don't need "-Dusedevel".
-(If you run Configure without options, it will interactively ask you about
-every possible option based on its probing of what's available on your
-particular machine, so you can choose as you go along.)
-
-Run GNU make to build Perl
-
-  make
-
-Run tests to ensure Perl is working correctly. Currently, there are about a
-dozen failing tests out of nearly 2500
-
-  make test_harness
-
-Install Perl into F</usr/local/perl/ascii>:
-
-  make install
-
-=head2 Building a 64-bit Dynamic EBCDIC Perl
-
-You will need a working perl on some box with connectivity to the destination
-machine.  On z/OS, it could be an ASCII perl, or a previous EBCDIC one.
-Many machines will already have a pre-built perl already running, or one can
-easily be downloaded from L<https://www.perl.org/get.html>.
-
-Follow the directions above in "Building a 64-bit Dynamic ASCII Perl" as far as
-getting a populated 'perl' directory.  Then come back here to proceed.
-
-The downloaded perl will need to be converted to 1047 EBCDIC.  To do this:
-
-  cd perl
-  Porting/makerel -e
-
-If the Porting/makerel step fails with an error that it can not issue the tar
-command, proceed to issue the command interactively, where V.R.M is the
-version/release/modification of Perl you are uploading:
-
-  cd ../
-  tar cf -  --format=ustar perl-V.R.M | gzip --best > perl-V.R.M.tar.gz
-
-Use sftp to upload the zipped tar file to z/OS:
-
-  sftp <your system>
-  cd /tmp
-  put perl-V.R.M.tar.gz
-
-Unzip and untar the zipped tar file on z/OS:
-
-  cd /tmp
   gunzip perl-V.R.M.tar.gz
-
-Then one of:
-
-  tar -xvf perl-V.R.M.tar
-
   pax -r -f perl-V.R.M.tar
+  mv perl-V.R.M perl
+  cd perl
 
-You now have the source code for the EBCDIC Perl on z/OS and can proceed to
-build it. This is analagous to how you would build the code for ASCII, but
-note: you B<should not> tag the code but instead leave it untagged.
+=head3 Configuring perl
 
-Configure the build environment as 64-bit, Dynamic, native, development,
-deploying it to F</usr/local/perl/ebcdic>:
+Now it is time to Configure it to your needs.  If you need a dynamically
+loading perl (see below), first do:
 
   export PATH=$PWD:$PATH
-  export LIBPATH=$PWD:$PATH
-  ./Configure -Dprefix=/usr/local/perl/ebcdic -des -Dusedevel \
-        -Duse64bitall -Dusedl
+  export LIBPATH=$PWD:$LIBPATH
 
-If you are building from a stable source, you don't need "-Dusedevel".
-(If you run Configure without options, it will interactively ask you about
-every possible option based on its probing of what's available on your
-particular machine, so you can choose as you go along.)
+Then run Configure
 
-Run GNU make to build Perl
+  ./Configure -Dprefix=/path-to/install/directory -des \
+                                OTHER-OPTIONS-AS-BELOW
 
-  make
+C<-d> means to use the default configuration values.  This is important, as we
+have set those up specifically for z/OS.
 
-Run tests to ensure Perl is working correctly.
+C<-e> means to continue on to the bitter end, not stopping the process early.
 
-  make test_harness
+C<-s> means to avoid unnecessary output verbiage.  This parameter is optional.
 
-You might also want to have GNU groff for OS/390 installed before
-running the "make install" step for Perl.
+If the perl is an unstable development release, add C<-Dusedevel> as one of the
+C<OTHER-OPTIONS-AS-BELOW>
 
-Install Perl into F</usr/local/perl/ebcdic>:
+If you think you may want to debug the perl, add C<-DDEBUGGING -Aoptimize=-g3
+-Aoptimize=-ggdb3>.
 
-  make install
+To silence some unnecessary compilation warnings, you can add
+C<-Accflags=-Wno-deprecated>.
 
-EBCDIC Perl is still a work in progress.  All the core code works as far as we
-know, but various modules you might want to download from CPAN do not.  The
-failures range from very minor to catastrophic.  Many of them are simply bugs
-in the tests, with the module actually working properly.  This happens because,
-for example, the test is coded to expect a certain character ASCII code point;
-when it gets the EBCDIC value back instead, it complains.  But the code
-actually worked.  Other potential failures that aren't really failures stem
-from checksums coming out differently, since C<A>, for example, has a different
-bit representation between the character sets.  A test that is expecting the
-ASCII value will show failure, even if the module is working perfectly.  Also
-in sorting, uppercase letters come before lowercase letters on ASCII systems;
-the reverse on EBCDIC.
+If you will want to use modules from CPAN (like C<DBI> (and C<DBD>s),
+C<JSON::XS>, and C<Text::CSV_XS>), consider using dynamic loading.  This isn't
+necessary if all such modules you might want are written only in Perl, but if
+some of them are compiled (they contain XS code), you'll either need to
+recompile all of perl when you add one, or set it up initially to use dynamic
+loading.  To do this, add C<-Dusedl> to the Configure options.
 
-Some CPAN modules come bundled with the downloaded perl.  And a few of those
-have yet to be fixed to pass on EBCDIC platforms.  As a result they are skipped
-when you run 'make test'.  The current list is:
-
- Archive::Tar
- Config::Perl::V
- CPAN::Meta
- CPAN::Meta::YAML
- Digest::MD5
- Digest::SHA
- Encode
- ExtUtils::MakeMaker
- ExtUtils::Manifest
- HTTP::Tiny
- IO::Compress
- IPC::Cmd
- JSON::PP
- libnet
- MIME::Base64
- Module::Metadata
- PerlIO::via-QuotedPrint
- Pod::Checker
- podlators
- Pod::Simple
- Socket
- Test::Harness
-
-See also F<hints/os390.sh> for other potential gotchas.
-
-=head2 Setup and utilities for Perl on OS/390
-
-This may also be a good time to ensure that your F</etc/protocol> file
-and either your F</etc/resolv.conf> or F</etc/hosts> files are in place.
-The IBM document that describes such USS system setup issues is
-"z/OS UNIX System Services Planning"
-
-For successful testing you may need to turn on the sticky bit for your
-world readable /tmp directory if you have not already done so (see man chmod).
-
-=head2 Useful files for trouble-shooting
-
-If your configuration is failing, read hints/os390.sh
-This file provides z/OS specific options to direct the build process.
-
-=head3 Shell
-
-A message of the form:
+When Configure is run using the z/OS native shell, you'll see a message like
 
  (I see you are using the Korn shell.  Some ksh's blow up on Configure,
  mainly on older exotic systems.  If yours does, try the Bourne shell
  instead.)
 
-is nothing to worry about at all.
+The native shell looks like C<ksh>, and it works fine, so just ignore the
+message.
 
-=head3 Dynamic loading
+F<Configure> currently will output errors in finding the header dependencies
+various object files have.  This just means that they may be recompiled
+unnecessarily.
 
-Dynamic loading is required if you want to use XS modules from CPAN (like
-DBI (and DBD's), JSON::XS, and Text::CSV_XS) or update CORE modules from
-CPAN with newer versions (like Encode) without rebuilding all of the perl
-binary.
+=head3 Building perl
 
-The instructions above will create a dynamic Perl. If you do not want to
-use dynamic loading, remove the -Dusedl option.
-See the comments in hints/os390.sh for more information on dynamic loading.
+Run GNU make to build Perl
 
-=head3 Optimizing
+  make
 
-Optimization has not been turned on yet. There may be issues if Perl
-is optimized.
+This will likely crash in making the Encode module.  To work around that,
+execute the following command
 
-=head2 Build Anomalies with Perl on OS/390
+ chtag -tc IBM-1047 cpan/Encode/Makefile
 
-"Out of memory!" messages during the build of Perl are most often fixed
-by re building the GNU make utility for OS/390 from a source code kit.
+and rerun C<make>.
 
-Within USS your F</etc/profile> or F<$HOME/.profile> may limit your ulimit
-settings.  Check that the following command returns reasonable values:
+=head3 Testing perl
 
-    ulimit -a
+  TEST_JOBS=n make test_harness
 
-To conserve memory you should have your compiler modules loaded into the
-Link Pack Area (LPA/ELPA) rather than in a link list or step lib.
+where I<n> is the number of tests to run in parallel.  On hardware that is
+single core, 2 or 3 work well.  A common value (if you aren't crowding out
+other users) is to set I<n> to twice the number of cores available, plus 1.
 
-If the compiler complains of syntax errors during the build of the
-Socket extension then be sure to fix the syntax error in the system
-header /usr/include/sys/socket.h.
+Some tests currently fail.  The only ones that are real known errors are
+in F<io/socket.t>.
 
-=head2 Testing Anomalies with Perl on OS/390
+The failing tests in C<Test-Simple>, C<Pod-Html>,
+F<op/signatures>, and F<io/nargv.t> are false alarms.
 
-The "make test" step runs a Perl Verification Procedure, usually before
-installation.  You might encounter STDERR messages even during a successful
-run of "make test".  Here is a guide to some of the more commonly seen
-anomalies:
+=head3 Installing perl
 
-=head3 Out of Memory (31-bit only)
+ make install
 
-Out of memory problems should not be an issue, unless you are attempting to build
-a 31-bit Perl.
+will install perl into the directory you gave in the command
 
-If you _are_ building a 31-bit Perl, the constrained environment may mean you
-need to change memory options for Perl.
-In addition to the comments
-above on memory limitations it is also worth checking for _CEE_RUNOPTS
-in your environment. Perl now has (in miniperlmain.c) a C #pragma for 31-bit only
-to set CEE run options, but the environment variable wins.
+  ./Configure -Dprefix=/path-to/install/directory ...
 
-The 31-bit C code asks for:
+=head2 Optimization
 
- #pragma runopts(HEAP(2M,500K,ANYWHERE,KEEP,8K,4K) STACK(,,ANY,) ALL31(ON))
+Optimization has not been tested.
 
-The important parts of that are the second argument (the increment) to HEAP,
-and allowing the stack to be "Above the (16M) line". If the heap
-increment is too small then when perl (for example loading unicode/Name.pl) tries
-to create a "big" (400K+) string it cannot fit in a single segment
-and you get "Out of Memory!" - even if there is still plenty of memory
-available.
-
-A related issue is use with perl's malloc. Perl's malloc uses C<sbrk()>
-to get memory, and C<sbrk()> is limited to the first allocation so in this
-case something like:
-
-  HEAP(8M,500K,ANYWHERE,KEEP,8K,4K)
-
-is needed to get through the test suite.
-
-=head2 Usage Hints for Perl on z/OS
-
-When using Perl on z/OS please keep in mind that the EBCDIC and ASCII
-character sets are different.  See L<perlebcdic> for more on such character
-set issues.  Perl builtin functions that may behave differently under
-EBCDIC are also mentioned in the perlport.pod document.
-
-If you are having trouble with square brackets then consider switching your
-rlogin or telnet client.  Try to avoid older 3270 emulators and ISHELL for
-working with Perl on USS.
-
-=head2 Modules and Extensions for Perl on z/OS (Static Only)
+=head2 Installing other modules
 
 Pure Perl (that is non XS) modules may be installed via the usual:
 
@@ -346,36 +244,12 @@ building a static perl + XS extension boils down to:
     make install
     make -f Makefile.aperl inst_perl MAP_TARGET=perl
 
-=head2 Running Perl on z/OS
+=head2 Running EBCDIC Perl on z/OS
 
 To run the 64-bit Dynamic Perl environment, update your PATH and LIBPATH
 to include the location you installed Perl into, and then run the perl you
 installed as perlV.R.M where V/R/M is the Version/Release/Modification level
 of the current development level.
-If you are running the ASCII/EBCDIC Bi-Modal Perl environment, you also need to
-set up your ASCII/EBCDIC Bi-Modal environment variables, and ensure any Perl
-source code you run is tagged appropriately as ASCII or EBCDIC using
-"chtag -t -c<CCSID>":
-
-=over 
-
-=item For ASCII Only:
-
- export _BPXK_AUTOCVT=ON
- export _CEE_RUNOPTS="FILETAG(AUTOCVT,AUTOTAG),POSIX(ON)"
- export _TAG_REDIR_ERR="txt"
- export _TAG_REDIR_IN="txt"
- export _TAG_REDIR_OUT="txt"
-
-=item For ASCII or EBCDIC:
-
- export PATH=/usr/local/perl/ascii:$PATH
- export LIBPATH=/usr/local/perl/ascii/lib:$LIBPATH
- perlV.R.M args
-
-=back
-
-If tcsh is your login shell then use the setenv command.
 
 =head1 AUTHORS
 
@@ -388,13 +262,9 @@ Thanks to John Goodyear for dynamic loading help.
 Mike Fulton and Karl Williamson have provided updates for UTF8, DLL, 64-bit and
 ASCII/EBCDIC Bi-Modal support
 
-=head1 OTHER SITES
-
-L<https://github.com/ZOSOpenTools/perlport/> provides documentation and tools
-for building various z/OS Perl configurations and has some useful tools in the
-'bin' directory you may want to use for building z/OS Perl yourself.
-
 =head1 HISTORY
+
+Updated 25 May 2026 to reflect Perl v5.44 and
 
 Updated 24 December 2021 to enable initial ASCII support
 
@@ -417,3 +287,6 @@ release of Perl.
 
 =cut
 
+(A blog
+post about its early development is here
+L<https://makingdeveloperslivesbetter.wordpress.com/2022/01/18/enabling-open-source-for-z-os-perl/>.)

--- a/ext/Errno/Errno_pm.PL
+++ b/ext/Errno/Errno_pm.PL
@@ -2,7 +2,7 @@ use ExtUtils::MakeMaker;
 use Config;
 use strict;
 
-our $VERSION = "1.38";
+our $VERSION = "1.39";
 
 my %err = ();
 
@@ -58,7 +58,8 @@ sub process_file {
             warn "Cannot open '$file'";
             return;
 	}     
-    } elsif ($Config{gccversion} ne '' && $^O ne 'darwin' ) {
+    }
+    elsif ($Config{gccversion} ne '' && $^O ne 'darwin' && $^O ne 'os390') {
 	# With the -dM option, gcc outputs every #define it finds
 	unless(open(FH,"$Config{cc} -E -dM $Config{cppflags} $file |")) {
             warn "Cannot open '$file'";
@@ -245,7 +246,16 @@ sub write_errno_pm {
 		$inhibit_linemarkers;
 	    open(CPPO,"$cpp errno.c |") or
 		die "Cannot run '$cpp errno.c'";
-	} else {
+	} elsif ($^O eq 'os390') {
+	    # XXX This could be because the pipe is reading with the wrong
+	    # character set, so there may be a better way to solve this
+	    my $cpp = default_cpp() . $inhibit_linemarkers;
+            $cpp =~ s/ $Config{cppminus} \s* $ //x;
+	    system "$cpp errno.c > errno.i" ;
+	    open(CPPO,"<", 'errno.i') or die "Cannot open errno.i";
+            unlink 'errno.i';
+	}
+	else {
 	    my $cpp = default_cpp() . $inhibit_linemarkers;
 	    open(CPPO,"$cpp < errno.c |")
 		or die "Cannot exec $cpp";

--- a/hints/os390.sh
+++ b/hints/os390.sh
@@ -17,26 +17,19 @@
 # z/OS 2.4 Support added thanks to:
 #     Mike Fulton
 #     Karl Williamson
+#     Igor Todorovsky
 #
-# The z/OS 'cc' and 'ld' are insufficient for our needs, so we use c99 instead
-# c99 has compiler options specified via standard Unix-style options, but some
-# options need to be specified using -Wc,<compiler-option> or -Wl,<link-option>
-me=$0
-case "$cc" in
-'') cc='c99' ;;
-esac
-case "$ld" in
-'') ld='c99' ;;
-esac
-
 # Prepend your favorites with Configure -Dccflags=your_favorites
 
 # This overrides the name the compiler was called with.  'ext' is required for
 # "unicode literals" to be enabled
-def_os390_cflags='-qlanglvl=extc1x';
+def_os390_cflags='-std=c99 -D_EXT -fvisibility=default -D_POSIX_C_SOURCE=200809L -D_XPLATFORM_SOURCE=1';
 
 # For #ifdefs in code
 def_os390_defs="-DOS390 -DZOS";
+
+def_os390_defs="$def_os390_defs -Duserelocatableinc -Duse64bitall"
+use64bitall=define
 
 # Turn on POSIX compatibility modes
 #  https://www.ibm.com/support/knowledgecenter/SSLTBW_2.4.0/com.ibm.zos.v2r4.bpxbd00/ftms.htm
@@ -46,31 +39,41 @@ def_os390_defs="$def_os390_defs -D_ALL_SOURCE";
 # For 64-bit addressing mode, the standard linkage works well
 
 case "$use64bitall" in
-'')
-  def_os390_cflags="$def_os390_cflags -qxplink"
-  def_os390_cccdlflags="-qxplink"
-  def_os390_ldflags="-qxplink"
-# defines a BSD-like socket interface for the function prototypes and structures involved (not required with 64-bit)
-  def_os390_defs="$def_os390_defs -D_OE_SOCKETS";
+'') echo "32-bit compilation not currently supported" >&4
+    # Though it could easily be added.  IBM says no such hardware now exists
+    exit 1;
   ;;
 *)
-  def_os390_cflags="$def_os390_cflags -Wc,lp64"
-  def_os390_cccdlflags="$def_os390_cflags -Wl,lp64"
-  def_os390_ldflags="-Wl,lp64"
+  # Use clang for 64-bit
+  case "$cc" in
+  '') cc='clang' ;;
+  esac
+  case "$ld" in
+  '') ld='clang' ;;
+  esac
+  def_os390_cflags="$def_os390_cflags -m64"
+  def_os390_cccdlflags="$def_os390_cflags $def_os390_cflags"
+  def_os390_ldflags="-Wl,-bedit=no -m64"
 esac
+
+arch_main_objs=""
+archobjs="os390.o"
+
+# Help make find os390.c
+test -h os390.c || ln -s os390/os390.c os390.c
 
 myfirstchar=$(od -A n -N 1 -t x $me | xargs | tr [:lower:] [:upper:] | tr -d 0)
 if [ "${myfirstchar}" = "23" ]; then # 23 is '#' in ASCII
   unset ebcdic
-  def_os390_cflags="$def_os390_cflags -qascii"
+  def_os390_cflags="$def_os390_cflags -fzos-le-char-mode=ascii -I /data/zopen/usr/local/include"
 else
   ebcdic=true
+  def_os390_cflags="$def_os390_cflags -fzos-le-char-mode=ebcdic"
+  def_os390_cflags="$def_os390_cflags -fexec-charset=IBM-1047"
 fi
 
 # Export all externally defined functions and variables in the compilation
 # unit so that a DLL application can use them.
-def_os390_cflags="$def_os390_cflags -qexportall";
-def_os390_cccdlflags="$def_os390_cccdlflags -qexportall"
 
 # 3296= #include file not found;
 # 4108= The use of keyword &1 is non-portable
@@ -79,9 +82,8 @@ def_os390_cccdlflags="$def_os390_cccdlflags -qexportall"
 #          INFORMATIONAL CCN4108 ./proto.h:4534 The use of keyword '__attribute__' is non-portable.
 # 3159= Bit field type specified for &1 is not valid. Type &2 assumed.
 #       We do not care about this warning - the bit field is 1 bit and is being specified on something smaller than an int
-def_os390_cflags="$def_os390_cflags -qhaltonmsg=3296:4108 -qsuppress=CCN3159 -qfloat=ieee"
 
-def_os390_defs="$def_os390_defs -DMAXSIG=39 -DNSIG=39";     # maximum signal number; not furnished by IBM
+def_os390_defs="$def_os390_defs -DMAXSIG=42 -DNSIG=42";     # maximum signal number; not furnished by IBM
 def_os390_defs="$def_os390_defs -DOEMVS";   # is used in place of #ifdef __MVS__
 
 # ensure that the OS/390 yacc generated parser is reentrant.
@@ -97,7 +99,7 @@ def_os390_defs="$def_os390_defs -D_OPEN_THREADS=3 -D_UNIX03_SOURCE=1 -D_AE_BIMOD
 # Combine -D with cflags
 case "$ccflags" in
 '') ccflags="$def_os390_cflags $def_os390_defs"  ;;
-*)  ccflags="$ccflags $def_os390_cflags $def_os390_defs" ;;
+*)  ccflags="$ccflags $cppflags $def_os390_cflags $def_os390_defs" ;;
 esac
 
 # Turning on optimization causes perl to not even compile from miniperl.  You
@@ -109,7 +111,7 @@ esac
 # To link via definition side decks we need the dll option
 # You can override this with Configure -Ucccdlflags or somesuch.
 case "$cccdlflags" in
-'') cccdlflags="$def_os390_cccdlflags -Wl,dll";;
+'') cccdlflags="$def_os390_cccdlflags -shared";;
 esac
 
 case "$so" in
@@ -220,26 +222,19 @@ case "$archname" in
 '') archname="$osname" ;;
 esac
 
-# We have our own cppstdin script.  This is not a variable since
-# Configure sees the presence of the script file.
-# We put system header -D definitions in so that Configure
-# can find the shmat() prototype in <sys/shm.h> and various
-# other things.  Unfortunately, cppflags occurs too late to be of
-# value external to the script.  This may need to be revisited
-#
-# khw believes some of this is obsolete.  DOLLARINNAMES allows '$' in variable
-# names, for whatever reason
-# NOLOC says to use the 1047 code page, and no locale
-case "$usedl" in
-define)
-echo 'cat >.$$.c; '"$cc"' -D_OE_SOCKETS -D_ALL_SOURCE -D_SHR_ENVIRON -E -Wc,"LANGLVL(DOLLARINNAMES)",NOLOC ${1+"$@"} .$$.c | fgrep -v "??="; rm .$$.c' > cppstdin
-   ;;
-*)
-echo 'cat >.$$.c; '"$cc"' -D_OE_SOCKETS -D_ALL_SOURCE -E -Wc,"LANGLVL(DOLLARINNAMES)",NOLOC ${1+"$@"} .$$.c | fgrep -v "??="; rm .$$.c' > cppstdin
-   ;;
-esac
+# Some header files on z/OS have trigraphs in them that clang doesn't handle
+# without this option.
+cppflags="-trigraphs"
 
-#
+# Suppress the trigraph warnings, and some headers have pragmas that clang
+# isn't familiar with
+def_os390_cflags="$def_os390_cflags -Wno-trigraphs -Wno-unknown-pragmas"
+
+# The compilation of shm.h that is supposed to show if that file includes a
+# prototype definition currently results in garbage (reason unknown) so the
+# grep fails.
+d_shmatprototype='define'
+
 # Note that Makefile.SH employs a bare yacc command to generate
 # perly.[hc], hence you may wish to:
 #

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -77,8 +77,8 @@ cpanp(1)
 CPANPLUS
 crypt(3)
 Crypt::PRNG
-Crypt::URandom
 Crypt::SysRandom
+Crypt::URandom
 ctime(3)
 curl(1)
 Dancer
@@ -429,7 +429,6 @@ pod/perlmacosx.pod	Verbatim line length including indents exceeds 78 by	3
 pod/perlmroapi.pod	? Should you be using L<...> instead of	1
 pod/perlos2.pod	? Should you be using L<...> instead of	1
 pod/perlos2.pod	Verbatim line length including indents exceeds 78 by	5
-pod/perlos390.pod	Verbatim line length including indents exceeds 78 by	1
 pod/perlperf.pod	Verbatim line length including indents exceeds 78 by	-1
 pod/perlrun.pod	Verbatim line length including indents exceeds 78 by	3
 pod/perlsolaris.pod	Verbatim line length including indents exceeds 78 by	-1


### PR DESCRIPTION
The Errno issue is a regression from 5.42, so should be a candidate for 5.44.0, and has been written so as to not affect any other platform.   The hints file can only affect z/OS.  The README affects no code.


* This set of changes does not require a perldelta entry.
