### PR TITLE
cpan/IO-Compress - Update to version 2.223

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -677,8 +677,8 @@ our %Modules = (
     },
 
     'IO-Compress' => {
-        'DISTRIBUTION' => 'PMQS/IO-Compress-2.220.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Sun May 17 07:54:14 2026',
+        'DISTRIBUTION' => 'PMQS/IO-Compress-2.223.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Mon Jul  6 12:27:06 2026',
         'MAIN_MODULE'  => 'IO::Compress::Base',
         'FILES'        => q[cpan/IO-Compress],
         'EXCLUDED'     => [

--- a/cpan/IO-Compress/Makefile.PL
+++ b/cpan/IO-Compress/Makefile.PL
@@ -3,8 +3,9 @@
 use strict ;
 require 5.006 ;
 
-$::VERSION = '2.220' ;
-$::DEP_VERSION = '2.218';
+$::VERSION = '2.222' ;
+$::DEP_ZLIB_VERSION = '2.222';
+$::DEP_BZIP2_VERSION = '2.218';
 
 use lib '.';
 use private::MakeUtil;
@@ -25,8 +26,8 @@ WriteMakefile(
     (
       $ENV{SKIP_FOR_CORE}
         ? ()
-	    : (PREREQ_PM   => { 'Compress::Raw::Bzip2' => $::DEP_VERSION,
-		                    'Compress::Raw::Zlib'  => $::DEP_VERSION,
+	    : (PREREQ_PM   => { 'Compress::Raw::Bzip2' => $::DEP_BZIP2_VERSION,
+		                    'Compress::Raw::Zlib'  => $::DEP_ZLIB_VERSION,
 		                    'Scalar::Util'  => 0,
                             'Encode'        => 0,
                             'Time::Local'   => 0,

--- a/cpan/IO-Compress/bin/zipdetails
+++ b/cpan/IO-Compress/bin/zipdetails
@@ -29,7 +29,7 @@ use Encode;
 use Getopt::Long;
 use List::Util qw(min max);
 
-my $VERSION = '4.006' ;
+my $VERSION = '4.008' ;
 
 sub fatal_tryWalk;
 sub fatal_truncated ;
@@ -2419,7 +2419,7 @@ sub redactFilename
     $filename =~ s(.)(X)g
         if $opt_Redact;
 
-    return $filename;
+    return wantarray ? ($filename, $filename, 0)  : $filename;
 }
 
 sub validateDirectory
@@ -8251,8 +8251,10 @@ L<https://github.com/pmqs/zipdetails/issues>.
 The primary reference for Zip files is
 L<APPNOTE.TXT|https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT>.
 
-An alternative reference is the Info-Zip appnote. This is available from
-L<ftp://ftp.info-zip.org/pub/infozip/doc/>
+If you need to investigate the extra fields that are used in zip
+files the "appnote" document covers a lot of them.
+The Info-ZIP zip distribution, available at L<https://infozip.sourceforge.net/>,
+contains additional extra field definitions. Look for the file "extrafld.txt".
 
 For details of WinZip AES encryption see L<AES Encryption Information:
 Encryption Specification AE-1 and

--- a/cpan/IO-Compress/lib/Compress/Zlib.pm
+++ b/cpan/IO-Compress/lib/Compress/Zlib.pm
@@ -7,17 +7,17 @@ use Carp ;
 use IO::Handle ;
 use Scalar::Util qw(dualvar);
 
-use IO::Compress::Base::Common 2.220 ;
-use Compress::Raw::Zlib 2.218 ;
-use IO::Compress::Gzip 2.220 ;
-use IO::Uncompress::Gunzip 2.220 ;
+use IO::Compress::Base::Common 2.223 ;
+use Compress::Raw::Zlib 2.222 ;
+use IO::Compress::Gzip 2.223 ;
+use IO::Uncompress::Gunzip 2.223 ;
 
 use strict ;
 use warnings ;
 use bytes ;
 our ($VERSION, $XS_VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -461,7 +461,7 @@ sub inflate
 
 package Compress::Zlib ;
 
-use IO::Compress::Gzip::Constants 2.220 ;
+use IO::Compress::Gzip::Constants 2.223 ;
 
 sub memGzip($)
 {

--- a/cpan/IO-Compress/lib/File/GlobMapper.pm
+++ b/cpan/IO-Compress/lib/File/GlobMapper.pm
@@ -315,7 +315,6 @@ sub _parseOutputGlob
     }
 
     my $noPreBS = '(?<!\\\)' ; # no preceding backslash
-    my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
 
     # escape any use of the delimiter symbols
     # $string =~ s/(${BEGIN_DELIM}|${END_DELIM}|${BACKSLASH_ESC})/$1$1/g;
@@ -325,7 +324,7 @@ sub _parseOutputGlob
     $string =~ s/\\\*/${STAR_ESC}/g;
 
     # Transform "#3" to BEGIN_DELIM 3 END_DELIM
-    $string =~ s/${noPreESC}#(\d)/${BEGIN_DELIM}${1}${END_DELIM}/g;
+    $string =~ s/#(\d)/${BEGIN_DELIM}${1}${END_DELIM}/g;
 
     $string =~ s#\*#${BEGIN_DELIM}${END_DELIM}#g;
 
@@ -351,20 +350,18 @@ sub _getFiles
         my $outFile = $inFile ;
         my @matches ;
 
-        my $noPreESC = '(?<![${BEGIN_DELIM}])' ; # no preceding backslash
-
         if (@matches = ($inFile =~ m/$self->{InputPattern}/ ))
         {
             $outFile = $self->{OutputPattern};
             my $ix = 1;
 
             # get the filename glob
-            $outFile =~ s/${noPreESC}${BEGIN_DELIM}${END_DELIM}/$inFile/g;
+            $outFile =~ s/${BEGIN_DELIM}${END_DELIM}/$inFile/g;
 
             # now each of the #1, #2,...
             for my $pattern (@matches)
             {
-                $outFile =~ s/${noPreESC}${BEGIN_DELIM}${ix}${END_DELIM}/$pattern/g;
+                $outFile =~ s/${BEGIN_DELIM}${ix}${END_DELIM}/$pattern/g;
 
                 ++ $ix;
             }

--- a/cpan/IO-Compress/lib/IO/Compress.pm
+++ b/cpan/IO-Compress/lib/IO/Compress.pm
@@ -1,6 +1,6 @@
 package IO::Compress;
 
-our $VERSION = '2.220' ;
+our $VERSION = '2.223' ;
 
 =head1 NAME
 

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Bzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Bzip2.pm
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.220 qw(:Status);
+use IO::Compress::Base::Common  2.223 qw(:Status);
 
 use Compress::Raw::Bzip2  2.218 ;
 
 our ($VERSION);
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 sub mkCompObject
 {

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Deflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Deflate.pm
@@ -4,13 +4,13 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.220 qw(:Status);
-use Compress::Raw::Zlib  2.218 qw( !crc32 !adler32 ) ;
+use IO::Compress::Base::Common 2.223 qw(:Status);
+use Compress::Raw::Zlib 2.222 qw( !crc32 !adler32 ) ;
 
 require Exporter;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, @EXPORT, %DEFLATE_CONSTANTS);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 @ISA = qw(Exporter);
 @EXPORT_OK = @Compress::Raw::Zlib::DEFLATE_CONSTANTS;
 %EXPORT_TAGS = %Compress::Raw::Zlib::DEFLATE_CONSTANTS;

--- a/cpan/IO-Compress/lib/IO/Compress/Adapter/Identity.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Adapter/Identity.pm
@@ -4,10 +4,10 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.220 qw(:Status);
+use IO::Compress::Base::Common  2.223 qw(:Status);
 our ($VERSION);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 sub mkCompObject
 {

--- a/cpan/IO-Compress/lib/IO/Compress/Base.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Base.pm
@@ -6,7 +6,7 @@ require 5.006 ;
 use strict ;
 use warnings;
 
-use IO::Compress::Base::Common 2.220 ;
+use IO::Compress::Base::Common 2.223 ;
 
 use IO::File ();
 use Scalar::Util ();
@@ -20,7 +20,7 @@ use Symbol();
 our (@ISA, $VERSION);
 @ISA    = qw(IO::File Exporter);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 #Can't locate object method "SWASHNEW" via package "utf8" (perhaps you forgot to load "utf8"?) at .../ext/Compress-Zlib/Gzip/blib/lib/Compress/Zlib/Common.pm line 16.
 

--- a/cpan/IO-Compress/lib/IO/Compress/Base/Common.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Base/Common.pm
@@ -11,7 +11,7 @@ use File::GlobMapper;
 require Exporter;
 our ($VERSION, @ISA, @EXPORT, %EXPORT_TAGS, $HAS_ENCODE);
 @ISA = qw(Exporter);
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 @EXPORT = qw( isaFilehandle isaFilename isaScalar
               whatIsInput whatIsOutput

--- a/cpan/IO-Compress/lib/IO/Compress/Bzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Bzip2.pm
@@ -5,16 +5,16 @@ use warnings;
 use bytes;
 require Exporter ;
 
-use IO::Compress::Base 2.220 ;
+use IO::Compress::Base 2.223 ;
 
-use IO::Compress::Base::Common  2.220 qw();
-use IO::Compress::Adapter::Bzip2 2.220 ;
+use IO::Compress::Base::Common  2.223 qw();
+use IO::Compress::Adapter::Bzip2 2.223 ;
 
 
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $Bzip2Error);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $Bzip2Error = '';
 
 @ISA    = qw(IO::Compress::Base Exporter);
@@ -51,7 +51,7 @@ sub getExtraParams
 {
     my $self = shift ;
 
-    use IO::Compress::Base::Common  2.220 qw(:Parse);
+    use IO::Compress::Base::Common  2.223 qw(:Parse);
 
     return (
             'blocksize100k' => [IO::Compress::Base::Common::Parse_unsigned,  1],

--- a/cpan/IO-Compress/lib/IO/Compress/Deflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Deflate.pm
@@ -8,16 +8,16 @@ use bytes;
 
 require Exporter ;
 
-use IO::Compress::RawDeflate 2.220 ();
-use IO::Compress::Adapter::Deflate 2.220 ;
+use IO::Compress::RawDeflate 2.223 ();
+use IO::Compress::Adapter::Deflate 2.223 ;
 
-use IO::Compress::Zlib::Constants 2.220 ;
-use IO::Compress::Base::Common  2.220 qw();
+use IO::Compress::Zlib::Constants 2.223 ;
+use IO::Compress::Base::Common  2.223 qw();
 
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $DeflateError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $DeflateError = '';
 
 @ISA    = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/FAQ.pod
+++ b/cpan/IO-Compress/lib/IO/Compress/FAQ.pod
@@ -189,8 +189,10 @@ Yes. Zip64 allows this. See previous question.
 The primary reference for zip files is the "appnote" document available at
 L<http://www.pkware.com/documents/casestudies/APPNOTE.TXT>
 
-An alternatively is the Info-Zip appnote. This is available from
-L<ftp://ftp.info-zip.org/pub/infozip/doc/>
+If you need to investigate the extra fields that are used in zip
+files the "appnote" document covers a lot of them.
+The Info-ZIP zip distribution, available at L<https://infozip.sourceforge.net/>,
+contains additional extra field definitions. Look for the file "extrafld.txt".
 
 =head1 GZIP
 
@@ -686,4 +688,3 @@ Copyright (c) 2005-2026 Paul Marquess. All rights reserved.
 
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
-

--- a/cpan/IO-Compress/lib/IO/Compress/Gzip.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Gzip.pm
@@ -8,12 +8,12 @@ use bytes;
 
 require Exporter ;
 
-use IO::Compress::RawDeflate 2.220 () ;
-use IO::Compress::Adapter::Deflate 2.220 ;
+use IO::Compress::RawDeflate 2.223 () ;
+use IO::Compress::Adapter::Deflate 2.223 ;
 
-use IO::Compress::Base::Common  2.220 qw(:Status );
-use IO::Compress::Gzip::Constants 2.220 ;
-use IO::Compress::Zlib::Extra 2.220 ;
+use IO::Compress::Base::Common  2.223 qw(:Status );
+use IO::Compress::Gzip::Constants 2.223 ;
+use IO::Compress::Zlib::Extra 2.223 ;
 
 BEGIN
 {
@@ -25,7 +25,7 @@ BEGIN
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $GzipError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $GzipError = '' ;
 
 @ISA    = qw(IO::Compress::RawDeflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Gzip/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Gzip/Constants.pm
@@ -9,7 +9,7 @@ require Exporter;
 our ($VERSION, @ISA, @EXPORT, %GZIP_OS_Names);
 our ($GZIP_FNAME_INVALID_CHAR_RE, $GZIP_FCOMMENT_INVALID_CHAR_RE);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/RawDeflate.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/RawDeflate.pm
@@ -6,16 +6,16 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base 2.220 ;
-use IO::Compress::Base::Common  2.220 qw(:Status :Parse);
-use IO::Compress::Adapter::Deflate 2.220 ;
-use Compress::Raw::Zlib  2.218 qw(Z_DEFLATED Z_DEFAULT_COMPRESSION Z_DEFAULT_STRATEGY);
+use IO::Compress::Base 2.223 ;
+use IO::Compress::Base::Common  2.223 qw(:Status :Parse);
+use IO::Compress::Adapter::Deflate 2.223 ;
+use Compress::Raw::Zlib 2.222 qw(Z_DEFLATED Z_DEFAULT_COMPRESSION Z_DEFAULT_STRATEGY);
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %DEFLATE_CONSTANTS, %EXPORT_TAGS, $RawDeflateError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $RawDeflateError = '';
 
 @ISA = qw(IO::Compress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Compress/Zip.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zip.pm
@@ -4,17 +4,17 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.220 qw(:Status );
-use IO::Compress::RawDeflate 2.220 ();
-use IO::Compress::Adapter::Deflate 2.220 ;
-use IO::Compress::Adapter::Identity 2.220 ;
-use IO::Compress::Zlib::Extra 2.220 ;
-use IO::Compress::Zip::Constants 2.220 ;
+use IO::Compress::Base::Common  2.223 qw(:Status );
+use IO::Compress::RawDeflate 2.223 ();
+use IO::Compress::Adapter::Deflate 2.223 ;
+use IO::Compress::Adapter::Identity 2.223 ;
+use IO::Compress::Zlib::Extra 2.223 ;
+use IO::Compress::Zip::Constants 2.223 ;
 
 use File::Spec();
 use Config;
 
-use Compress::Raw::Zlib  2.218 ();
+use Compress::Raw::Zlib 2.222 ();
 
 BEGIN
 {
@@ -47,17 +47,18 @@ require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $ZipError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $ZipError = '';
 
 @ISA = qw(IO::Compress::RawDeflate Exporter);
 @EXPORT_OK = qw( $ZipError zip ) ;
 %EXPORT_TAGS = %IO::Compress::RawDeflate::DEFLATE_CONSTANTS ;
 
-$EXPORT_TAGS{all} = [ defined $EXPORT_TAGS{all} ? @{ $EXPORT_TAGS{all} } : (), @EXPORT_OK ] ;
+my @zip_methods = qw( ZIP_CM_STORE ZIP_CM_DEFLATE ZIP_CM_BZIP2 ZIP_CM_LZMA ZIP_CM_XZ ZIP_CM_ZSTD ) ;
+$EXPORT_TAGS{all} = [ defined $EXPORT_TAGS{all} ? @{ $EXPORT_TAGS{all} } : (), @EXPORT_OK, @zip_methods ] ;
 
-$EXPORT_TAGS{zip_method} = [qw( ZIP_CM_STORE ZIP_CM_DEFLATE ZIP_CM_BZIP2 ZIP_CM_LZMA ZIP_CM_XZ ZIP_CM_ZSTD)];
-push @{ $EXPORT_TAGS{all} }, @{ $EXPORT_TAGS{zip_method} };
+$EXPORT_TAGS{zip_method} = [ @zip_methods ];
+push @{ $EXPORT_TAGS{constants} }, @zip_methods ;
 
 Exporter::export_ok_tags('all');
 

--- a/cpan/IO-Compress/lib/IO/Compress/Zip/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zip/Constants.pm
@@ -7,7 +7,7 @@ require Exporter;
 
 our ($VERSION, @ISA, @EXPORT, %ZIP_CM_MIN_VERSIONS);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/Zlib/Constants.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zlib/Constants.pm
@@ -9,7 +9,7 @@ require Exporter;
 
 our ($VERSION, @ISA, @EXPORT);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 @ISA = qw(Exporter);
 

--- a/cpan/IO-Compress/lib/IO/Compress/Zlib/Extra.pm
+++ b/cpan/IO-Compress/lib/IO/Compress/Zlib/Extra.pm
@@ -8,9 +8,9 @@ use bytes;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
-use IO::Compress::Gzip::Constants 2.220 ;
+use IO::Compress::Gzip::Constants 2.223 ;
 
 sub ExtraFieldError
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Bunzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Bunzip2.pm
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.220 qw(:Status);
+use IO::Compress::Base::Common 2.223 qw(:Status);
 
 use Compress::Raw::Bzip2 2.218 ;
 
 our ($VERSION, @ISA);
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 sub mkUncompObject
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Identity.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Identity.pm
@@ -4,14 +4,14 @@ use warnings;
 use strict;
 use bytes;
 
-use IO::Compress::Base::Common  2.220 qw(:Status);
+use IO::Compress::Base::Common  2.223 qw(:Status);
 use IO::Compress::Zip::Constants ;
 
 our ($VERSION);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
-use Compress::Raw::Zlib  2.218 ();
+use Compress::Raw::Zlib 2.222 ();
 
 sub mkUncompObject
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Inflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Adapter/Inflate.pm
@@ -4,11 +4,11 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.220 qw(:Status);
-use Compress::Raw::Zlib  2.218 qw(Z_OK Z_BUF_ERROR Z_STREAM_END Z_FINISH MAX_WBITS);
+use IO::Compress::Base::Common  2.223 qw(:Status);
+use Compress::Raw::Zlib 2.222 qw(Z_OK Z_BUF_ERROR Z_STREAM_END Z_FINISH MAX_WBITS);
 
 our ($VERSION);
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 
 

--- a/cpan/IO-Compress/lib/IO/Uncompress/AnyInflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/AnyInflate.pm
@@ -6,22 +6,22 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.220 qw(:Parse);
+use IO::Compress::Base::Common 2.223 qw(:Parse);
 
-use IO::Uncompress::Adapter::Inflate  2.220 ();
+use IO::Uncompress::Adapter::Inflate  2.223 ();
 
 
-use IO::Uncompress::Base  2.220 ;
-use IO::Uncompress::Gunzip  2.220 ;
-use IO::Uncompress::Inflate  2.220 ;
-use IO::Uncompress::RawInflate  2.220 ;
-use IO::Uncompress::Unzip  2.220 ;
+use IO::Uncompress::Base  2.223 ;
+use IO::Uncompress::Gunzip  2.223 ;
+use IO::Uncompress::Inflate  2.223 ;
+use IO::Uncompress::RawInflate  2.223 ;
+use IO::Uncompress::Unzip  2.223 ;
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $AnyInflateError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $AnyInflateError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/AnyUncompress.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/AnyUncompress.pm
@@ -4,16 +4,16 @@ use strict;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.220 ();
+use IO::Compress::Base::Common 2.223 ();
 
-use IO::Uncompress::Base 2.220 ;
+use IO::Uncompress::Base 2.223 ;
 
 
 require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $AnyUncompressError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $AnyUncompressError = '';
 
 @ISA = qw(IO::Uncompress::Base Exporter);
@@ -33,8 +33,8 @@ BEGIN
    # Don't trigger any __DIE__ Hooks.
    local $SIG{__DIE__};
 
-   eval ' use IO::Uncompress::Adapter::Inflate 2.220 ;';
-   eval ' use IO::Uncompress::Adapter::Bunzip2 2.220 ;';
+   eval ' use IO::Uncompress::Adapter::Inflate 2.223 ;';
+   eval ' use IO::Uncompress::Adapter::Bunzip2 2.223 ;';
    eval ' use IO::Uncompress::Adapter::LZO 2.217 ;';
    eval ' use IO::Uncompress::Adapter::Lzf 2.217 ;';
    eval ' use IO::Uncompress::Adapter::UnLzma 2.217 ;';
@@ -42,12 +42,12 @@ BEGIN
    eval ' use IO::Uncompress::Adapter::UnZstd 2.217 ;';
    eval ' use IO::Uncompress::Adapter::UnLzip 2.217 ;';
 
-   eval ' use IO::Uncompress::Bunzip2 2.220 ;';
+   eval ' use IO::Uncompress::Bunzip2 2.223 ;';
    eval ' use IO::Uncompress::UnLzop 2.217 ;';
-   eval ' use IO::Uncompress::Gunzip 2.220 ;';
-   eval ' use IO::Uncompress::Inflate 2.220 ;';
-   eval ' use IO::Uncompress::RawInflate 2.220 ;';
-   eval ' use IO::Uncompress::Unzip 2.220 ;';
+   eval ' use IO::Uncompress::Gunzip 2.223 ;';
+   eval ' use IO::Uncompress::Inflate 2.223 ;';
+   eval ' use IO::Uncompress::RawInflate 2.223 ;';
+   eval ' use IO::Uncompress::Unzip 2.223 ;';
    eval ' use IO::Uncompress::UnLzf 2.217 ;';
    eval ' use IO::Uncompress::UnLzma 2.217 ;';
    eval ' use IO::Uncompress::UnXz 2.217 ;';

--- a/cpan/IO-Compress/lib/IO/Uncompress/Base.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Base.pm
@@ -9,12 +9,12 @@ our (@ISA, $VERSION, @EXPORT_OK, %EXPORT_TAGS);
 @ISA    = qw(IO::File Exporter);
 
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 use constant G_EOF => 0 ;
 use constant G_ERR => -1 ;
 
-use IO::Compress::Base::Common 2.220 ;
+use IO::Compress::Base::Common 2.223 ;
 
 use IO::File ;
 use Symbol;

--- a/cpan/IO-Compress/lib/IO/Uncompress/Bunzip2.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Bunzip2.pm
@@ -4,15 +4,15 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common 2.220 qw(:Status );
+use IO::Compress::Base::Common 2.223 qw(:Status );
 
-use IO::Uncompress::Base 2.220 ;
-use IO::Uncompress::Adapter::Bunzip2 2.220 ;
+use IO::Uncompress::Base 2.223 ;
+use IO::Uncompress::Adapter::Bunzip2 2.223 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $Bunzip2Error);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $Bunzip2Error = '';
 
 @ISA    = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/Gunzip.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Gunzip.pm
@@ -9,12 +9,12 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Uncompress::RawInflate 2.220 ;
+use IO::Uncompress::RawInflate 2.223 ;
 
-use Compress::Raw::Zlib 2.218 () ;
-use IO::Compress::Base::Common 2.220 qw(:Status );
-use IO::Compress::Gzip::Constants 2.220 ;
-use IO::Compress::Zlib::Extra 2.220 ;
+use Compress::Raw::Zlib 2.222 () ;
+use IO::Compress::Base::Common 2.223 qw(:Status );
+use IO::Compress::Gzip::Constants 2.223 ;
+use IO::Compress::Zlib::Extra 2.223 ;
 
 require Exporter ;
 
@@ -28,7 +28,7 @@ Exporter::export_ok_tags('all');
 
 $GunzipError = '';
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 
 sub new
 {

--- a/cpan/IO-Compress/lib/IO/Uncompress/Inflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Inflate.pm
@@ -5,15 +5,15 @@ use strict ;
 use warnings;
 use bytes;
 
-use IO::Compress::Base::Common  2.220 qw(:Status );
-use IO::Compress::Zlib::Constants 2.220 ;
+use IO::Compress::Base::Common  2.223 qw(:Status );
+use IO::Compress::Zlib::Constants 2.223 ;
 
-use IO::Uncompress::RawInflate  2.220 ;
+use IO::Uncompress::RawInflate  2.223 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $InflateError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $InflateError = '';
 
 @ISA    = qw(IO::Uncompress::RawInflate Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/RawInflate.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/RawInflate.pm
@@ -5,16 +5,16 @@ use strict ;
 use warnings;
 use bytes;
 
-use Compress::Raw::Zlib  2.218 ;
-use IO::Compress::Base::Common  2.220 qw(:Status );
+use Compress::Raw::Zlib 2.222 ;
+use IO::Compress::Base::Common  2.223 qw(:Status );
 
-use IO::Uncompress::Base  2.220 ;
-use IO::Uncompress::Adapter::Inflate  2.220 ;
+use IO::Uncompress::Base  2.223 ;
+use IO::Uncompress::Adapter::Inflate  2.223 ;
 
 require Exporter ;
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, %DEFLATE_CONSTANTS, $RawInflateError);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $RawInflateError = '';
 
 @ISA    = qw(IO::Uncompress::Base Exporter);

--- a/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
+++ b/cpan/IO-Compress/lib/IO/Uncompress/Unzip.pm
@@ -9,14 +9,14 @@ use warnings;
 use bytes;
 
 use IO::File;
-use IO::Uncompress::RawInflate  2.220 ;
-use IO::Compress::Base::Common  2.220 qw(:Status );
-use IO::Uncompress::Adapter::Inflate  2.220 ;
-use IO::Uncompress::Adapter::Identity 2.220 ;
-use IO::Compress::Zlib::Extra 2.220 ;
-use IO::Compress::Zip::Constants 2.220 ;
+use IO::Uncompress::RawInflate  2.223 ;
+use IO::Compress::Base::Common  2.223 qw(:Status );
+use IO::Uncompress::Adapter::Inflate  2.223 ;
+use IO::Uncompress::Adapter::Identity 2.223 ;
+use IO::Compress::Zlib::Extra 2.223 ;
+use IO::Compress::Zip::Constants 2.223 ;
 
-use Compress::Raw::Zlib  2.218 () ;
+use Compress::Raw::Zlib 2.222 () ;
 
 BEGIN
 {
@@ -24,7 +24,7 @@ BEGIN
    local $SIG{__DIE__};
 
     eval{ require IO::Uncompress::Adapter::Bunzip2 ;
-          IO::Uncompress::Adapter::Bunzip2->VERSION(2.220) } ;
+          IO::Uncompress::Adapter::Bunzip2->VERSION(2.223) } ;
     eval{ require IO::Uncompress::Adapter::UnLzma ;
           IO::Uncompress::Adapter::UnLzma->VERSION(2.217) } ;
     eval{ require IO::Uncompress::Adapter::UnXz ;
@@ -38,7 +38,7 @@ require Exporter ;
 
 our ($VERSION, @ISA, @EXPORT_OK, %EXPORT_TAGS, $UnzipError, %headerLookup);
 
-$VERSION = '2.220';
+$VERSION = '2.223';
 $UnzipError = '';
 
 @ISA    = qw(IO::Uncompress::RawInflate Exporter);

--- a/cpan/IO-Compress/t/006zip.t
+++ b/cpan/IO-Compress/t/006zip.t
@@ -19,7 +19,7 @@ BEGIN {
     $extra = 1
         if eval { require Test::NoWarnings ;  Test::NoWarnings->import; 1 };
 
-    plan tests => 115 + $extra ;
+    plan tests => 138 + $extra ;
 
     use_ok('IO::Compress::Zip', qw(:all)) ;
     use_ok('IO::Uncompress::Unzip', qw(unzip $UnzipError)) ;
@@ -419,7 +419,6 @@ EOM
         my $name = $u->getHeaderInfo()->{Name};
 
         my $hdr = $u->getHeaderInfo();
-        is $hdr->{Name}, 'hello.txt', "Name is 'hello.txt'";
         is $hdr->{Time}, 0, "Time is zero";
     }
 
@@ -435,8 +434,68 @@ EOM
         my $name = $u->getHeaderInfo()->{Name};
 
         my $hdr = $u->getHeaderInfo();
-        is $hdr->{Name}, 'hello.txt', "Name is 'hello.txt'";
         is $hdr->{Time}, 0, "Time is zero";
     }
 
+}
+
+
+
+{
+
+    title "Tag :constants no longer exports all constants";
+    # https://github.com/pmqs/IO-Compress/issues/78
+    # https://github.com/pmqs/IO-Compress/issues/64
+
+    {
+        package t1;
+
+        use IO::Compress::Zip qw( ZIP_CM_STORE ZIP_CM_DEFLATE ZIP_CM_BZIP2 ZIP_CM_LZMA ZIP_CM_ZSTD ZIP_CM_XZ  );
+
+        ::is ZIP_CM_STORE, 0, "ZIP_CM_STORE is 0";
+        ::is ZIP_CM_DEFLATE, 8, "ZIP_CM_DEFLATE is 9";
+        ::is ZIP_CM_BZIP2, 12, "ZIP_CM_BZIP2 is 12";
+        ::is ZIP_CM_LZMA, 14, "ZIP_CM_LZMA is 14";
+        ::is ZIP_CM_ZSTD, 93, "ZIP_CM_ZSTD is 93";
+        ::is ZIP_CM_XZ, 95, "ZIP_CM_XZ is 95";
+    }
+
+    {
+        package t2;
+
+        use IO::Compress::Zip qw( :zip_method ) ;
+
+        ::is ZIP_CM_STORE, 0, "ZIP_CM_STORE is 0";
+        ::is ZIP_CM_DEFLATE, 8, "ZIP_CM_DEFLATE is 9";
+        ::is ZIP_CM_BZIP2, 12, "ZIP_CM_BZIP2 is 12";
+        ::is ZIP_CM_LZMA, 14, "ZIP_CM_LZMA is 14";
+        ::is ZIP_CM_ZSTD, 93, "ZIP_CM_ZSTD is 93";
+        ::is ZIP_CM_XZ, 95, "ZIP_CM_XZ is 95";
+    }
+
+    {
+        package t3;
+
+        use IO::Compress::Zip qw( :constants ) ;
+
+        ::is ZIP_CM_STORE, 0, "ZIP_CM_STORE is 0";
+        ::is ZIP_CM_DEFLATE, 8, "ZIP_CM_DEFLATE is 9";
+        ::is ZIP_CM_BZIP2, 12, "ZIP_CM_BZIP2 is 12";
+        ::is ZIP_CM_LZMA, 14, "ZIP_CM_LZMA is 14";
+        ::is ZIP_CM_ZSTD, 93, "ZIP_CM_ZSTD is 93";
+        ::is ZIP_CM_XZ, 95, "ZIP_CM_XZ is 95";
+    }
+
+    {
+        package t4;
+
+        use IO::Compress::Zip qw( :all ) ;
+
+        ::is ZIP_CM_STORE, 0, "ZIP_CM_STORE is 0";
+        ::is ZIP_CM_DEFLATE, 8, "ZIP_CM_DEFLATE is 9";
+        ::is ZIP_CM_BZIP2, 12, "ZIP_CM_BZIP2 is 12";
+        ::is ZIP_CM_LZMA, 14, "ZIP_CM_LZMA is 14";
+        ::is ZIP_CM_ZSTD, 93, "ZIP_CM_ZSTD is 93";
+        ::is ZIP_CM_XZ, 95, "ZIP_CM_XZ is 95";
+    }
 }

--- a/cpan/IO-Compress/t/112utf8-zip.t
+++ b/cpan/IO-Compress/t/112utf8-zip.t
@@ -42,10 +42,10 @@ BEGIN {
 
     my $lex = LexFile->new( my $file1 );
 
-    my @names = ( 'alpha \N{GREEK SMALL LETTER ALPHA}',
-                  'beta \N{GREEK SMALL LETTER BETA}',
-                  'gamma \N{GREEK SMALL LETTER GAMMA}',
-                  'delta \N{GREEK SMALL LETTER DELTA}'
+    my @names = ( 'alpha \N{GREEK SMALL LETTER ALPHA}', # CE B1
+                  'beta \N{GREEK SMALL LETTER BETA}',   # CE B2
+                  'gamma \N{GREEK SMALL LETTER GAMMA}', # CE B3
+                  'delta \N{GREEK SMALL LETTER DELTA}'  # CE B4
                 ) ;
 
     my @encoded = map { Encode::encode_utf8($_) } @names;

--- a/cpan/IO-Compress/t/compress/CompTestUtils.pm
+++ b/cpan/IO-Compress/t/compress/CompTestUtils.pm
@@ -233,7 +233,7 @@ sub hexDump
         }
         print "   " x (16 - @array)
             if @array < 16 ;
-        $data =~ tr/\0-\37\177-\377/./;
+        $data =~ s/[[:^print:]]/./g;
         print "  $data\n";
     }
 

--- a/cpan/IO-Compress/t/globmapper.t
+++ b/cpan/IO-Compress/t/globmapper.t
@@ -24,7 +24,7 @@ Perl $]" )
     $extra = 1
         if eval { require Test::NoWarnings ;  Test::NoWarnings->import; 1 };
 
-    plan tests => 76 + $extra ;
+    plan tests => 80 + $extra ;
 
     use_ok('File::GlobMapper') ;
 }
@@ -337,6 +337,24 @@ Perl $]" )
         [ [map { "$tmpDir/$_" } ("abc1.tmp", "X-c1-#1*-X")],
           [map { "$tmpDir/$_" } ("abc2.tmp", "X-c2-#1*-X")],
           [map { "$tmpDir/$_" } ("abc3.tmp", "X-c3-#1*-X")],
+        ], "  got mapping";
+}
+
+{
+    title "check wildcard references after ordinary letters";
+
+    my $tmpDir ;#= 'td';
+    my $lex = LexDir->new( $tmpDir );
+
+    touch map { "$tmpDir/$_.tmp" } qw( abc ) ;
+
+    my $map = File::GlobMapper::globmap("$tmpDir/a*.tmp", "$tmpDir/B#1.out");
+    ok $map, "  got map"
+        or diag $File::GlobMapper::Error ;
+
+    is @{ $map }, 1, "  returned 1 map";
+    is_deeply $map,
+        [ [map { "$tmpDir/$_" } ("abc.tmp", "Bbc.out")],
         ], "  got mapping";
 }
 


### PR DESCRIPTION
  2.223 4 July 2026

    * Fix typo in Makefile.PL Fixes #79 Sat Jul 4 09:22:42 2026 +0100 5e2d96044b22be0c6cd0ba408b671281d15e5a9c

    * * Error:  Compress::Raw::Zlib version 2.222 required--this is only version 2.221
      * Update to version 2.223 Fixes #79 Sat Jul 4 09:16:41 2026 +0100 b9031b0fc30ad378e6cfda5c3dfbede82ec6ac59

    * Update to version 2.222 Fri Jul 3 13:08:15 2026 +0100 68f1713d94521e8990fa92f7947d0f5f92ead6ce

    * Tag `:constants` no longer exports all constants Fixes #78, #64 Fri Jul 3 11:55:19 2026 +0100 a2a91df2d64c5731287e6ca9ad47462cd8907f32

    * Bump actions/checkout from 6 to 7 Fri Jul 3 00:06:22 2026 +0100 941a75e143d7fc707483a30fc4b8097f406485e5

  2.222 3 July 2026

    * Update to version 2.222 Fri Jul 3 13:08:15 2026 +0100 68f1713d94521e8990fa92f7947d0f5f92ead6ce

    * Tag `:constants` no longer exports all constants Fixes #78, #64 Fri Jul 3 11:55:19 2026 +0100 a2a91df2d64c5731287e6ca9ad47462cd8907f32

    * Bump actions/checkout from 6 to 7 Fri Jul 3 00:06:22 2026 +0100 941a75e143d7fc707483a30fc4b8097f406485e5

  2.221 16 June 2026
    * Version 2.221 Tue Jun 16 15:45:21 2026 +0100 245a6818d4215bb5ee6c27bb509caee5f8c4dd68
    * update zipdetails  to version 4.008 Tue Jun 16 15:29:27 2026 +0100 1da3c5fcecf6fbe230a17ea9b358f50ef27d70f7
    * Update reference for  the info-zip estrafld  file. Tue Jun 16 15:25:06 2026 +0100 914f39406bc164221bfa94905ac1335669ddf446
    * Add hex values for utf8 encoding as a comment Tue Jun 16 14:30:54 2026 +0100 9d5ead52df529f96645e38f3a49924235f74092b
    * Fix File::GlobMapper wildcard replacement after ordinary letters Sat Jun 13 23:49:17 2026 +0100 3651e9eb3fca0bd3718d1d8b12e96b9e80096144
    * Update to zipdetails 4.007 Mon Jun 1 22:55:05 2026 +0100 865b8388aa5d1028724ddde5e411c0868aa077c7
    * Remove test for filename when not needed. Helps with EBCDIC support. #73 Sun May 31 15:23:31 2026 +0100 6a477fc83776a0fa5d2aea5d923cadd323985ad1
    * IO-Compress: generalize for EBCDIC Sat May 30 00:39:09 2026 +0100 648120dfc768a1de22ee2a76aacf17c61d13cac6
