### PR TITLE
Add high resolution time support (nanoseconds) to `Time::HiRes` via a new method: `hrtime()`

### DIFF
--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -157,6 +157,7 @@ Time::HiRes - High resolution alarm, sleep, gettimeofday, interval timers
   use Time::HiRes qw( hrtime );
 
   my $nanoseconds = hrtime();
+  my ($seconds, $nanosec) = hrtime(1);
 
   use Time::HiRes qw( stat lstat );
 
@@ -436,11 +437,17 @@ compatibility limitations the returned value may wrap around at about
 
 =item hrtime ()
 
+=item hrtime ($as_array)
+
 Returns a 64-bit unsigned integer representing the value of the
-CLOCK_MONOTONIC clock in nanoseconds.  This is a monotonic clock,
-meaning that it is unaffected by system clock adjustments.  The
-reference epoch of this clock is not specified, so only I<differences>
-between hrtime() values are meaningful.
+CLOCK_MONOTONIC clock in nanoseconds.  When called with a true
+argument, returns a two-element array of (seconds, nanoseconds)
+from the same clock.
+
+This is a monotonic clock, meaning that it is unaffected by system
+clock adjustments.  The reference epoch of this clock is not
+specified, so only I<differences> between hrtime() values are
+meaningful.
 
 On 64bit systems the counter will roll after 584 years. On 32bit
 systems the counter will roll after ~4.2 seconds.

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -75,7 +75,6 @@ sub AUTOLOAD {
 
 sub import {
     for my $i (@_[1 .. $#_]) {
-
         if (($i eq 'clock_getres'    && !&d_clock_getres)    ||
             ($i eq 'clock_gettime'   && !&d_clock_gettime)   ||
             ($i eq 'clock_nanosleep' && !&d_clock_nanosleep) ||
@@ -154,6 +153,10 @@ Time::HiRes - High resolution alarm, sleep, gettimeofday, interval timers
   clock_nanosleep(CLOCK_REALTIME, time()*1e9 + 10e9, TIMER_ABSTIME);
 
   my $ticktock = clock();
+
+  use Time::HiRes qw( hrtime );
+
+  my $nanoseconds = hrtime();
 
   use Time::HiRes qw( stat lstat );
 
@@ -430,6 +433,21 @@ somewhat like the second value returned by the times() of core Perl,
 but not necessarily identical.  Note that due to backward
 compatibility limitations the returned value may wrap around at about
 2147 seconds or at about 36 minutes.
+
+=item hrtime ()
+
+Returns a 64-bit unsigned integer representing the value of the
+CLOCK_MONOTONIC clock in nanoseconds.  This is a monotonic clock,
+meaning that it is unaffected by system clock adjustments.  The
+reference epoch of this clock is not specified, so only I<differences>
+between hrtime() values are meaningful.
+
+On 64bit systems the counter will roll after 584 years. On 32bit
+systems the counter will roll after ~4.2 seconds.
+
+This function was added in Time::HiRes 1.9780 and requires a
+system that supports clock_gettime() (i.e., a POSIX-like system
+or equivalent).
 
 =item stat
 

--- a/dist/Time-HiRes/HiRes.pm
+++ b/dist/Time-HiRes/HiRes.pm
@@ -12,7 +12,7 @@ our @EXPORT = qw( );
 # More or less this same list is in Makefile.PL.  Should unify.
 our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  getitimer setitimer nanosleep clock_gettime clock_getres
-                 clock clock_nanosleep
+                 clock clock_nanosleep hrtime
                  CLOCKS_PER_SEC
                  CLOCK_BOOTTIME
                  CLOCK_HIGHRES
@@ -45,7 +45,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
                  TIMER_ABSTIME
                  d_usleep d_ualarm d_gettimeofday d_getitimer d_setitimer
                  d_nanosleep d_clock_gettime d_clock_getres
-                 d_clock d_clock_nanosleep d_hires_stat
+                 d_clock d_clock_nanosleep d_hrtime d_hires_stat
                  d_futimens d_utimensat d_hires_utime
                  stat lstat utime
                 );
@@ -75,6 +75,7 @@ sub AUTOLOAD {
 
 sub import {
     for my $i (@_[1 .. $#_]) {
+
         if (($i eq 'clock_getres'    && !&d_clock_getres)    ||
             ($i eq 'clock_gettime'   && !&d_clock_gettime)   ||
             ($i eq 'clock_nanosleep' && !&d_clock_nanosleep) ||
@@ -82,6 +83,7 @@ sub import {
             ($i eq 'nanosleep'       && !&d_nanosleep)       ||
             ($i eq 'usleep'          && !&d_usleep)          ||
             ($i eq 'utime'           && !&d_hires_utime)     ||
+            ($i eq 'hrtime'          && !&d_hrtime)          ||
             ($i eq 'ualarm'          && !&d_ualarm)) {
             require Carp;
             Carp::croak("Time::HiRes::$i(): unimplemented in this platform");

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -1409,6 +1409,33 @@ clock_gettime(clock_id = 0)
 
 #endif /*  #if defined(TIME_HIRES_CLOCK_GETTIME) */
 
+#if defined(TIME_HIRES_CLOCK_GETTIME)
+
+void
+hrtime()
+    PPCODE:
+        struct timespec ts;
+        int status;
+#  ifdef TIME_HIRES_CLOCK_GETTIME_SYSCALL
+        status = syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &ts);
+#  else
+        status = clock_gettime(CLOCK_MONOTONIC, &ts);
+#  endif
+        if (status == 0) {
+            UV ret = (UV)ts.tv_sec * (UV)IV_1E9 + (UV)ts.tv_nsec;
+            EXTEND(SP, 1);
+            PUSHs(sv_2mortal(newSVuv(ret)));
+        }
+
+#else  /* if defined(TIME_HIRES_CLOCK_GETTIME) */
+
+void
+hrtime()
+    PPCODE:
+        croak("Time::HiRes::hrtime(): unimplemented in this platform");
+
+#endif  /* #if defined(TIME_HIRES_CLOCK_GETTIME) */
+
 #if defined(TIME_HIRES_CLOCK_GETRES)
 
 NV

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -1411,11 +1411,13 @@ clock_gettime(clock_id = 0)
 
 #if defined(TIME_HIRES_CLOCK_GETTIME)
 
-UV
-hrtime()
-    CODE:
+void
+hrtime(as_array = 0)
+    bool as_array
+    PREINIT:
         struct timespec ts;
         int status;
+    PPCODE:
 #  ifdef TIME_HIRES_CLOCK_GETTIME_SYSCALL
         status = syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &ts);
 #  else
@@ -1423,15 +1425,22 @@ hrtime()
 #  endif
         if (status != 0)
             XSRETURN_EMPTY;
-        RETVAL = (UV)ts.tv_sec * (UV)IV_1E9 + (UV)ts.tv_nsec;
-    OUTPUT:
-        RETVAL
+        if (as_array) {
+            EXTEND(sp, 2);
+            PUSHs(sv_2mortal(newSViv(ts.tv_sec)));
+            PUSHs(sv_2mortal(newSViv(ts.tv_nsec)));
+        } else {
+            EXTEND(sp, 1);
+            PUSHs(sv_2mortal(newSVuv((UV)ts.tv_sec * (UV)IV_1E9 + (UV)ts.tv_nsec)));
+        }
 
 #else  /* if defined(TIME_HIRES_CLOCK_GETTIME) */
 
 void
-hrtime()
+hrtime(as_array = 0)
+    bool as_array
     PPCODE:
+        PERL_UNUSED_ARG(as_array);
         croak("Time::HiRes::hrtime(): unimplemented in this platform");
 
 #endif  /* #if defined(TIME_HIRES_CLOCK_GETTIME) */

--- a/dist/Time-HiRes/HiRes.xs
+++ b/dist/Time-HiRes/HiRes.xs
@@ -1411,9 +1411,9 @@ clock_gettime(clock_id = 0)
 
 #if defined(TIME_HIRES_CLOCK_GETTIME)
 
-void
+UV
 hrtime()
-    PPCODE:
+    CODE:
         struct timespec ts;
         int status;
 #  ifdef TIME_HIRES_CLOCK_GETTIME_SYSCALL
@@ -1421,11 +1421,11 @@ hrtime()
 #  else
         status = clock_gettime(CLOCK_MONOTONIC, &ts);
 #  endif
-        if (status == 0) {
-            UV ret = (UV)ts.tv_sec * (UV)IV_1E9 + (UV)ts.tv_nsec;
-            EXTEND(SP, 1);
-            PUSHs(sv_2mortal(newSVuv(ret)));
-        }
+        if (status != 0)
+            XSRETURN_EMPTY;
+        RETVAL = (UV)ts.tv_sec * (UV)IV_1E9 + (UV)ts.tv_nsec;
+    OUTPUT:
+        RETVAL
 
 #else  /* if defined(TIME_HIRES_CLOCK_GETTIME) */
 

--- a/dist/Time-HiRes/Makefile.PL
+++ b/dist/Time-HiRes/Makefile.PL
@@ -984,7 +984,7 @@ sub doConstants {
                       );
         foreach (qw (d_usleep d_ualarm d_gettimeofday d_getitimer d_setitimer
                      d_nanosleep d_clock_gettime d_clock_getres
-                     d_clock d_clock_nanosleep d_hires_stat
+                     d_clock d_clock_nanosleep d_hrtime d_hires_stat
                      d_futimens d_utimensat d_hires_utime)) {
             my $macro = $_;
             if ($macro =~ /^(d_nanosleep|d_clock)$/) {
@@ -1001,6 +1001,11 @@ sub doConstants {
                     ($DEFINE =~ /-DHAS_FUTIMENS/ ||
                      $DEFINE =~ /-DHAS_UTIMENSAT/);
                 push @names, {name => $_, macro => "TIME_HIRES_UTIME", value => $d_hires_utime,
+                              default => ["IV", "0"]};
+                next;
+            } elsif ($macro =~ /^d_hrtime$/) {
+                my $d_hrtime = ($DEFINE =~ /-DTIME_HIRES_CLOCK_GETTIME\b/) ? 1 : 0;
+                push @names, {name => $_, macro => "TIME_HIRES_CLOCK_GETTIME", value => $d_hrtime,
                               default => ["IV", "0"]};
                 next;
             } elsif ($macro =~ /^(d_clock_gettime|d_clock_getres|d_clock_nanosleep)$/) {

--- a/dist/Time-HiRes/t/clock.t
+++ b/dist/Time-HiRes/t/clock.t
@@ -1,6 +1,6 @@
 use strict;
 
-use Test::More tests => 5;
+use Test::More tests => 6;
 BEGIN { push @INC, '.' }
 use t::Watchdog;
 
@@ -18,6 +18,7 @@ printf("# have_clock_gettime   = %d\n", &Time::HiRes::d_clock_gettime);
 printf("# have_clock_getres    = %d\n", &Time::HiRes::d_clock_getres);
 printf("# have_clock_nanosleep = %d\n", &Time::HiRes::d_clock_nanosleep);
 printf("# have_clock           = %d\n", &Time::HiRes::d_clock);
+printf("# have_hrtime          = %d\n", &Time::HiRes::d_hrtime);
 
 # Ideally, we'd like to test that the timers are rather precise.
 # However, if the system is busy, there are no guarantees on how
@@ -96,4 +97,15 @@ SKIP: {
         $clock[1] > $clock[0] &&
         $clock[2] > $clock[1] &&
         $clock[3] > $clock[2];
+}
+
+SKIP: {
+    skip "no hrtime", 1 unless &Time::HiRes::d_hrtime;
+    my @got = Time::HiRes::hrtime(1);
+    my $ok = @got == 2
+          && $got[0] >= 0
+          && $got[1] >= 0
+          && $got[1] < 1_000_000_000;
+    ok $ok
+        or print("# got: @got, size: " . scalar(@got) . "\n");
 }


### PR DESCRIPTION
I would like to get fast, integer based, timing from Perl. `Time::HiRes` returns a float, and is not ideal for this kind of thing.

Using `CLOCK_GETTIME` on Posix systems this PR adds the `hrtime()` method to `Time::HiRes` to return a UV of nanosecods. Care was taken to make this similar in style to the other hires functions of this module. It will fail gracefully with a `croak()` error if `CLOCK_GETTIME` is not available.

POD documentation has been included with explanations of the epoch, and the counter roll-over.

It has been tested out-of-tree as a standalone module and passes except for one test:

```text
#   Failed test 'Time::HiRes::sleep's prototype matches CORE::sleep's'
#   at ./t/sleep.t line 13.
#          got: ';@'
#     expected: ';$'
# Looks like you failed 1 test of 5.
```

I didn't touch any of this code, so I suspect this is a side-effect of building out of tree? Not sure what this error is.

**See also:** PHP's [hrtime()](https://www.php.net/manual/en/function.hrtime.php)