### PR TITLE
hints/darwin.sh: disable readdir_r on anything vaguely recent

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -527,3 +527,17 @@ d_mkostemp=undef
 # Apparently the MACH-O format can't support _Thread_local in shared objects,
 # but clang isn't wise to this, so our probe works but the build fails...
 d_thread_local=undef
+
+# from man readdir_r
+#     The readdir_r() interface is deprecated because it cannot be used
+#     correctly unless {NAME_MAX} is a fixed value.
+# This note is present in the 10.15.7 man pages, but not the 10.13.6
+# man page.
+#
+# OS X 10.15 is kernel version 19 (https://en.wikipedia.org/wiki/MacOS)
+#
+# https://man.freebsd.org/cgi/man.cgi?query=readdir_r&apropos=0&sektion=0&manpath=macOS+10.15.7&format=html
+case "$osvers" in
+    [0-9].*|1[0-8].*) ;;
+    *) d_readdir_r=undef ;;
+esac


### PR DESCRIPTION
readdir_r() has been deprecated since at least 10.15, current threaded builds complained:
```
pp_sys.c:4336:28: warning: 'readdir_r' is deprecated: This function cannot be
      used safely as it does not take into account the variability of
      {NAME_MAX}. It is highly recommended that you use readdir(3) instead.
      [-Wdeprecated-declarations]
 4336 |         dp = (Direntry_t *)PerlDir_read(IoDIRP(io));
      |                            ^
./iperlsys.h:443:41: note: expanded from macro 'PerlDir_read'
  443 | #  define PerlDir_read(dir)             readdir((dir))
      |                                         ^
./reentr.h:1503:29: note: expanded from macro 'readdir'
 1503 | #        define readdir(a) (readdir_r(a, PL_reentrant_buffer->_readdir_s...
      |                             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dirent.h:114:1: note:
      'readdir_r' has been explicitly marked deprecated here
  114 | __deprecated_msg("This function cannot be used safely as it does not tak...
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:227:48: note:
      expanded from macro '__deprecated_msg'
  227 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
1 warning generated.
```
See https://perl5.test-smoke.org/report/5533313 for example, It looks like github is running an older toolset, LLVM 15 on github vs LLVM 21 on my smoker (LLVM 17 on brian's smoker).

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
