### PR TITLE
cpan/HTTP-Tiny - Update to version 0.094

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -641,8 +641,8 @@ our %Modules = (
     },
 
     'HTTP::Tiny' => {
-        'DISTRIBUTION' => 'HAARG/HTTP-Tiny-0.092.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Fri Jan  9 10:31:50 2026',
+        'DISTRIBUTION' => 'HAARG/HTTP-Tiny-0.094.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Mon May 25 17:49:36 2026',
         'FILES'        => q[cpan/HTTP-Tiny],
         'EXCLUDED'     => [
             't/00-report-prereqs.t',

--- a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+++ b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 # ABSTRACT: A small, simple, correct HTTP/1.1 client
 
-our $VERSION = '0.092';
+our $VERSION = '0.094';
 
 sub _croak { require Carp; Carp::croak(@_) }
 
@@ -1396,6 +1396,8 @@ sub write_header_lines {
         my $field_name = $HeaderCase{$k};
         my $v = $headers->{$k};
         for (ref $v eq 'ARRAY' ? @$v : $v) {
+            die(qq/Invalid HTTP header field value ($field_name): / . $Printable->($_). "\n")
+              unless $_ eq '' || /\A $Field_Content \z/xo;
             $_ = '' unless defined $_;
             $buf .= "$field_name: $_\x0D\x0A";
         }
@@ -1587,6 +1589,12 @@ sub write_request_header {
     @_ == 5 || die(q/Usage: $handle->write_request_header(method, request_uri, headers, header_case)/ . "\n");
     my ($self, $method, $request_uri, $headers, $header_case) = @_;
 
+    die (q/Invalid characters in Request-URI /. $Printable->($request_uri). "\n")
+      if $request_uri =~ /[\x00-\x20\x7F]/;
+
+    die (q/Invalid characters in Method /. $Printable->($method). "\n")
+      if $method =~ /[\x00-\x20\x7F]/;
+
     return $self->write_header_lines($headers, $header_case, "$method $request_uri HTTP/1.1\x0D\x0A");
 }
 
@@ -1768,7 +1776,7 @@ HTTP::Tiny - A small, simple, correct HTTP/1.1 client
 
 =head1 VERSION
 
-version 0.092
+version 0.094
 
 =head1 SYNOPSIS
 
@@ -2628,7 +2636,7 @@ Xavier Guimard <yadd@debian.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2025 by Christian Hansen.
+This software is copyright (c) 2026 by Christian Hansen.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/cpan/HTTP-Tiny/t/020_headers.t
+++ b/cpan/HTTP-Tiny/t/020_headers.t
@@ -59,3 +59,58 @@ use HTTP::Tiny;
     is_deeply($handle->read_header_lines, $headers, "roundtrip header lines");
 }
 
+{
+    my $fh     = tmpfile();
+    my $handle = HTTP::Tiny::Handle->new(fh => $fh);
+    eval { $handle->write_header_lines({ range => "bytes=13-37${CRLF}X-Injected: foo" }) };
+    like($@, qr/Invalid HTTP header field value \(Range\)/,
+         "reject CRLF in control field value");
+}
+
+{
+    my $fh     = tmpfile();
+    my $handle = HTTP::Tiny::Handle->new(fh => $fh);
+    eval { $handle->write_header_lines({ "X-Foo-Bar" => "foo${CRLF}X-Injected: foo" }) };
+    like($@, qr/Invalid HTTP header field value \(X-Foo-Bar\)/,
+         "reject CRLF in other header value");
+}
+
+{
+    my $fh     = tmpfile();
+    my $handle = HTTP::Tiny::Handle->new(fh => $fh);
+    eval { $handle->write_request_header("GET${CRLF}", "/foo", {}, {}) };
+    like($@, qr/Invalid characters in Method/,
+         "->write_request_header() reject CRLF in method");
+}
+
+{
+    my $fh     = tmpfile();
+    my $handle = HTTP::Tiny::Handle->new(fh => $fh);
+    eval { $handle->write_request_header("GET\x00", "/foo", {}, {}) };
+    like($@, qr/Invalid characters in Method/,
+         "->write_request_header() reject nullbyte in method");
+}
+
+{
+    my $fh     = tmpfile();
+    my $handle = HTTP::Tiny::Handle->new(fh => $fh);
+    eval { $handle->write_request_header("GET ", "/foo", {}, {}) };
+    like($@, qr/Invalid characters in Method/,
+         "->write_request_header() reject trailing space in method");
+}
+
+{
+    my $fh     = tmpfile();
+    my $handle = HTTP::Tiny::Handle->new(fh => $fh);
+    eval { $handle->write_request_header("GET", "/foo${CRLF}Foo: 1", {}, {}) };
+    like($@, qr/Invalid characters in Request-URI/,
+         "->write_request_header() reject CRLF in request-uri");
+}
+
+{
+    my $fh     = tmpfile();
+    my $handle = HTTP::Tiny::Handle->new(fh => $fh);
+    eval { $handle->write_request_header("GET", "/foo bar", {}, {}) };
+    like($@, qr/Invalid characters in Request-URI/,
+         "->write_request_header() reject space in request-uri");
+}


### PR DESCRIPTION
0.094     2026-05-17 10:31:00+02:00 Europe/Brussels
    - No changes from 0.093-TRIAL

0.093     2026-05-11 17:18:12+02:00 Europe/Brussels (TRIAL RELEASE)
    - fix to prevent invalid characters in all headers, and prevent header
      smuggling (CVE-2026-7010)

@ap @Leont @leonerd PSC should evaluate whether this p.r. changes behavior such that it should be deferred to 5.45 dev cycle.