### PR TITLE
Avoid segfault when :isa(Foo) does not load a package called Foo

### DIFF
--- a/class.c
+++ b/class.c
@@ -550,9 +550,8 @@ apply_class_attribute_isa(pTHX_ HV *stash, SV *value)
         superstash = gv_stashsv(superclassname, 0);
     }
     if(!superstash || !HvSTASH_IS_CLASS(superstash))
-        /* TODO: This would be a useful feature addition */
-        croak("Class :isa attribute requires a class but %" HvNAMEf_QUOTEDPREFIX " is not one",
-            HvNAMEfARG(superstash));
+        croak("Class :isa attribute requires a class but %" SVf_QUOTEDPREFIX " is not one",
+            superclassname);
 
     if(superclassver && SvOK(superclassver))
         ensure_module_version(superclassname, superclassver);

--- a/sv.c
+++ b/sv.c
@@ -13759,6 +13759,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                         escape_it = TRUE;
                     }
                     argsv = MUTABLE_SV(va_arg(*args, void*));
+                    assert(argsv);
                     eptr = SvPV_const(argsv, elen);
                     if (DO_UTF8(argsv))
                         is_utf8 = TRUE;
@@ -13769,6 +13770,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                          width == 7 || width == 8)
                 {        /* HEKf, HEKf256, HEKf_QUOTEDPREFIX, HEKf256_QUOTEDPREFIX */
                     HEK * const hek = va_arg(*args, HEK *);
+                    assert(hek);
                     eptr = HEK_KEY(hek);
                     elen = HEK_LEN(hek);
                     if (HEK_UTF8(hek))
@@ -13784,6 +13786,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 }
                 else if (width == 1) {
                     eptr = va_arg(*args,char *);
+                    assert(eptr);
                     elen = strlen(eptr);
                     escape_it = TRUE;
                     width = 0;
@@ -13791,6 +13794,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 }
                 else if (width == 6 || width == 10) {
                     HV *hv = va_arg(*args, HV *);
+                    assert(hv);
                     eptr = HvNAME(hv);
                     elen = HvNAMELEN(hv);
                     if (HvNAMEUTF8(hv))

--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -263,3 +263,18 @@ say Foo->new(message => "yeehaw")->$meth();
 EXPECT
 OPTIONS nonfatal
 yeehaw
+########
+# NAME isa that doesn't define the class GH 24157
+--FILE-- Mod24517.pm
+package MOD24517; # different capitalisation to filename
+
+1;
+--FILE--
+use v5.36;
+use feature 'class';
+no warnings 'experimental::class';
+class X :isa(Mod24517) {
+  field $x;
+}
+EXPECT
+Class :isa attribute requires a class but "Mod24517" is not one at - line 4.


### PR DESCRIPTION
A small thinko in the message generation attempted to use HvNAMEf on the stash pointer, which would segfault when NULL (e.g. because the loaded file did not in fact provide such a package). But we know the superclassname SV is definitely defined and nicely printable and would print the same string anyway, so we might as well just use that and avoid the NULL problem.

Also delete the TODO comment that I recall was wishing that HvNAMEf existed, when in fact it already does so. In any case the comment no longer makes sense with this code.

Fixes #24517

* This set of changes does not require a perldelta entry.