### PR TITLE
util.c: Fix missing parens for sizeof arguments

### DIFF
--- a/util.c
+++ b/util.c
@@ -127,21 +127,21 @@ S_maybe_protect_ro(pTHX_ struct perl_memory_debug_header *header)
 #endif
 
 /* Sanity check: Format strings must not be empty */
-STATIC_ASSERT_DECL(sizeof I32df > 1);
-STATIC_ASSERT_DECL(sizeof U32of > 1);
-STATIC_ASSERT_DECL(sizeof U32uf > 1);
-STATIC_ASSERT_DECL(sizeof U32xf > 1);
-STATIC_ASSERT_DECL(sizeof U32Xf > 1);
-STATIC_ASSERT_DECL(sizeof IVdf > 1);
-STATIC_ASSERT_DECL(sizeof UVuf > 1);
-STATIC_ASSERT_DECL(sizeof UVof > 1);
-STATIC_ASSERT_DECL(sizeof UVxf > 1);
-STATIC_ASSERT_DECL(sizeof UVXf > 1);
-STATIC_ASSERT_DECL(sizeof NVef > 1);
-STATIC_ASSERT_DECL(sizeof NVff > 1);
-STATIC_ASSERT_DECL(sizeof NVgf > 1);
-STATIC_ASSERT_DECL(sizeof Gid_t_f > 1);
-STATIC_ASSERT_DECL(sizeof Uid_t_f > 1);
+STATIC_ASSERT_DECL(sizeof(I32df) > 1);
+STATIC_ASSERT_DECL(sizeof(U32of) > 1);
+STATIC_ASSERT_DECL(sizeof(U32uf) > 1);
+STATIC_ASSERT_DECL(sizeof(U32xf) > 1);
+STATIC_ASSERT_DECL(sizeof(U32Xf) > 1);
+STATIC_ASSERT_DECL(sizeof(IVdf) > 1);
+STATIC_ASSERT_DECL(sizeof(UVuf) > 1);
+STATIC_ASSERT_DECL(sizeof(UVof) > 1);
+STATIC_ASSERT_DECL(sizeof(UVxf) > 1);
+STATIC_ASSERT_DECL(sizeof(UVXf) > 1);
+STATIC_ASSERT_DECL(sizeof(NVef) > 1);
+STATIC_ASSERT_DECL(sizeof(NVff) > 1);
+STATIC_ASSERT_DECL(sizeof(NVgf) > 1);
+STATIC_ASSERT_DECL(sizeof(Gid_t_f) > 1);
+STATIC_ASSERT_DECL(sizeof(Uid_t_f) > 1);
 
 /*
 =for apidoc_section $memory


### PR DESCRIPTION
Fixes #24533

These were added in c5df4fd1012 in 2024, so are not a release blocker.

The fix is just to parenthesize the sizeof argument.  I was unaware that you didn't have to, at least on some compilers.


* This set of changes does not require a perldelta entry.
