### PR TITLE
Configure: Fix compile when stack-protector only ldflag

### DIFF
--- a/Configure
+++ b/Configure
@@ -8593,10 +8593,6 @@ EOM
 	    esac
 	done
 
-	case "$dflt" in
-	    ''|' ') dflt='none' ;;
-	esac
-
 	case "$ldflags" in
 	    *-fstack-protector-strong*)
 		case "$dflt" in
@@ -8610,6 +8606,10 @@ EOM
 		    *) dflt="$dflt -fstack-protector" ;;
 		esac
 		;;
+	esac
+
+	case "$dflt" in
+	    ''|' ') dflt='none' ;;
 	esac
 
 	rp="Any special flags to pass to $ld to create a dynamically loaded library?"


### PR DESCRIPTION
This moves three lines of Configure down a code paragraph.  Before this commit, those lines would change empty load flags to `none`.  Then the next paragraph would add one of the stack-protector arguments if needed. When needed, the result would be both "none" and the stack-protector argument.  Compilation would then fail because 'none' is not a recognized parameter.

By moving the lines down, the stack-protector check is done while the load flags are still empty.  Then 'none' is added only if there were no stack-protector arguments.  Later, unchanged, code removes 'none' when it is the only thing.  So we get either empty or just the stack-protector, which is correct behavior.

* This set of changes does not require a perldelta entry.
