### PR TITLE
Makefile.SH: z/OS use clang option, only 64 bit

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -126,15 +126,8 @@ true)
 		linklibperl="-L `pwd | sed 's/\/UU$//'` -Wl,+s -Wl,+b$archlibexp/CORE -lperl"
 		;;
 	os390*)
-            case "$use64bitall" in
-            define|true|[yY]*) shrpldflags='-Wl,LP64,dll'
-                   linklibperl='libperl.x'
-                   ;;
-            *)     shrpldflags='-Wl,XPLINK,dll'
-	           linklibperl='libperl.x'
-	           ;;
-            esac
-            ;;
+            shrpldflags='-shared'
+            linklibperl='libperl.x'
 	esac
 	case "$ldlibpthname" in
 	'') ;;


### PR DESCRIPTION
z/OS is now using clang.  clang has a different option than previously used compilers to signify to use shared libraries for linking.  This commit changes to use that.  Further, we are now only supporting 64-bit builds on z/OS, so remove the 32-bit case.

This commit only affects z/OS, and no other platforms.


* This set of changes does not require a perldelta entry.
