### PR TITLE
[COPY OF #24434] pp_accept: fix potential out-of-bounds read on oversized accept() addrlen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -517,6 +517,7 @@ Georg Schwarz                  <geos@epost.de>
 George Greer                   <perl@greerga.m-l.org>
 George Hartzell                <georgewh@gene.com>
 George Necula                  <necula@eecs.berkeley.edu>
+Georgij Tsarin                 <68424751+crystarm@users.noreply.github.com>
 Geraint A Edwards              <gedge@serf.org>
 Gerard Goossen                 <gerard@ggoossen.net>
 Gerben Wierda                  <G.C.Th.Wierda@AWT.nl>

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -6453,6 +6453,13 @@ so there can't be any left to fill later parameters.
 overload it: Perl refuses to use the object's underlying structure
 for the smart match.
 
+=item Socket address truncated in %s()
+
+(W io) The operating system reported a socket address length larger than
+Perl's supplied buffer for the C<%s()> call.  Perl truncated the address
+to the buffer size to avoid reading or writing past the end of that
+buffer.
+
 =item Sorry, hash keys must be smaller than 2**31 bytes
 
 (F) You tried to create a hash containing a very large key, where "very

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2014,6 +2014,7 @@ PP_wrapped(pp_sysread, 0, 1)
         if (bufsize >= 256)
             bufsize = 255;
 #endif
+        const Sock_size_t namesize = bufsize;
         buffer = SvGROW(bufsv, (STRLEN)(length+1));
         /* 'offset' means 'flags' here */
         count = PerlSock_recvfrom(fd, buffer, length, offset,
@@ -2041,6 +2042,9 @@ PP_wrapped(pp_sysread, 0, 1)
         if (bufsize == sizeof namebuf)
             bufsize = 0;
 #endif
+        /* recvfrom() may return a length larger than the supplied buffer. */
+        if (bufsize > namesize)
+            bufsize = namesize;
         sv_setpvn(TARG, namebuf, bufsize);
         PUSHs(TARG);
         RETURN;
@@ -2834,6 +2838,7 @@ PP_wrapped(pp_accept, 2, 0)
 #else
     Sock_size_t len = sizeof namebuf;
 #endif
+    const Sock_size_t namesize = len;
     GV * const ggv = MUTABLE_GV(POPs);
     GV * const ngv = MUTABLE_GV(POPs);
     int fd;
@@ -2872,6 +2877,10 @@ PP_wrapped(pp_accept, 2, 0)
 #ifdef __SCO_VERSION__
     len = sizeof (struct sockaddr_in); /* OpenUNIX 8 somehow truncates info */
 #endif
+
+    /* accept() may return a length larger than the supplied buffer. */
+    if (len > namesize)
+        len = namesize;
 
     PUSHp(namebuf, len);
     RETURN;
@@ -2998,6 +3007,7 @@ PP_wrapped(pp_getpeername, 1, 0)
 #else
     len = 256;
 #endif
+    const Sock_size_t namesize = len;
     sv = sv_2mortal(newSV(len+1));
     (void)SvPOK_only(sv);
     SvCUR_set(sv, len);
@@ -3032,6 +3042,10 @@ PP_wrapped(pp_getpeername, 1, 0)
     if (len == BOGUS_GETNAME_RETURN)
         len = sizeof(struct sockaddr);
 #endif
+    /* getpeername() and getsockname() may return a length larger than the
+     * supplied buffer. */
+    if (len > namesize)
+        len = namesize;
     SvCUR_set(sv, len);
     *SvEND(sv) ='\0';
     PUSHs(sv);

--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2014,6 +2014,7 @@ PP_wrapped(pp_sysread, 0, 1)
         if (bufsize >= 256)
             bufsize = 255;
 #endif
+        const Sock_size_t namesize = bufsize;
         buffer = SvGROW(bufsv, (STRLEN)(length+1));
         /* 'offset' means 'flags' here */
         count = PerlSock_recvfrom(fd, buffer, length, offset,
@@ -2041,6 +2042,12 @@ PP_wrapped(pp_sysread, 0, 1)
         if (bufsize == sizeof namebuf)
             bufsize = 0;
 #endif
+        /* recvfrom() may return a length larger than the supplied buffer. */
+        if (bufsize > namesize) {
+            ck_warner(packWARN(WARN_IO),
+                      "Socket address truncated in %s()", "recvfrom");
+            bufsize = namesize;
+        }
         sv_setpvn(TARG, namebuf, bufsize);
         PUSHs(TARG);
         RETURN;
@@ -2834,6 +2841,7 @@ PP_wrapped(pp_accept, 2, 0)
 #else
     Sock_size_t len = sizeof namebuf;
 #endif
+    const Sock_size_t namesize = len;
     GV * const ggv = MUTABLE_GV(POPs);
     GV * const ngv = MUTABLE_GV(POPs);
     int fd;
@@ -2872,6 +2880,13 @@ PP_wrapped(pp_accept, 2, 0)
 #ifdef __SCO_VERSION__
     len = sizeof (struct sockaddr_in); /* OpenUNIX 8 somehow truncates info */
 #endif
+
+    /* accept() may return a length larger than the supplied buffer. */
+    if (len > namesize) {
+        ck_warner(packWARN(WARN_IO),
+                  "Socket address truncated in %s()", "accept");
+        len = namesize;
+    }
 
     PUSHp(namebuf, len);
     RETURN;
@@ -2987,6 +3002,7 @@ PP_wrapped(pp_getpeername, 1, 0)
     GV * const gv = MUTABLE_GV(POPs);
     IO * const io = GvIOn(gv);
     Sock_size_t len;
+    Sock_size_t namesize;
     SV *sv;
     int fd;
 
@@ -2998,6 +3014,7 @@ PP_wrapped(pp_getpeername, 1, 0)
 #else
     len = 256;
 #endif
+    namesize = len;
     sv = sv_2mortal(newSV(len+1));
     (void)SvPOK_only(sv);
     SvCUR_set(sv, len);
@@ -3032,6 +3049,13 @@ PP_wrapped(pp_getpeername, 1, 0)
     if (len == BOGUS_GETNAME_RETURN)
         len = sizeof(struct sockaddr);
 #endif
+    /* getpeername() and getsockname() may return a length larger than the
+     * supplied buffer. */
+    if (len > namesize) {
+        ck_warner(packWARN(WARN_IO),
+                  "Socket address truncated in %s()", OP_NAME(PL_op));
+        len = namesize;
+    }
     SvCUR_set(sv, len);
     *SvEND(sv) ='\0';
     PUSHs(sv);


### PR DESCRIPTION
**COPY OF #24434** 

Summary: This PR fixes a potential out-of-bounds read in `pp_accept` (`pp_sys.c`).

Problem: `PerlSock_accept_cloexec()` (via `accept()/accept4()`) can return an `addrlen` larger than the supplied buffer size when the peer address is truncated. The previous code used the returned `len` directly in `PUSHp(namebuf, len)`.

Fix: Clamp `len` to `sizeof(namebuf)` before calling `PUSHp`.

Impact: No behavior change for valid lengths. Prevents reading past `namebuf` when `addrlen` is oversized.

Context: Change was motivated by static analysis finding. [BUFFER_OVERFLOW.PROC pp_sys.c:[2631:10].log](https://github.com/user-attachments/files/28054805/BUFFER_OVERFLOW.PROC.pp_sys.c.2631.10.log)

This set of changes does not require a perldelta entry.
