### PR TITLE
cpan/Archive-Tar - Update to version 3.10

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -129,8 +129,8 @@ our @IGNORABLE = qw(
 our %Modules = (
 
     'Archive::Tar' => {
-        'DISTRIBUTION' => 'BINGOS/Archive-Tar-3.04.tar.gz',
-        'SYNCINFO'     => 'mauke on Wed Mar 19 08:01:30 2025',
+        'DISTRIBUTION' => 'BINGOS/Archive-Tar-3.10.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Mon May 25 17:43:28 2026',
         'FILES'        => q[cpan/Archive-Tar],
         'BUGS'         => 'bug-archive-tar@rt.cpan.org',
         'EXCLUDED'     => [

--- a/cpan/Archive-Tar/lib/Archive/Tar.pm
+++ b/cpan/Archive-Tar/lib/Archive/Tar.pm
@@ -24,7 +24,7 @@ use strict;
 use vars qw[$DEBUG $error $VERSION $WARN $FOLLOW_SYMLINK $CHOWN $CHMOD
             $DO_NOT_USE_PREFIX $HAS_PERLIO $HAS_IO_STRING $SAME_PERMISSIONS
             $INSECURE_EXTRACT_MODE $ZERO_PAD_NUMBERS @ISA @EXPORT $RESOLVE_SYMLINK
-            $EXTRACT_BLOCK_SIZE
+            $EXTRACT_BLOCK_SIZE $EXTRACT_HARDLINK $MAX_FILE_SIZE
          ];
 
 @ISA                    = qw[Exporter];
@@ -32,7 +32,7 @@ use vars qw[$DEBUG $error $VERSION $WARN $FOLLOW_SYMLINK $CHOWN $CHMOD
 $DEBUG                  = 0;
 $WARN                   = 1;
 $FOLLOW_SYMLINK         = 0;
-$VERSION                = "3.04";
+$VERSION                = "3.10";
 $CHOWN                  = 1;
 $CHMOD                  = 1;
 $SAME_PERMISSIONS       = $> == 0 ? 1 : 0;
@@ -41,6 +41,8 @@ $INSECURE_EXTRACT_MODE  = 0;
 $ZERO_PAD_NUMBERS       = 0;
 $RESOLVE_SYMLINK        = $ENV{'PERL5_AT_RESOLVE_SYMLINK'} || 'speed';
 $EXTRACT_BLOCK_SIZE     = 1024 * 1024 * 1024;
+$EXTRACT_HARDLINK       = 0;
+$MAX_FILE_SIZE          = 1024 * 1024 * 1024;
 
 BEGIN {
     use Config;
@@ -443,6 +445,14 @@ sub _read_tar {
             }
 
             my $block = BLOCK_SIZE->( $entry->size );
+
+            if ( $MAX_FILE_SIZE && $entry->size > $MAX_FILE_SIZE ) {
+                $self->_error( qq[Entry '] . $entry->full_path .
+                    qq[' declared size ] . $entry->size .
+                    qq[ bytes exceeds \$Archive::Tar::MAX_FILE_SIZE ] .
+                    qq[($MAX_FILE_SIZE); refusing to allocate] );
+                next LOOP;
+            }
 
             $data = $entry->get_content_by_ref;
 
@@ -922,19 +932,19 @@ sub _extract_file {
     ### only update the timestamp if it's not a symlink; that will change the
     ### timestamp of the original. This addresses bug #33669: Could not update
     ### timestamp warning on symlinks
-    if( not -l $full ) {
+    if( not -l $full and not ( $entry->is_hardlink and ON_UNIX and $EXTRACT_HARDLINK ) ) {
         utime time, $entry->mtime - TIME_OFFSET, $full or
             $self->_error( qq[Could not update timestamp] );
     }
 
-    if( $CHOWN && CAN_CHOWN->() and not -l $full ) {
+    if( $CHOWN && CAN_CHOWN->() and not -l $full and not ( $entry->is_hardlink and ON_UNIX and $EXTRACT_HARDLINK ) ) {
         CORE::chown( $entry->uid, $entry->gid, $full ) or
             $self->_error( qq[Could not set uid/gid on '$full'] );
     }
 
     ### only chmod if we're allowed to, but never chmod symlinks, since they'll
     ### change the perms on the file they're linking too...
-    if( $CHMOD and not -l $full ) {
+    if( $CHMOD and not -l $full and not ( $entry->is_hardlink and ON_UNIX and $EXTRACT_HARDLINK ) ) {
         my $mode = $entry->mode;
         unless ($SAME_PERMISSIONS) {
             $mode &= ~(oct(7000) | umask);
@@ -954,6 +964,19 @@ sub _make_special_file {
     my $err;
 
     if( $entry->is_symlink ) {
+        if( !$INSECURE_EXTRACT_MODE ) {
+            my $linkname = $entry->linkname;
+            if( File::Spec->file_name_is_absolute($linkname) ) {
+                $self->_error( qq[Symlink '] . $entry->full_path .
+                    qq[' has absolute target. Not extracting under SECURE EXTRACT MODE] );
+                return;
+            }
+            if( grep { $_ eq '..' } File::Spec->splitdir($linkname) ) {
+                $self->_error( qq[Symlink '] . $entry->full_path .
+                    qq[' target attempts traversal. Not extracting under SECURE EXTRACT MODE] );
+                return;
+            }
+        }
         my $fail;
         if( ON_UNIX ) {
             symlink( $entry->linkname, $file ) or $fail++;
@@ -967,8 +990,25 @@ sub _make_special_file {
                 $entry->linkname .q[' failed] if $fail;
 
     } elsif ( $entry->is_hardlink ) {
+        if( !$INSECURE_EXTRACT_MODE ) {
+            my $linkname = $entry->linkname;
+            if( File::Spec->file_name_is_absolute($linkname) ) {
+                $self->_error( qq[Hardlink '] . $entry->full_path .
+                    qq[' has absolute target '$linkname'. Not extracting ] .
+                    qq[under SECURE EXTRACT MODE: extraction itself chmods ] .
+                    qq[the shared inode.] );
+                return;
+            }
+            if( grep { $_ eq '..' } File::Spec->splitdir($linkname) ) {
+                $self->_error( qq[Hardlink '] . $entry->full_path .
+                    qq[' target '$linkname' attempts traversal. Not ] .
+                    qq[extracting under SECURE EXTRACT MODE: extraction ] .
+                    qq[itself chmods the shared inode.] );
+                return;
+            }
+        }
         my $fail;
-        if( ON_UNIX ) {
+        if( ON_UNIX && $EXTRACT_HARDLINK ) {
             link( $entry->linkname, $file ) or $fail++;
 
         } else {
@@ -2118,6 +2158,12 @@ set this variable to C<true>.
 Note that this is a backwards incompatible change from version
 C<1.36> and before.
 
+=head2 $Archive::Tar::EXTRACT_HARDLINK
+
+Prior to version C<3.06> Archive::Tar would honour hardlinks in
+archives. Version C<3.06> and onwards will skip hardlinks unless
+this flag is set. Exercise caution when enabling this.
+
 =head2 $Archive::Tar::HAS_PERLIO
 
 This variable holds a boolean indicating if we currently have
@@ -2186,6 +2232,13 @@ writing files during extraction. It defaults to 1 GiB. Please note that this
 cannot be arbitrarily large since some operating systems limit the number of
 bytes that can be written in one call to C<write(2)>, so if this is too large,
 extraction may fail with an error.
+
+=head2 $Archive::Tar::MAX_FILE_SIZE
+
+This variable holds an upper bound on the per-entry declared size that
+C<Archive::Tar> will accept when reading an archive. Entries whose header
+claims a larger size are refused with an error before any read allocation.
+Defaults to 1 GiB. Set to 0 to disable the cap.
 
 =cut
 

--- a/cpan/Archive-Tar/lib/Archive/Tar/Constant.pm
+++ b/cpan/Archive-Tar/lib/Archive/Tar/Constant.pm
@@ -8,7 +8,7 @@ use vars qw[$VERSION @ISA @EXPORT];
 BEGIN {
     require Exporter;
 
-    $VERSION    = '3.04';
+    $VERSION    = '3.10';
     @ISA        = qw[Exporter];
 
     require Time::Local if $^O eq "MacOS";

--- a/cpan/Archive-Tar/lib/Archive/Tar/File.pm
+++ b/cpan/Archive-Tar/lib/Archive/Tar/File.pm
@@ -11,7 +11,7 @@ use Archive::Tar::Constant;
 
 use vars qw[@ISA $VERSION];
 #@ISA        = qw[Archive::Tar];
-$VERSION    = '3.04';
+$VERSION    = '3.10';
 
 ### set value to 1 to oct() it during the unpack ###
 

--- a/cpan/Archive-Tar/t/04_resolved_issues.t
+++ b/cpan/Archive-Tar/t/04_resolved_issues.t
@@ -220,6 +220,7 @@ if ($^O ne 'msys') # symlink tests fail on Windows/msys2
 		}
 
     { #use case 1 - in memory extraction
+      local $Archive::Tar::INSECURE_EXTRACT_MODE=1;
 			my $t=Archive::Tar->new;
 			$t->read( $archname );
 			my $r = eval{ $t->extract };
@@ -231,6 +232,7 @@ if ($^O ne 'msys') # symlink tests fail on Windows/msys2
 
 		{ #use case 2 - iter extraction
 		  #$DB::single = 2;
+      local $Archive::Tar::INSECURE_EXTRACT_MODE=1;
 			my $next=Archive::Tar->iter( $archname, 1 );
 			my $failed = 0;
 			#use Data::Dumper;


### PR DESCRIPTION
3.10  25/05/2026 (Stig Palmquist)
- Added MAX_FILE_SIZE setting, defaulting to 1GB, for extracting files

3.08  22/05/2026 (Stig Palmquist)
- Validate symlink and hardlink linkname in SECURE MODE

3.06  10/05/2026
- Hardlinks not extracted by default, added EXTRACT_HARDLINK flag
- If hardlinks are extracted, they are now subject to the same rules as symlinks with regards to chown and chmod