### PR TITLE
PathTools: fix cwd_noent test trying to delete current directory

### DIFF
--- a/dist/PathTools/t/cwd_enoent.t
+++ b/dist/PathTools/t/cwd_enoent.t
@@ -5,6 +5,7 @@ use Config;
 use Errno qw();
 use File::Temp qw(tempdir);
 use Test::More;
+use Cwd ();
 
 if($^O eq "cygwin") {
     # This test skipping should be removed when the Cygwin bug is fixed.
@@ -13,13 +14,15 @@ if($^O eq "cygwin") {
 my $prefix = $Config{prefix};
 my $osvers = $Config{osvers};
 
+my $cwd = Cwd::getcwd();
+END { chdir $cwd; }
+
 my $tmp = tempdir(CLEANUP => 1);
 unless(mkdir("$tmp/testdir") && chdir("$tmp/testdir") && rmdir("$tmp/testdir")){
     plan skip_all => "can't be in non-existent directory";
 }
 
 plan tests => 8;
-require Cwd;
 
 my @acceptable_errnos = (&Errno::ENOENT, (defined &Errno::ESTALE ? &Errno::ESTALE : ()));
 foreach my $type (qw(regular perl)) {
@@ -58,7 +61,5 @@ foreach my $type (qw(regular perl)) {
 }
 
 chdir $tmp or die "$tmp: $!";
-
-END { chdir $tmp; }
 
 1;


### PR DESCRIPTION
File::Path will refuse to remove the current directory. This is used by File::Temp's CLEANUP option, so we need to be sure to chdir out of the temp directory used before its cleanup is triggered in its END block.