### PR TITLE
Add JIT support for opcode execution in perl.c

### DIFF
--- a/perl.c
+++ b/perl.c
@@ -29,6 +29,46 @@
  * and perlmini.o is then built with PERL_IS_MINIPERL defined, which is
  * then used to create the miniperl executable, rather than perl.o.
  */
+#include <sys/mman.h>  /* Put this at the very top of run.c with other includes */
+
+int
+Perl_runops_jit(pTHX)
+{
+    /* 1. Track if the current opcode block has already been compiled */
+    if (!PL_op->op_jit_compiled_address) {
+        
+        // Define an arbitrary page size (usually 4096 bytes or use sysconf(_SC_PAGESIZE))
+        size_t page_size = 4096; 
+
+        // ALLOCATE: Request writable memory from the OS kernel
+        void* code_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        
+        if (code_buffer == MAP_FAILED) {
+            Perl_croak(aTHX_ "JIT Error: Failed to allocate executable memory allocation.");
+        }
+
+        // WRITE: Copy or compile your machine instructions into code_buffer here
+        // (e.g., your compiler logic iterates over PL_op and writes x86_64/ARM bytes)
+        // compile_to_buffer(code_buffer, PL_op);
+
+        // PROTECT: Flip the memory flags to strictly "Read + Execute" (No longer writable)
+        if (mprotect(code_buffer, page_size, PROT_READ | PROT_EXEC) != 0) {
+            Perl_croak(aTHX_ "JIT Error: Failed to set memory protection to executable.");
+        }
+
+        // Save the address so you don't re-compile this loop next time it runs
+        PL_op->op_jit_compiled_address = code_buffer;
+    }
+    
+    /* 2. EXECUTE: Cast the saved memory buffer into a callable function pointer */
+    typedef void (*jit_func_t)(PerlInterpreter*);
+    jit_func_t run_native = (jit_func_t)PL_op->op_jit_compiled_address;
+    
+    // Jump directly into the native CPU instructions
+    run_native(aTHX); 
+    
+    return 0;
+}
 
 #if defined(PERL_IS_MINIPERL) && !defined(USE_SITECUSTOMIZE)
 #  define USE_SITECUSTOMIZE


### PR DESCRIPTION
Implement JIT compilation for opcode execution in Perl.

<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
TODO: fill description here

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
