### PR TITLE
Add svtypename() as an API function for debug purposes

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5205,6 +5205,7 @@ ext/XS-APItest/t/stuff_modify_bug.t		test for eval side-effecting source string
 ext/XS-APItest/t/stuff_svcur_bug.t		test for a bug in lex_stuff_pvn
 ext/XS-APItest/t/subcall.t			Test XSUB calls
 ext/XS-APItest/t/subsignature.t			Test parse_subsignature()
+ext/XS-APItest/t/sv.t				Test other parts of SV API
 ext/XS-APItest/t/sv_numcmp.t			Test sv_numcmp
 ext/XS-APItest/t/sv_numeq.t			Test sv_numeq
 ext/XS-APItest/t/sv_numlget.t			Test sv_num[lg][et]

--- a/dump.c
+++ b/dump.c
@@ -50,6 +50,32 @@ static const char* const svtypenames[SVt_LAST] = {
     "PVOBJ",
 };
 
+/*
+=for apidoc svtypename
+
+Returns a human-readable string name corresponding to the given C<SvTYPE()>
+value; specifically the part after the C<SVt_> prefix. For example when given
+C<SVt_PVMG> it will return C<"PVMG">.  This is a direct representation of the
+underlying C-level type value and distinguishes the various scalar types from
+each other, but does not consider things like vstring magic.
+
+For a more Perl-centric result that more closely matches the behaviour of the
+C<ref()> perl function, see instead C</sv_reftype>.
+
+=cut
+*/
+
+const char *
+Perl_svtypename(U8 type)
+{
+    PERL_ARGS_ASSERT_SVTYPENAME;
+
+    if (type < SVt_LAST)
+        return svtypenames[type];
+    else
+        return NULL;
+}
+
 
 static const char* const svshorttypenames[SVt_LAST] = {
     "UNDEF",

--- a/embed.fnc
+++ b/embed.fnc
@@ -3773,6 +3773,7 @@ Cip	|bool	|SvTRUE_common	|NN SV *sv				\
 				|const bool sv_2bool_is_fallback
 Adip	|bool	|SvTRUE_NN	|NN SV *sv
 Adip	|bool	|SvTRUE_nomg	|NULLOK SV *sv
+APTdp	|const char *|svtypename|U8 type
 ARdp	|char * |sv_uni_display |NN SV *dsv				\
 				|NN SV *ssv				\
 				|STRLEN pvlim				\

--- a/embed.h
+++ b/embed.h
@@ -772,6 +772,7 @@
 # define sv_vsetpvf_mg(a,b,c)                   Perl_sv_vsetpvf_mg(aTHX_ a,b,c)
 # define sv_vsetpvfn(a,b,c,d,e,f,g)             Perl_sv_vsetpvfn(aTHX_ a,b,c,d,e,f,g)
 # define sv_vstring_get(a,b)                    Perl_sv_vstring_get(aTHX_ a,b)
+# define svtypename                             Perl_svtypename
 # define switch_argstack(a)                     Perl_switch_argstack(aTHX_ a)
 # define switch_to_global_locale()              Perl_switch_to_global_locale(aTHX)
 # define sync_locale()                          Perl_sync_locale(aTHX)

--- a/ext/B/Makefile.PL
+++ b/ext/B/Makefile.PL
@@ -15,8 +15,23 @@ if ($core) {
 }
 
 my @names = ({ name => 'HEf_SVKEY', macro => 1, type => "IV" },
-             qw(SVTYPEMASK SVt_PVGV SVt_PVHV PAD_FAKELEX_ANON
+             qw(SVTYPEMASK PAD_FAKELEX_ANON
                 PAD_FAKELEX_MULTI SVpad_STATE SVpad_TYPED SVpad_OUR));
+
+{
+    # Collect up the names of all the SVt_* constants for SvTYPE etc...
+    # These live in an enum in sv.h, not #define
+    my $path = File::Spec->catfile($headerpath, 'sv.h');
+    open my $fh, '<', $path or die "Cannot open $path: $!";
+
+    my $in_enum;
+    while (<$fh>) {
+        $in_enum++, next if m/enum\s*{/;
+        $in_enum = 0, next if m/^\s*}/;
+
+        push @names, {name => $1, macro => 1} if $in_enum and m/^\s*(SVt_\w+)/;
+    }
+}
 
 my @depend;
 

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '1.50';
+our $VERSION = '1.51';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -5200,6 +5200,9 @@ newSVpvf_blank()
     OUTPUT:
         RETVAL
 
+const char *
+svtypename(U8 type)
+
 MODULE = XS::APItest PACKAGE = XS::APItest::AUTOLOADtest
 
 int

--- a/ext/XS-APItest/t/sv.t
+++ b/ext/XS-APItest/t/sv.t
@@ -1,0 +1,16 @@
+#!perl -w
+
+use v5.42;
+
+use Test::More;
+
+use XS::APItest;
+use B qw( SVt_NULL SVt_IV SVt_PVMG SVt_PVGV );
+
+is(svtypename(SVt_NULL), "NULL");
+is(svtypename(SVt_IV),   "IV");
+is(svtypename(SVt_PVMG), "PVMG");
+is(svtypename(SVt_PVGV), "PVGV");
+is(svtypename(123),      undef);
+
+done_testing();

--- a/proto.h
+++ b/proto.h
@@ -6991,6 +6991,12 @@ Perl_sv_vstring_get(pTHX_ SV * const sv, STRLEN *lenp)
 #define PERL_ARGS_ASSERT_SV_VSTRING_GET         \
         Perl_assert_aTHX; assert(sv)
 
+PERL_CALLCONV const char *
+Perl_svtypename(U8 type)
+        __attribute__warn_unused_result__
+        __attribute__pure__;
+#define PERL_ARGS_ASSERT_SVTYPENAME
+
 PERL_CALLCONV void
 Perl_switch_to_global_locale(pTHX)
         Perl_attribute_nonnull_aTHX;


### PR DESCRIPTION
There are times when I've wanted to have this array for debug printing in code, XS modules, and so on. It seemed odd not to have it visible.

* This set of changes does not require a perldelta entry.