### PR TITLE
Improve perlclass POD - more information, better synopsis

### DIFF
--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -385,7 +385,7 @@ details.
     }
 
     my $obj = WithDestructor->new;
-    undef $obj; # destroying Test=OBJECT(0x2e4307e0)
+    undef $obj; # destroying WithDestructor=OBJECT(0x2e4307e0)
 
 =head1 TODO
 

--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -4,18 +4,14 @@ perlclass - Perl class syntax reference
 
 =head1 SYNOPSIS
 
-    use v5.38;
+    use v5.42;
     use feature 'class';
 
     class My::Example 1.234 {
-        field $x;
-
-        ADJUST {
-            $x = "Hello, world";
-        }
+        field $message = "Hello, world";
 
         method print_message {
-            say $x;
+            say $message;
         }
     }
 
@@ -174,7 +170,7 @@ will not appear in the arguments list as far as the signature is concerned.
         }
     }
 
-Just like regular subroutines, methods I<can> be anonymous:
+Just like regular subroutines, methods B<can> be anonymous:
 
     class AnonMethodFactory {
 
@@ -323,7 +319,16 @@ named C<new> and is invoked like a method call on the class name:
     my $object = My::Class->new(%arguments);
 
 During object construction, class fields are looked up in the C<%arguments>
-hash and populated where possible.
+hash and populated with the found keys according to C<:param> attributes. If
+any C<%arguments> key was not declared as a C<:param> field, an exception is
+raised with a list of surplus key. This means that B<the constructor is
+strict by default>.
+
+In addition, the constructor does not need to be called in the class context
+exclusively. It works just as well to call it on an instance of a class, which
+will automatically create another instance of the same class:
+
+    my $other_object = $object->new(%arguments);
 
 =head2 Adjustment
 
@@ -348,14 +353,16 @@ they are declared).
     #   x = 42
 
 C<ADJUST> blocks are syntactically similar to L<C<BEGIN> or C<INIT>
-blocks|perlmod/BEGIN, UNITCHECK, CHECK, INIT and END>, which only run once.
-However, C<ADJUST> blocks, like methods, have access to C<$self> (a lexical
+blocks|perlmod/BEGIN, UNITCHECK, CHECK, INIT and END>, which only run once
+during compilation phase. However, C<ADJUST> blocks run each time an object is
+instantiated, and much like methods, have access to C<$self> (a lexical
 variable holding the object being constructed) as well as all object fields
 created up to that point.
 
 =head2 Lifetime
 
-After the construction phase, the object is ready to be used.
+After the construction phase, the object is ready to be used. Same as blessed
+references, native objects are always subclasses of L<UNIVERSAL>.
 
 Using C<blessed> (C<Scalar::Util::blessed> or C<builtin::blessed>) on the
 object will return the name of the class, while C<reftype>
@@ -366,6 +373,19 @@ C<'OBJECT'>.
 
 An object is destroyed when the last reference to it goes away, just as with
 other data structures in Perl.
+
+Same as with bless-based objects, attaching behavior on object destruction is
+done by defining a C<DESTROY> method. See L<perlobj/Destructors> for more
+details.
+
+    class WithDestructor {
+        method DESTROY () {
+            say "destroying $self";
+        }
+    }
+
+    my $obj = WithDestructor->new;
+    undef $obj; # destroying Test=OBJECT(0x2e4307e0)
 
 =head1 TODO
 

--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -170,7 +170,7 @@ will not appear in the arguments list as far as the signature is concerned.
         }
     }
 
-Just like regular subroutines, methods B<can> be anonymous:
+Just like regular subroutines, methods are permitted to be anonymous:
 
     class AnonMethodFactory {
 
@@ -321,14 +321,8 @@ named C<new> and is invoked like a method call on the class name:
 During object construction, class fields are looked up in the C<%arguments>
 hash and populated with the found keys according to C<:param> attributes. If
 any C<%arguments> key was not declared as a C<:param> field, an exception is
-raised with a list of surplus key. This means that B<the constructor is
+raised with a list of surplus keys. This means that B<the constructor is
 strict by default>.
-
-In addition, the constructor does not need to be called in the class context
-exclusively. It works just as well to call it on an instance of a class, which
-will automatically create another instance of the same class:
-
-    my $other_object = $object->new(%arguments);
 
 =head2 Adjustment
 
@@ -374,19 +368,6 @@ C<'OBJECT'>.
 An object is destroyed when the last reference to it goes away, just as with
 other data structures in Perl.
 
-Same as with bless-based objects, attaching behavior on object destruction is
-done by defining a C<DESTROY> method. See L<perlobj/Destructors> for more
-details.
-
-    class WithDestructor {
-        method DESTROY () {
-            say "destroying $self";
-        }
-    }
-
-    my $obj = WithDestructor->new;
-    undef $obj; # destroying WithDestructor=OBJECT(0x2e4307e0)
-
 =head1 TODO
 
 This feature is still experimental and very incomplete. The following list
@@ -431,6 +412,13 @@ classes, methods, fields, ADJUST blocks, and other such class-related details.
 
 Ways in which out-of-core modules can interact with the class system,
 including an ability for them to provide new class or field attributes.
+
+=item * Destructors
+
+Currently, attaching behavior on object destruction is done by defining a
+C<DESTROY> method, same as for bless-based classes. Eventually, object
+destruction phasers will be implemented, but their semantics remain undecided
+at this time.
 
 =back
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
This PR adds more information about object lifecycle, expanding this section which wasn't very developed. In addition, synopsis is upgraded to show default field values can be assigned without `ADJUST` block, and a minor editorial change from italics to bold in a place where we want to stress the word "can".

New information in this document was something I was missing when I started adopting perlclass in my project recently, so it should be useful to people who are looking for some specific answers.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
