### PR TITLE
Revert #24078 and #24127 because of rand() regressions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -3256,7 +3256,7 @@ EXpx	|char * |scan_word	|NN char *s				\
 				|STRLEN destlen 			\
 				|int allow_package			\
 				|NN STRLEN *slp
-Cp	|U64	|seed
+Cp	|U32	|seed
 : Only used by perl.c/miniperl.c, but defined in caretx.c
 ep	|void	|set_caret_X
 CTdp	|void	|set_context	|NN void *t

--- a/embed.fnc
+++ b/embed.fnc
@@ -6471,6 +6471,7 @@ S	|void	|warn_on_first_deprecated_use				\
 #if defined(PERL_IN_UTIL_C)
 S	|bool	|ckwarn_common	|U32 w
 S	|SV *	|mess_alloc
+Ti	|U32	|ptr_hash	|PTRV u
 S	|SV *	|with_queued_errors					\
 				|NN SV *ex
 So	|void	|xs_version_bootcheck					\

--- a/embed.h
+++ b/embed.h
@@ -1771,6 +1771,7 @@
 #   if defined(PERL_IN_UTIL_C)
 #     define ckwarn_common(a)                   S_ckwarn_common(aTHX_ a)
 #     define mess_alloc()                       S_mess_alloc(aTHX)
+#     define ptr_hash                           S_ptr_hash
 #     define with_queued_errors(a)              S_with_queued_errors(aTHX_ a)
 #     if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 #       define mem_log_common                   S_mem_log_common

--- a/proto.h
+++ b/proto.h
@@ -5692,7 +5692,7 @@ Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
 #define PERL_ARGS_ASSERT_SCAN_WORD              \
         Perl_assert_aTHX; assert(s); assert(dest); assert(slp)
 
