### PR TITLE
Add various CVE references to the perl 5.44.0 perldelta

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -97,6 +97,13 @@ Perl_study_chunk in regcomp_study.c checked the size of the joined substring
 buffer in characters rather than bytes. On 32-bit builds, this can lead to
 an integer overflow of the size of the buffer leading to out-of-bounds writes.
 
+=head2 CVE-2026-57432 - Buffer overflow in S_measure_struct
+
+If you call C<pack> or C<unpack> to operate on a structure whose computed size
+is too large to fit in memory, an integer overflow could happen that would
+result in a buffer overflow. This usually happens as a result of embedding a
+large number as the repeat count for an item.
+
 =head1 Incompatible Changes
 
 =head2 Unicode rules are now fully enforced on identifier and regular expression group names.

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -218,6 +218,8 @@ string operands known at compile time is commonly now faster. [L<GH #24228|https
 
 L<Archive::Tar> has been upgraded from version 3.04 to 3.12.
 
+This fixes CVE-2026-9538, CVE-2026-42496, and CVE-2026-42497.
+
 =item *
 
 L<attributes> has been upgraded from version 0.36 to 0.37.
@@ -342,6 +344,8 @@ L<Getopt::Std> has been upgraded from version 1.14 to 1.15.
 
 L<HTTP::Tiny> has been upgraded from version 0.090 to 0.096.
 
+This fixes CVE-2026-7010 and CVE-2026-7017.
+
 =item *
 
 L<IO> has been upgraded from version 1.55 to 1.56.
@@ -349,6 +353,8 @@ L<IO> has been upgraded from version 1.55 to 1.56.
 =item *
 
 L<IO::Compress> has been upgraded from version 2.213 to 2.220.
+
+This fixes CVE-2025-15649, CVE-2026-48961, CVE-2026-48962, and CVE-2026-48959.
 
 =item *
 
@@ -414,9 +420,13 @@ L<SelfLoader> has been upgraded from version 1.28 to 1.29.
 
 L<Socket> has been upgraded from version 2.038 to 2.041.
 
+This fixes CVE-2026-12087.
+
 =item *
 
 L<Storable> has been upgraded from version 3.37 to 3.41.
+
+This fixes CVE-2026-57433.
 
 =item *
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -104,6 +104,10 @@ is too large to fit in memory, an integer overflow could happen that would
 result in a buffer overflow. This usually happens as a result of embedding a
 large number as the repeat count for an item.
 
+=head2 CVE-2026-13221 - Regex trie 16-bit field overflow
+
+The trie optimization in the regex engine could overflow in an alternation with more than ~65k branches. This could cause both false positives and false negatives on such regular expressions.
+
 =head1 Incompatible Changes
 
 =head2 Unicode rules are now fully enforced on identifier and regular expression group names.


### PR DESCRIPTION
This adds a paragraph about `CVE-2026-57432`, and mentions CVEs that impacted various dual-life modules.