### PR TITLE
Quiet `-Wmissing-field-initializers` when building with `g++`

### DIFF
--- a/cflags.SH
+++ b/cflags.SH
@@ -341,6 +341,9 @@ case "$cc" in
       ;;
     esac
   done
+  # g++ warns about things that are perfectly valid C99 and we've chosen not
+  # to worry about. Quiet these warnings
+  warn="$warn -Wno-missing-field-initializers"
   ;;
 esac
 


### PR DESCRIPTION
Otherwise we get lots of warnings about it, both from core code (which we could technically fix), but also CPAN modules which we're less able to.

Fixes #24553

* This set of changes does not require a perldelta entry.