### PR TITLE
Add API `av_splice_simple()`

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5127,6 +5127,7 @@ ext/XS-APItest/APItest.pm			XS::APItest extension
 ext/XS-APItest/APItest.xs			XS::APItest extension
 ext/XS-APItest/APItest_autoload.xs		XS::APItest AUTOLOAD-related XS split
 ext/XS-APItest/APItest_autoloadtest.xs		XS::APItest AUTOLOADtest XS split
+ext/XS-APItest/APItest_av.xs			XS::APItest AV API-related XS split
 ext/XS-APItest/APItest_backrefs.xs		XS::APItest backrefs-related XS split
 ext/XS-APItest/APItest_bool_internals.xs	XS::APItest BoolInternals-related XS split
 ext/XS-APItest/APItest_BS			autogenerate APItest.bs
@@ -5170,6 +5171,7 @@ ext/XS-APItest/numeric.xs			XS::APItest wrappers for numeric.c
 ext/XS-APItest/t/addissub.t			test op check wrapping
 ext/XS-APItest/t/arrayexpr.t			test recursive descent expression parsing
 ext/XS-APItest/t/autoload.t			Test XS AUTOLOAD routines
+ext/XS-APItest/t/av.t				test av_* XS API functions
 ext/XS-APItest/t/BHK.pm				Helper for ./blockhooks.t
 ext/XS-APItest/t/Block.pm			Helper for ./blockhooks.t
 ext/XS-APItest/t/blockasexpr.t			test recursive descent block parsing

