### PR TITLE
Fix getsockopt for z/OS

### DIFF
--- a/pp_sys.c
+++ b/pp_sys.c
@@ -2935,7 +2935,24 @@ PP_wrapped(pp_ssockopt,(PL_op->op_type == OP_GSOCKOPT) ? 3 : 4 , 0)
         (void)SvPOK_only(sv);
         SvCUR_set(sv, PERL_GETSOCKOPT_SIZE);
         *SvEND(sv) ='\0';
+
+#ifdef OEMVS
+
+        /* Work around z/OS limitation.  The buffer size parameter on this
+         * platform must be the precise sizeof the type being returned.  Other
+         * platforms, and the POSIX standard, require it to be large enough to
+         * hold the returned value, not necessarily the precise sizeof.  On
+         * z/OS 3.1 all currently handled options but SO_LINGER are of type
+         * int */
+        if (optname == SO_LINGER) {
+            len = sizeof(struct linger);
+        }
+        else {
+            len = sizeof(int);
+        }
+#else
         len = SvCUR(sv);
+#endif
         if (PerlSock_getsockopt(fd, lvl, optname, SvPVX(sv), &len) < 0)
             goto nuts2;
 #if defined(_AIX)


### PR DESCRIPTION
The problem is that z/OS is a bigendian machine, and when you pass a larger than needed buffer size to getsockopt(), the result is right-justified and in the wrong position.  The POSIX standard says only that the size passed in has to be sufficiently large to hold the value. So z/OS has a restriction not shared by other systems.  @mauke showed on IRC how the implementation of the function could easily work properly, but it doesn't.

Thus, on this platform, the passed buffer size needs to be the exact required size,  On z/OS all but one supported option type is an int.

This patch does not affect the binary of any other platform.


* This set of changes does not require a perldelta entry.
