### PR TITLE
improve "uninitialized value" warning for multiconcat

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -18507,6 +18507,16 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             )
             continue;
 
+            if (
+                obase->op_type == OP_MULTICONCAT
+                && (obase->op_flags & OPf_STACKED)
+                && !(obase->op_private & OPpMULTICONCAT_APPEND)
+                && !OpHAS_SIBLING(kid)
+            ) {
+                /* target of multiconcat op, not an input value */
+                continue;
+            }
+
             if (o2) { /* more than one found */
                 o2 = NULL;
                 break;

--- a/sv.c
+++ b/sv.c
@@ -18510,8 +18510,11 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             if (
                 obase->op_type == OP_MULTICONCAT
                 && (obase->op_flags & OPf_STACKED)
-                && !(obase->op_private & OPpMULTICONCAT_APPEND)
-                && !OpHAS_SIBLING(kid)
+                && (
+                    obase->op_private & OPpMULTICONCAT_APPEND
+                        ? kid == o
+                        : !OpHAS_SIBLING(kid)
+                )
             ) {
                 /* target of multiconcat op, not an input value */
                 continue;

--- a/t/lib/warnings/pp_hot
+++ b/t/lib/warnings/pp_hot
@@ -312,6 +312,20 @@ Use of uninitialized value $y in concatenation (.) or string at - line 6.
 Use of uninitialized value $y in concatenation (.) or string at - line 7.
 Use of uninitialized value $y in concatenation (.) or string at - line 8.
 ########
+# NOTE GH #24460
+# pp_hot.c [pp_multiconcat]
+use warnings 'uninitialized';
+my $x;
+{ my $y = 3 + length $x; }
+{ our $y = 3 + length $x; }
+{ my $y = "foo" . length $x; }
+{ our $y = "foo" . length $x; }
+EXPECT
+Use of uninitialized value length($x) in addition (+) at - line 4.
+Use of uninitialized value length($x) in addition (+) at - line 5.
+Use of uninitialized value length($x) in concatenation (.) or string at - line 6.
+Use of uninitialized value length($x) in concatenation (.) or string at - line 7.
+########
 # pp_hot.c [pp_aelem]
 {
 use warnings 'misc';

--- a/t/lib/warnings/pp_hot
+++ b/t/lib/warnings/pp_hot
@@ -317,14 +317,18 @@ Use of uninitialized value $y in concatenation (.) or string at - line 8.
 use warnings 'uninitialized';
 my $x;
 { my $y = 3 + length $x; }
-{ our $y = 3 + length $x; }
+{ our $y = 3 + length $x; undef $y; }
 { my $y = "foo" . length $x; }
-{ our $y = "foo" . length $x; }
+{ our $y = "foo" . length $x; undef $y; }
+{ my $y .= "foo" . length $x; }
+{ our $y .= "foo" . length $x; undef $y; }
 EXPECT
 Use of uninitialized value length($x) in addition (+) at - line 4.
 Use of uninitialized value length($x) in addition (+) at - line 5.
 Use of uninitialized value length($x) in concatenation (.) or string at - line 6.
 Use of uninitialized value length($x) in concatenation (.) or string at - line 7.
+Use of uninitialized value length($x) in concatenation (.) or string at - line 8.
+Use of uninitialized value length($x) in concatenation (.) or string at - line 9.
 ########
 # pp_hot.c [pp_aelem]
 {


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
The Perl code `$y = "foo" . length($x)` is compiled to a single multiconcat op. When the code encounters an `undef` value, it tries to determine the source, which in this case must be `length($x)`, propagating `undef` from `$x`. But `$y`, the target of the assignment, is also one of multiconcat's children, and was also considered a potential source of undefs, preventing the right variable from being blamed.

This patch makes the scan for potential sources of undefs skip over multiconcat's target if OPf_STACKED is set.

Fixes #24460.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
