### PR TITLE
perldelta - clearer presentation of preemptive hekification items

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -982,33 +982,17 @@ added and are used to hekify some C<OP_CONST> hash keys at compile time.
 
 =item *
 
-C<Perl_check_hash_fields_and_hekify>, partly called as a compile-time
-optimization, no longer preemptively converts an NV to a HEK if the
-compile time and run time locales could differ.
-[L<GH #24252|https://github.com/Perl/perl5/issues/24252>]
-
-=item *
-
-C<Perl_check_hash_fields_and_hekify>, partly called as a compile-time
-optimization, no longer preemptively converts a UTF-8 string to a HEK
-when this will downgrade the string to a single byte representation.
-
-At present, multiple functions inadequately handle the flag used to
-denote when a key originally had UTF-8 encoding, making it impossible to
-restore the encoding when keys are extracted from a hash (using C<keys>
-for example).
-
-Tracking of UTF-8 origins can hopefully be improved in the next development
-cycle, allowing for preemptive conversion of all UTF-8 strings once again.
-[L<GH #24266|https://github.com/Perl/perl5/issues/24266>]
-[L<GH #24287|https://github.com/Perl/perl5/issues/24287>]
-
-=item *
-
 The macro L<perlapi/C<fromCTRL>> has been added to be the inverse of the
 existing L<perlapi/C<toCTRL>>.  C<toCTRL('A')> yields 1 (the control
 character C<SOH> on all platforms Perl works on); C<fromCTRL(1)>
 yields 'A'.
+
+=item *
+
+C<Perl_check_hash_fields_and_hekify>, partly called as a compile-time
+optimization, no longer preemptively converts an NV to a HEK if the
+compile time and run time locales could differ.
+[L<GH #24252|https://github.com/Perl/perl5/issues/24252>]
 
 =item *
 
@@ -1022,6 +1006,7 @@ would not be in the original, expected UTF-8 encoding.
 
 The original encoding is now captured and propagated.
 [L<GH #24266|https://github.com/Perl/perl5/issues/24266>]
+[L<GH #24290|https://github.com/Perl/perl5/pull/24290>]
 
 =item *
 


### PR DESCRIPTION
Two main changes:
* The item about `Perl_check_hash_fields_and_hekify` no longer downgrading UTF-8 strings due to problems propagating `HVhek_WASUTF8` isn't needed. As per a later item, handling of that flag was improved within the dev cycle, allowing the downgrading of UTF-8 strings to be restored.

* The item about `Perl_check_hash_fields_and_hekify` no longer hekifying NVs was moved down to be contiguous with the remaining other preemptive hekification items.

-------------------------------------------------------------------------------
* This set of changes is to perldelta.
