### PR TITLE
IO: fix version checks in Makefile.PL

### DIFF
--- a/dist/IO/Makefile.PL
+++ b/dist/IO/Makefile.PL
@@ -45,7 +45,7 @@ WriteMakefile(
     ( ( $mm_version > 6.30 ) ? ( LICENSE => 'perl' )  : () ),
     META_MERGE => {
         resources => {
-            license     => 'http://dev.perl.org/licenses/',
+            license     => 'https://dev.perl.org/licenses/',
             bugtracker  => 'https://github.com/perl/perl5/issues',
             repository  => 'https://github.com/Perl/perl5/tree/blead/dist/IO',
             MailingList => 'http://lists.perl.org/list/perl5-porters.html',

--- a/dist/IO/Makefile.PL
+++ b/dist/IO/Makefile.PL
@@ -21,6 +21,8 @@ unless ( $PERL_CORE or exists $Config{'i_poll'} ) {
 
 #--- Write the Makefile
 
+(my $mm_version = ExtUtils::MakeMaker->VERSION) =~ tr/_//d;
+
 WriteMakefile(
     VERSION_FROM => "IO.pm",
     NAME         => "IO",
@@ -39,8 +41,8 @@ WriteMakefile(
             clean       => { FILES => 'typemap' },
         )
     ),
-    ( $define                                      ? ( DEFINE    => $define ) : () ),
-    ( ( ExtUtils::MakeMaker->VERSION() gt '6.30' ) ? ( 'LICENSE' => 'perl' )  : () ),
+    ( $define                ? ( DEFINE  => $define ) : () ),
+    ( ( $mm_version > 6.30 ) ? ( LICENSE => 'perl' )  : () ),
     META_MERGE => {
         resources => {
             license     => 'http://dev.perl.org/licenses/',

--- a/dist/IO/Makefile.PL
+++ b/dist/IO/Makefile.PL
@@ -1,6 +1,6 @@
 # This -*- perl -*- script makes the Makefile
 
-BEGIN { require 5.008_001 }
+use 5.008_001;
 use ExtUtils::MakeMaker;
 use Config qw(%Config);
 my $PERL_CORE = grep { $_ eq 'PERL_CORE=1' } @ARGV;


### PR DESCRIPTION
A string comparison against `'6.30'` avoids warnings on older MakeMakers (where VERSION may contain underscores), but will produce wrong results when ExtUtils::MakeMaker reaches version 10 or higher.

Also, simplify the minimum perl version assertion. The BEGIN/require form is only needed for compatibility with perl versions 5.000 .. 5.003.¹ Starting with 5.004, `use VERSION` works fine. (And before 5.000, `BEGIN` was a syntax error anyway.)

---

¹ Happy 30th birthday, perl 5.003!

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
