### PR TITLE
cpan/HTTP-Tiny - Update to version 0.096

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1243,6 +1243,20 @@ cpan/HTTP-Tiny/corpus/redirect-07.txt	Test file related to HTTP::Tiny
 cpan/HTTP-Tiny/corpus/redirect-08.txt	Test file related to HTTP::Tiny
 cpan/HTTP-Tiny/corpus/redirect-09.txt	Test file related to HTTP::Tiny
 cpan/HTTP-Tiny/corpus/redirect-10.txt	Test file related to HTTP::Tiny
+cpan/HTTP-Tiny/corpus/redirect-11.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-12.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-13.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-14.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-15.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-16.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-17.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-18.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-19.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-20.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-21.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-22.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-23.txt	HTTP-Tiny
+cpan/HTTP-Tiny/corpus/redirect-24.txt	HTTP-Tiny
 cpan/HTTP-Tiny/corpus/snake-oil.crt	Test file related to HTTP::Tiny
 cpan/HTTP-Tiny/lib/HTTP/Tiny.pm		Module related to HTTP::Tiny
 cpan/HTTP-Tiny/t/000_load.t		Test file related to HTTP::Tiny

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -641,8 +641,8 @@ our %Modules = (
     },
 
     'HTTP::Tiny' => {
-        'DISTRIBUTION' => 'HAARG/HTTP-Tiny-0.094.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Mon May 25 17:49:36 2026',
+        'DISTRIBUTION' => 'HAARG/HTTP-Tiny-0.096.tar.gz',
+        'SYNCINFO'     => 'leont on Mon Jun  8 16:26:22 2026',
         'FILES'        => q[cpan/HTTP-Tiny],
         'EXCLUDED'     => [
             't/00-report-prereqs.t',

--- a/cpan/HTTP-Tiny/corpus/redirect-11.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-11.txt
@@ -1,0 +1,21 @@
+url
+  https://victim.example/secret
+expected
+  refused-redirect-body
+expected_url
+  https://victim.example/secret
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 21
+Location: http://victim.example/secret
+
+refused-redirect-body
+

--- a/cpan/HTTP-Tiny/corpus/redirect-12.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-12.txt
@@ -1,0 +1,36 @@
+url
+  https://victim.example/secret
+expected
+  success
+expected_url
+  http://victim.example/secret
+new_args
+  allow_downgrade: 1
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://victim.example/secret
+
+redirect
+
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 7
+
+success

--- a/cpan/HTTP-Tiny/corpus/redirect-13.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-13.txt
@@ -1,0 +1,35 @@
+url
+  https://example.com/index.html
+expected
+  abcdefghijklmnopqrstuvwxyz1234567890abcdef
+expected_url
+  https://example.com/index2.html
+----------
+GET /index.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/html
+Content-Length: 53
+Location: https://example.com/index2.html
+
+<a href="https://example.com/index2.html">redirect</a>
+
+----------
+GET /index2.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 42
+
+abcdefghijklmnopqrstuvwxyz1234567890abcdef
+

--- a/cpan/HTTP-Tiny/corpus/redirect-14.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-14.txt
@@ -1,0 +1,35 @@
+url
+  http://example.com/index.html
+expected
+  abcdefghijklmnopqrstuvwxyz1234567890abcdef
+expected_url
+  https://example.com/index2.html
+----------
+GET /index.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/html
+Content-Length: 53
+Location: https://example.com/index2.html
+
+<a href="https://example.com/index2.html">redirect</a>
+
+----------
+GET /index2.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 42
+
+abcdefghijklmnopqrstuvwxyz1234567890abcdef
+

--- a/cpan/HTTP-Tiny/corpus/redirect-15.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-15.txt
@@ -1,0 +1,57 @@
+url
+  http://victim.example/secret
+expected
+  pwned
+expected_url
+  http://victim.example/back
+headers
+  Authorization: Bearer SECRET-TOKEN
+  Cookie: session=SECRET-SESSION
+  Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://victim.example/back
+
+redirect
+
+----------
+GET /back HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 5
+
+pwned
+

--- a/cpan/HTTP-Tiny/corpus/redirect-16.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-16.txt
@@ -1,0 +1,47 @@
+url
+  http://victim.example/secret
+expected
+  pwned
+expected_url
+  http://attacker.example/loot
+new_args
+  allow_credentialed_redirects: 1
+headers
+  Authorization: Bearer SECRET-TOKEN
+  Cookie: session=SECRET-SESSION
+  Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 5
+
+pwned
+

--- a/cpan/HTTP-Tiny/corpus/redirect-17.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-17.txt
@@ -1,0 +1,39 @@
+url
+  http://example.com/a
+expected
+  ok
+expected_url
+  http://example.com/b
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+GET /a HTTP/1.1
+Host: example.com
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://example.com/b
+
+redirect
+
+----------
+GET /b HTTP/1.1
+Host: example.com
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/cpan/HTTP-Tiny/corpus/redirect-18.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-18.txt
@@ -1,0 +1,38 @@
+url
+  http://example.com:8080/foo
+expected
+  ok
+expected_url
+  http://example.com:8081/bar
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+GET /foo HTTP/1.1
+Host: example.com:8080
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://example.com:8081/bar
+
+redirect
+
+----------
+GET /bar HTTP/1.1
+Host: example.com:8081
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/cpan/HTTP-Tiny/corpus/redirect-19.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-19.txt
@@ -1,0 +1,40 @@
+url
+  https://example.com:8443/foo
+expected
+  ok
+expected_url
+  http://example.com:8443/foo
+new_args
+  allow_downgrade: 1
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+GET /foo HTTP/1.1
+Host: example.com:8443
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://example.com:8443/foo
+
+redirect
+
+----------
+GET /foo HTTP/1.1
+Host: example.com:8443
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/cpan/HTTP-Tiny/corpus/redirect-20.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-20.txt
@@ -1,0 +1,41 @@
+url
+  http://victim.example/submit
+method
+  POST
+expected
+  ok
+expected_url
+  http://attacker.example/loot
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+POST /submit HTTP/1.1
+Host: victim.example
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+Content-Length: 0
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 303 See Other
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/cpan/HTTP-Tiny/corpus/redirect-21.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-21.txt
@@ -1,0 +1,38 @@
+url
+  https://victim.example/x
+expected
+  pwned
+expected_url
+  https://attacker.example/loot
+headers
+  Authorization: Bearer TRUSTED-TOKEN
+----------
+GET /x HTTP/1.1
+Host: victim.example
+Authorization: Bearer TRUSTED-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: //attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 5
+
+pwned
+

--- a/cpan/HTTP-Tiny/corpus/redirect-22.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-22.txt
@@ -1,0 +1,40 @@
+url
+  http://example.com/login
+expected
+  ok
+expected_url
+  https://example.com/login
+headers
+  Authorization: Bearer SECRET-TOKEN
+  Cookie: session=SECRET-SESSION
+----------
+GET /login HTTP/1.1
+Host: example.com
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: https://example.com/login
+
+redirect
+
+----------
+GET /login HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/cpan/HTTP-Tiny/corpus/redirect-23.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-23.txt
@@ -1,0 +1,36 @@
+url
+  https://user:pass@victim.example/secret
+expected
+  ok
+expected_url
+  https://attacker.example/loot
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+Authorization: Basic dXNlcjpwYXNz
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: https://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/cpan/HTTP-Tiny/corpus/redirect-24.txt
+++ b/cpan/HTTP-Tiny/corpus/redirect-24.txt
@@ -1,0 +1,38 @@
+url
+  https://user:pass@victim.example/secret
+expected
+  ok
+expected_url
+  https://attacker.example/loot
+new_args
+  allow_credentialed_redirects: 1
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+Authorization: Basic dXNlcjpwYXNz
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: https://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
+++ b/cpan/HTTP-Tiny/lib/HTTP/Tiny.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 # ABSTRACT: A small, simple, correct HTTP/1.1 client
 
-our $VERSION = '0.094';
+our $VERSION = '0.096';
 
 sub _croak { require Carp; Carp::croak(@_) }
 
@@ -15,9 +15,19 @@ sub _croak { require Carp; Carp::croak(@_) }
 #pod This constructor returns a new HTTP::Tiny object.  Valid attributes include:
 #pod
 #pod =for :list
-#pod * C<agent> — A user-agent string (defaults to 'HTTP-Tiny/$VERSION'). If
+#pod * C<agent> — A user-agent string (defaults to 'C<HTTP-Tiny/$VERSION>'). If
 #pod   C<agent> — ends in a space character, the default user-agent string is
 #pod   appended.
+#pod * C<allow_credentialed_redirects> - If a C<3XX> redirects to a different scheme,
+#pod   host or port, by default HTTP::Tiny will strip away caller-supplied
+#pod   C<Authorization>, C<Cookie> and C<Proxy-Authorization> headers from the
+#pod   redirected request and from all subsequent requests in the chain. Set this to a
+#pod   true value to revert to the legacy behavior of forwarding those headers.
+#pod   Default is C<false>.
+#pod * C<allow_downgrade> — If a C<3XX> redirect changes the scheme from C<https> to
+#pod   plain C<http>, HTTP::Tiny will by default refuse to follow it, returning the
+#pod   C<3XX> response. Set this to a true value to revert to the legacy behavior of
+#pod   redirecting C<https> to C<http>. Default is C<false>.
 #pod * C<cookie_jar> — An instance of L<HTTP::CookieJar> — or equivalent class
 #pod   that supports the C<add> and C<cookie_header> methods
 #pod * C<default_headers> — A hashref of default headers to apply to requests
@@ -81,9 +91,9 @@ sub _croak { require Carp; Carp::croak(@_) }
 my @attributes;
 BEGIN {
     @attributes = qw(
-        cookie_jar default_headers http_proxy https_proxy keep_alive
-        local_address max_redirect max_size proxy no_proxy
-        SSL_options verify_SSL
+        allow_credentialed_redirects allow_downgrade cookie_jar default_headers
+        http_proxy https_proxy keep_alive local_address max_redirect max_size
+        proxy no_proxy SSL_options verify_SSL
     );
     my %persist_ok = map {; $_ => 1 } qw(
         cookie_jar default_headers max_redirect max_size
@@ -227,7 +237,7 @@ sub _set_proxies {
 #pod URL must have unsafe characters escaped and international domain names encoded.
 #pod See C<request()> for valid options and a description of the response.
 #pod
-#pod The C<success> field of the response will be true if the status code is 2XX.
+#pod The C<success> field of the response will be true if the status code is C<2XX>.
 #pod
 #pod =cut
 
@@ -260,7 +270,7 @@ HERE
 #pod encoded.  See C<request()> for valid options and a description of the response.
 #pod Any C<content-type> header or content in the options hashref will be ignored.
 #pod
-#pod The C<success> field of the response will be true if the status code is 2XX.
+#pod The C<success> field of the response will be true if the status code is C<2XX>.
 #pod
 #pod =cut
 
@@ -301,8 +311,8 @@ sub post_form {
 #pod may specify a different C<If-Modified-Since> header yourself in the C<<
 #pod $options->{headers} >> hash.
 #pod
-#pod The C<success> field of the response will be true if the status code is 2XX
-#pod or if the status code is 304 (unmodified).
+#pod The C<success> field of the response will be true if the status code is C<2XX>
+#pod or if the status code is C<304> (unmodified).
 #pod
 #pod If the file was modified and the server response includes a properly
 #pod formatted C<Last-Modified> header, the file modification time will
@@ -364,8 +374,7 @@ sub mirror {
 #pod how this applies to redirection.
 #pod
 #pod If the URL includes a "user:password" stanza, they will be used for Basic-style
-#pod authorization headers.  (Authorization headers will not be included in a
-#pod redirected request.) For example:
+#pod authorization headers.  For example:
 #pod
 #pod     $http->request('GET', 'http://Aladdin:open sesame@example.com/');
 #pod
@@ -373,6 +382,10 @@ sub mirror {
 #pod be percent-escaped:
 #pod
 #pod     $http->request('GET', 'http://john%40example.com:password@example.com/');
+#pod
+#pod Caller-supplied C<Authorization>, C<Cookie> and C<Proxy-Authorization> headers
+#pod are stripped on cross-origin redirects. See L</new>'s
+#pod C<allow_credentialed_redirects> attribute to opt out.
 #pod
 #pod A hashref of options may be appended to modify the request.
 #pod
@@ -427,7 +440,7 @@ sub mirror {
 #pod
 #pod =for :list
 #pod * C<success> —
-#pod     Boolean indicating whether the operation returned a 2XX status code
+#pod     Boolean indicating whether the operation returned a C<2XX> status code
 #pod * C<url> —
 #pod     URL that provided the response. This is the URL of the request unless
 #pod     there were redirections, in which case it is the last URL queried
@@ -458,6 +471,7 @@ sub mirror {
 #pod =cut
 
 my %idempotent = map { $_ => 1 } qw/GET HEAD PUT DELETE OPTIONS TRACE/;
+my %sensitive_headers = map { $_ => 1 } qw/authorization cookie proxy-authorization/;
 
 sub request {
     my ($self, $method, $url, $args) = @_;
@@ -842,6 +856,7 @@ sub _prepare_headers_and_cb {
     for ($self->{default_headers}, $args->{headers}) {
         next unless defined;
         while (my ($k, $v) = each %$_) {
+            next if $args->{_strip_credentials} && exists $sensitive_headers{lc $k};
             $request->{headers}{lc $k} = $v;
             $request->{header_case}{lc $k} = $k;
         }
@@ -969,9 +984,24 @@ sub _maybe_redirect {
         and $headers->{location}
         and @{$args->{_redirects}} < $self->{max_redirect}
     ) {
-        my $location = ($headers->{location} =~ /^\//)
+        my $location = $headers->{location} =~ m{^//}
+        ? "$request->{scheme}:$headers->{location}"
+        : $headers->{location} =~ m{^/}
             ? "$request->{scheme}://$request->{host_port}$headers->{location}"
-            : $headers->{location} ;
+            : $headers->{location};
+        my ($to_scheme, $to_host, $to_port) = $self->_split_url($location);
+        if (!$self->{allow_downgrade} && $request->{scheme} eq 'https' && $to_scheme eq 'http' ) {
+            return;
+        }
+        if (
+            !$self->{allow_credentialed_redirects}
+            && (   $request->{scheme} ne $to_scheme
+                || $request->{host} ne $to_host
+                || $request->{port} ne $to_port )
+        ) {
+            $args->{_strip_credentials} = 1;
+        }
+
         return (($status eq '303' ? 'GET' : $method), $location);
     }
     return;
@@ -1776,7 +1806,7 @@ HTTP::Tiny - A small, simple, correct HTTP/1.1 client
 
 =head1 VERSION
 
-version 0.094
+version 0.096
 
 =head1 SYNOPSIS
 
@@ -1821,7 +1851,15 @@ This constructor returns a new HTTP::Tiny object.  Valid attributes include:
 
 =item *
 
-C<agent> — A user-agent string (defaults to 'HTTP-Tiny/$VERSION'). If C<agent> — ends in a space character, the default user-agent string is appended.
+C<agent> — A user-agent string (defaults to 'C<HTTP-Tiny/$VERSION>'). If C<agent> — ends in a space character, the default user-agent string is appended.
+
+=item *
+
+C<allow_credentialed_redirects> - If a C<3XX> redirects to a different scheme, host or port, by default HTTP::Tiny will strip away caller-supplied C<Authorization>, C<Cookie> and C<Proxy-Authorization> headers from the redirected request and from all subsequent requests in the chain. Set this to a true value to revert to the legacy behavior of forwarding those headers. Default is C<false>.
+
+=item *
+
+C<allow_downgrade> — If a C<3XX> redirect changes the scheme from C<https> to plain C<http>, HTTP::Tiny will by default refuse to follow it, returning the C<3XX> response. Set this to a true value to revert to the legacy behavior of redirecting C<https> to C<http>. Default is C<false>.
 
 =item *
 
@@ -1919,7 +1957,7 @@ These methods are shorthand for calling C<request()> for the given method.  The
 URL must have unsafe characters escaped and international domain names encoded.
 See C<request()> for valid options and a description of the response.
 
-The C<success> field of the response will be true if the status code is 2XX.
+The C<success> field of the response will be true if the status code is C<2XX>.
 
 =head2 post_form
 
@@ -1937,7 +1975,7 @@ The URL must have unsafe characters escaped and international domain names
 encoded.  See C<request()> for valid options and a description of the response.
 Any C<content-type> header or content in the options hashref will be ignored.
 
-The C<success> field of the response will be true if the status code is 2XX.
+The C<success> field of the response will be true if the status code is C<2XX>.
 
 =head2 mirror
 
@@ -1953,8 +1991,8 @@ C<If-Modified-Since> header with the modification timestamp of the file.  You
 may specify a different C<If-Modified-Since> header yourself in the C<<
 $options->{headers} >> hash.
 
-The C<success> field of the response will be true if the status code is 2XX
-or if the status code is 304 (unmodified).
+The C<success> field of the response will be true if the status code is C<2XX>
+or if the status code is C<304> (unmodified).
 
 If the file was modified and the server response includes a properly
 formatted C<Last-Modified> header, the file modification time will
@@ -1974,8 +2012,7 @@ Don't use C<get> when you really want C<GET>.  See L</LIMITATIONS> for
 how this applies to redirection.
 
 If the URL includes a "user:password" stanza, they will be used for Basic-style
-authorization headers.  (Authorization headers will not be included in a
-redirected request.) For example:
+authorization headers.  For example:
 
     $http->request('GET', 'http://Aladdin:open sesame@example.com/');
 
@@ -1983,6 +2020,10 @@ If the "user:password" stanza contains reserved characters, they must
 be percent-escaped:
 
     $http->request('GET', 'http://john%40example.com:password@example.com/');
+
+Caller-supplied C<Authorization>, C<Cookie> and C<Proxy-Authorization> headers
+are stripped on cross-origin redirects. See L</new>'s
+C<allow_credentialed_redirects> attribute to opt out.
 
 A hashref of options may be appended to modify the request.
 
@@ -2041,7 +2082,7 @@ will have the following keys:
 
 =item *
 
-C<success> — Boolean indicating whether the operation returned a 2XX status code
+C<success> — Boolean indicating whether the operation returned a C<2XX> status code
 
 =item *
 
@@ -2121,6 +2162,8 @@ host has closed its end of the socket.
 
 =for Pod::Coverage SSL_options
 agent
+allow_credentialed_redirects
+allow_downgrade
 cookie_jar
 default_headers
 http_proxy
@@ -2336,10 +2379,10 @@ L<URI::_punycode> and L<Net::IDN::Encode>.
 =item *
 
 Redirection is very strict against the specification.  Redirection is only
-automatic for response codes 301, 302, 307 and 308 if the request method is
-'GET' or 'HEAD'.  Response code 303 is always converted into a 'GET'
-redirection, as mandated by the specification.  There is no automatic support
-for status 305 ("Use proxy") redirections.
+automatic for response codes C<301>, C<302>, C<307> and C<308> if the request
+method is 'GET' or 'HEAD'.  Response code C<303> is always converted into a
+'GET' redirection, as mandated by the specification.  There is no automatic
+support for status C<305> ("Use proxy") redirections.
 
 =item *
 

--- a/cpan/HTTP-Tiny/t/001_api.t
+++ b/cpan/HTTP-Tiny/t/001_api.t
@@ -7,8 +7,9 @@ use Test::More tests => 2;
 use HTTP::Tiny;
 
 my @accessors = qw(
-  agent default_headers http_proxy https_proxy keep_alive local_address
-  max_redirect max_size proxy no_proxy timeout SSL_options verify_SSL cookie_jar
+    agent allow_credentialed_redirects allow_downgrade default_headers http_proxy
+    https_proxy keep_alive local_address max_redirect max_size proxy no_proxy timeout
+    SSL_options verify_SSL cookie_jar
 );
 my @methods   = qw(
   new get head put post patch delete post_form request mirror www_form_urlencode can_ssl


### PR DESCRIPTION
0.096     2026-06-08 11:21:49+02:00 Europe/Brussels

- No changes from 0.095-TRIAL

0.095     2026-06-03 13:10:05+02:00 Europe/Brussels (TRIAL RELEASE)  

- Caller-supplied `Authorization`, `Cookie`, and `Proxy-Authorization`
      headers are now stripped on cross-origin redirects by default. Use
      allow_credentialed_redirects to opt out.

- Redirects are no longer automatically followed when going from https to http.
      Use allow_downgrade to revert to the original behaviour.
