### PR TITLE
Storable: fix bugtracker metadata

### DIFF
--- a/dist/Storable/Makefile.PL
+++ b/dist/Storable/Makefile.PL
@@ -34,7 +34,9 @@ WriteMakefile(
     META_MERGE          => {
         "meta-spec" => { version => 2 },
         resources   => {
-            bugtracker => 'https://github.com/Perl/perl5/issues',
+            bugtracker => {
+                web => 'https://github.com/Perl/perl5/issues',
+            },
         },
         provides    => {
             'Storable'  => {


### PR DESCRIPTION
Fix the format of the bugtracker metadata for Storable so it appears properly in META.json.

* This set of changes does not require a perldelta entry.
