### PR TITLE
ExtUtils-ParseXS: silence warnings on older perls

### DIFF
--- a/dist/ExtUtils-ParseXS/t/lib/TestMany.pm
+++ b/dist/ExtUtils-ParseXS/t/lib/TestMany.pm
@@ -146,6 +146,8 @@ sub test_many {
             else {
                 $str = $out;
             }
+            $str = ''
+                if !defined $str;
             local $TODO = $todo if $flags & TODO;
 
             if ($flags & NOT) {


### PR DESCRIPTION
Running on older perls where Test::More has not been updated would show uninitialized warnings because the empty outputs were undefined.