### PR TITLE
sv.c: Forbid SVt_PVOBJ instances from various functions (fixes #24469)

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -911,6 +911,19 @@ not permitted.
 (F) Similar to above, but involving a C<finally> block at the end of a
 C<try>/C<catch> construction rather than a C<defer> block.
 
+=item Can't assign reference to %s into a GLOB
+
+(F) An attempt was made to assign a reference to something into a GLOB, but
+the thing being referred to by that reference is not something that can be
+stored in a GLOB.  Typically this is because you attempted to store an object
+(as created by C<use feature 'class'>) directly in the GLOB, rather than
+storing a scalar containing a reference to the object.
+
+  *xyz = My::Object::Class->new;   # incorrect, will cause this error
+
+  *xyz = \My::Object::Class->new;  # correct, $xyz will now store the
+                                   # object reference
+
 =item Can't bless an object reference
 
 (F) You attempted to call C<bless> on a value that already refers to a real

--- a/sv.c
+++ b/sv.c
@@ -1585,6 +1585,7 @@ Perl_sv_setiv(pTHX_ SV *const sv, const IV i)
     case SVt_PVCV:
     case SVt_PVFM:
     case SVt_PVIO:
+    case SVt_PVOBJ:
         /* diag_listed_as: Can't coerce %s to %s in %s */
         croak("Can't coerce %s to integer in %s", sv_reftype(sv,0),
                    OP_DESC(PL_op));
@@ -1697,6 +1698,7 @@ Perl_sv_setnv(pTHX_ SV *const sv, const NV num)
     case SVt_PVCV:
     case SVt_PVFM:
     case SVt_PVIO:
+    case SVt_PVOBJ:
         /* diag_listed_as: Can't coerce %s to %s in %s */
         croak("Can't coerce %s to number in %s", sv_reftype(sv,0),
                    OP_DESC(PL_op));

--- a/sv.c
+++ b/sv.c
@@ -4032,6 +4032,9 @@ Perl_gv_setref(pTHX_ SV *const dsv, SV *const ssv)
     case SVt_PVFM:
         location = (SV **) &GvFORM(dsv);
         goto common;
+    case SVt_PVOBJ:
+        croak("Can't assign reference to %s into a GLOB", sv_reftype(sref, false));
+
     default:
         location = &GvSV(dsv);
         import_flag = GVf_IMPORTED_SV;

--- a/t/lib/croak/gv
+++ b/t/lib/croak/gv
@@ -69,3 +69,10 @@ $# is no longer supported as of Perl 5.30 at - line 1.
 $a = $*;
 EXPECT
 $* is no longer supported as of Perl 5.30 at - line 1.
+########
+# NAME assigning object to glob disallowed [GH#24469]
+use feature 'class'; no warnings 'experimental::class';
+class C {}
+*x = C->new;
+EXPECT
+Can't assign reference to OBJECT into a GLOB at - line 3.


### PR DESCRIPTION
As #24469 notes, previously this referent type was permitted in a GLOB assignment and caused weird failures when it happened.
Additionally while I was there I added it to the banned lists in `sv_setiv()` and `sv_setnv()`.

* This set of changes does not require a perldelta entry.