### PR TITLE
provide long_names on unthreaded builds

### DIFF
--- a/long_names.c
+++ b/long_names.c
@@ -35,8 +35,6 @@
 #define PERL_IN_LONG_NAMES_C
 #include "perl.h"
 
-#ifdef USE_THREADS
-
 #if !defined(USE_ITHREADS)
 void
 Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv)
@@ -1049,7 +1047,5 @@ Perl_whichsig(pTHX_ const char *sig)
     return whichsig(sig);
 }
 
-
-#endif
 
 /* ex: set ro ft=c: */

--- a/proto.h
+++ b/proto.h
@@ -115,6 +115,12 @@ Perl_Slab_Free(pTHX_ void *op)
 #define PERL_ARGS_ASSERT_SLAB_FREE              \
         Perl_assert_aTHX; assert(op)
 
+PERL_CALLCONV void
+Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SVREFCNT_DEC_SET_NULL  \
+        Perl_assert_aTHX
+
 PERL_CALLCONV_NO_RET void
 Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
         Perl_attribute_nonnull_aTHX
@@ -480,6 +486,14 @@ Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_BYTES_TO_UTF8_FREE_ME  \
         Perl_assert_aTHX; assert(s); assert(lenp)
+
+PERL_CALLCONV bool
+Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_C9STRICT_UTF8_TO_UV    \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
 
 PERL_CALLCONV SSize_t
 Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
@@ -1186,6 +1200,14 @@ Perl_do_op_dump(pTHX_ I32 level, PerlIO *file, const OP *o)
         Perl_assert_aTHX; assert(file)
 
 PERL_CALLCONV bool
+Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_DO_OPEN                \
+        Perl_assert_aTHX; assert(gv); assert(name)
+
+PERL_CALLCONV bool
 Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, SV **svp, U32 num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
@@ -1449,6 +1471,18 @@ Perl_eval_sv(pTHX_ SV *sv, I32 flags)
 #define PERL_ARGS_ASSERT_EVAL_SV                \
         Perl_assert_aTHX; assert(sv)
 
+PERL_CALLCONV Size_t
+Perl_expected_size(UV size);
+#define PERL_ARGS_ASSERT_EXPECTED_SIZE
+
+PERL_CALLCONV bool
+Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_EXTENDED_UTF8_TO_UV    \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
+
 PERL_CALLCONV void
 Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull_aTHX
@@ -1531,6 +1565,14 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_SCRIPT            \
         Perl_assert_aTHX; assert(scriptname)
+
+PERL_CALLCONV I32
+Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_5);
+#define PERL_ARGS_ASSERT_FOLDEQ_UTF8            \
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_CALLCONV I32
 Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2, U32 flags)
