### PR TITLE
autouse: clean up code and tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3522,10 +3522,12 @@ dist/Attribute-Handlers/t/constants.t			Test constants and Attribute::Handlers
 dist/Attribute-Handlers/t/data_convert.t		Test attribute data conversion
 dist/Attribute-Handlers/t/linerep.t			See if Attribute::Handlers works
 dist/Attribute-Handlers/t/multi.t			See if Attribute::Handlers works
-dist/autouse/lib/autouse.pm		Load and call a function only when it's used
-dist/autouse/t/autouse.t		See if autouse works
-dist/autouse/t/lib/MyTestModule.pm	Test module for autouse
-dist/autouse/t/lib/MyTestModule2.pm	Test module for autouse
+dist/autouse/lib/autouse.pm			Load and call a function only when it's used
+dist/autouse/t/autouse.t			See if autouse works
+dist/autouse/t/lib/MyTestModule.pm		Test module for autouse
+dist/autouse/t/lib/MyTestModule2.pm		Test module for autouse
+dist/autouse/t/lib/MyTestModuleNormal.pm	Test module for autouse
+dist/autouse/t/lib/MyTestModuleWithProto.pm	Test module for autouse
 dist/base/Changes			base.pm changelog
 dist/base/lib/base.pm			Establish IS-A relationship at compile time
 dist/base/lib/fields.pm			Set up object field names for pseudo-hash-using classes

--- a/MANIFEST
+++ b/MANIFEST
@@ -3522,6 +3522,7 @@ dist/Attribute-Handlers/t/constants.t			Test constants and Attribute::Handlers
 dist/Attribute-Handlers/t/data_convert.t		Test attribute data conversion
 dist/Attribute-Handlers/t/linerep.t			See if Attribute::Handlers works
 dist/Attribute-Handlers/t/multi.t			See if Attribute::Handlers works
+dist/autouse/Changes				autouse change log
 dist/autouse/lib/autouse.pm			Load and call a function only when it's used
 dist/autouse/t/autouse.t			See if autouse works
 dist/autouse/t/lib/MyTestModule.pm		Test module for autouse

--- a/dist/autouse/Changes
+++ b/dist/autouse/Changes
@@ -1,0 +1,20 @@
+1.11  Sun, 13 Mar 2016 18:45:00 -0400
+  * skip a failing test on very old perls
+
+1.10  Wed,  9 Mar 2016 18:38:00 -0400
+  * bump up the Scalar::Util requirement to match use of isdual
+
+1.09  Sun,  6 Mar 2016 15:33:15 -0400
+  * update a test that used ok() when it meant like()
+
+1.08  Thu,  5 Jun 2014 19:07:40 -0400
+  * Add descriptions for tests in dist/autouse/t/autouse.t lacking them.
+  * Fix autouse test, failing since commit 52102bb4f9
+
+1.07  Tue, 11 Sep 2012 09:52:12 -0400
+  * Restore autouse’s exemption from redef warnings.
+  * Add authority metadata.
+
+1.06  Fri, 10 Dec 2010 23:13:40 +0100
+  * First upload to cpan. Identical with version 1.06 in the perl core. Upstream
+    for this module is still blead perl.

--- a/dist/autouse/Changes
+++ b/dist/autouse/Changes
@@ -1,3 +1,9 @@
+1.12
+  * use strict and warnings consistently
+  * test using sample modules rather than core modules to ensure predictable
+    loading
+  * other test refactoring
+
 1.11  Sun, 13 Mar 2016 18:45:00 -0400
   * skip a failing test on very old perls
 

--- a/dist/autouse/lib/autouse.pm
+++ b/dist/autouse/lib/autouse.pm
@@ -3,7 +3,7 @@ package autouse;
 #use strict;		# debugging only
 use 5.006;		# use warnings
 
-$autouse::VERSION = '1.11';
+$autouse::VERSION = '1.12';
 
 $autouse::DEBUG ||= 0;
 

