### PR TITLE
Fix perlexperiment warning categories for any and all

### DIFF
--- a/pod/perlexperiment.pod
+++ b/pod/perlexperiment.pod
@@ -189,8 +189,8 @@ L<[perl #22139]|https://github.com/Perl/perl5/issues/22139>.
 
 Introduced in Perl 5.41.7.
 
-Using these features triggers warnings in the categories C<experimental::any>
-or C<experiment::all>.
+Using these features triggers warnings in the categories C<experimental::keyword_any>
+or C<experimental::keyword_all>.
 
 This adds new list processing operators named C<any> and C<all>, each as their
 own named feature.


### PR DESCRIPTION
As stated in https://github.com/Perl/perl5/issues/22794#issuecomment-4670770745, warning categories are wrong in perlexperiment doc for `keyword_any` and `keyword_all`. This commit fixes this.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
