### PR TITLE
pad_findlex: propagate FIELD_OK recursively

### DIFF
--- a/pad.c
+++ b/pad.c
@@ -1154,8 +1154,10 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
     *out_flags = 0;
 
     DEBUG_Xv(PerlIO_printf(Perl_debug_log,
-        "Pad findlex cv=0x%" UVxf " searching \"%.*s\" seq=%d%s\n",
-                           PTR2UV(cv), (int)namelen, namepv, (int)seq,
+        "Pad findlex cv=0x%" UVxf " searching \"%.*s\" seq=%" U32uf
+        " flags=%" U32uf "%s\n",
+                           PTR2UV(cv), (int)namelen, namepv, seq, flags,
+                           
         out_capture ? " capturing" : "" ));
 
     /* first, search this pad */
@@ -1315,7 +1317,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV* cv,
     U32 recurse_flags = flags;
     if(new_capturep == &new_capture)
         recurse_flags |= padadd_STALEOK;
-    if(CvIsMETHOD(cv))
+    if(CvIsMETHOD(cv) || fieldok)
         recurse_flags |= padfind_FIELD_OK;
 
     offset = pad_findlex(namepv, namelen, recurse_flags,

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -366,7 +366,20 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+Allow field lookups within methods in nested scopes to succeed,
+previously they could complain that C<Field $fieldname is not
+accessible outside a method...>.
+
+This was most confusingly broken with a use:
+
+  class A {
+    field $fieldname;
+    use overload '""' => method (@) { $fieldname };
+  }
+
+since the syntax hides the C<BEGIN> sub.
+
+[GH #24464]
 
 =back
 

--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -222,3 +222,44 @@ X->new for 0;
 EXPECT
 Exiting subroutine via last at - line 7.
 Can't "last" outside a loop block at - line 7.
+########
+# NAME GH 24418 test case
+use v5.40;
+use experimental 'class';
+
+class Foo {
+    field $message :param :reader;
+
+    use overload '""' => method ($,$) { $message }, fallback => 1;
+}
+
+say Foo->new(message => "yeehaaw");
+EXPECT
+OPTIONS nonfatal
+yeehaaw
+########
+# NAME GH 23446 test case
+use experimental "class";
+class Foo;
+field $foo = 42;
+use overload q{""} => method (@) { $foo };
+EXPECT
+OPTIONS nonfatal
+########
+# NAME GH 24418 clarifying test case
+use v5.40;
+use experimental 'class';
+
+class Foo {
+    field $message :param :reader;
+
+    sub foo {
+        return method () { $message };
+    }
+}
+
+my $meth = Foo->foo;
+say Foo->new(message => "yeehaw")->$meth();
+EXPECT
+OPTIONS nonfatal
+yeehaw


### PR DESCRIPTION
Code like:
```
class Foo {
   field $message :param :reader;

   sub foo {
       return method () { $message }
   }
}
```
would fail to build because pad_findlex() didn't propagate the padfind_FIELD_OK flag from the anonymous method scope through to the class scope, and reported:

  Field $message is not accessible outside a method ...

so propagate the flag.

In the original test cases the scope was a BEGIN block, hidden in a use:
```
  use overload '""' => method (@) { $message };
```
I thought this might allow code like:
```
use v5.40;
use experimental 'class';

class Outer {
    field $outer :param :reader;

    class Inner {
        field $inner :param :reader;
        method foo () { $outer }
    }
}
```
to compile, but this is already caught by a check of the field stash against the method expected stash.

Fixes #24418 #23446

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it will be included.

Edit: add code quotes for the code