--- a/dist/autouse/lib/autouse.pm
+++ b/dist/autouse/lib/autouse.pm
@@ -1,11 +1,11 @@
 package autouse;
+use 5.006;
+use strict;
+use warnings;
 
-#use strict;		# debugging only
-use 5.006;		# use warnings
+our $VERSION = '1.12';
 
-$autouse::VERSION = '1.12';
-
-$autouse::DEBUG ||= 0;
+our $DEBUG ||= 0;
 
 sub vet_import ($);
 
@@ -30,7 +30,7 @@ sub import {
 
     # It is not loaded: need to do real work.
     my $callpkg = caller(0);
-    print "autouse called from $callpkg\n" if $autouse::DEBUG;
+    print "autouse called from $callpkg\n" if $DEBUG;
 
     my $index;
     for my $f (@_) {
@@ -54,13 +54,15 @@ sub import {
                 vet_import $module;
             }
             no warnings qw(redefine prototype);
+            no strict 'refs';
             *$closure_import_func = \&{"${module}::$closure_func"};
             print "autousing $module; "
                   ."imported $closure_func as $closure_import_func\n"
-                if $autouse::DEBUG;
+                if $DEBUG;
             goto &$closure_import_func;
         };
 
+        no strict 'refs';
         if (defined $proto) {
             *$closure_import_func = eval "sub ($proto) { goto &\$load_sub }"
                 || die;

--- a/dist/autouse/lib/autouse.pm
+++ b/dist/autouse/lib/autouse.pm
@@ -22,10 +22,10 @@ sub import {
     (my $pm = $module) =~ s{::}{/}g;
     $pm .= '.pm';
     if (exists $INC{$pm}) {
-	vet_import $module;
-	local $Exporter::ExportLevel = $Exporter::ExportLevel + 1;
-	# $Exporter::Verbose = 1;
-	return $module->import(map { (my $f = $_) =~ s/\(.*?\)$//; $f } @_);
+        vet_import $module;
+        local $Exporter::ExportLevel = $Exporter::ExportLevel + 1;
+        # $Exporter::Verbose = 1;
+        return $module->import(map { (my $f = $_) =~ s/\(.*?\)$//; $f } @_);
     }
 
     # It is not loaded: need to do real work.
@@ -34,49 +34,49 @@ sub import {
 
     my $index;
     for my $f (@_) {
-	my $proto;
-	$proto = $1 if (my $func = $f) =~ s/\((.*)\)$//;
+        my $proto;
+        $proto = $1 if (my $func = $f) =~ s/\((.*)\)$//;
 
-	my $closure_import_func = $func;	# Full name
-	my $closure_func = $func;		# Name inside package
-	my $index = rindex($func, '::');
-	if ($index == -1) {
-	    $closure_import_func = "${callpkg}::$func";
-	} else {
-	    $closure_func = substr $func, $index + 2;
-	    croak "autouse into different package attempted"
-		unless substr($func, 0, $index) eq $module;
-	}
+        my $closure_import_func = $func;        # Full name
+        my $closure_func = $func;               # Name inside package
+        my $index = rindex($func, '::');
+        if ($index == -1) {
+            $closure_import_func = "${callpkg}::$func";
+        } else {
+            $closure_func = substr $func, $index + 2;
+            croak "autouse into different package attempted"
+                unless substr($func, 0, $index) eq $module;
+        }
 
-	my $load_sub = sub {
-	    unless ($INC{$pm}) {
-		require $pm;
-		vet_import $module;
-	    }
+        my $load_sub = sub {
+            unless ($INC{$pm}) {
+                require $pm;
+                vet_import $module;
+            }
             no warnings qw(redefine prototype);
-	    *$closure_import_func = \&{"${module}::$closure_func"};
-	    print "autousing $module; "
-		  ."imported $closure_func as $closure_import_func\n"
-		if $autouse::DEBUG;
-	    goto &$closure_import_func;
-	};
+            *$closure_import_func = \&{"${module}::$closure_func"};
+            print "autousing $module; "
+                  ."imported $closure_func as $closure_import_func\n"
+                if $autouse::DEBUG;
+            goto &$closure_import_func;
+        };
 
-	if (defined $proto) {
-	    *$closure_import_func = eval "sub ($proto) { goto &\$load_sub }"
-	        || die;
-	} else {
-	    *$closure_import_func = $load_sub;
-	}
+        if (defined $proto) {
+            *$closure_import_func = eval "sub ($proto) { goto &\$load_sub }"
+                || die;
+        } else {
+            *$closure_import_func = $load_sub;
+        }
     }
 }
 
 sub vet_import ($) {
     my $module = shift;
     if (my $import = $module->can('import')) {
-	croak "autoused module $module has unique import() method"
-	    unless defined(&Exporter::import)
-		   && ($import == \&Exporter::import ||
-		       $import == \&UNIVERSAL::import)
+        croak "autoused module $module has unique import() method"
+            unless defined(&Exporter::import)
+                  && ($import == \&Exporter::import ||
+                      $import == \&UNIVERSAL::import)
     }
 }
 
@@ -90,18 +90,18 @@ autouse - postpone load of modules until a function is used
 
 =head1 SYNOPSIS
 
-  use autouse 'Carp' => qw(carp croak);
-  carp "this carp was predeclared and autoused ";
+    use autouse 'Carp' => qw(carp croak);
+    carp "this carp was predeclared and autoused ";
 
 =head1 DESCRIPTION
 
 If the module C<Module> is already loaded, then the declaration
 
-  use autouse 'Module' => qw(func1 func2($;$));
+    use autouse 'Module' => qw(func1 func2($;$));
 
 is equivalent to
 
-  use Module qw(func1 func2);
+    use Module qw(func1 func2);
 
 if C<Module> defines func2() with prototype C<($;$)>, and func1() has
 no prototypes.  (At least if C<Module> uses C<Exporter>'s C<import>,
@@ -114,11 +114,11 @@ and substitute themselves with the correct definitions.
 
 =begin _deprecated
 
-   use Module qw(Module::func3);
+    use Module qw(Module::func3);
 
 will work and is the equivalent to:
 
-   use Module qw(func3);
+    use Module qw(func3);
 
 It is not a very useful feature and has been deprecated.
 

--- a/dist/autouse/t/autouse.t
+++ b/dist/autouse/t/autouse.t
@@ -89,11 +89,11 @@ SKIP: {
     *MyTestModule2::test_function2 = \&test_function2;
     require MyTestModule2;
     is $w, undef,
-       'no redefinition warning when clobbering autouse stub with new sub';
+        'no redefinition warning when clobbering autouse stub with new sub';
     undef $w;
     MyTestModule2->import('test_function2');
     is $w, undef,
-       'no redefinition warning when clobbering autouse stub via *a=\&b';
+        'no redefinition warning when clobbering autouse stub via *a=\&b';
 }
 SKIP: {
     skip "Fails in 5.15.5 and below (perl bug)", 1 if $] < 5.0150051;
@@ -107,5 +107,5 @@ SKIP: {
     *Hash::Util::all_keys = \&all_keys;
     require Hash::Util;
     is $w, undef,
-      'no redefinition warning when clobbering autouse stub with new XSUB';
+        'no redefinition warning when clobbering autouse stub with new XSUB';
 }

--- a/dist/autouse/t/autouse.t
+++ b/dist/autouse/t/autouse.t
@@ -2,46 +2,40 @@
 use strict;
 use warnings;
 
-BEGIN {
-    require Config;
-    if ($Config::Config{'extensions'} !~ m!\bList/Util\b!){
-	print "1..0 # Skip -- Perl configured without List::Util module\n";
-	exit 0;
-    }
-}
-
 use lib 't/lib';
 use autouse ();
 
-my ($ok1, $ok2);
-BEGIN {
-    eval {
-        "autouse"->import('Scalar::Util' => 'Scalar::Util::set_prototype(&$)');
-    };
-    $ok1 = !$@;
+use Test::More tests => 19;
 
-    eval {
-        "autouse"->import('Scalar::Util' => 'Foo::min');
-    };
-    $ok2 = $@;
+eval {
+    "autouse"->import('MyTestModuleNormal' => 'MyTestModuleNormal::test_function_normal');
+};
+is( $@, '', "Import of fully qualified function from same package works");
 
-    "autouse"->import('Scalar::Util' => qw(isdual set_prototype(&$)));
-}
+eval {
+    "autouse"->import('MyTestModuleNormal' => 'Foo::min');
+};
+like( $@, qr/^autouse into different package attempted/, "Catch autouse into different package" );
 
-use Test::More tests => 15;
+use autouse 'MyTestModuleWithProto' => qw(test_function_another(@) test_function_with_proto(&$));
 
-ok( $ok1, "Function from package with custom 'import()' correctly imported" );
-like( $ok2, qr/^autouse into different package attempted/, "Catch autouse into different package" );
+is prototype(\&test_function_with_proto), '&$',
+    'specified prototype set correctly';
 
-ok( isdual($!),
-    "Function imported via 'autouse' performs as expected");
+is eval { test_function_with_proto(sub {}, 1) }, 'works',
+    "Function imported via 'autouse' performs as expected";
 
+is prototype(\&test_function_with_proto), '&$',
+    'prototype still correct after call';
 
-# set_prototype() has a prototype of &$.  Make sure that's preserved.
-sub sum { return $_[0] + $_[1] };
-is( (set_prototype \&sum, '$$'), \&sum,
-    "Subroutine prototype preserved after import via 'autouse'");
+is prototype(\&test_function_another), '@',
+    'specified incorrect prototype set correctly';
 
+is eval { test_function_another() }, 'works',
+    "Function imported via 'autouse' with incorrect prototype performs as expected";
+
+is prototype(\&test_function_another), undef,
+    'specified incorrect prototype updated to real prototype';
 
 # Example from the docs.
 use autouse 'Carp' => qw(carp croak);

--- a/dist/autouse/t/autouse.t
+++ b/dist/autouse/t/autouse.t
@@ -1,4 +1,6 @@
 #!./perl
+use strict;
+use warnings;
 
 BEGIN {
     require Config;

--- a/dist/autouse/t/autouse.t
+++ b/dist/autouse/t/autouse.t
@@ -5,7 +5,7 @@ use warnings;
 use lib 't/lib';
 use autouse ();
 
-use Test::More tests => 19;
+use Test::More tests => 18;
 
 eval {
     "autouse"->import('MyTestModuleNormal' => 'MyTestModuleNormal::test_function_normal');
@@ -19,6 +19,9 @@ like( $@, qr/^autouse into different package attempted/, "Catch autouse into dif
 
 use autouse 'MyTestModuleWithProto' => qw(test_function_another(@) test_function_with_proto(&$));
 
+ok !exists $INC{'MyTestModuleWithProto.pm'},
+    'Module not yet loaded';
+
 is prototype(\&test_function_with_proto), '&$',
     'specified prototype set correctly';
 
@@ -27,6 +30,9 @@ is eval { test_function_with_proto(sub {}, 1) }, 'works',
 
 is prototype(\&test_function_with_proto), '&$',
     'prototype still correct after call';
+
+ok exists $INC{'MyTestModuleWithProto.pm'},
+    'Module has been lazily loaded';
 
 is prototype(\&test_function_another), '@',
     'specified incorrect prototype set correctly';
@@ -53,14 +59,6 @@ use autouse 'Carp' => qw(carp croak);
         "Failure message received as expected" );
 }
 
-
-# Test that autouse's lazy module loading works.
-use autouse 'Errno' => qw(EPERM);
-
-my $mod_file = 'Errno.pm';   # just fine and portable for %INC
-ok( !exists $INC{$mod_file}, "Module not yet loaded" );
-ok( EPERM, "Access a constant from that module" ); # test if non-zero
-ok( exists $INC{$mod_file}, "Module has been lazily loaded" );
 
 use autouse Env => "something";
 eval { something() };

--- a/dist/autouse/t/autouse.t
+++ b/dist/autouse/t/autouse.t
@@ -10,9 +10,11 @@ BEGIN {
     }
 }
 
+use lib 't/lib';
+use autouse ();
+
 my ($ok1, $ok2);
 BEGIN {
-    require autouse;
     eval {
         "autouse"->import('Scalar::Util' => 'Scalar::Util::set_prototype(&$)');
     };
@@ -74,8 +76,6 @@ like( $@, qr/^\Qautoused module Env has unique import() method/,
 # Check that UNIVERSAL.pm doesn't interfere with modules that don't use
 # Exporter and have no import() of their own.
 require UNIVERSAL;
-require File::Spec;
-unshift @INC, File::Spec->catdir('t', 'lib'), 'lib';
 autouse->import("MyTestModule" => 'test_function');
 my $ret = test_function();
 is( $ret, 'works', "No interference from UNIVERSAL.pm" );

--- a/dist/autouse/t/lib/MyTestModule.pm
+++ b/dist/autouse/t/lib/MyTestModule.pm
@@ -2,7 +2,7 @@ package MyTestModule;
 use strict;
 
 sub test_function {
-  return 'works';
+    return 'works';
 }
 
 1;

--- a/dist/autouse/t/lib/MyTestModule.pm
+++ b/dist/autouse/t/lib/MyTestModule.pm
@@ -1,5 +1,6 @@
 package MyTestModule;
 use strict;
+use warnings;
 
 sub test_function {
     return 'works';

--- a/dist/autouse/t/lib/MyTestModule2.pm
+++ b/dist/autouse/t/lib/MyTestModule2.pm
@@ -6,7 +6,7 @@ require Exporter;
 @EXPORT_OK = 'test_function2';
 
 sub test_function2 {
-  return 'works';
+    return 'works';
 }
 
 1;

--- a/dist/autouse/t/lib/MyTestModule2.pm
+++ b/dist/autouse/t/lib/MyTestModule2.pm
@@ -1,9 +1,10 @@
 package MyTestModule2;
+use strict;
 use warnings;
 
-@ISA = Exporter;
-require Exporter;
-@EXPORT_OK = 'test_function2';
+use Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = 'test_function2';
 
 sub test_function2 {
     return 'works';

--- a/dist/autouse/t/lib/MyTestModuleNormal.pm
+++ b/dist/autouse/t/lib/MyTestModuleNormal.pm
@@ -1,0 +1,13 @@
+package MyTestModuleNormal;
+use strict;
+use warnings;
+
+use Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = 'test_function_normal';
+
+sub test_function_normal {
+    return 'works';
+}
+
+1;

--- a/dist/autouse/t/lib/MyTestModuleWithProto.pm
+++ b/dist/autouse/t/lib/MyTestModuleWithProto.pm
@@ -1,0 +1,20 @@
+package MyTestModuleWithProto;
+use strict;
+use warnings;
+
+use Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(test_function_with_proto test_function_another);
+
+sub test_function_with_proto (&$) {
+    if (@_ == 2 && ref $_[0] eq 'CODE') {
+        return 'works';
+    }
+    return 'fails';
+}
+
+sub test_function_another {
+    return 'works';
+}
+
+1;


### PR DESCRIPTION
A few cleanups for autouse.

  * Normalize whitespace
  * use strict and warnings
  * use test modules to test loading rather than reusing and interfering with core modules
  * Add change log from CPAN

This silences a warning when running autouse's tests on older perl versions.

This shouldn't cause any functional changes.