### PR TITLE
regcomp: switch to BRANCHJ before overflow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1375,6 +1375,7 @@ Tels                           <nospam-abuse@bloodgate.com>
 Teun Burgers                   <burgers@ecn.nl>
 Thad Floryan                   <thad@thadlabs.com>
 Theo Buehler                   <theo@math.ethz.ch>
+theoremoon                     <theoldmoon0602@gmail.com>
 Thibault Duponchelle           <thibault.duponchelle@gmail.com>
 Thomas Bowditch                <bowditch@inmet.com>
 Thomas Conté                   <tom@fr.uu.net>

--- a/regcomp.c
+++ b/regcomp.c
@@ -4604,6 +4604,17 @@ S_regbranch(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, I32 first, U32 depth)
             }
         }
         chain = latest;
+        if (UNLIKELY(chain > U16_MAX && ! RExC_use_BRANCHJ)) {
+            /* A later link from an early node can overflow once the emitted
+             * program has grown this large.  Switch formats now, instead of
+             * finishing this (potentially very large) compilation pass only
+             * to discover the overflow while joining the branches. */
+            RExC_use_BRANCHJ = 1;
+            if (! IN_PARENS_PASS) {
+                *flagp |= RESTART_PARSE;
+                return 0;
+            }
+        }
         c++;
     }
     if (chain == 0) {	/* Loop ran zero times. */


### PR DESCRIPTION
Large assembled regexps may be compiled with `BRANCH` nodes and then
recompiled with `BRANCHJ` after a 16-bit offset overflow is detected
late in compilation.

This restores the earlier conservative check in `S_regbranch()`, while
retaining the exact overflow checks in `regtail()` and
`regtail_study()`.

In my reproduction, compilation time decreases from 0.36s to 0.18s and
VmRSS from 145 MB to 85 MB.

Reproduction:

- https://github.com/theoremoon/perl-regexp-branchj-repro

I am unsure what regression test would be appropriate for this
performance issue. Would `t/perf/benchmarks` be the preferred location?

---

* This set of changes requires a perldelta entry, and I need help writing it.