### PR TITLE
regex pod fixes related to /p as it stands today

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -531,6 +531,24 @@ New entry for "New object system and C<class> syntax".
 
 =back
 
+=head3 L<perlre>, L<perlop>, L<perlretut>, L<perlvar>, L<perlreapi>
+
+=over 4
+
+=item *
+
+The documentation for the regular expression C</p> modifier has been
+corrected.  Some older Perl releases, including versions from Perl 5.20
+through Perl 5.42, incorrectly stated that C</p> was ignored after
+Perl 5.20 because of copy-on-write.  News of its demise was somewhat
+premature.  In fact, C</p> still controls
+whether C<${^PREMATCH}>, C<${^MATCH}>, and C<${^POSTMATCH}> are
+guaranteed to be defined, and it remains relevant for operations such as
+scalar matches with C</g>, which avoid copying the target string by
+default.
+
+=back
+
 =head3 L<perlxs>
 
 =over 4

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -2171,9 +2171,12 @@ Options (specified by the following modifiers) are:
         x's means \t and the SPACE character are ignored within
         square-bracketed character classes
     p   When matching preserve a copy of the matched string so
-        that ${^PREMATCH}, ${^MATCH}, ${^POSTMATCH} will be
-        defined (ignored starting in v5.20 as these are always
-        defined starting in that release)
+        that ${^PREMATCH}, ${^MATCH}, and ${^POSTMATCH} will
+        be defined; since v5.20, copy-on-write has largely
+        removed the old performance penalty, but the modifier
+        still controls whether these variables are guaranteed
+        to be defined, and may still matter for operations
+        such as scalar matches with /g
     o   Compile pattern only once.
     a   ASCII-restrict: Use ASCII for \d, \s, \w and [[:posix:]]
         character classes; specifying two a's adds the further
