### PR TITLE
Add sub signatures performance note to perldelta

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -201,18 +201,10 @@ Simple (non-overflowing) addition (C<+>), subtraction (C<->) and
 multiplication (C<*>) of integers are slightly sped up, as long as
 sufficient underlying C compiler support is available.
 
-=back
-
-=over 4
-
 =item *
 
 Populating a hash from a list of key/value pairs when the keys are constant
 string operands known at compile time is commonly now faster. [L<GH #24228|https://github.com/Perl/perl5/issues/24228>]
-
-=back
-
-=over 4
 
 =item *
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -212,6 +212,15 @@ string operands known at compile time is commonly now faster. [L<GH #24228|https
 
 =back
 
+=over 4
+
+=item *
+
+Processing of signatures at the start of a subroutine under the C<signatures>
+feature is now more efficient at runtime.
+
+=back
+
 =head1 Modules and Pragmata
 
 =head2 Updated Modules and Pragmata


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
This adds a note to perldelta about signatures having less runtime overhead due to internal changes made to support named parameters (or so I heard). 

This was discussed on IRC, and I checked that there is indeed a performance difference. Here is the benchmark code:

```perl
use v5.42;

use Benchmark qw(cmpthese);

sub s_raw { my ($x1, $x2, $x3, $x4) = @_; }
sub s_sig ($x1, $x2, $x3, $x4) {}

cmpthese -2, {
	raw => sub { s_raw($_, $_, $_, $_) for 1 .. 1000 },
	signatures => sub { s_sig($_, $_, $_, $_) for 1 .. 1000 },
};
```

It consistently shows `raw` case being ~25% faster than `signatures` on 5.42, and ~5% faster on compiled blead. While this is not the best way to benchmark, that much of a difference should be enough to determine that indeed signatures are now more efficient. Note that `raw` only serves as a base for comparison here, so that we see efficiency difference between two variants of argument unpacking, without the need to take overall perl interpreter efficiency into account.

Example results:
```
$ ~/localperl/bin/perl bench.pl
             Rate signatures        raw
signatures 7378/s         --        -3%
raw        7622/s         3%         --

$ perl bench.pl
             Rate signatures        raw
signatures 5183/s         --       -25%
raw        6950/s        34%         --
```
-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
