### PR TITLE
IO.t: fix version check on older perls

### DIFF
--- a/dist/IO/t/IO.t
+++ b/dist/IO/t/IO.t
@@ -49,7 +49,7 @@ local $SIG{__WARN__} = sub { $warn = "@_" } ;
 
 {
     local $^W = 0;
-    no if $^V >= 5.17.4, warnings => "deprecated";
+    no if $^V ge v5.17.4, warnings => "deprecated";
     IO->import();
     is( $warn, '', "... import default, should not warn");
     $warn = '' ;


### PR DESCRIPTION
In perls before 5.10, $^V was a plain string, not an object with an overloaded >= operator, causing this warning on perl 5.8:

    Argument "^E^Q^D" isn't numeric in numeric ge (>=) at t/IO.t line 52.

See https://www.cpantesters.org/cpan/report/a0c62db2-9159-11ef-a300-4746a6543889 for an example.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