@@ -2356,7 +2359,12 @@ The position after the last match can be read or set using the C<pos()>
 function; see L<perlfunc/pos>.  A failed match normally resets the
 search position to the beginning of the string, but you can avoid that
 by adding the C</c> modifier (for example, C<m//gc>).  Modifying the target
-string also resets the search position.
+string also resets the search position.  For performance, these scalar
+C</g> matches do not preserve the whole matched string by default.
+They do not simply rely on copy-on-write for that, since copy-on-write
+sharing is bounded and some target strings cannot use it.  Use C</p> if
+you need C<${^PREMATCH}>, C<${^MATCH}>, or C<${^POSTMATCH}> after such a
+match.
 
 =item C<\G I<assertion>>
 

--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -383,9 +383,17 @@ X</p> X<regex, preserve> X<regexp, preserve>
 Preserve the string matched such that C<${^PREMATCH}>, C<${^MATCH}>, and
 C<${^POSTMATCH}> are available for use after matching.
 
-In Perl 5.20 and higher this is ignored. Due to a new copy-on-write
-mechanism, C<${^PREMATCH}>, C<${^MATCH}>, and C<${^POSTMATCH}> will be available
-after the match regardless of the modifier.
+This modifier still affects whether those variables are guaranteed to be
+defined after a successful match.  What changed in Perl 5.20 is the
+performance cost of preserving match strings: a copy-on-write mechanism
+largely eliminated the old global penalty associated with match copying.
+This does not make the modifier useless: some match operations, such as
+scalar matches with C</g>, may still avoid preserving the whole matched
+string unless C</p> is present.
+
+Some older Perl releases, including versions from Perl 5.20 through
+Perl 5.42, incorrectly documented this modifier as being ignored after
+Perl 5.20.  That was a documentation bug.
 
 =item B<C<a>>, B<C<d>>, B<C<l>>, and B<C<u>>
 X</a> X</d> X</l> X</u>

--- a/pod/perlreapi.pod
+++ b/pod/perlreapi.pod
@@ -149,7 +149,23 @@ TODO: Document those cases.
 
 =item C</p> - RXf_PMf_KEEPCOPY
 
-TODO: Document this
+This corresponds to the C</p> pattern modifier.  If present, the engine
+must preserve sufficient match-string state for C<${^PREMATCH}>,
+C<${^MATCH}>, and C<${^POSTMATCH}> to be retrieved after a successful
+match.  This affects the numbered capture callbacks that fetch those
+variables.  In particular, code paths that would otherwise preserve only
+part of the matched string, such as scalar matches with C</g>, must still
+provide the full information needed when this modifier is in effect.
+Those scalar C</g> code paths are optimized not to copy the target string
+by default, and do not simply rely on copy-on-write: copy-on-write sharing
+is bounded, and some target strings cannot be shared that way at all, so
+depending on it would still leave those paths vulnerable to repeated
+copying.
+
+In core this may be present either on the compiled regex itself or on the
+PMOP that invoked it, such as in C</$qr/p>.  Engine implementations should
+therefore preserve behavior consistent with the numbered-buffer callbacks
+when this modifier is in effect.
 
 =item Character set
 

--- a/pod/perlretut.pod
+++ b/pod/perlretut.pod
@@ -972,9 +972,12 @@ C<@+> instead:
 As of Perl 5.10, the C<${^PREMATCH}>, C<${^MATCH}> and C<${^POSTMATCH}>
 variables may be used.  These are only set if the C</p> modifier is
 present.  Consequently they do not penalize the rest of the program.  In
-Perl 5.20, C<${^PREMATCH}>, C<${^MATCH}> and C<${^POSTMATCH}> are available
-whether the C</p> has been used or not (the modifier is ignored), and
-C<$`>, C<$'> and C<$&> do not cause any speed difference.
+Perl 5.20, copy-on-write largely eliminated the old performance costs of
+C<$`>, C<$'> and C<$&>, but C<${^PREMATCH}>, C<${^MATCH}> and
+C<${^POSTMATCH}> are still only guaranteed to be defined after a
+successful match with C</p>.  This remains relevant for some operations,
+such as scalar matches with C</g>, which may otherwise avoid preserving
+the whole matched string.
 
 =head2 Non-capturing groupings
 
@@ -1680,7 +1683,11 @@ you don't want the position reset after failure to match, add the
 C</c>, as in C</regexp/gc>.  The current position in the string is
 associated with the string, not the regexp.  This means that different
 strings have different positions and their respective positions can be
-set or read independently.
+set or read independently.  For performance, scalar matches with C</g>
+do not preserve the whole matched string by default.  They do not simply
+rely on copy-on-write for that, since copy-on-write sharing is bounded
+and some target strings cannot use it.  Use C</p> if you need
+C<${^PREMATCH}>, C<${^MATCH}>, or C<${^POSTMATCH}> after such a match.
 
 In list context, C</g> returns a list of matched groupings, or if
 there are no groupings, a list of matches to the whole regexp.  So if
@@ -3032,4 +3039,3 @@ Haworth, Ronald J Kimball, and Joe Smith for all their helpful
 comments.
 
 =cut
-

--- a/pod/perlvar.pod
+++ b/pod/perlvar.pod
@@ -1068,6 +1068,17 @@ In Perl 5.20.0 a new copy-on-write system was enabled by default, which
 finally fixes most of the performance issues with these three variables, and
 makes them safe to use anywhere.
 
+However, for performance reasons, some operations still avoid preserving
+the whole matched string unless explicitly asked to do so.  In particular,
+scalar matches with C</g> do not copy the target string by default, and do
+not rely on the copy-on-write mechanism for C<${^PREMATCH}>,
+C<${^MATCH}>, and C<${^POSTMATCH}>; use C</p> if you need those variables
+to be available there.  Relying on copy-on-write alone would still leave
+those matches open to quadratic behavior: the sharing count is finite, so
+it is not hard to construct code that exhausts it and falls back to
+repeated copying, and some strings are not copy-on-write sharable in the
+first place.
+
 The C<Devel::NYTProf> and C<Devel::FindAmpersand> modules can help you
 find uses of these problematic match variables in your code.
 


### PR DESCRIPTION
This documentation patch updates the docs to explain when and where /p is still relevent, and documents the performance reasons why. For a long time the docs have been incorrectly stating /p is not used or relevant anymore and that COW has made it redundant. This is unfortunately not the case, and it is still relevant for /g matches where the target string is not copied. Its a weird edge case, I bet no-one cares or actually needs it, but because of the flaws in our COW model we would make some code quadratic out of the box by making scalar /g matches copy the target string. As such we need an escape hatch for when the user wants to override that for some reason.

I am inclined to think that removing PL_saw_ampersand was premature as well, COW isnt a complete solution for the performance issues that PL_saw_ampersand was solving.

* This set of changes does not require a perldelta entry, but one is included anyway to call peoples attention to it.
