### PR TITLE
WORTH_PER_WORD_LOOP() Add assertion on argument

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -1528,7 +1528,8 @@ Perl_valid_utf8_to_uv(const U8 *s, STRLEN *retlen)
  * platform. */
 #  define WORTH_PER_WORD_LOOP_BINMODE(s, e, full_words_needed)      \
        /* Note multiple evaluations of 's' */                       \
-       ( ( ( (s) + BYTES_REMAINING_IN_WORD(s)                       \
+         (assert(full_words_needed > 0),                            \
+         ( ( (s) + BYTES_REMAINING_IN_WORD(s)                       \
                  + (full_words_needed) * PERL_WORDSIZE) < (e) )     \
         ? ((s) + BYTES_REMAINING_IN_WORD(s))                        \
         : NULL)


### PR DESCRIPTION
This makes sure this is called properly.  If the argument is a compile time constant, the compiler should optimize it away.  I considered a STATIC_ASSERT, but it seems to me that someone might want to call it with values varying at runtime


* This set of changes does not require a perldelta entry.