-PERL_CALLCONV U64
+PERL_CALLCONV U32
 Perl_seed(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SEED                   \

--- a/proto.h
+++ b/proto.h
@@ -13322,6 +13322,12 @@ S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const cha
         assert(type_name); assert(filename); assert(funcname)
 
 # endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
+# if !defined(PERL_NO_INLINE_FUNCTIONS)
+PERL_STATIC_INLINE U32
+S_ptr_hash(PTRV u);
+#   define PERL_ARGS_ASSERT_PTR_HASH
+
+# endif
 # if defined(PERL_USES_PL_PIDSTATUS)
 static void
 S_pidgone(pTHX_ Pid_t pid, int status)

--- a/util.c
+++ b/util.c
@@ -4651,7 +4651,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
 #endif
 
 /* Splitmix64 is a simple PRNG and integer hashing function. It was
- * introduced in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
+ * introducted in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
  * Examples: https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64
  */
 static U64

--- a/util.c
+++ b/util.c
@@ -4650,6 +4650,38 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
 #  include <starlet.h>
 #endif
 
+/* hash a pointer and return a U32 */
+
+PERL_STATIC_INLINE U32 S_ptr_hash(PTRV u) {
+    PERL_ARGS_ASSERT_PTR_HASH;
+/* 64 bit input */
+#if PTRSIZE == 8
+    /*
+     * This is one of Thomas Wang's hash functions for 64-bit integers from:
+     * https://gist.github.com/scottchiefbaker/9e21877a0c6041fbf54bd583cd1c52b4
+     */
+    u = (~u) + (u << 18);
+    u = u ^ (u >> 31);
+    u = u * 21;
+    u = u ^ (u >> 11);
+    u = u + (u << 6);
+    u = u ^ (u >> 22);
+/* 32 bit input */
+#else
+    /*
+     * This is one of Bob Jenkins' hash functions for 32-bit integers
+     * from: https://burtleburtle.net/bob/hash/integer.html
+     */
+    u = (u + 0x7ed55d16) + (u << 12);
+    u = (u ^ 0xc761c23c) ^ (u >> 19);
+    u = (u + 0x165667b1) + (u << 5);
+    u = (u + 0xd3a2646c) ^ (u << 9);
+    u = (u + 0xfd7046c5) + (u << 3);
+    u = (u ^ 0xb55a4f09) ^ (u >> 16);
+#endif
+    return (U32)u;
+}
+
 /* Splitmix64 is a simple PRNG and integer hashing function. It was
  * introducted in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
  * Examples: https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64

--- a/util.c
+++ b/util.c
@@ -4683,7 +4683,7 @@ PERL_STATIC_INLINE U32 S_ptr_hash(PTRV u) {
 }
 
 
-U64
+U32
 Perl_seed(pTHX)
 {
     PERL_ARGS_ASSERT_SEED;

--- a/util.c
+++ b/util.c
@@ -4682,30 +4682,43 @@ PERL_STATIC_INLINE U32 S_ptr_hash(PTRV u) {
     return (U32)u;
 }
 
-/* Splitmix64 is a simple PRNG and integer hashing function. It was
- * introducted in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
- * Examples: https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64
- */
-static U64
-splitmix64(U64 *state)
-{
-    U64 z = (*state += 0x9e3779b97f4a7c15);
-    z     = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
-    z     = (z ^ (z >> 27)) * 0x94d049bb133111eb;
-
-    return z ^ (z >> 31);
-}
 
 U64
 Perl_seed(pTHX)
 {
     PERL_ARGS_ASSERT_SEED;
 
-   /*
-    * Attempt to read from /dev/urandom to generate a pseudo-random number.
-    * If that does not work, or it is unavailable, we fall back to gathering
-    * several state variables and hashing them into a seed value.
-    */
+    /*
+     * This is really just a quick hack which grabs various garbage
+     * values.  It really should be a real hash algorithm which
+     * spreads the effect of every input bit onto every output bit,
+     * if someone who knows about such things would bother to write it.
+     * Might be a good idea to add that function to CORE as well.
+     * No numbers below come from careful analysis or anything here,
+     * except they are primes and SEED_C1 > 1E6 to get a full-width
+     * value from (tv_sec * SEED_C1 + tv_usec).  The multipliers should
+     * probably be bigger too.
+     */
+#if RANDBITS > 16
+#  define SEED_C1	1000003
+#define   SEED_C4	73819
+#else
+#  define SEED_C1	25747
+#define   SEED_C4	20639
+#endif
+#define   SEED_C2	3
+#define   SEED_C3	269
+#define   SEED_C5	26107
+
+#ifndef PERL_NO_DEV_RANDOM
+    int fd;
+#endif
+    U64 u;
+#ifdef HAS_GETTIMEOFDAY
+    struct timeval when;
+#else
+    Time_t when;
+#endif
 
 /* This test is an escape hatch, this symbol isn't set by Configure. */
 #ifndef PERL_NO_DEV_RANDOM
@@ -4715,13 +4728,11 @@ Perl_seed(pTHX)
     * PERL_RANDOM_DEVICE to it if you'd prefer Perl to block until there
     * is enough real entropy to fill the seed. */
 #  ifdef __amigaos4__
-   /* https://wiki.amigaos.net/wiki/AmigaOS_Manual%3A_AmigaDOS_Additional_Amiga_Directories#Random-Handler_(RANDOM:) */
-#    define PERL_RANDOM_DEVICE "RANDOM:"
+#    define PERL_RANDOM_DEVICE "RANDOM:SIZE=4"
 #  else
 #    define PERL_RANDOM_DEVICE "/dev/urandom"
 #  endif
 #endif
-    U64 u;
 
 #ifdef HAS_GETENTROPY
     U8 ok = (getentropy(&u, sizeof(u)) == 0);
@@ -4730,49 +4741,30 @@ Perl_seed(pTHX)
     }
 #endif
 
-    int fd = PerlLIO_open_cloexec(PERL_RANDOM_DEVICE, 0);
+    fd = PerlLIO_open_cloexec(PERL_RANDOM_DEVICE, 0);
     if (fd != -1) {
-        if (PerlLIO_read(fd, (void*)&u, sizeof u) != sizeof u) {
+        if (PerlLIO_read(fd, (void*)&u, sizeof u) != sizeof u)
             u = 0;
-        }
-
         PerlLIO_close(fd);
-
-        if (u) {
+        if (u)
             return u;
-        }
     }
 #endif
 
-    /* We only get this far if /dev/urandom is not available or the read fails.
-     * Grab several state variables and hash those for randomness instead. */
-
 #ifdef HAS_GETTIMEOFDAY
-    struct timeval when;
-
     PerlProc_gettimeofday(&when,NULL);
-    /* Milliseconds */
-    U64 epoch = ((U64)when.tv_sec * 1000000) + when.tv_usec;
+    u = (U32)SEED_C1 * when.tv_sec + (U32)SEED_C2 * when.tv_usec;
 #else
-    Time_t when;
-
     (void)time(&when);
-    /* Seconds */
-    U64 epoch = when;
+    u = (U32)SEED_C1 * when;
 #endif
-
-    UV pid      = PerlProc_getpid();
-    UV time_ptr = PTR2UV(&when);
-
-    /* epoch in microseconds is ~52 bits, PIDs are ~22 bits, PTRs are ~48 bits.
-     * We mix the bits for all three together to get a good spread of entropy */
-    U64 tmp = (time_ptr << 16) | (pid << 8) | (epoch);
-    U64 ret = splitmix64(&tmp);
-
-    /* PerlIO_printf(Perl_debug_log, "XXXX: TIME:%lu PID:%lu PTR:%lu\n", epoch, pid, time_ptr); */
-    /* PerlIO_printf(Perl_debug_log, "SEED: %lu\n", ret); */
-
-    return ret;
+    u += SEED_C3 * (U32)PerlProc_getpid();
+    u += SEED_C4 * (U32)PTR2UV(PL_stack_sp);
+#ifndef PLAN9           /* XXX Plan9 assembler chokes on this; fix needed  */
+    UV ptruv = PTR2UV(&when);
+    u += SEED_C5 * ptr_hash(ptruv);
+#endif
+    return u;
 }
 
 void

--- a/util.c
+++ b/util.c
@@ -4721,26 +4721,25 @@ Perl_seed(pTHX)
 #    define PERL_RANDOM_DEVICE "/dev/urandom"
 #  endif
 #endif
-    U64 seed;
+    U64 u;
 
 #ifdef HAS_GETENTROPY
-    U8 ok = (getentropy(&seed, sizeof(seed)) == 0);
-    /* PerlIO_printf(Perl_debug_log, "Entropy: OK:%i Seed:%lu\n", ok, seed); */
+    U8 ok = (getentropy(&u, sizeof(u)) == 0);
     if (ok) {
-        return seed;
+        return u;
     }
 #endif
 
     int fd = PerlLIO_open_cloexec(PERL_RANDOM_DEVICE, 0);
     if (fd != -1) {
-        if (PerlLIO_read(fd, (void*)&seed, sizeof seed) != sizeof seed) {
-            seed = 0;
+        if (PerlLIO_read(fd, (void*)&u, sizeof u) != sizeof u) {
+            u = 0;
         }
 
         PerlLIO_close(fd);
 
-        if (seed) {
-            return seed;
+        if (u) {
+            return u;
         }
     }
 #endif


### PR DESCRIPTION
This reverts recent changes to `rand()`s fallback code, because it was regressing #24446 on Windows (and presumably other non-unix platforms). Care was taken not to also have to revert the new getentropy code (#24111) @sisyphus @scottchiefbaker.