@@ -1782,6 +1824,30 @@ Perl_grok_uint_by_base(pTHX_ const char * const start, STRLEN *len_p, I32 *flags
         Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
 
 PERL_CALLCONV GV *
+Perl_gv_AVadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_GV_AVADD               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV GV *
+Perl_gv_HVadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_GV_HVADD               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV GV *
+Perl_gv_IOadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_GV_IOADD               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV GV *
+Perl_gv_SVadd(pTHX_ GV *gv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_GV_SVADD               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV GV *
 Perl_gv_add_by_type(pTHX_ GV *gv, svtype type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GV_ADD_BY_TYPE         \
@@ -1833,6 +1899,14 @@ Perl_gv_dump(pTHX_ GV *gv)
         Perl_assert_aTHX
 
 PERL_CALLCONV void
+Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_GV_EFULLNAME3          \
+        Perl_assert_aTHX; assert(sv); assert(gv)
+
+PERL_CALLCONV void
 Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
@@ -1852,6 +1926,20 @@ Perl_gv_fetchfile_flags(pTHX_ const char * const name, const STRLEN len, const U
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE_FLAGS     \
+        Perl_assert_aTHX; assert(name)
+
+PERL_CALLCONV GV *
+Perl_gv_fetchmeth(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_GV_FETCHMETH           \
+        Perl_assert_aTHX; assert(name)
+
+PERL_CALLCONV GV *
+Perl_gv_fetchmeth_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_GV_FETCHMETH_AUTOLOAD  \
         Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV GV *
@@ -1895,6 +1983,14 @@ Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV_AUTOLOAD \
         Perl_assert_aTHX; assert(namesv)
+
+PERL_CALLCONV GV *
+Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_GV_FETCHMETHOD         \
+        Perl_assert_aTHX; assert(stash); assert(name)
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
@@ -1950,6 +2046,14 @@ Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
         Perl_assert_aTHX; assert(name)
 
 PERL_CALLCONV void
+Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_GV_FULLNAME3           \
+        Perl_assert_aTHX; assert(sv); assert(gv)
+
+PERL_CALLCONV void
 Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
@@ -1963,6 +2067,15 @@ Perl_gv_handler(pTHX_ HV *stash, I32 id)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_HANDLER             \
         Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
+
+PERL_CALLCONV void
+Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_3);
+#define PERL_ARGS_ASSERT_GV_INIT                \
+        Perl_assert_aTHX; assert(gv); \
+        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
 Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
@@ -2099,6 +2212,20 @@ Perl_hv_delayfree_ent(pTHX_ HV *notused, HE *entry)
 #define PERL_ARGS_ASSERT_HV_DELAYFREE_ENT       \
         Perl_assert_aTHX; assert(!notused || SvTYPE(notused) == SVt_PVHV)
 
+PERL_CALLCONV SV *
+Perl_hv_delete(pTHX_ HV *hv, const char *key, I32 klen, I32 flags)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_HV_DELETE              \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+
+PERL_CALLCONV SV *
+Perl_hv_delete_ent(pTHX_ HV *hv, SV *keysv, I32 flags, U32 hash)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_HV_DELETE_ENT          \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+
 PERL_CALLCONV void
 Perl_hv_dump(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX;
@@ -2140,6 +2267,36 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
         assert(name)
 
+PERL_CALLCONV bool
+Perl_hv_exists(pTHX_ HV *hv, const char *key, I32 klen)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_HV_EXISTS              \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+
+PERL_CALLCONV bool
+Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_HV_EXISTS_ENT          \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+
+PERL_CALLCONV SV **
+Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_HV_FETCH               \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+
+PERL_CALLCONV HE *
+Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_HV_FETCH_ENT           \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+
 PERL_CALLCONV STRLEN
 Perl_hv_fill(pTHX_ HV * const hv)
         Perl_attribute_nonnull_aTHX
@@ -2178,6 +2335,14 @@ Perl_hv_iterkeysv(pTHX_ HE *entry)
         Perl_assert_aTHX; assert(entry)
 
 PERL_CALLCONV HE *
+Perl_hv_iternext(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_HV_ITERNEXT            \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+
+PERL_CALLCONV HE *
 Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
@@ -2211,6 +2376,13 @@ Perl_hv_ksplit(pTHX_ HV *hv, IV newmax)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_KSPLIT              \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+
+PERL_CALLCONV void
+Perl_hv_magic(pTHX_ HV *hv, GV *gv, int how)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_HV_MAGIC               \
         Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV void
@@ -2281,11 +2453,63 @@ Perl_hv_scalar(pTHX_ HV *hv)
 #define PERL_ARGS_ASSERT_HV_SCALAR              \
         Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
 
+PERL_CALLCONV SV **
+Perl_hv_store(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_HV_STORE               \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+
+PERL_CALLCONV HE *
+Perl_hv_store_ent(pTHX_ HV *hv, SV *key, SV *val, U32 hash)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_HV_STORE_ENT           \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+
+PERL_CALLCONV SV **
+Perl_hv_store_flags(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash, int flags)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_HV_STORE_FLAGS         \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+
+PERL_CALLCONV void
+Perl_hv_undef(pTHX_ HV *hv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_HV_UNDEF               \
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+
 PERL_CALLCONV void
 Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_UNDEF_FLAGS         \
         Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+
+PERL_CALLCONV I32
+Perl_ibcmp(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        __attribute__warn_unused_result__
+        __attribute__pure__;
+#define PERL_ARGS_ASSERT_IBCMP                  \
+        Perl_assert_aTHX; assert(a); assert(b)
+
+PERL_CALLCONV I32
+Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        __attribute__warn_unused_result__
+        __attribute__pure__;
+#define PERL_ARGS_ASSERT_IBCMP_LOCALE           \
+        Perl_assert_aTHX; assert(a); assert(b)
+
+PERL_CALLCONV I32
+Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_5);
+#define PERL_ARGS_ASSERT_IBCMP_UTF8             \
+        Perl_assert_aTHX; assert(s1); assert(s2)
 
 PERL_CALLCONV STRLEN
 Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct Perl_custom_infix **def)
@@ -2359,6 +2583,15 @@ Perl_init_uniprops(pTHX)
 #define PERL_ARGS_ASSERT_INIT_UNIPROPS          \
         Perl_assert_aTHX
 
+PERL_CALLCONV char *
+Perl_instr(const char *big, const char *little)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        __attribute__warn_unused_result__
+        __attribute__pure__;
+#define PERL_ARGS_ASSERT_INSTR                  \
+        assert(big); assert(little)
+
 PERL_CALLCONV U32
 Perl_intro_my(pTHX)
         Perl_attribute_nonnull_aTHX;
@@ -2394,6 +2627,20 @@ Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
         Perl_assert_aTHX; assert(io)
 
 PERL_CALLCONV bool
+Perl_is_c9strict_utf8_string(const U8 *s, STRLEN len)
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING \
+        assert(s)
+
+PERL_CALLCONV bool
+Perl_is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOC \
+        assert(s); assert(ep)
+
+PERL_CALLCONV bool
 Perl_is_in_locale_category_(pTHX_ const bool compiling, const int category)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_IS_IN_LOCALE_CATEGORY_ \
@@ -2405,6 +2652,20 @@ Perl_is_lvalue_sub(pTHX)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_LVALUE_SUB          \
         Perl_assert_aTHX
+
+PERL_CALLCONV bool
+Perl_is_strict_utf8_string(const U8 *s, STRLEN len)
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING  \
+        assert(s)
+
+PERL_CALLCONV bool
+Perl_is_strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOC \
+        assert(s); assert(ep)
 
 PERL_CALLCONV bool
 Perl_is_uni_FOO_(pTHX_ const U8 classnum, const UV c)
@@ -2446,6 +2707,13 @@ Perl_is_utf8_FOO_(pTHX_ const U8 classnum, const U8 *p, const U8 * const e)
         Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
 
 PERL_CALLCONV STRLEN
+Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2);
+#define PERL_ARGS_ASSERT_IS_UTF8_CHAR_BUF       \
+        assert(buf); assert(buf_end); assert(buf <= buf_end)
+
+PERL_CALLCONV STRLEN
 Perl_is_utf8_char_helper_(const U8 * const s, const U8 *e, const U32 flags)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2)
@@ -2453,6 +2721,18 @@ Perl_is_utf8_char_helper_(const U8 * const s, const U8 *e, const U32 flags)
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IS_UTF8_CHAR_HELPER_   \
         assert(s); assert(e); assert(s < e)
+
+PERL_CALLCONV bool
+Perl_is_utf8_fixed_width_buf_flags(const U8 * const s, STRLEN len, const U32 flags)
+        Perl_attribute_nonnull(1);
+#define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_FLAGS \
+        assert(s)
+
+PERL_CALLCONV bool
+Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 **ep, const U32 flags)
+        Perl_attribute_nonnull(1);
+#define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOC_FLAGS \
+        assert(s)
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
@@ -2471,6 +2751,36 @@ Perl_is_utf8_perl_idstart_(pTHX_ const U8 *p, const U8 * const e)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_PERL_IDSTART_  \
         Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
+
+PERL_CALLCONV bool
+Perl_is_utf8_string(const U8 *s, STRLEN len)
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_IS_UTF8_STRING         \
+        assert(s)
+
+PERL_CALLCONV bool
+Perl_is_utf8_string_loc(const U8 *s, const STRLEN len, const U8 **ep)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC     \
+        assert(s); assert(ep)
+
+PERL_CALLCONV bool
+Perl_is_utf8_string_loc_flags(const U8 *s, STRLEN len, const U8 **ep, const U32 flags)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC_FLAGS \
+        assert(s); assert(ep)
+
+PERL_CALLCONV bool
+Perl_is_utf8_valid_partial_char(const U8 * const s0, const U8 * const e)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        __attribute__warn_unused_result__
+        __attribute__pure__;
+#define PERL_ARGS_ASSERT_IS_UTF8_VALID_PARTIAL_CHAR \
+        assert(s0); assert(e); assert(s0 < e)
 
 PERL_CALLCONV bool
 Perl_isinfnan(NV nv)
@@ -3675,9 +3985,22 @@ Perl_newASSIGNOP(pTHX_ I32 flags, OP *left, I32 optype, OP *right)
         Perl_assert_aTHX
 
 PERL_CALLCONV CV *
+Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_NEWATTRSUB             \
+        Perl_assert_aTHX
+
+PERL_CALLCONV CV *
 Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block, bool o_is_gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWATTRSUB_X           \
+        Perl_assert_aTHX
+
+PERL_CALLCONV AV *
+Perl_newAV(pTHX)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWAV                  \
         Perl_assert_aTHX
 
 PERL_CALLCONV OP *
@@ -3687,6 +4010,27 @@ Perl_newAVREF(pTHX_ OP *o)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVREF               \
         Perl_assert_aTHX; assert(o)
+
+PERL_CALLCONV AV *
+Perl_newAV_alloc_x(pTHX_ SSize_t size)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWAV_ALLOC_X          \
+        Perl_assert_aTHX
+
+PERL_CALLCONV AV *
+Perl_newAV_alloc_xz(pTHX_ SSize_t size)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWAV_ALLOC_XZ         \
+        Perl_assert_aTHX
+
+PERL_CALLCONV AV *
+Perl_newAV_mortal(pTHX)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWAV_MORTAL           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV AV *
 Perl_newAVav(pTHX_ AV *oav)
@@ -3797,12 +4141,26 @@ Perl_newGVREF(pTHX_ I32 type, OP *o)
         Perl_assert_aTHX
 
 PERL_CALLCONV GV *
+Perl_newGVgen(pTHX_ const char *pack)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_NEWGVGEN               \
+        Perl_assert_aTHX; assert(pack)
+
+PERL_CALLCONV GV *
 Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVGEN_FLAGS         \
         Perl_assert_aTHX; assert(pack)
+
+PERL_CALLCONV HV *
+Perl_newHV(pTHX)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWHV                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newHVREF(pTHX_ OP *o)
@@ -3818,6 +4176,13 @@ Perl_newHVhv(pTHX_ HV *ohv)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVHV                \
         Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
+
+PERL_CALLCONV IO *
+Perl_newIO(pTHX)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWIO                  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_newLISTOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
@@ -3974,6 +4339,12 @@ Perl_newSTUB(pTHX_ GV *gv, bool fake)
 #define PERL_ARGS_ASSERT_NEWSTUB                \
         Perl_assert_aTHX; assert(gv)
 
+PERL_CALLCONV CV *
+Perl_newSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *block)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_NEWSUB                 \
+        Perl_assert_aTHX
+
 PERL_CALLCONV SV *
 Perl_newSV(pTHX_ const STRLEN len)
         Perl_attribute_nonnull_aTHX
@@ -4114,12 +4485,26 @@ Perl_newSVrv(pTHX_ SV * const rv, const char * const classname)
         Perl_assert_aTHX; assert(rv)
 
 PERL_CALLCONV SV *
+Perl_newSVsv(pTHX_ SV * const old)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWSVSV                \
+        Perl_assert_aTHX
+
+PERL_CALLCONV SV *
 Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVSV_FLAGS_NN       \
         Perl_assert_aTHX; assert(old)
+
+PERL_CALLCONV SV *
+Perl_newSVsv_nomg(pTHX_ SV * const old)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_NEWSVSV_NOMG           \
+        Perl_assert_aTHX
 
 PERL_CALLCONV SV *
 Perl_newSVuv(pTHX_ const UV u)
@@ -4366,6 +4751,12 @@ Perl_op_linklist(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_LINKLIST            \
         Perl_assert_aTHX; assert(o)
+
+PERL_CALLCONV OP *
+Perl_op_lvalue(pTHX_ OP *o, I32 type)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_OP_LVALUE              \
+        Perl_assert_aTHX
 
 PERL_CALLCONV OP *
 Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
@@ -4761,6 +5152,12 @@ PERL_CALLCONV Signal_t
 Perl_perly_sighandler(int sig, Siginfo_t *info, void *uap, bool safe);
 #define PERL_ARGS_ASSERT_PERLY_SIGHANDLER
 
+PERL_CALLCONV const char *
+Perl_phase_name(pTHX_ enum perl_phase phase)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_PHASE_NAME             \
+        Perl_assert_aTHX
+
 PERL_CALLCONV void
 Perl_pmop_dump(pTHX_ PMOP *pm)
         Perl_attribute_nonnull_aTHX;
@@ -4902,6 +5299,13 @@ Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV f
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_UNI_DISPLAY         \
         Perl_assert_aTHX; assert(dsv); assert(spv)
+
+PERL_CALLCONV void
+Perl_qerror(pTHX_ SV *err)
+        Perl_attribute_nonnull_aTHX
+        __attribute__deprecated__;
+#define PERL_ARGS_ASSERT_QERROR                 \
+        Perl_assert_aTHX
 
 PERL_CALLCONV char *
 Perl_rcpv_copy(pTHX_ char * const pv)
@@ -5191,6 +5595,20 @@ Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save)
 #define PERL_ARGS_ASSERT_RESUME_COMPCV          \
         Perl_assert_aTHX; assert(buffer)
 
+PERL_CALLCONV void
+Perl_resume_compcv_and_save(pTHX_ struct suspended_compcv *buffer)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_RESUME_COMPCV_AND_SAVE \
+        Perl_assert_aTHX; assert(buffer)
+
+PERL_CALLCONV void
+Perl_resume_compcv_final(pTHX_ struct suspended_compcv *buffer)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_RESUME_COMPCV_FINAL    \
+        Perl_assert_aTHX; assert(buffer)
+
 PERL_CALLCONV char *
 Perl_rninstr(const char *big, const char *bigend, const char *little, const char *lend)
         Perl_attribute_nonnull(1)
@@ -5329,6 +5747,15 @@ Perl_save_adelete(pTHX_ AV *av, SSize_t key)
         Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
 PERL_CALLCONV void
+Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_3);
+#define PERL_ARGS_ASSERT_SAVE_AELEM             \
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        assert(sptr)
+
+PERL_CALLCONV void
 Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
@@ -5394,11 +5821,29 @@ Perl_save_destructor_x(pTHX_ DESTRUCTORFUNC_t f, void *p)
         Perl_assert_aTHX
 
 PERL_CALLCONV void
+Perl_save_freeop(pTHX_ OP *o)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SAVE_FREEOP            \
+        Perl_assert_aTHX
+
+PERL_CALLCONV void
+Perl_save_freepv(pTHX_ char *pv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SAVE_FREEPV            \
+        Perl_assert_aTHX
+
+PERL_CALLCONV void
 Perl_save_freercpv(pTHX_ char *rcpv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_FREERCPV          \
         Perl_assert_aTHX; assert(rcpv)
+
+PERL_CALLCONV void
+Perl_save_freesv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SAVE_FREESV            \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_generic_pvref(pTHX_ char **str)
@@ -5436,6 +5881,16 @@ Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
 #define PERL_ARGS_ASSERT_SAVE_HDELETE           \
         Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
         assert(keysv)
+
+PERL_CALLCONV void
+Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2)
+        Perl_attribute_nonnull(pTHX_3);
+#define PERL_ARGS_ASSERT_SAVE_HELEM             \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        assert(key); assert(sptr)
 
 PERL_CALLCONV void
 Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
@@ -5480,6 +5935,19 @@ Perl_save_iv(pTHX_ IV *ivp)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_IV                \
         Perl_assert_aTHX; assert(ivp)
+
+PERL_CALLCONV void
+Perl_save_mortalizesv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SAVE_MORTALIZESV       \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV void
+Perl_save_op(pTHX)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SAVE_OP                \
+        Perl_assert_aTHX
 
 PERL_CALLCONV void
 Perl_save_padsv(pTHX_ PADOFFSET padix)
@@ -5827,6 +6295,14 @@ Perl_str_to_version(pTHX_ SV *sv)
 #define PERL_ARGS_ASSERT_STR_TO_VERSION         \
         Perl_assert_aTHX; assert(sv)
 
+PERL_CALLCONV bool
+Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_STRICT_UTF8_TO_UV      \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
+
 PERL_CALLCONV void
 Perl_sub_crush_depth(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
@@ -5888,6 +6364,13 @@ Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer)
         Perl_assert_aTHX; assert(buffer)
 
 PERL_CALLCONV bool
+Perl_sv_2bool(pTHX_ SV * const sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_2BOOL               \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV bool
 Perl_sv_2bool_flags(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
@@ -5907,6 +6390,13 @@ Perl_sv_2io(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IO                 \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV IV
+Perl_sv_2iv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_2IV                 \
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV IV
@@ -5938,10 +6428,32 @@ Perl_sv_2nv_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
+Perl_sv_2pv(pTHX_ SV *sv, STRLEN *lp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_2PV                 \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
 Perl_sv_2pv_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PV_FLAGS           \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
+Perl_sv_2pv_nolen(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SV_2PV_NOLEN           \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
+Perl_sv_2pvbyte(pTHX_ SV *sv, STRLEN * const lp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_2PVBYTE             \
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
@@ -5952,10 +6464,40 @@ Perl_sv_2pvbyte_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
+Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SV_2PVBYTE_NOLEN       \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
+Perl_sv_2pvutf8(pTHX_ SV *sv, STRLEN * const lp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_2PVUTF8             \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
 Perl_sv_2pvutf8_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVUTF8_FLAGS       \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
+Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SV_2PVUTF8_NOLEN       \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV UV
+Perl_sv_2uv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_2UV                 \
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV UV
@@ -6039,6 +6581,14 @@ Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_assert_aTHX; assert(sv); assert(pat)
 
 PERL_CALLCONV void
+Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_CATPVN              \
+        Perl_assert_aTHX; assert(dsv); assert(sstr)
+
+PERL_CALLCONV void
 Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
@@ -6047,10 +6597,32 @@ Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, c
         Perl_assert_aTHX; assert(dsv); assert(sstr)
 
 PERL_CALLCONV void
+Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_CATPVN_MG           \
+        Perl_assert_aTHX; assert(dsv); assert(sstr)
+
+PERL_CALLCONV void
+Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_CATSV               \
+        Perl_assert_aTHX; assert(dsv)
+
+PERL_CALLCONV void
 Perl_sv_catsv_flags(pTHX_ SV * const dsv, SV * const sstr, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATSV_FLAGS         \
+        Perl_assert_aTHX; assert(dsv)
+
+PERL_CALLCONV void
+Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_CATSV_MG            \
         Perl_assert_aTHX; assert(dsv)
 
 PERL_CALLCONV void
@@ -6106,11 +6678,27 @@ Perl_sv_cmp_locale_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags)
         Perl_assert_aTHX
 
 PERL_CALLCONV void
+Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_COPYPV              \
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
+
+PERL_CALLCONV void
 Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_COPYPV_FLAGS        \
+        Perl_assert_aTHX; assert(dsv); assert(ssv)
+
+PERL_CALLCONV void
+Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_SV_COPYPV_NOMG         \
         Perl_assert_aTHX; assert(dsv); assert(ssv)
 
 PERL_CALLCONV void
@@ -6233,10 +6821,23 @@ Perl_sv_dump_depth(pTHX_ SV *sv, I32 depth)
         Perl_assert_aTHX
 
 PERL_CALLCONV I32
+Perl_sv_eq(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_EQ                  \
+        Perl_assert_aTHX
+
+PERL_CALLCONV I32
 Perl_sv_eq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_EQ_FLAGS            \
         Perl_assert_aTHX
+
+PERL_CALLCONV void
+Perl_sv_force_normal(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_FORCE_NORMAL        \
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
 Perl_sv_force_normal_flags(pTHX_ SV * const sv, const U32 flags)
@@ -6304,6 +6905,14 @@ Perl_sv_inc_nomg(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_INC_NOMG            \
         Perl_assert_aTHX
+
+PERL_CALLCONV void
+Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char * const little, const STRLEN littlelen)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_4);
+#define PERL_ARGS_ASSERT_SV_INSERT              \
+        Perl_assert_aTHX; assert(bigstr); assert(little)
 
 PERL_CALLCONV void
 Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char *little, const STRLEN littlelen, const U32 flags)
@@ -6378,6 +6987,13 @@ Perl_sv_magicext(pTHX_ SV * const sv, SV * const obj, const int how, const MGVTB
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV SV *
+Perl_sv_mortalcopy(pTHX_ SV * const oldsv)
+        Perl_attribute_nonnull_aTHX
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SV_MORTALCOPY          \
+        Perl_assert_aTHX
+
+PERL_CALLCONV SV *
 Perl_sv_mortalcopy_flags(pTHX_ SV * const oldsv, U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
@@ -6404,9 +7020,21 @@ Perl_sv_nosharing(pTHX_ SV *sv)
         Perl_assert_aTHX
 
 PERL_CALLCONV I32
+Perl_sv_numcmp(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_NUMCMP              \
+        Perl_assert_aTHX
+
+PERL_CALLCONV I32
 Perl_sv_numcmp_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMCMP_FLAGS        \
+        Perl_assert_aTHX
+
+PERL_CALLCONV bool
+Perl_sv_numeq(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_NUMEQ               \
         Perl_assert_aTHX
 
 PERL_CALLCONV bool
@@ -6416,9 +7044,21 @@ Perl_sv_numeq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_assert_aTHX
 
 PERL_CALLCONV bool
+Perl_sv_numge(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_NUMGE               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV bool
 Perl_sv_numge_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMGE_FLAGS         \
+        Perl_assert_aTHX
+
+PERL_CALLCONV bool
+Perl_sv_numgt(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_NUMGT               \
         Perl_assert_aTHX
 
 PERL_CALLCONV bool
@@ -6428,15 +7068,33 @@ Perl_sv_numgt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_assert_aTHX
 
 PERL_CALLCONV bool
+Perl_sv_numle(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_NUMLE               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV bool
 Perl_sv_numle_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMLE_FLAGS         \
         Perl_assert_aTHX
 
 PERL_CALLCONV bool
+Perl_sv_numlt(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_NUMLT               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV bool
 Perl_sv_numlt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMLT_FLAGS         \
+        Perl_assert_aTHX
+
+PERL_CALLCONV bool
+Perl_sv_numne(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_NUMNE               \
         Perl_assert_aTHX
 
 PERL_CALLCONV bool
@@ -6480,6 +7138,22 @@ Perl_sv_pos_u2b_flags(pTHX_ SV * const sv, STRLEN uoffset, STRLEN * const lenp, 
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
+Perl_sv_pv(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SV_PV                  \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
+Perl_sv_pvbyte(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SV_PVBYTE              \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
 Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
@@ -6487,10 +7161,25 @@ Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
+Perl_sv_pvn_force(pTHX_ SV *sv, STRLEN *lp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_PVN_FORCE           \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
 Perl_sv_pvn_force_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE_FLAGS     \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV char *
+Perl_sv_pvutf8(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_SV_PVUTF8              \
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV char *
@@ -6781,6 +7470,13 @@ Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref)
         Perl_assert_aTHX; assert(sv); assert(ref)
 
 PERL_CALLCONV void
+Perl_sv_setsv(pTHX_ SV *dsv, SV *ssv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_SETSV               \
+        Perl_assert_aTHX; assert(dsv)
+
+PERL_CALLCONV void
 Perl_sv_setsv_flags(pTHX_ SV *dsv, SV *ssv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
@@ -6809,6 +7505,12 @@ Perl_sv_setuv_mg(pTHX_ SV * const sv, const UV u)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
+Perl_sv_streq(pTHX_ SV *sv1, SV *sv2)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_SV_STREQ               \
+        Perl_assert_aTHX
+
+PERL_CALLCONV bool
 Perl_sv_streq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_STREQ_FLAGS         \
@@ -6834,6 +7536,13 @@ Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_STRING_FROM_ERRNUM  \
         Perl_assert_aTHX
+
+PERL_CALLCONV void
+Perl_sv_taint(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_TAINT               \
+        Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
 Perl_sv_tainted(pTHX_ SV * const sv)
@@ -6873,6 +7582,13 @@ Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
+Perl_sv_unref(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_UNREF               \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV void
 Perl_sv_unref_flags(pTHX_ SV * const ref, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
@@ -6894,10 +7610,24 @@ Perl_sv_upgrade(pTHX_ SV * const sv, svtype new_type)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
+Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_USEPVN              \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV void
 Perl_sv_usepvn_flags(pTHX_ SV * const sv, char *ptr, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_USEPVN_FLAGS        \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV void
+Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_USEPVN_MG           \
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
@@ -6908,10 +7638,24 @@ Perl_sv_utf8_decode(pTHX_ SV * const sv)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV bool
+Perl_sv_utf8_downgrade(pTHX_ SV * const sv, const bool fail_ok)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE      \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV bool
 Perl_sv_utf8_downgrade_flags(pTHX_ SV * const sv, const bool fail_ok, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_FLAGS \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV bool
+Perl_sv_utf8_downgrade_nomg(pTHX_ SV * const sv, const bool fail_ok)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_NOMG \
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
@@ -6922,10 +7666,31 @@ Perl_sv_utf8_encode(pTHX_ SV * const sv)
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV STRLEN
+Perl_sv_utf8_upgrade(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE        \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV STRLEN
+Perl_sv_utf8_upgrade_flags(pTHX_ SV * const sv, const I32 flags)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS  \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV * const sv, const I32 flags, STRLEN extra)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS_GROW \
+        Perl_assert_aTHX; assert(sv)
+
+PERL_CALLCONV STRLEN
+Perl_sv_utf8_upgrade_nomg(pTHX_ SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_NOMG   \
         Perl_assert_aTHX; assert(sv)
 
 PERL_CALLCONV void
@@ -7053,6 +7818,14 @@ Perl_tmps_grow_p(pTHX_ SSize_t ix)
         Perl_assert_aTHX
 
 PERL_CALLCONV UV
+Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_2)
+        Perl_attribute_nonnull(pTHX_3);
+#define PERL_ARGS_ASSERT_TO_UNI_FOLD            \
+        Perl_assert_aTHX; assert(p); assert(lenp)
+
+PERL_CALLCONV UV
 Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2)
@@ -7173,6 +7946,32 @@ Perl_upg_version(pTHX_ SV *ver, bool qv)
 #define PERL_ARGS_ASSERT_UTF16_TO_UTF8_BASE     \
         Perl_assert_aTHX; assert(p); assert(d); assert(newlen)
 
+PERL_CALLCONV U8 *
+Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_UTF8_HOP_BACK          \
+        assert(s); assert(start); assert(start <= s)
+
+PERL_CALLCONV U8 *
+Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD       \
+        assert(s); assert(end); assert(s <= end)
+
+PERL_CALLCONV U8 *
+Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(3)
+        Perl_attribute_nonnull(4)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_UTF8_HOP_SAFE          \
+        assert(s); assert(start); assert(end); assert(start <= s); \
+        assert(s <= end)
+
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
         Perl_attribute_nonnull_aTHX
@@ -7203,12 +8002,48 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to
         Perl_assert_aTHX; assert(s); assert(d); assert(newlen)
 
 PERL_CALLCONV bool
+Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_UTF8_TO_UV             \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
+
+PERL_CALLCONV bool
+Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_UTF8_TO_UV_ERRORS      \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
+
+PERL_CALLCONV bool
+Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags)
+        Perl_attribute_nonnull(1)
+        Perl_attribute_nonnull(2)
+        Perl_attribute_nonnull(3);
+#define PERL_ARGS_ASSERT_UTF8_TO_UV_FLAGS       \
+        assert(s); assert(e); assert(cp_p); assert(s <= e)
+
+PERL_CALLCONV bool
 Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_UTF8_TO_UV_MSGS_HELPER_ \
         assert(s0); assert(e); assert(cp_p); assert(s0 <= e)
+
+PERL_CALLCONV UV
+Perl_utf8n_to_uvchr(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags)
+        Perl_attribute_nonnull(1);
+#define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR         \
+        assert(s)
+
+PERL_CALLCONV UV
+Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors)
+        Perl_attribute_nonnull(1);
+#define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_ERROR   \
+        assert(s)
 
 PERL_CALLCONV void
 Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
@@ -7217,6 +8052,41 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_UTILIZE                \
         Perl_assert_aTHX; assert(idop)
+
+PERL_CALLCONV U8 *
+Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_UV_TO_UTF8_MSGS        \
+        Perl_assert_aTHX; assert(d)
+
+PERL_CALLCONV U8 *
+Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_UVCHR_TO_UTF8          \
+        Perl_assert_aTHX; assert(d)
+
+PERL_CALLCONV U8 *
+Perl_uvchr_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS    \
+        Perl_assert_aTHX; assert(d)
+
+PERL_CALLCONV U8 *
+Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS_MSGS \
+        Perl_assert_aTHX; assert(d)
+
+PERL_CALLCONV U8 *
+Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS \
+        Perl_assert_aTHX; assert(d)
 
 PERL_CALLCONV U8 *
 Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **msgs)
@@ -7245,6 +8115,13 @@ Perl_valid_identifier_sv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_SV    \
         Perl_assert_aTHX
+
+PERL_CALLCONV UV
+Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
+        Perl_attribute_nonnull(1)
+        __attribute__warn_unused_result__;
+#define PERL_ARGS_ASSERT_VALID_UTF8_TO_UVCHR    \
+        assert(s)
 
 #define PERL_ARGS_ASSERT_VALIDATE_PROTO         \
         Perl_assert_aTHX; assert(name)
@@ -7406,6 +8283,13 @@ Perl_watch(pTHX_ char **addr)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WATCH                  \
         Perl_assert_aTHX; assert(addr)
+
+PERL_CALLCONV I32
+Perl_whichsig(pTHX_ const char *sig)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1);
+#define PERL_ARGS_ASSERT_WHICHSIG               \
+        Perl_assert_aTHX; assert(sig)
 
 PERL_CALLCONV I32
 Perl_whichsig_pv(pTHX_ const char *sig)
@@ -8161,12 +9045,16 @@ PERL_CALLCONV MAGIC *
 Perl_sv_magicext_mglob(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
+/* PERL_CALLCONV U8 *
+Perl_utf16_to_utf8(U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 PERL_CALLCONV U8 *
 Perl_utf16_to_utf8_base(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
+/* PERL_CALLCONV U8 *
+Perl_utf16_to_utf8_reversed(U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
 PERL_CALLCONV U8 *
 Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
         Perl_attribute_nonnull_aTHX
@@ -8211,6 +9099,8 @@ PERL_CALLCONV SV *
 Perl_add_range_to_invlist_(pTHX_ SV *invlist, UV start, UV end)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
+/* PERL_CALLCONV void
+invlist_intersection_(SV * const a, SV * const b, SV **i); */
 PERL_CALLCONV void
 Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **i)
         Perl_attribute_nonnull_aTHX
@@ -8220,6 +9110,10 @@ PERL_CALLCONV void
 Perl_invlist_invert_(pTHX_ SV * const invlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
+/* PERL_CALLCONV void
+invlist_subtract_(SV * const a, SV * const b, SV **result); */
+/* PERL_CALLCONV void
+invlist_union_(SV * const a, SV * const b, SV **output); */
 PERL_CALLCONV void
 Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **output)
         Perl_attribute_nonnull_aTHX
@@ -14966,17 +15860,14 @@ Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
 
 # endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #else /* if !defined(USE_ITHREADS) */
-
-# if defined(USE_THREADS)
 PERL_CALLCONV void
 Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
-#   define PERL_ARGS_ASSERT_COPFILEGV_SET       \
+# define PERL_ARGS_ASSERT_COPFILEGV_SET         \
         Perl_assert_aTHX; assert(c); assert(gv)
 
-# endif
 #endif /* !defined(USE_ITHREADS) */
 #if defined(USE_LOCALE_COLLATE)
 PERL_CALLCONV int
@@ -14999,6 +15890,14 @@ Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
 
 # define PERL_ARGS_ASSERT_STRXFRM               \
         Perl_assert_aTHX; assert(src)
+
+PERL_CALLCONV char *
+Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+# define PERL_ARGS_ASSERT_SV_COLLXFRM           \
+        Perl_assert_aTHX; assert(sv); assert(nxp)
 
 PERL_CALLCONV char *
 Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
@@ -15027,16 +15926,6 @@ Perl_mem_collxfrm_(pTHX_ const char *input_string, STRLEN len, STRLEN *xlen, boo
      defined(PERL_IN_SV_C)
 #   define PERL_ARGS_ASSERT_MEM_COLLXFRM_       \
         Perl_assert_aTHX; assert(input_string); assert(xlen)
-
-# endif
-# if defined(USE_THREADS)
-PERL_CALLCONV char *
-Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-#   define PERL_ARGS_ASSERT_SV_COLLXFRM         \
-        Perl_assert_aTHX; assert(sv); assert(nxp)
 
 # endif
 #endif /* defined(USE_LOCALE_COLLATE) */
@@ -15226,890 +16115,6 @@ Perl_quadmath_format_valid(const char *format)
 #endif /* defined(USE_QUADMATH) */
 #if defined(USE_THREADS)
 PERL_CALLCONV void
-Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SVREFCNT_DEC_SET_NULL \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_C9STRICT_UTF8_TO_UV   \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
-
-PERL_CALLCONV bool
-Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_DO_OPEN               \
-        Perl_assert_aTHX; assert(gv); assert(name)
-
-PERL_CALLCONV Size_t
-Perl_expected_size(UV size);
-# define PERL_ARGS_ASSERT_EXPECTED_SIZE
-
-PERL_CALLCONV bool
-Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_EXTENDED_UTF8_TO_UV   \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
-
-PERL_CALLCONV I32
-Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_5);
-# define PERL_ARGS_ASSERT_FOLDEQ_UTF8           \
-        Perl_assert_aTHX; assert(s1); assert(s2)
-
-PERL_CALLCONV GV *
-Perl_gv_AVadd(pTHX_ GV *gv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_AVADD              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV GV *
-Perl_gv_HVadd(pTHX_ GV *gv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_HVADD              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV GV *
-Perl_gv_IOadd(pTHX_ GV *gv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_IOADD              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV GV *
-Perl_gv_SVadd(pTHX_ GV *gv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_GV_SVADD              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_GV_EFULLNAME3         \
-        Perl_assert_aTHX; assert(sv); assert(gv)
-
-PERL_CALLCONV GV *
-Perl_gv_fetchmeth(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_GV_FETCHMETH          \
-        Perl_assert_aTHX; assert(name)
-
-PERL_CALLCONV GV *
-Perl_gv_fetchmeth_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_GV_FETCHMETH_AUTOLOAD \
-        Perl_assert_aTHX; assert(name)
-
-PERL_CALLCONV GV *
-Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_GV_FETCHMETHOD        \
-        Perl_assert_aTHX; assert(stash); assert(name)
-
-PERL_CALLCONV void
-Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_GV_FULLNAME3          \
-        Perl_assert_aTHX; assert(sv); assert(gv)
-
-PERL_CALLCONV void
-Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
-# define PERL_ARGS_ASSERT_GV_INIT               \
-        Perl_assert_aTHX; assert(gv); \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
-
-PERL_CALLCONV SV *
-Perl_hv_delete(pTHX_ HV *hv, const char *key, I32 klen, I32 flags)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_HV_DELETE             \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
-
-PERL_CALLCONV SV *
-Perl_hv_delete_ent(pTHX_ HV *hv, SV *keysv, I32 flags, U32 hash)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_HV_DELETE_ENT         \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
-
-PERL_CALLCONV bool
-Perl_hv_exists(pTHX_ HV *hv, const char *key, I32 klen)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_HV_EXISTS             \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
-
-PERL_CALLCONV bool
-Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_HV_EXISTS_ENT         \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
-
-PERL_CALLCONV SV **
-Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_HV_FETCH              \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
-
-PERL_CALLCONV HE *
-Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_HV_FETCH_ENT          \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
-
-PERL_CALLCONV HE *
-Perl_hv_iternext(pTHX_ HV *hv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_HV_ITERNEXT           \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
-
-PERL_CALLCONV void
-Perl_hv_magic(pTHX_ HV *hv, GV *gv, int how)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_HV_MAGIC              \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
-
-PERL_CALLCONV SV **
-Perl_hv_store(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_HV_STORE              \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
-
-PERL_CALLCONV HE *
-Perl_hv_store_ent(pTHX_ HV *hv, SV *key, SV *val, U32 hash)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_HV_STORE_ENT          \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
-
-PERL_CALLCONV SV **
-Perl_hv_store_flags(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash, int flags)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_HV_STORE_FLAGS        \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
-
-PERL_CALLCONV void
-Perl_hv_undef(pTHX_ HV *hv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_HV_UNDEF              \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
-
-PERL_CALLCONV I32
-Perl_ibcmp(pTHX_ const char *a, const char *b, I32 len)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2)
-        __attribute__warn_unused_result__
-        __attribute__pure__;
-# define PERL_ARGS_ASSERT_IBCMP                 \
-        Perl_assert_aTHX; assert(a); assert(b)
-
-PERL_CALLCONV I32
-Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2)
-        __attribute__warn_unused_result__
-        __attribute__pure__;
-# define PERL_ARGS_ASSERT_IBCMP_LOCALE          \
-        Perl_assert_aTHX; assert(a); assert(b)
-
-PERL_CALLCONV I32
-Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_5);
-# define PERL_ARGS_ASSERT_IBCMP_UTF8            \
-        Perl_assert_aTHX; assert(s1); assert(s2)
-
-PERL_CALLCONV char *
-Perl_instr(const char *big, const char *little)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        __attribute__warn_unused_result__
-        __attribute__pure__;
-# define PERL_ARGS_ASSERT_INSTR                 \
-        assert(big); assert(little)
-
-PERL_CALLCONV bool
-Perl_is_c9strict_utf8_string(const U8 *s, STRLEN len)
-        Perl_attribute_nonnull(1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING \
-        assert(s)
-
-PERL_CALLCONV bool
-Perl_is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOC \
-        assert(s); assert(ep)
-
-PERL_CALLCONV bool
-Perl_is_strict_utf8_string(const U8 *s, STRLEN len)
-        Perl_attribute_nonnull(1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING \
-        assert(s)
-
-PERL_CALLCONV bool
-Perl_is_strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOC \
-        assert(s); assert(ep)
-
-PERL_CALLCONV STRLEN
-Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2);
-# define PERL_ARGS_ASSERT_IS_UTF8_CHAR_BUF      \
-        assert(buf); assert(buf_end); assert(buf <= buf_end)
-
-PERL_CALLCONV bool
-Perl_is_utf8_fixed_width_buf_flags(const U8 * const s, STRLEN len, const U32 flags)
-        Perl_attribute_nonnull(1);
-# define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_FLAGS \
-        assert(s)
-
-PERL_CALLCONV bool
-Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 **ep, const U32 flags)
-        Perl_attribute_nonnull(1);
-# define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOC_FLAGS \
-        assert(s)
-
-PERL_CALLCONV bool
-Perl_is_utf8_string(const U8 *s, STRLEN len)
-        Perl_attribute_nonnull(1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_IS_UTF8_STRING        \
-        assert(s)
-
-PERL_CALLCONV bool
-Perl_is_utf8_string_loc(const U8 *s, const STRLEN len, const U8 **ep)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC    \
-        assert(s); assert(ep)
-
-PERL_CALLCONV bool
-Perl_is_utf8_string_loc_flags(const U8 *s, STRLEN len, const U8 **ep, const U32 flags)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC_FLAGS \
-        assert(s); assert(ep)
-
-PERL_CALLCONV bool
-Perl_is_utf8_valid_partial_char(const U8 * const s0, const U8 * const e)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        __attribute__warn_unused_result__
-        __attribute__pure__;
-# define PERL_ARGS_ASSERT_IS_UTF8_VALID_PARTIAL_CHAR \
-        assert(s0); assert(e); assert(s0 < e)
-
-PERL_CALLCONV CV *
-Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_NEWATTRSUB            \
-        Perl_assert_aTHX
-
-PERL_CALLCONV AV *
-Perl_newAV(pTHX)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV                 \
-        Perl_assert_aTHX
-
-PERL_CALLCONV AV *
-Perl_newAV_alloc_x(pTHX_ SSize_t size)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV_ALLOC_X         \
-        Perl_assert_aTHX
-
-PERL_CALLCONV AV *
-Perl_newAV_alloc_xz(pTHX_ SSize_t size)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV_ALLOC_XZ        \
-        Perl_assert_aTHX
-
-PERL_CALLCONV AV *
-Perl_newAV_mortal(pTHX)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWAV_MORTAL          \
-        Perl_assert_aTHX
-
-PERL_CALLCONV GV *
-Perl_newGVgen(pTHX_ const char *pack)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_NEWGVGEN              \
-        Perl_assert_aTHX; assert(pack)
-
-PERL_CALLCONV HV *
-Perl_newHV(pTHX)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWHV                 \
-        Perl_assert_aTHX
-
-PERL_CALLCONV IO *
-Perl_newIO(pTHX)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWIO                 \
-        Perl_assert_aTHX
-
-PERL_CALLCONV CV *
-Perl_newSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *block)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_NEWSUB                \
-        Perl_assert_aTHX
-
-PERL_CALLCONV SV *
-Perl_newSVsv(pTHX_ SV * const old)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWSVSV               \
-        Perl_assert_aTHX
-
-PERL_CALLCONV SV *
-Perl_newSVsv_nomg(pTHX_ SV * const old)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_NEWSVSV_NOMG          \
-        Perl_assert_aTHX
-
-PERL_CALLCONV OP *
-Perl_op_lvalue(pTHX_ OP *o, I32 type)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_OP_LVALUE             \
-        Perl_assert_aTHX
-
-PERL_CALLCONV const char *
-Perl_phase_name(pTHX_ enum perl_phase phase)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_PHASE_NAME            \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_qerror(pTHX_ SV *err)
-        Perl_attribute_nonnull_aTHX
-        __attribute__deprecated__;
-# define PERL_ARGS_ASSERT_QERROR                \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_resume_compcv_and_save(pTHX_ struct suspended_compcv *buffer)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_RESUME_COMPCV_AND_SAVE \
-        Perl_assert_aTHX; assert(buffer)
-
-PERL_CALLCONV void
-Perl_resume_compcv_final(pTHX_ struct suspended_compcv *buffer)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_RESUME_COMPCV_FINAL   \
-        Perl_assert_aTHX; assert(buffer)
-
-PERL_CALLCONV void
-Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
-# define PERL_ARGS_ASSERT_SAVE_AELEM            \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
-        assert(sptr)
-
-PERL_CALLCONV void
-Perl_save_freeop(pTHX_ OP *o)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_FREEOP           \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_save_freepv(pTHX_ char *pv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_FREEPV           \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_save_freesv(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_FREESV           \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2)
-        Perl_attribute_nonnull(pTHX_3);
-# define PERL_ARGS_ASSERT_SAVE_HELEM            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
-        assert(key); assert(sptr)
-
-PERL_CALLCONV void
-Perl_save_mortalizesv(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SAVE_MORTALIZESV      \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV void
-Perl_save_op(pTHX)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SAVE_OP               \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_STRICT_UTF8_TO_UV     \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
-
-PERL_CALLCONV bool
-Perl_sv_2bool(pTHX_ SV * const sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_2BOOL              \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV IV
-Perl_sv_2iv(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_2IV                \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_2pv(pTHX_ SV *sv, STRLEN *lp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_2PV                \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_2pv_nolen(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_2PV_NOLEN          \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_2pvbyte(pTHX_ SV *sv, STRLEN * const lp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_2PVBYTE            \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_2PVBYTE_NOLEN      \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_2pvutf8(pTHX_ SV *sv, STRLEN * const lp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_2PVUTF8            \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_2PVUTF8_NOLEN      \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV UV
-Perl_sv_2uv(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_2UV                \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV void
-Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_SV_CATPVN             \
-        Perl_assert_aTHX; assert(dsv); assert(sstr)
-
-PERL_CALLCONV void
-Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_SV_CATPVN_MG          \
-        Perl_assert_aTHX; assert(dsv); assert(sstr)
-
-PERL_CALLCONV void
-Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_CATSV              \
-        Perl_assert_aTHX; assert(dsv)
-
-PERL_CALLCONV void
-Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_CATSV_MG           \
-        Perl_assert_aTHX; assert(dsv)
-
-PERL_CALLCONV void
-Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_SV_COPYPV             \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
-
-PERL_CALLCONV void
-Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_SV_COPYPV_NOMG        \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
-
-PERL_CALLCONV I32
-Perl_sv_eq(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_EQ                 \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_sv_force_normal(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_FORCE_NORMAL       \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV void
-Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char * const little, const STRLEN littlelen)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_4);
-# define PERL_ARGS_ASSERT_SV_INSERT             \
-        Perl_assert_aTHX; assert(bigstr); assert(little)
-
-PERL_CALLCONV SV *
-Perl_sv_mortalcopy(pTHX_ SV * const oldsv)
-        Perl_attribute_nonnull_aTHX
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_MORTALCOPY         \
-        Perl_assert_aTHX
-
-PERL_CALLCONV I32
-Perl_sv_numcmp(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMCMP             \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_sv_numeq(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMEQ              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_sv_numge(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMGE              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_sv_numgt(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMGT              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_sv_numle(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMLE              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_sv_numlt(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMLT              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV bool
-Perl_sv_numne(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_NUMNE              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV char *
-Perl_sv_pv(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_PV                 \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_pvbyte(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_PVBYTE             \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_pvn_force(pTHX_ SV *sv, STRLEN *lp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_PVN_FORCE          \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV char *
-Perl_sv_pvutf8(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_SV_PVUTF8             \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV void
-Perl_sv_setsv(pTHX_ SV *dsv, SV *ssv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_SETSV              \
-        Perl_assert_aTHX; assert(dsv)
-
-PERL_CALLCONV bool
-Perl_sv_streq(pTHX_ SV *sv1, SV *sv2)
-        Perl_attribute_nonnull_aTHX;
-# define PERL_ARGS_ASSERT_SV_STREQ              \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_sv_taint(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_TAINT              \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV void
-Perl_sv_unref(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_UNREF              \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV void
-Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_USEPVN             \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV void
-Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_USEPVN_MG          \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV bool
-Perl_sv_utf8_downgrade(pTHX_ SV * const sv, const bool fail_ok)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE     \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV bool
-Perl_sv_utf8_downgrade_nomg(pTHX_ SV * const sv, const bool fail_ok)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_NOMG \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV STRLEN
-Perl_sv_utf8_upgrade(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE       \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV STRLEN
-Perl_sv_utf8_upgrade_flags(pTHX_ SV * const sv, const I32 flags)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV STRLEN
-Perl_sv_utf8_upgrade_nomg(pTHX_ SV *sv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_NOMG  \
-        Perl_assert_aTHX; assert(sv)
-
-PERL_CALLCONV UV
-Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_2)
-        Perl_attribute_nonnull(pTHX_3);
-# define PERL_ARGS_ASSERT_TO_UNI_FOLD           \
-        Perl_assert_aTHX; assert(p); assert(lenp)
-
-PERL_CALLCONV U8 *
-Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(3)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_UTF8_HOP_BACK         \
-        assert(s); assert(start); assert(start <= s)
-
-PERL_CALLCONV U8 *
-Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(3)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD      \
-        assert(s); assert(end); assert(s <= end)
-
-PERL_CALLCONV U8 *
-Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(3)
-        Perl_attribute_nonnull(4)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_UTF8_HOP_SAFE         \
-        assert(s); assert(start); assert(end); assert(start <= s); \
-        assert(s <= end)
-
-PERL_CALLCONV bool
-Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_UTF8_TO_UV            \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
-
-PERL_CALLCONV bool
-Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_UTF8_TO_UV_ERRORS     \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
-
-PERL_CALLCONV bool
-Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags)
-        Perl_attribute_nonnull(1)
-        Perl_attribute_nonnull(2)
-        Perl_attribute_nonnull(3);
-# define PERL_ARGS_ASSERT_UTF8_TO_UV_FLAGS      \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
-
-PERL_CALLCONV UV
-Perl_utf8n_to_uvchr(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags)
-        Perl_attribute_nonnull(1);
-# define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR        \
-        assert(s)
-
-PERL_CALLCONV UV
-Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors)
-        Perl_attribute_nonnull(1);
-# define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_ERROR  \
-        assert(s)
-
-PERL_CALLCONV U8 *
-Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_UV_TO_UTF8_MSGS       \
-        Perl_assert_aTHX; assert(d)
-
-PERL_CALLCONV U8 *
-Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_UVCHR_TO_UTF8         \
-        Perl_assert_aTHX; assert(d)
-
-PERL_CALLCONV U8 *
-Perl_uvchr_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS   \
-        Perl_assert_aTHX; assert(d)
-
-PERL_CALLCONV U8 *
-Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS_MSGS \
-        Perl_assert_aTHX; assert(d)
-
-PERL_CALLCONV U8 *
-Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS \
-        Perl_assert_aTHX; assert(d)
-
-PERL_CALLCONV UV
-Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
-        Perl_attribute_nonnull(1)
-        __attribute__warn_unused_result__;
-# define PERL_ARGS_ASSERT_VALID_UTF8_TO_UVCHR   \
-        assert(s)
-
-PERL_CALLCONV I32
-Perl_whichsig(pTHX_ const char *sig)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1);
-# define PERL_ARGS_ASSERT_WHICHSIG              \
-        Perl_assert_aTHX; assert(sig)
-
-PERL_CALLCONV void
 Perl_thread_locale_init(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT    \
@@ -16121,25 +16126,6 @@ Perl_thread_locale_term(pTHX)
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM    \
         Perl_assert_aTHX
 
-# if defined(PERL_CORE) || defined(PERL_EXT)
-/* PERL_CALLCONV U8 *
-Perl_utf16_to_utf8(U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
-/* PERL_CALLCONV U8 *
-Perl_utf16_to_utf8_reversed(U8 *p, U8 *d, Size_t bytelen, Size_t *newlen); */
-#   if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
-       defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
-/* PERL_CALLCONV void
-invlist_intersection_(SV * const a, SV * const b, SV **i); */
-/* PERL_CALLCONV void
-invlist_subtract_(SV * const a, SV * const b, SV **result); */
-/* PERL_CALLCONV void
-invlist_union_(SV * const a, SV * const b, SV **output); */
-#   endif
-# endif
-# if defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) || \
-     defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C)
-
-# endif
 #endif /* defined(USE_THREADS) */
 #if defined(VMS) || defined(WIN32)
 PERL_CALLCONV int

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4556,8 +4556,6 @@ sub generate_proto_h {
             if $static_inline;
         $ret = "#${ind}ifndef NO_MATHOMS\n$ret\n#${ind}endif"
             if $binarycompat;
-        $ret = "#${ind}ifdef USE_THREADS\n$ret\n#${ind}endif"
-            if $has_mflag;
 
         $ret .= @attrs ? "\n\n" : "\n";
 
@@ -5742,8 +5740,6 @@ sub generate_long_names_c {
 #define PERL_IN_LONG_NAMES_C
 #include "perl.h"
 
-#ifdef USE_THREADS
-
 EOT
 
     for my $full_name (sort keys %{$longs}) {
@@ -5804,11 +5800,6 @@ EOT
         my $group = $hp->group_content([$parser_object]);
         print $fh $hp->lines_as_str($group), "\n";;
     }
-
-    print $fh <<~'EOT';
-
-        #endif
-        EOT
 
     read_only_bottom_close_and_rename($fh) if ! $error_count;
 }


### PR DESCRIPTION
Otherwise API symbols like Perl_hv_store will have no definition at all, not even a macro, on unthreaded builds.

Fixes #24535.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