--- a/av.c
+++ b/av.c
@@ -981,6 +981,163 @@ Perl_av_shift(pTHX_ AV *av)
 }
 
 /*
+=for apidoc av_splice_simple
+
+Deletes a contiguous sub-sequence of elements within an array, and inserts
+another sub-sequence provided by the caller. Either sub-sequence may be empty.
+I<idx> may be negative; if so it starts counting backwards from the end of the
+initial array elements. The array must be a simple regular AV and not tied. It
+is permitted to have set magic.
+
+First, the sub-sequence of up to I<delcount> elements in the array from I<idx>
+onwards is removed, and either returned to the caller via the I<out_svs> array
+or discarded. Next, storage of the array is grown if required. Finally, the
+sub-sequence of I<inscount> elements given by the caller in I<in_svs> is
+inserted into the array starting at I<idx> onwards. Elements before I<idx> are
+preserved entirely. Elements after the deleted sub-sequence are moved upwards
+or downwards as required by the difference in the lengths of the two
+sub-sequences.
+
+If I<delcount> is non-zero but no I<out_svs> array is provided, the deleted
+SVs are discarded by C<SvREFCNT_dec>. If an array is provided, pointers are
+copied into it without modifying the reference count and it becomes the
+caller's responsiblity to discard them.
+
+If I<inscount> is non-zero but no I<in_svs> array is provided, the
+newly-created gap is filled with NULL pointers and the caller can use API
+functions like C<av_store> to fill the elements. If an array is provided,
+pointers are copied from it into the array without modifying the reference
+count and it is caller's responsibility to increment that if required.
+
+There must be no pointer aliasing between I<in_svs> itself and the array
+stored in the AV. However, individual SV pointers within it may be aliased, so
+long as the caller takes care to handle reference counts correctly. This may
+be used, for example, to implement an in-place rotation of the elements in the
+AV.
+
+This is B<mostly> identical to the operation of the Perl C<splice> function,
+but with some differences.
+
+=over 4
+
+=item *
+
+I<av> must not be tied.
+
+=item *
+
+I<delcount> may not be negative.
+
+=item *
+
+The caller must perform any reference count modification of inserted or
+returned SVs as necessary.
+
+=back
+
+=cut
+*/
+
+Size_t
+Perl_av_splice_simple(pTHX_ AV *av, SSize_t idx, Size_t delcount, Size_t inscount,
+        SV **in_svs, SV **out_svs)
+{
+    PERL_ARGS_ASSERT_AV_SPLICE_SIMPLE;
+
+    /* This does not work on tied AVs */
+    assert(!SvTIED_mg((const SV *)av, PERL_MAGIC_tied));
+
+    if (SvREADONLY(av))
+        croak_no_modify();
+
+    Size_t was_end = AvFILLp(av) + 1;
+    if (idx < 0)
+        idx += was_end;
+
+    if (idx < 0 || (Size_t)idx > was_end)
+        croak(PL_no_aelem, idx);
+
+    if (idx + delcount > was_end)
+        delcount = was_end - idx;
+
+    SV **svp = AvARRAY(av);
+
+    if (delcount) {
+        /* Rather than test inside every loop iteration, we'll write three
+         * different loops for the three cases
+         */
+        if (out_svs)
+            /* regardless of AvREAL it's now the caller's problem to handle
+             * refcounts */
+            for (Size_t i = 0; i < delcount; i++) {
+                SV *sv = svp[idx + i];
+                out_svs[i] = sv ? sv : &PL_sv_undef;
+                svp[idx + i] = NULL;
+            }
+        else if (AvREAL(av))
+            for (Size_t i = 0; i < delcount; i++) {
+                SvREFCNT_dec(svp[idx + i]);
+                svp[idx + i] = NULL;
+            }
+        else
+            for (Size_t i = 0; i < delcount; i++) {
+                svp[idx + i] = NULL;
+            }
+    }
+
+    SSize_t growth = inscount - delcount;
+    Size_t tailstart = idx + delcount;
+    Size_t tailcount = was_end - tailstart;
+
+    /* Any delete insert or delete from index zero might be doable by making
+     * use of the prealloc area; the gap between AvALLOC and AvARRAY
+     */
+    Size_t prealloc_gap = AvARRAY(av) - AvALLOC(av);
+
+    if ((idx == 0) && (growth != 0) && (growth < 0 || prealloc_gap > 0)) {
+        SSize_t adjust = growth;
+        if (adjust > 0 && (Size_t)adjust > prealloc_gap)
+            /* We can only account for some of it; do the rest by Move() */
+            adjust = prealloc_gap;
+
+        AvARRAY(av) -= adjust;
+        AvMAX(av)   += adjust;
+        AvFILLp(av) += adjust;
+        growth      -= adjust;
+        tailstart   += adjust;
+
+        svp = AvARRAY(av);
+    }
+
+    if (growth > 0) {
+        av_extend(av, was_end + growth);
+        svp = AvARRAY(av);
+    }
+    /* else don't bother to shrink the alloc */
+
+    AvFILLp(av) += growth;
+
+    if (tailcount && growth) {
+        Move(svp + tailstart, svp + tailstart + growth, tailcount, SV *);
+    }
+
+    /* Now insert the new elements */
+    if (inscount) {
+        if (in_svs)
+            for (Size_t i = 0; i < inscount; i++)
+                svp[idx + i] = in_svs[i];
+        else
+            for (Size_t i = 0; i < inscount; i++)
+                svp[idx + i] = NULL;
+    }
+
+    if (SvSMAGICAL(av))
+        mg_set(MUTABLE_SV(av));
+
+    return delcount;
+}
+
+/*
 =for apidoc      av_top_index
 =for apidoc_item av_tindex
 =for apidoc_item AvFILL

--- a/embed.fnc
+++ b/embed.fnc
@@ -974,6 +974,13 @@ EXp	|void	|av_reify	|NN AV *av
 ipx	|void	|av_remove_offset					\
 				|NN AV *av
 ARdp	|SV *	|av_shift	|NN AV *av
+Adp	|Size_t |av_splice_simple					\
+				|NN AV *av				\
+				|SSize_t idx				\
+				|Size_t delcount			\
+				|Size_t inscount			\
+				|NULLOK SV **in_svs			\
+				|NULLOK SV **out_svs
 Adp	|SV **	|av_store	|NN AV *av				\
 				|SSize_t key				\
 				|NULLOK SV *val

--- a/embed.h
+++ b/embed.h
@@ -371,6 +371,7 @@
 # define av_push(a,b)                           Perl_av_push(aTHX_ a,b)
 # define av_push_simple(a,b)                    Perl_av_push_simple(aTHX_ a,b)
 # define av_shift(a)                            Perl_av_shift(aTHX_ a)
+# define av_splice_simple(a,b,c,d,e,f)          Perl_av_splice_simple(aTHX_ a,b,c,d,e,f)
 # define av_store(a,b,c)                        Perl_av_store(aTHX_ a,b,c)
 # define av_store_simple(a,b,c)                 Perl_av_store_simple(aTHX_ a,b,c)
 # define av_undef(a)                            Perl_av_undef(aTHX_ a)

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.52';
+our $VERSION = '1.53';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1048,3 +1048,5 @@ INCLUDE: APItest_savestack.xs
 INCLUDE: APItest_vstring.xs
 
 INCLUDE: APItest_magicv2.xs
+
+INCLUDE: APItest_av.xs

--- a/ext/XS-APItest/APItest_av.xs
+++ b/ext/XS-APItest/APItest_av.xs
@@ -1,0 +1,34 @@
+MODULE = XS::APItest            PACKAGE = XS::APItest::av
+
+void
+av_splice_simple(AV *av, IV idx, IV delcount, ...)
+    PROTOTYPE: \@$$@
+    PPCODE:
+    {
+        Size_t inscount = items - 3;
+        SV **in_svs = NULL, **out_svs = NULL;
+
+        if (inscount) {
+            Newx(in_svs, inscount, SV *);
+            SAVEFREEPV(in_svs);
+
+            for (Size_t i = 0; i < inscount; i++)
+                in_svs[i] = newSVsv(ST(i + 3));
+        }
+
+        if (delcount && GIMME_V == G_LIST) {
+            Newx(out_svs, delcount, SV *);
+            SAVEFREEPV(out_svs);
+        }
+
+        Size_t out_count = av_splice_simple(av, idx, delcount, inscount, in_svs, out_svs);
+
+        if (out_svs && out_count) {
+            EXTEND(SP, (IV)out_count);
+
+            for (Size_t i = 0; i < out_count; i++)
+                mPUSHs(out_svs[i]);
+
+            XSRETURN(out_count);
+        }
+    }

--- a/ext/XS-APItest/t/av.t
+++ b/ext/XS-APItest/t/av.t
@@ -1,0 +1,187 @@
+#!perl
+
+use v5.36;
+
+use Test::More tests => 37;
+use XS::APItest;
+
+# code stolen from t/op/hash.t
+sub guard::DESTROY {
+    ${ $_[0] }->();
+}
+sub guard :prototype(&) {
+    my $callback = shift;
+    return bless \$callback, "guard";
+}
+
+# to insert
+{
+    my @arr;
+
+    @arr = ('a' .. 'd');
+    av_splice_simple @arr, 0, 0, '<';
+    is_deeply \@arr, ['<', 'a', 'b', 'c', 'd'];
+
+    @arr = ('a' .. 'd');
+    av_splice_simple @arr, 2, 0, '|';
+    is_deeply \@arr, ['a', 'b', '|', 'c', 'd'];
+
+    @arr = ('a' .. 'd');
+    av_splice_simple @arr, 4, 0, '>';
+    is_deeply \@arr, ['a', 'b', 'c', 'd', '>'];
+
+    # insert multiple
+
+    @arr = ('e' .. 'h');
+    av_splice_simple @arr, 0, 0, 'a' .. 'd';
+    is_deeply \@arr, ['a'..'h'];
+
+    @arr = ('a', 'b',  'g', 'h');
+    av_splice_simple @arr, 2, 0, 'c' .. 'f';
+    is_deeply \@arr, ['a'..'h'];
+
+    @arr = ('a' .. 'd');
+    av_splice_simple @arr, 4, 0, 'e' .. 'h';
+    is_deeply \@arr, ['a'..'h'];
+
+    # insert into prealloc area
+    @arr = (undef, 'b' .. 'e');
+    shift @arr;
+    av_splice_simple @arr, 0, 0, 'a';
+    is_deeply \@arr, ['a' .. 'e'];
+
+    # insert into mix of prealloc and Move()d area
+    shift @arr;
+    av_splice_simple @arr, 0, 0, 'Y', 'Z', 'a';
+    is_deeply \@arr, ['Y', 'Z', 'a' .. 'e'];
+
+    # we can't really unit-test if this used the prealloc area but at least we
+    # hope not to crash or upset valgrind
+}
+
+# insert idx from end
+{
+    my @arr;
+
+    @arr = ('a' .. 'd');
+    av_splice_simple @arr, -2, 0, '|';
+    is_deeply \@arr, ['a', 'b', '|', 'c', 'd'];
+
+    @arr = ('a' .. 'd');
+    av_splice_simple @arr, -4, 0, '<';
+    is_deeply \@arr, ['<', 'a', 'b', 'c', 'd'];
+}
+
+# to replace
+{
+    my @arr;
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 0, 1, 'A';
+    is_deeply \@arr, ['A', 'b', 'c', 'd', 'e'];
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 2, 1, 'C';
+    is_deeply \@arr, ['a', 'b', 'C', 'd', 'e'];
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 4, 1, 'E';
+    is_deeply \@arr, ['a', 'b', 'c', 'd', 'E'];
+}
+
+# to delete
+{
+    my @arr;
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 0, 1;
+    is_deeply \@arr, [     'b', 'c', 'd', 'e'];
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 2, 1;
+    is_deeply \@arr, ['a', 'b',      'd', 'e'];
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 4, 1;
+    is_deeply \@arr, ['a', 'b', 'c', 'd'     ];
+
+    # delete multiple
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 0, 3;
+    is_deeply \@arr, [               'd', 'e'];
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 1, 3;
+    is_deeply \@arr, ['a',                'e'];
+
+    @arr = ('a' .. 'e');
+    av_splice_simple @arr, 2, 3;
+    is_deeply \@arr, ['a', 'b',              ];
+}
+
+# delete invokes destructor immediately
+{
+    my $destroyed;
+
+    my @arr = ( guard { $destroyed++ } );
+
+    ok !$destroyed, 'Not destroyed before av_splice as delete';
+    av_splice_simple @arr, 0, 1;
+    ok $destroyed, 'Destroyed after av_splice as delete';
+
+    undef $destroyed;
+    (sub {
+        ok !$destroyed, 'Not destroyed before av_splice as delete on @_';
+        av_splice_simple @_, 0, 1;
+    })->( guard { $destroyed++ } );
+    ok $destroyed, 'Destroyed after av_splice as delete on @_';
+}
+
+# to extract
+{
+    my @arr;
+
+    @arr = ('a' .. 'e');
+    is_deeply [av_splice_simple @arr, 0, 1], ['a'];
+
+    @arr = ('a' .. 'e');
+    is_deeply [av_splice_simple @arr, 2, 1], ['c'];
+
+    @arr = ('a' .. 'e');
+    is_deeply [av_splice_simple @arr, 4, 1], ['e'];
+}
+
+# extract invokes destructor later
+{
+    my $destroyed;
+
+    my @arr = ( guard { $destroyed++ } );
+
+    ok !$destroyed, 'Not destroyed before av_splice as extract';
+    my @ret = av_splice_simple @arr, 0, 1;
+    ok !$destroyed, 'Not destroyed after av_splice as extract';
+    @ret = ();
+    ok $destroyed, 'Destroyed after result array cleared';
+}
+
+# delete count bounding
+{
+    my @arr = ('a' .. 'e');
+    is_deeply [av_splice_simple @arr, 2, 15], ['c', 'd', 'e'];
+    is_deeply \@arr, ['a', 'b'];
+
+    # nothing left
+    is_deeply [av_splice_simple @arr, 2, 1], [];
+    is_deeply \@arr, ['a', 'b'];
+}
+
+{
+    my @arr = 1 .. 3;
+
+    ok !eval { av_splice_simple @arr, 5, 1; } and
+        like $@, qr/^Modification of non-creatable array value attempted, subscript 5 /;
+
+    ok !eval { av_splice_simple @arr, -12, 1; } and
+        like $@, qr/^Modification of non-creatable array value attempted, subscript -9 /;
+}

--- a/proto.h
+++ b/proto.h
@@ -366,6 +366,13 @@ Perl_av_shift(pTHX_ AV *av)
 #define PERL_ARGS_ASSERT_AV_SHIFT               \
         Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
+PERL_CALLCONV Size_t
+Perl_av_splice_simple(pTHX_ AV *av, SSize_t idx, Size_t delcount, Size_t inscount, SV **in_svs, SV **out_svs)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_AV_SPLICE_SIMPLE       \
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+
 PERL_CALLCONV SV **
 Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
         Perl_attribute_nonnull_aTHX


### PR DESCRIPTION
A simple version of this behaviour which avoids all the problems of tied arrays. Useful for callers who are using a known AV under their control, as actual data storage.

* This set of changes requires a perldelta entry, and I will write one by the time I merge it