### PR TITLE
S_maybe_targlex: don't leak the unused PADTMP pad slot

### DIFF
--- a/op.c
+++ b/op.c
@@ -14267,8 +14267,10 @@ S_maybe_targlex(pTHX_ OP *o)
                 kid->op_flags =   (kid->op_flags & ~OPf_WANT)
                                 | (o->op_flags   &  OPf_WANT);
               swipe_and_detach:
+                assert(kid->op_targ);
+                PADOFFSET temp = kid->op_targ;
                 kid->op_targ = kkid->op_targ;
-                kkid->op_targ = 0;
+                kkid->op_targ = temp;
                 /* Now we do not need PADSV and SASSIGN.
                  * Detach kid and free the rest. */
                 op_sibling_splice(o, NULL, 1, NULL);

--- a/op.c
+++ b/op.c
@@ -6187,6 +6187,61 @@ Perl_newMETHOP_named (pTHX_ I32 type, I32 flags, SV* const_meth)
     return newMETHOP_internal(type, flags, NULL, const_meth);
 }
 
+
+
+/* S_maybe_targlex is invoked when constructing a new OP_SASSIGN.
+ * It implements the TARGMY optimization, where the OP_SASSIGN
+ * and OP_PADSV in the following tree are discarded, with the
+ * remaining OP's op_targ offset taken from the OP_PADSV.
+ *     <2> sassign
+ *      |_  <2> some_op
+ *      |_  <1> padsv
+*/
+
+static OP *
+S_maybe_targlex(pTHX_ OP *o)
+{
+    OP * const kid = cLISTOPo->op_first;
+    /* has a disposable target? */
+    if ((PL_opargs[kid->op_type] & OA_TARGLEX)
+        && !(kid->op_flags & OPf_STACKED)
+        /* Cannot steal the second time! */
+        && !(kid->op_private & OPpTARGET_MY)
+        )
+    {
+        OP * const kkid = OpSIBLING(kid);
+
+        /* Can just relocate the target. */
+        if (kkid && kkid->op_type == OP_PADSV) {
+            if (kid->op_type == OP_EMPTYAVHV) {
+                kid->op_flags |= kid->op_flags |
+                    (o->op_flags & (OPf_WANT|OPf_PARENS));
+                kid->op_private |= OPpTARGET_MY |
+                              (kkid->op_private & (OPpLVAL_INTRO|OPpPAD_STATE));
+                goto swipe_and_detach;
+            } else if (!(kkid->op_private & OPpLVAL_INTRO)
+                   || (kkid->op_private & OPpPAD_STATE))
+            {
+                kid->op_private |= OPpTARGET_MY;       /* Used for context settings */
+                /* give the lexical op the context of the parent sassign */
+                kid->op_flags =   (kid->op_flags & ~OPf_WANT)
+                                | (o->op_flags   &  OPf_WANT);
+              swipe_and_detach:
+                assert(kid->op_targ);
+                PADOFFSET temp = kid->op_targ;
+                kid->op_targ = kkid->op_targ;
+                kkid->op_targ = temp;
+                /* Now we do not need PADSV and SASSIGN.
+                 * Detach kid and free the rest. */
+                op_sibling_splice(o, NULL, 1, NULL);
+                op_free(o);
+                return kid;
+            }
+        }
+    }
+    return o;
+}
+
 /*
 =for apidoc newBINOP
 
@@ -14234,51 +14289,6 @@ Perl_ck_smartmatch(pTHX_ OP *o)
         }
     }
 
-    return o;
-}
-
-
-static OP *
-S_maybe_targlex(pTHX_ OP *o)
-{
-    OP * const kid = cLISTOPo->op_first;
-    /* has a disposable target? */
-    if ((PL_opargs[kid->op_type] & OA_TARGLEX)
-        && !(kid->op_flags & OPf_STACKED)
-        /* Cannot steal the second time! */
-        && !(kid->op_private & OPpTARGET_MY)
-        )
-    {
-        OP * const kkid = OpSIBLING(kid);
-
-        /* Can just relocate the target. */
-        if (kkid && kkid->op_type == OP_PADSV) {
-            if (kid->op_type == OP_EMPTYAVHV) {
-                kid->op_flags |= kid->op_flags |
-                    (o->op_flags & (OPf_WANT|OPf_PARENS));
-                kid->op_private |= OPpTARGET_MY |
-                              (kkid->op_private & (OPpLVAL_INTRO|OPpPAD_STATE));
-                goto swipe_and_detach;
-            } else if (!(kkid->op_private & OPpLVAL_INTRO)
-                   || (kkid->op_private & OPpPAD_STATE))
-            {
-                kid->op_private |= OPpTARGET_MY;       /* Used for context settings */
-                /* give the lexical op the context of the parent sassign */
-                kid->op_flags =   (kid->op_flags & ~OPf_WANT)
-                                | (o->op_flags   &  OPf_WANT);
-              swipe_and_detach:
-                assert(kid->op_targ);
-                PADOFFSET temp = kid->op_targ;
-                kid->op_targ = kkid->op_targ;
-                kkid->op_targ = temp;
-                /* Now we do not need PADSV and SASSIGN.
-                 * Detach kid and free the rest. */
-                op_sibling_splice(o, NULL, 1, NULL);
-                op_free(o);
-                return kid;
-            }
-        }
-    }
     return o;
 }
 

