### PR TITLE
utf8_length(): Assert input positioned properly

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -2626,8 +2626,9 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0,
 =for apidoc utf8_length
 
 Returns the number of characters in the sequence of UTF-8-encoded bytes starting
-at C<s> and ending at the byte just before C<e>.  If <s> and <e> point to the
-same place, it returns 0 with no warning raised.
+at C<s> (which must be positioned at the start of a character) and ending at
+the byte just before C<e>.  If <s> and <e> point to the same place, it returns
+0 with no warning raised.
 
 If C<e E<lt> s> or if the scan would end up past C<e>, it raises a UTF8 warning
 and returns the number of valid characters.
@@ -2650,6 +2651,7 @@ STRLEN
 Perl_utf8_length(pTHX_ const U8 * const s0, const U8 * const e)
 {
     PERL_ARGS_ASSERT_UTF8_LENGTH;
+    assert(s0 == e || ! UTF8_IS_CONTINUATION(*s0));
 
     STRLEN continuations = 0;
     STRLEN len = 0;


### PR DESCRIPTION
I rewrote this function in 2019 via 71d63d0dc to do advancing per-word versus by character for long enough strings, thus saving significant amounts of execution time.  FYI, at the bottom is a copy of some of the data presented in that commit message.

The function traditionally did just a bit of syntax error checking of the parsed string.  I chose to not add any, since the goal was speed, but also chose to not take any away, so that it would behave the same as always.  That caused a tiny bit of slowdown than if checking were eliminated.

This commit adds a new check at the beginning of the function in the form of an assert (active only in DEBUG builds) that the input string is positioned at the beginning of a character.  This should have been a no-brainer, adding essentially nothing and verifying an important sanity criterium

------------------------- Data from 2019 commit

 Very long strings run an order of magnitude fewer instructions than
 blead.  Here are worst case scenarios (7 bytes after word boundary).
 The values are in terms of percent, with blead (at the time) always
 set to 100.  Numbers above 100 are good; below bad

     string length 10000000 characters; 1 bytes per character

            blead   patch
            ------ -------
         Ir 100.00  814.53
         Dr 100.00 1069.58
         Dw 100.00 3296.55
       COND 100.00 1575.83
        IND 100.00  100.00

     string length 5000000 characters; 2 bytes per character

            blead   patch
            ------ -------
         Ir 100.00  408.86
         Dr 100.00  536.32
         Dw 100.00 1698.31
       COND 100.00  788.72
        IND 100.00  100.00

     string length 3333333 characters; 3 bytes per character

            blead   patch
            ------ -------
         Ir 100.00  273.64
         Dr 100.00  358.56
         Dw 100.00 1165.55
       COND 100.00  526.35
        IND 100.00  100.00

     string length 2500000 characters; 4 bytes per character

            blead   patch
            ------ -------
         Ir 100.00  206.03
         Dr 100.00  269.68
         Dw 100.00  899.17
       COND 100.00  395.17
        IND 100.00  100.00


* This set of changes requires a perldelta entry, to be furnished

