### PR TITLE
hints/os390.sh: Fix syntax error

### DIFF
--- a/hints/os390.sh
+++ b/hints/os390.sh
@@ -352,8 +352,8 @@ EOWARN
 fi
 
 # Doesn't find the prototype
-case "d_gethostbyaddr" in)
-  d_gethostbyaddr_r='undef'
+case "d_gethostbyaddr" in
+  "") d_gethostbyaddr_r='undef'
   ;;
 esac
 


### PR DESCRIPTION
My z/OS test machine was down for almost two weeks during which time I made minor changes to this file, and botched one of them.  It came back up yesterday, and I was able to test, and found only this one.

Without this patch Configuring z/OS bombs almost immediately; with the patch, everything works as documented.

* This set of changes does not require a perldelta entry.
