### PR TITLE
Minor improvements to Porting/test-dist-modules.pl

### DIFF
--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -85,6 +85,9 @@ if (@dists) {
     for my $dist (@dists) {
         -d "dist/$dist" or die "dist/$dist not a directory\n";
     }
+    # we might only want to test Devel-PPPort, it has already been
+    # tested, so don't do it again
+    @dists = grep { $_ ne "Devel-PPPort" } @dists;
 }
 else {
     opendir my $distdir, "dist"

--- a/Porting/test-dist-modules.pl
+++ b/Porting/test-dist-modules.pl
@@ -11,6 +11,8 @@ use ExtUtils::Manifest "maniread";
 use Cwd "getcwd";
 use Getopt::Long;
 use Config;
+use File::Copy "cp";
+use File::Path "mkpath";
 
 my $continue;
 my $separate;
@@ -124,8 +126,16 @@ sub test_dist {
     my $dir = tempdir( CLEANUP => !$keep);
     print "$name testing in $dir\n" if $keep;
 
-    run("cp", "-a", "dist/$name/.", "$dir/.")
-      or die "Cannot copy dist files to working directory\n";
+    my $base = "dist/$name/";
+    my @files = sort grep /^\Q$base\E/, keys %$manifest;
+    for my $from (@files) {
+        (my $to = $from) =~ s(^\Q$base\E)($dir/)
+          or die "Could not replace output directory for $from";
+        (my $to_dir = $to) =~ s([^/]+$)();
+        -d $to_dir or mkpath($to_dir);
+        cp($from, $to)
+          or die "Cannot copy $from to $to: $!";
+    }
     chdir $dir
       or die "Cannot chdir to dist working directory '$dir': $!\n";
     if ($pppfile) {


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->

I've been using this a lot to test Devel::PPPort against old perls, so I made two minor improvements:
- allow it to work with a dirty tree - only copying the files found in MANIFEST
- don't test Devel::PPPort twice when you request testing of Devel::PPPort itself.
-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
