### PR TITLE
Update KNOWN BUGS section in perlclass.pod

### DIFF
--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -416,33 +416,25 @@ including an ability for them to provide new class or field attributes.
 
 =head1 KNOWN BUGS
 
-The following bugs have been found in the experimental C<class> feature:
+The following unresolved bugs exist in the experimental C<class> feature:
 
 =over 4
 
 =item *
 
-Since Perl v5.38, inheriting from a parent class which is declared in the same
-file and which hadn't already been sealed can cause a segmentation fault.
-[L<GH #20890|https://github.com/Perl/perl5/issues/20890>]
-
-=item *
-
-Since Perl v5.38 and with the experimental C<refaliasing> feature, trying to
-replace a field variable causes a segmentation fault.
-[L<GH #20947|https://github.com/Perl/perl5/issues/20947>]
-
-=item *
-
-Since Perl v5.38, it's possible to craft a class with leaky encapsulation,
+It's possible to craft a class with leaky encapsulation,
 which can cause a segmentation fault.
 [L<GH #20956|https://github.com/Perl/perl5/issues/20956>]
 
 =item *
+Declaring fields after declaring a nested subclass corrupts the object storage.
+[L<GH #24393|https://github.com/Perl/perl5/issues/24393>]
 
-In Perl v5.38, inheriting from a class would not always attempt to load the
-parent class (fixed in Perl v5.40).
-[L<GH #21332|https://github.com/Perl/perl5/issues/21332>]
+=item *
+
+Fields cannot be used by anonymous C<method> expressions during C<BEGIN>
+phasers or as part of a C<use> statement.
+[L<GH #24418|https://github.com/Perl/perl5/issues/24418>]
 
 =back
 


### PR DESCRIPTION
The summary of known bugs in perlclass.pod is no longer accurate. This change aims to bring it up-to-date with blead for the 5.44 release.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
