### PR TITLE
OP_SASSIGN is a BINOP, not a viable type for newUNOP()

### DIFF
--- a/dump.c
+++ b/dump.c
@@ -3737,9 +3737,6 @@ Perl_op_class(pTHX_ const OP *o)
         return (o->op_flags & OPf_KIDS) ? OPclass_UNOP : OPclass_BASEOP;
     }
 
-    if (o->op_type == OP_SASSIGN)
-        return ((o->op_private & OPpASSIGN_BACKWARDS) ? OPclass_UNOP : OPclass_BINOP);
-
     if (o->op_type == OP_AELEMFAST) {
 #ifdef USE_ITHREADS
             return OPclass_PADOP;

--- a/op.c
+++ b/op.c
@@ -6045,7 +6045,6 @@ Perl_newUNOP(pTHX_ I32 type, I32 flags, OP *first)
         || (PL_opargs[type] & OA_CLASS_MASK) == OA_BASEOP_OR_UNOP
         || (PL_opargs[type] & OA_CLASS_MASK) == OA_FILESTATOP
         || (PL_opargs[type] & OA_CLASS_MASK) == OA_LOOPEXOP
-        || type == OP_SASSIGN
         || type == OP_ENTERTRY
         || type == OP_ENTERTRYCATCH
         || type == OP_CUSTOM


### PR DESCRIPTION
An assertion in `Perl_newUNOP` permits the requested `type` to be `OP_SASSIGN`, but that OP is a BINOP not an UNOP.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
