### PR TITLE
B::Deparse: better output of anonhashes following map, grep, sort

### DIFF
--- a/lib/B/Deparse.pm
+++ b/lib/B/Deparse.pm
@@ -7,7 +7,7 @@
 # This is based on the module of the same name by Malcolm Beattie,
 # but essentially none of his code remains.
 
-package B::Deparse 1.89;
+package B::Deparse 1.90;
 use strict;
 use builtin qw( true false );
 use Carp;
@@ -3889,7 +3889,13 @@ sub indirop {
 	$indir = '{$b cmp $a} ';
     }
     for (; !null($kid); $kid = $kid->sibling) {
-	$expr = $self->deparse($kid, !$indir && $kid == $firstkid && $name eq "sort" && $firstkid->name eq "entersub" ? 16 : 6);
+        my $is_first = !$indir && $kid == $firstkid;
+        $expr = $self->deparse($kid, $is_first && $name eq "sort" && $firstkid->name eq "entersub" ? 16 : 6);
+
+        # Disambiguate anonhash from block
+        # e.g. sort +{ $_ => 1 }, @array;
+        $expr = '+'.$expr if $is_first && $expr =~ /^{/;
+
 	push @exprs, $expr;
     }
     my $name2;
@@ -3947,6 +3953,9 @@ sub mapop {
 	$code = "{" . $self->deparse($code, 0) . "} ";
     } else {
 	$code = $self->deparse($code, 24);
+        # Disambiguate anonhash from a block
+        # e.g. map +{ $_ => 1 }, @array
+        $code = '+'.$code if $code =~ /^{/;
 	$code .= ", " if !null($kid->sibling);
     }
     $kid = $kid->sibling;

--- a/lib/B/Deparse.t
+++ b/lib/B/Deparse.t
@@ -3659,3 +3659,8 @@ elsif ($y) {
 }
 >>>>
 {;};
+####
+# Deparse +{} as anonymous hash, not block
+map +{$_, 1}, 1;
+grep +{$_, 1}, 1;
+sort +{$_, 1}, @ARGV;


### PR DESCRIPTION
When a `map`, `grep`, or `sort` keyword is followed by an anonymous hash constructor, disambiguated from a block declaration by a plus character, `B::Deparse` struggled to always include the plus in its output, meaning that deparsed Perl code would behave differently to the original.

For example:

    map +{ $_ => 1}. 1

would deparse to:

    map { $_ => 1}, 1

It now deparses correctly - for at least cases of the same nature.

Improves #9108, but does not address the inverse problem included in that ticket, where characters used to force block behaviour are not output correctly.

Note: I'm not 100% confident that is an entirely correct fix, or that no other OPs also need modifying in the same way.

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and one will be added once the next development cycle begins.
