### PR TITLE
Porting/test-dist-modules.pl: fix typo in comment

### DIFF
--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -878,7 +878,7 @@ sub _create_runperl { # Create the string to qx in runperl().
     } elsif (defined $args{progfile}) {
         $runperl .= qq( "$args{progfile}");
     } else {
-        # You probaby didn't want to be sucking in from the upstream stdin
+        # You probably didn't want to be sucking in from the upstream stdin
         die "test.pl:runperl(): none of prog, progs, progfile, args, "
             . " switches or stdin specified"
             unless defined $args{args} or defined $args{switches}


### PR DESCRIPTION


-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