--- a/op.c
+++ b/op.c
@@ -6199,47 +6199,46 @@ Perl_newMETHOP_named (pTHX_ I32 type, I32 flags, SV* const_meth)
 */
 
 static OP *
-S_maybe_targlex(pTHX_ OP *o)
+S_maybe_targlex(pTHX_ const U32 op_flags, OP * const kid, OP * const kkid)
 {
-    OP * const kid = cLISTOPo->op_first;
+    /* Caller should have checked OA_TARGLEX */
+    assert(PL_opargs[kid->op_type] & OA_TARGLEX);
     /* has a disposable target? */
-    if ((PL_opargs[kid->op_type] & OA_TARGLEX)
-        && !(kid->op_flags & OPf_STACKED)
+    if ( !(kid->op_flags & OPf_STACKED)
         /* Cannot steal the second time! */
         && !(kid->op_private & OPpTARGET_MY)
         )
     {
-        OP * const kkid = OpSIBLING(kid);
+        assert(kkid && OP_TYPE_IS(kkid, OP_PADSV));
 
         /* Can just relocate the target. */
-        if (kkid && kkid->op_type == OP_PADSV) {
-            if (kid->op_type == OP_EMPTYAVHV) {
-                kid->op_flags |= kid->op_flags |
-                    (o->op_flags & (OPf_WANT|OPf_PARENS));
-                kid->op_private |= OPpTARGET_MY |
+        PADOFFSET op_targ_temp = kid->op_targ;
+
+        if (OP_TYPE_IS(kid, OP_EMPTYAVHV)) {
+            kid->op_flags |= op_flags & (OPf_WANT|OPf_PARENS);
+            kid->op_private |= OPpTARGET_MY |
                               (kkid->op_private & (OPpLVAL_INTRO|OPpPAD_STATE));
-                goto swipe_and_detach;
-            } else if (!(kkid->op_private & OPpLVAL_INTRO)
-                   || (kkid->op_private & OPpPAD_STATE))
-            {
-                kid->op_private |= OPpTARGET_MY;       /* Used for context settings */
-                /* give the lexical op the context of the parent sassign */
-                kid->op_flags =   (kid->op_flags & ~OPf_WANT)
-                                | (o->op_flags   &  OPf_WANT);
-              swipe_and_detach:
-                assert(kid->op_targ);
-                PADOFFSET temp = kid->op_targ;
-                kid->op_targ = kkid->op_targ;
-                kkid->op_targ = temp;
-                /* Now we do not need PADSV and SASSIGN.
-                 * Detach kid and free the rest. */
-                op_sibling_splice(o, NULL, 1, NULL);
-                op_free(o);
-                return kid;
-            }
+            goto swipe_and_detach;
+        } else if (!(kkid->op_private & (OPpLVAL_INTRO|OPpPAD_STATE)) ) {
+            /* Note: OP_ONCE is not currently supported. At present,
+             * this branch prevents an OP_SASSIGN being created, but
+             * creation of the OP_ONCE structure used for a 'state'
+             * declaration occurs via Perl_ck_sassign. */
+            kid->op_private |= OPpTARGET_MY;
+            /* give the lexical op the context of the intended sassign */
+            kid->op_flags = (kid->op_flags & ~OPf_WANT)
+                                | (op_flags & OPf_WANT);
+          swipe_and_detach:
+            kid->op_targ = kkid->op_targ;
+            kkid->op_targ = op_targ_temp;
+            /* Now we do not need the OP_PADSV.
+             * Free it, along with the now-unused pad slot. */
+            op_free(kkid);
+            assert(kid->op_private & OPpTARGET_MY);
+            return kid;
         }
     }
-    return o;
+    return NULL;
 }
 
 /*
@@ -6268,7 +6267,20 @@ Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
 
     if (!first)
         first = newOP(OP_NULL, 0);
-    else if (type != OP_SASSIGN && S_is_control_transfer(aTHX_ first)) {
+
+    else if (type == OP_SASSIGN) {
+        if (last && OP_TYPE_IS(last, OP_PADSV)
+            /* Most of the often very common OP_TYPES fail this check, which
+             * is why it's here and not in S_maybe_targlex(). */
+            && (PL_opargs[first->op_type] & OA_TARGLEX)
+        ) {
+            /* Try to implement the TARGMY optimization now, instead of unpicking
+             * an OP_SASSIGN OP later. */
+            OP *targmy = S_maybe_targlex(aTHX_ flags, first, last);
+            if (targmy)
+                return targmy; /* source == targmy, last has already been freed. */
+        }
+    } else if (S_is_control_transfer(aTHX_ first)) {
         /* Skip OP_SASSIGN.
          * '$x = return 42' is represented by (SASSIGN (RETURN 42) (GVSV *x));
          * in other words, OP_SASSIGN has its operands "backwards". Skip the
@@ -14313,7 +14325,7 @@ Perl_ck_sassign(pTHX_ OP *o)
             return S_newONCEOP(aTHX_ o, kkid);
         }
     }
-    return S_maybe_targlex(aTHX_ o);
+    return o;
 }
 
 

--- a/pad.c
+++ b/pad.c
@@ -1836,8 +1836,12 @@ Perl_pad_free(pTHX_ PADOFFSET po)
     if (sv && sv != &PL_sv_undef && !SvPADMY(sv))
         SvFLAGS(sv) &= ~SVs_PADTMP;
 
-    if (po < PL_padix)
+    if (po <= PL_padix)
         PL_padix = po - 1;
+#if defined(USE_ITHREADS)
+    if (po <= PL_constpadix)
+        PL_constpadix = po - 1;
+#endif
 #endif
 }
 


### PR DESCRIPTION
The TARGMY optimization converts an optree like this:

    <2> sassign [no pad slot allocated]
        <2> some_op [pad slot B allocated]
        <1> padsv [pad slot A allocated]

into:

    <2> some_op [pad slot A swiped]

using the code:

    swipe_and_detach:
      kid->op_targ = kkid->op_targ; <--- some_op now points to slot A
      kkid->op_targ = 0;            <--- padsv doesn't point to any slot
      /* Now we do not need PADSV and SASSIGN.
      * Detach kid and free the rest. */
      op_sibling_splice(o, NULL, 1, NULL);
      op_free(o);
      return kid;

At this point, slot B has been abandoned but not made available for any newly created OPs to use. The slot is filled, but serves no purpose.

This commit swaps the `op_targ` values of `kid` and `kkid`, so that when `kkid` is freed, slot B is made available for reuse. It also ensures that new PADTMP and CONST type searches for available slots start at this slot, rather than just after it.

At run time, potentially lower pad sizes and better memory locality may help with overall performance. At compile time, activities like `S_pad_findlex` scanning through the pad to resolve a variable is more efficient if the pad isn't littered with holes from abandoned slots.

Pad sizes and savings will greatly vary, from mimimal to meaningful. Notable outliers in the difference in slots "used" within core include:
 * ExtUtils::MM_Any::_add_requirements_to_meta      71 ->  41
 * HTTP::Tiny::_prepare_headers_and_cb             167 -> 110
 * Pod::Html::process_options                      128 ->  74
 * Term::Table::init                                80 ->  52
 * Test2::API::Context::init                        36 ->  23
 * Test2::Event::Plan::facet_data                   44 ->  28
 * Time::Piece::use_locale                          91 ->  68
 * Unicode::Collate::new                           101 ->  66

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
