### PR TITLE
Add MAYBE modifier to ExtUtils::ParseXS

### DIFF
--- a/dist/ExtUtils-ParseXS/Changes
+++ b/dist/ExtUtils-ParseXS/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension ExtUtils::ParseXS.
 
 3.65
+  - Add MAYBE modifier to arguments and return values
 
 3.64
   - Respect output arguments in INTERFACES

--- a/dist/ExtUtils-ParseXS/Changes
+++ b/dist/ExtUtils-ParseXS/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension ExtUtils::ParseXS.
 
+3.65
+
 3.64
   - Respect output arguments in INTERFACES
   - PERL_UNUSED_VAR() the CV declared when an ALIAS or

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -76,7 +76,7 @@ use Symbol;
 
 our $VERSION;
 BEGIN {
-  $VERSION = '3.64';
+  $VERSION = '3.65';
   require ExtUtils::ParseXS::Constants; ExtUtils::ParseXS::Constants->VERSION($VERSION);
   require ExtUtils::ParseXS::CountLines; ExtUtils::ParseXS::CountLines->VERSION($VERSION);
   require ExtUtils::ParseXS::Node; ExtUtils::ParseXS::Node->VERSION($VERSION);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Constants.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/CountLines.pm
@@ -14,7 +14,7 @@ package ExtUtils::ParseXS::CountLines;
 use strict;
 use warnings;
 
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 our $SECTION_END_MARKER;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Eval.pm
@@ -2,7 +2,7 @@ package ExtUtils::ParseXS::Eval;
 use strict;
 use warnings;
 
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -3280,16 +3280,6 @@ sub as_input_code {
         my $xsauto_var = $lenp->{var};
         print "\tSTRLEN\tSTRLEN_length_of_$var;\n";
         print "\t$lenp->{type}\t$xsauto_var;\n";
-
-        # The "var = SvPV()" line will be emitted by the main body of this
-        # function. Note that the T_PV typemap entry will have already
-        # been overridden in lookup_input_typemap() during parse time
-        # to change SvPV_nolen() to SvPV() or similar.
-        #
-        # The final assign should be deferred to come after all
-        # declarations.
-        $xbody->{input_part}{deferred_code_lines} .=
-            "\n\t$xsauto_var = STRLEN_length_of_$var;\n";
     }
 
     # Emit the variable's type and name.
@@ -3417,6 +3407,19 @@ sub as_input_code {
                 "Internal error: typemap doesn't start with '\$var='\n");
 
         printf "%s;\n", $init_code;
+    }
+
+    if ($self->{length_param}) {
+        # The "var = SvPV()" line will be emitted by the main body of this
+        # function. Note that the T_PV typemap entry will have already
+        # been overridden in lookup_input_typemap() during parse time
+        # to change SvPV_nolen() to SvPV() or similar.
+        #
+        # The final assign should be deferred to come after all
+        # declarations.
+
+        $xbody->{input_part}{deferred_code_lines} .=
+            "\n\t$self->{length_param}{var} = STRLEN_length_of_$var;\n";
     }
 
     if (defined $defer) {

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -2553,6 +2553,7 @@ BEGIN { $build_subclass->(
     'is_synthetic',  # Bool: var like 'THIS': we pretend it was in the sig
 
     # values derived from both the XSUB's signature and/or INPUT line
+    'sentinel',      # Str:  The C constant expression to map undef to
     'type',          # Str:  The C type of the parameter
     'no_init',       # Bool: don't initialise the parameter
 
@@ -2589,12 +2590,16 @@ sub parse {
     # Decompose parameter into its components.
     # Note that $name can be either 'foo' or 'length(foo)'
 
-    my ($out_type, $type, $name, $sp1, $sp2, $default) =
+    my ($out_type, $maybe, $sentinel, $type, $name, $sp1, $sp2, $default) =
         $param_text =~
             /^
                  (?:
                      (IN|IN_OUT|IN_OUTLIST|OUT|OUTLIST)
                      \b\s*
+                 )?
+                 (
+                     MAYBE (?: \( ([+-]? \w+) \) | \b)?
+                     \s*
                  )?
                  (.*?)                             # optional type
                  \s*
@@ -2622,6 +2627,9 @@ sub parse {
 
     undef $type unless length($type) && $type =~ /\S/;
     $self->{var} = $name;
+
+    $sentinel = 'NULL' if $maybe and not defined $sentinel;
+    $self->{sentinel} = $sentinel;
 
     # Check for duplicates
 
@@ -2827,8 +2835,8 @@ sub lookup_input_typemap {
     my ExtUtils::ParseXS::Node::xsub $xsub  = shift;
     my                               $xbody = shift;
 
-    my ($type, $arg_num, $var, $init, $no_init, $default)
-        = @{$self}{qw(type arg_num var init no_init default)};
+    my ($type, $arg_num, $var, $init, $no_init, $default, $sentinel)
+        = @{$self}{qw(type arg_num var init no_init default sentinel)};
     my $arg = $pxs->ST($arg_num);
 
     # whitespace-tidy the type
@@ -3011,7 +3019,7 @@ EOF
         $init_template = $expr;
     }
 
-    return ($init_template, $eval_vars, 1);
+    return ($init_template, $eval_vars, $sentinel, 1);
 }
 
 
@@ -3320,7 +3328,7 @@ sub as_input_code {
                 . "doesn't have input_typemap_vals")
         unless $lookup;
 
-    my ($init_template, $eval_vars, $is_template) = @$lookup;
+    my ($init_template, $eval_vars, $sentinel, $is_template) = @$lookup;
 
     return unless defined $init_template; # an error occurred
 
@@ -3335,6 +3343,27 @@ sub as_input_code {
 
     # Now finally, emit the actual variable declaration and initialisation
     # line(s). The variable type and name will already have been emitted.
+
+    my %overrides = (
+        SvPVbyte_nolen => 'SvPVbyte_nomg(%s, PL_na',
+        SvPVutf8_nolen => 'SvPVutf8_nomg(%s, PL_na',
+    );
+    if ($init_template && defined $sentinel) {
+        $init_template =~ s/^(?!\A)/\t/g;
+        $init_template =~ s/(Sv(?:[IUN]V|PV(?:|byte|utf8)?))(|_nolen)\((\$arg)/ $overrides{$1.$2} ? sprintf $overrides{$1.$2}, $3 : "$1_nomg$2($3" /e;
+
+        my $if_null = "\$var = $sentinel;";
+        $if_null .= "\n\t\tSTRLEN_length_of_\$var = 0;" if $self->{length_param};
+
+        $init_template = <<END;
+	SvGETMAGIC(\$arg);
+	if (SvOK(\$arg)) {
+	$init_template;
+	} else {
+		$if_null;
+	}
+END
+    }
 
     my $init_code =
         length $init_template

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -2447,6 +2447,7 @@ BEGIN { $build_subclass->(
     'extern_C',       # Bool: saw 'extern C'
     'static',         # Bool: saw 'static'
     'use_early_targ', # Bool: emit an early dTARG for backcompat
+    'retval_sentinel' # Str:  The C constant to map undef from
 )};
 
 
@@ -2471,6 +2472,8 @@ sub parse {
     my $type = $line;
 
     $self->{no_output} = 1 if $type =~ s/^NO_OUTPUT\s+//;
+
+    $self->{retval_sentinel} = defined($1) ? $1 : 'NULL' if $type =~ s/^\s* MAYBE (?: \( (-? \w+) \) )? \s*//x;
 
     # Allow one-line declarations. This splits a single line like:
     #    int foo(....)
@@ -3046,8 +3049,8 @@ sub lookup_output_typemap {
     my                               $xbody   = shift;
     my                               $out_num = shift;
 
-    my ($type, $num, $var, $do_setmagic, $output_code)
-        = @{$self}{qw(type arg_num var do_setmagic output_code)};
+    my ($type, $num, $var, $do_setmagic, $output_code, $sentinel)
+        = @{$self}{qw(type arg_num var do_setmagic output_code sentinel)};
 
     # values to return
     my ($expr, $eval_vars, $is_template, $saw_DAE);
@@ -3244,7 +3247,7 @@ sub lookup_output_typemap {
         $saw_DAE = 1;
     }
 
-    return $expr, $eval_vars, $is_template, $saw_DAE;
+    return $expr, $eval_vars, $is_template, $saw_DAE, $sentinel;
 }
 
 
@@ -3569,7 +3572,7 @@ sub as_output_code {
                 . "doesn't have output_typemap_vals")
         unless $lookup;
 
-    my ($expr, $eval_vars, $is_template, $saw_DAE) = @$lookup;
+    my ($expr, $eval_vars, $is_template, $saw_DAE, $sentinel) = @$lookup;
 
     return unless defined $expr; # error
 
@@ -3634,8 +3637,18 @@ sub as_output_code {
         my $code = defined $output_code
                 ? "\t$output_code\n"
                 : $pxs->eval_output_typemap_code("qq\a$expr\a", $eval_vars);
-        print $code;
 
+        if (defined $sentinel) {
+            $code = <<END;
+	if ($var == $sentinel) {
+		sv_setsv($arg, &PL_sv_undef);
+	} else {
+	$code;
+	}
+END
+        }
+
+        print $code;
         # For parameters in the OUTPUT section, honour the SETMAGIC in force
         # at the time. For parameters instead being output because of an OUT
         # keyword in the signature, assume set magic always.
@@ -3758,6 +3771,24 @@ sub as_output_code {
             # declaring 'SV* RETVALSV' as an intermediate var.
             $retvar = $var if $ntype eq "SVPtr";
         }
+        if (defined $sentinel) {
+            if ($var eq $retvar) {
+                $evalexpr = <<END;
+	if ($var == $sentinel) {
+		$retvar = &PL_sv_undef;
+	}
+END
+            }
+            else {
+                $evalexpr = <<END;
+	if ($var == $sentinel) {
+		$retvar = &PL_sv_undef;
+	} else {
+	$evalexpr;
+	}
+END
+            }
+        }
     }
     else {
         # Handle this (eval-expanded) form of typemap:
@@ -3784,7 +3815,17 @@ sub as_output_code {
         #   SV * targ = (PL_op->op_private & OPpENTERSUB_HASTARG)
         #               ? PAD_SV(PL_op->op_targ) : sv_newmortal()
 
-        if (   $pxs->{config_optimize}
+        if (defined $sentinel) {
+            $evalexpr = <<END;
+	if ($var == $sentinel) {
+		sv_setsv($retvar, &PL_sv_undef);
+	} else {
+	$evalexpr;
+	}
+END
+            $want_newmortal = 1;
+        }
+        elsif (   $pxs->{config_optimize}
                 && ExtUtils::Typemaps::OutputMap->targetable($evalexpr)
                 && !$xbody->{output_part}{targ_used})
         {
@@ -4059,6 +4100,7 @@ sub parse {
                 type         => $xsub->{decl}{return_type}{type},
                 no_init      => 1, # just declare the var, don't initialise it
                 is_synthetic => 1,
+                sentinel     => $xsub->{decl}{return_type}{retval_sentinel},
             } );
 
         push @{$self->{kids}}, $param;

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Symbol;
 
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Utilities.pm
@@ -5,7 +5,7 @@ use Exporter;
 use File::Spec;
 use ExtUtils::ParseXS::Constants ();
 
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 our (@ISA, @EXPORT_OK);
 @ISA = qw(Exporter);

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 require ExtUtils::ParseXS;
 require ExtUtils::ParseXS::Constants;

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Cmd.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::Cmd;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 use ExtUtils::Typemaps;
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/InputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::InputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/OutputMap.pm
@@ -2,7 +2,7 @@ package ExtUtils::Typemaps::OutputMap;
 use 5.006001;
 use strict;
 use warnings;
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/Typemaps/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 require ExtUtils::Typemaps;
 
-our $VERSION = '3.64';
+our $VERSION = '3.65';
 
 =head1 NAME
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -171,7 +171,8 @@ accurately specify where line breaks can occur.
  xsub_decl         = return_type
                      xsub_name "(" parameters ")" "const" ?
 
- return_type       = "NO_OUTPUT" ? "extern \"C\"" ? "static" ? C_type
+ return_type       = "NO_OUTPUT" ? maybe ? "extern \"C\"" ? "static" ?
+                      C_type
 
  C_type            = [const char *]  // etc: any valid C type
 
@@ -186,6 +187,7 @@ accurately specify where line breaks can occur.
 
  parameter         = (
                        in_out_decl ?
+                       maybe ?
                        C_type ?
                        /\w+/   // variable name
                        // Default or optional value:
@@ -197,6 +199,9 @@ accurately specify where line breaks can occur.
                      )
 
  in_out_decl       = "IN" | "OUT" | "IN_OUT" | "OUTLIST" | "IN_OUTLIST"
+
+ maybe             = "MAYBE"
+                     ( "(" "-" ? /\w+/ ")" ) ?
 
  cases             = (
                         "CASE:" ( C_expression | empty )
@@ -1268,6 +1273,15 @@ There are similar macros
 which allow you to return Perl's true and false values, or to return
 an empty list.
 
+Since ExtUtils::ParseXS 3.64, you can also use the C<MAYBE> modifier to
+return undef:
+
+    MAYBE(-1) int
+    file_size(char *filename)
+
+If no argument is given to C<MAYBE>, C<NULL> is assumed to be the sentinel
+value.
+
 If your XSUB will always explicitly return a special SV and won't ever
 require typemap conversions (e.g. it always returns via C<XSRETURN_YES> or
 C<XSRETURN_NO>), then just declare the return type as C<SV*>.
@@ -2071,6 +2085,12 @@ C<die()> with a meaningful error message on error. The XSUB's return type
 of C<int> is only meaningful for declaring C<RETVAL> and for doing the
 autocall.
 
+It can also be prefixed with C<MAYBE> or C<MAYBE(sentinel)>. In such an XSUB,
+if the return value is equal to the given sentinel (which defaults to C<NULL>
+if none is given explicitly), then C<undef> shall be returned instead of the
+usual typemapped value. This value should either be a number (e.g. C<-1>) or
+a C constant (e.g. C<LIB_NO_ERROR>).
+
 The return type can also include the C<extern "C"> and C<static>
 modifiers, which if present must be in that order, and come between any
 C<NO_OUTPUT> keyword and the return type. The C<extern> declaration must
@@ -2162,6 +2182,7 @@ Some examples of valid XSUB parameter declarations:
     char *foo = NO_INIT   # doesn't complain if arg missing
     OUT char *foo         # caller's arg gets updated
     IN_OUTLIST char *foo  # parameter value gets returned
+    MAYBE char *foo       # parameter value may be undef
     int length(foo)       # pseudo-parameter that gets the length of foo
     foo                   # placeholder, or parameter without type
     SV*                   # placeholder
@@ -2284,6 +2305,14 @@ C_ARGS: Keyword> to override the missing argument. For example:
     void
     foo(int a, b, char *c)
         C_ARGS: a, c
+
+=head3 XSUB parameters with sentinels
+
+Sometimes you want to map undef to a sentinel value such as C<NULL> or C<-1>.
+The C<MAYBE> modifier allows you to do this, while still using the usual
+typemap logic for any defined values. If an arguments it given to the C<MAYBE>
+(e.g. C<MAYBE(-1)>) then that value is used as the sentinel, otherwise C<NULL>
+is used.
 
 =head3 Updating and returning parameter values: the IN_OUT etc keywords
 

--- a/dist/ExtUtils-ParseXS/lib/perlxs.pod
+++ b/dist/ExtUtils-ParseXS/lib/perlxs.pod
@@ -5025,7 +5025,7 @@ this model, the less likely conflicts will occur.
 
 =head1 XS VERSION
 
-This document covers features supported by F<xsubpp> 3.64.
+This document covers features supported by F<xsubpp> 3.65.
 
 =head1 AUTHOR DIAGNOSTICS
 

--- a/dist/ExtUtils-ParseXS/t/005-parse-parameters.t
+++ b/dist/ExtUtils-ParseXS/t/005-parse-parameters.t
@@ -182,6 +182,8 @@ EOF
                 |foo(OUT MAYBE char* output)
 EOF
             [ 1, qr/if \(SvOK\(ST\(0\)\)\)/, 'check for SvOK' ],
+            [ 0, qr/if \(output == NULL\)/, 'Check for NULL check' ],
+            [ 0, qr/sv_setsv\(ST\(0\), &PL_sv_undef\)/, ''],
         ],
 
         [

--- a/dist/ExtUtils-ParseXS/t/005-parse-parameters.t
+++ b/dist/ExtUtils-ParseXS/t/005-parse-parameters.t
@@ -142,6 +142,84 @@ EOF
 EOF
             [ERR, qr/Error: no OUTPUT definition for type 'myint'/m, "" ],
         ],
+
+        [
+            "test MAYBE",
+            Q(<<'EOF'),
+                |void
+                |foo(MAYBE char* input)
+EOF
+            [  0, qr/if \(SvOK\(ST\(0\)\)\)/, 'check for SvOK' ],
+            [  0, qr/input = NULL;/, 'falls back to setting to null'],
+        ],
+
+        [
+            "test MAYBE(-1)",
+            Q(<<'EOF'),
+                |void
+                |foo(MAYBE(-1) int input)
+EOF
+            [  0, qr/if \(SvOK\(ST\(0\)\)\)/, 'check for SvOK' ],
+            [  0, qr/input = -1;/, 'falls back to setting to -1'],
+        ],
+
+        [
+            "test MAYBE with length",
+            Q(<<'EOF'),
+                |void
+                |foo(MAYBE char* input, size_t length(input))
+EOF
+            [  0, qr/if \(SvOK\(ST\(0\)\)\)/, 'check for SvOK' ],
+            [  0, qr/input = NULL;/, 'falls back to setting to null'],
+            [  0, qr/STRLEN_length_of_input = 0;/, ''],
+            [  0, qr/SvPV_nomg\(ST\(0\), STRLEN_length_of_input\)/, 'uses SvPV_nomg'],
+        ],
+
+        [
+            "test MAYBE with OUT param",
+            Q(<<'EOF'),
+                |void
+                |foo(OUT MAYBE char* output)
+EOF
+            [ 1, qr/if \(SvOK\(ST\(0\)\)\)/, 'check for SvOK' ],
+        ],
+
+        [
+            "test MAYBE with utf8 type strings",
+            Q(<<'EOF'),
+                |TYPEMAP: <<EOF
+                |char* T_UTF8CHAR
+                |INPUT
+                |T_UTF8CHAR
+                |  $var = ($type)SvPVutf8_nolen($arg)
+                |EOF
+                |
+                |void
+                |foo(MAYBE char* input)
+EOF
+            [  0, qr/if \(SvOK\(ST\(0\)\)\)/, 'check for SvOK' ],
+            [  0, qr/input = NULL;/, 'falls back to setting to null'],
+            [  0, qr/SvPVutf8_nomg\(ST\(0\), PL_na\)/, 'uses PvPVutf8_nomg'],
+        ],
+
+        [
+            "test MAYBE with utf8 type strings and length",
+            Q(<<'EOF'),
+                |TYPEMAP: <<EOF
+                |char* T_UTF8CHAR
+                |INPUT
+                |T_UTF8CHAR
+                |  $var = ($type)SvPVutf8_nolen($arg)
+                |EOF
+                |
+                |void
+                |foo(MAYBE char* input, size_t length(input))
+EOF
+            [  0, qr/if \(SvOK\(ST\(0\)\)\)/, 'check for SvOK' ],
+            [  0, qr/input = NULL;/, 'falls back to setting to null'],
+            [  0, qr/SvPVutf8_nomg\(ST\(0\), STRLEN_length_of_input\)/, 'uses PvPVutf8_nomg'],
+        ],
+
     );
 
     test_many($preamble, 'XS_Foo_', \@test_fns);

--- a/dist/ExtUtils-ParseXS/t/006-parse-return-type.t
+++ b/dist/ExtUtils-ParseXS/t/006-parse-return-type.t
@@ -71,6 +71,32 @@ EOF
             [  0, qr/^\s+int\s+B\s+=/m,      "has B decl"    ],
             [  0, qr/\QRETVAL = foo(A, B);/, "has autocall"  ],
         ],
+
+        [
+            "test MAYBE char*",
+            Q(<<'EOF'),
+                | MAYBE char* foo()
+EOF
+            [  0, qr/if \(RETVAL == NULL\)/, '' ],
+            # [  0, qr/asdf/, ''],
+        ],
+
+        [
+            "test MAYBE int",
+            Q(<<'EOF'),
+                | MAYBE(-1) int foo()
+EOF
+            [  0, qr/if \(RETVAL == -1\)/, '' ],
+        ],
+
+        [
+            "test MAYBE SV*",
+            Q(<<'EOF'),
+                | MAYBE SV* foo()
+EOF
+            [  0, qr/if \(RETVAL == NULL\)/, '' ],
+            [  0, qr/RETVAL = &PL_sv_undef;/, ''],
+        ],
     );
 
     test_many($preamble, 'XS_Foo_', \@test_fns);


### PR DESCRIPTION
As I suggested [here](https://www.nntp.perl.org/group/perl.perl5.porters/2025/09/msg270308.html) before, I've added a `MAYBE` modifier to arguments and return values. This will map undef to/from a sentinel value such as `NULL`, but otherwise use the typemap as usual.

* This set of changes does not require a perldelta entry, because ExtUtils::ParseXS has its own Changes file