### PR TITLE
ExtUtils::ParseXS: Respect output arguments in INTERFACES

### DIFF
--- a/dist/ExtUtils-ParseXS/Changes
+++ b/dist/ExtUtils-ParseXS/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension ExtUtils::ParseXS.
 
 3.64
+  - Respect output arguments in INTERFACES
   - PERL_UNUSED_VAR() the CV declared when an ALIAS or
     XSINTERFACE_FUNC_SET has been seen.
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -4156,10 +4156,13 @@ sub C_func_signature {
                  or $param->{is_length};
 
         my $a = $param->{var};
-        $a = "&$a" if $param->{is_addr} or $io =~ /OUT/;
+        my $t = defined $param->{type} ? $param->{type} : 'void*';
+        if ($param->{is_addr} or $io =~ /OUT/) {
+            $a = "&$a";
+            $t = "$t*";
+        }
         push @args, $a;
-        my $t = $param->{type};
-        push @types, defined $t ? $t : 'void*';
+        push @types, $t;
     }
 
     return \@args, \@types;
@@ -4951,8 +4954,11 @@ sub parse {
             $var =~ s/\s+$//;
             my $param = $ioparams->{names}{$var};
             # 'void*' is a desperate guess if no such parameter
-            push @$types, ($param && defined $param->{type})
+            my $type = $param && defined $param->{type}
                             ? $param->{type} : 'void*';
+            $type .= '*' if $param && $param->{is_addr}
+                || (defined $param->{in_out} && $param->{in_out} =~ /OUT/);
+            push @$types, $type;
         }
         $self->{args}  = $args;
     }

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::Cmd;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.63';
+our $VERSION = '3.64';
 
 use ExtUtils::Typemaps;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::InputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.63';
+our $VERSION = '3.64';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::OutputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.63';
+our $VERSION = '3.64';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 require ExtUtils::Typemaps;
 
-our $VERSION = '3.63';
+our $VERSION = '3.64';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/t/008-parse-xsub-keywords.t
+++ b/dist/ExtUtils-ParseXS/t/008-parse-xsub-keywords.t
@@ -1024,6 +1024,15 @@ EOF
             qr{\QError: duplicate INTERFACE name: 'f1'},
                    "got expected err" ],
         ],
+        [
+            'INTERFACE with OUT arguments',
+            Q(<<'EOF'),
+                |void
+                |foo(OUT int value)
+                |    INTERFACE: abc
+EOF
+            [  0, qr{\(int\*\)}, "OUT argument" ],
+        ],
     );
 
     test_many($preamble, 'XS_Foo_', \@test_fns);


### PR DESCRIPTION
OUT, IN_OUT and OUTLIST arguments should be passed as pointers when autocalling, so the function pointer type needs to use that pointer type for the argument.