### PR TITLE
Expose the `export_lexical()` API as public functions

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -37,42 +37,6 @@ static void S_warn_experimental_builtin(pTHX_ const char *name)
                 "Built-in function 'builtin::%s' is experimental", name);
 }
 
-/* These three utilities might want to live elsewhere to be reused from other
- * code sometime
- */
-void
-Perl_prepare_export_lexical(pTHX)
-{
-    PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL;
-
-    assert(PL_compcv);
-
-    /* We need to have PL_comppad / PL_curpad set correctly for lexical importing */
-    ENTER;
-    SAVESPTR(PL_comppad_name); PL_comppad_name = PadlistNAMES(CvPADLIST(PL_compcv));
-    SAVECOMPPAD();
-    PL_comppad      = PadlistARRAY(CvPADLIST(PL_compcv))[1];
-    PL_curpad       = PadARRAY(PL_comppad);
-}
-
-#define export_lexical(name, sv)  S_export_lexical(aTHX_ name, sv)
-static void S_export_lexical(pTHX_ SV *name, SV *sv)
-{
-    PADOFFSET off = pad_add_name_sv(name, padadd_STATE, 0, 0);
-    SvREFCNT_dec(PL_curpad[off]);
-    PL_curpad[off] = SvREFCNT_inc(sv);
-}
-
-void
-Perl_finish_export_lexical(pTHX)
-{
-    PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL;
-
-    intro_my();
-
-    LEAVE;
-}
-
 
 XS(XS_builtin_true);
 XS(XS_builtin_true)

--- a/embed.fnc
+++ b/embed.fnc
@@ -1378,6 +1378,8 @@ AOdp	|SV *	|eval_pv	|NN const char *p			\
 AOdp	|SSize_t|eval_sv	|NN SV *sv				\
 				|I32 flags
 CTmpx	|Size_t |expected_size	|UV size
+Adp	|void	|export_lexical |NN SV *name				\
+				|NN SV *sv
 ATdmp	|bool	|extended_utf8_to_uv					\
 				|SPTR const U8 * const s		\
 				|EPTRge const U8 * const e		\
@@ -1411,6 +1413,8 @@ p	|char * |find_script	|NN const char *scriptname			\
 				|bool dosearch					\
 				|NULLOK const char * const * const search_ext	\
 				|I32 flags
+
+Adp	|void	|finish_export_lexical
 Adip	|I32	|foldEQ 	|NN const char *s1			\
 				|NN const char *s2			\
 				|I32 len
@@ -2828,6 +2832,7 @@ Adhp	|I32	|pregexec	|NN REGEXP * const prog 		\
 				|U32 nosave
 Cp	|void	|pregfree	|NULLOK REGEXP *r
 Cp	|void	|pregfree2	|NN REGEXP *rx
+Adp	|void	|prepare_export_lexical
 Adp	|const char *|prescan_version					\
 				|NN const char *s			\
 				|bool strict				\
@@ -4491,10 +4496,8 @@ i	|bool	|PerlEnv_putenv |NN char *str
 S	|MAGIC *|get_aux_mg	|NN AV *av
 #endif
 #if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
-p	|void	|finish_export_lexical
 p	|void	|import_builtin_bundle					\
 				|U16 ver
-p	|void	|prepare_export_lexical
 p	|void	|XS_builtin_indexed					\
 				|NN CV *cv
 #endif

--- a/embed.h
+++ b/embed.h
@@ -192,6 +192,7 @@
 # define dump_vindent(a,b,c,d)                  Perl_dump_vindent(aTHX_ a,b,c,d)
 # define eval_pv(a,b)                           Perl_eval_pv(aTHX_ a,b)
 # define eval_sv(a,b)                           Perl_eval_sv(aTHX_ a,b)
+# define export_lexical(a,b)                    Perl_export_lexical(aTHX_ a,b)
 # define fatal_warner(a,...)                    Perl_fatal_warner(aTHX_ a,__VA_ARGS__)
 # define fbm_compile(a,b)                       Perl_fbm_compile(aTHX_ a,b)
 # define fbm_instr(a,b,c,d)                     Perl_fbm_instr(aTHX_ a,b,c,d)
@@ -200,6 +201,7 @@
 # define filter_read(a,b,c)                     Perl_filter_read(aTHX_ a,b,c)
 # define find_runcv(a)                          Perl_find_runcv(aTHX_ a)
 # define find_rundefsv()                        Perl_find_rundefsv(aTHX)
+# define finish_export_lexical()                Perl_finish_export_lexical(aTHX)
 # define foldEQ(a,b,c)                          Perl_foldEQ(aTHX_ a,b,c)
 # define foldEQ_latin1(a,b,c)                   Perl_foldEQ_latin1(aTHX_ a,b,c)
 # define foldEQ_locale(a,b,c)                   Perl_foldEQ_locale(aTHX_ a,b,c)
@@ -491,6 +493,7 @@
 # define pregexec(a,b,c,d,e,f,g)                Perl_pregexec(aTHX_ a,b,c,d,e,f,g)
 # define pregfree(a)                            Perl_pregfree(aTHX_ a)
 # define pregfree2(a)                           Perl_pregfree2(aTHX_ a)
+# define prepare_export_lexical()               Perl_prepare_export_lexical(aTHX)
 # define prescan_version(a,b,c,d,e,f,g)         Perl_prescan_version(aTHX_ a,b,c,d,e,f,g)
 # define ptr_table_fetch(a,b)                   Perl_ptr_table_fetch(aTHX_ a,b)
 # define ptr_table_free(a)                      Perl_ptr_table_free(aTHX_ a)
@@ -1226,9 +1229,7 @@
 #   endif
 #   if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
 #     define XS_builtin_indexed(a)              Perl_XS_builtin_indexed(aTHX_ a)
-#     define finish_export_lexical()            Perl_finish_export_lexical(aTHX)
 #     define import_builtin_bundle(a)           Perl_import_builtin_bundle(aTHX_ a)
-#     define prepare_export_lexical()           Perl_prepare_export_lexical(aTHX)
 #   endif
 #   if defined(PERL_IN_CLASS_C)
 #     define class_cleanup_definition(a)        S_class_cleanup_definition(aTHX_ a)

--- a/pad.c
+++ b/pad.c
@@ -3087,5 +3087,78 @@ Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save)
 }
 
 /*
+=for apidoc prepare_export_lexical
+
+Sets up the parser state ready to call L</export_lexical> one or more times.
+Calling this function implies a call to C<ENTER>, and must be paired with a
+corresponding call to L</finish_export_lexical> to end it.
+
+=cut
+ */
+void
+Perl_prepare_export_lexical(pTHX)
+{
+    PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL;
+
+    assert(PL_compcv);
+
+    /* We need to have PL_comppad / PL_curpad set correctly for lexical importing */
+    ENTER;
+    SAVESPTR(PL_comppad_name); PL_comppad_name = PadlistNAMES(CvPADLIST(PL_compcv));
+    SAVECOMPPAD();
+    PL_comppad      = PadlistARRAY(CvPADLIST(PL_compcv))[1];
+    PL_curpad       = PadARRAY(PL_comppad);
+}
+
+/*
+=for apidoc export_lexical
+
+Adds an entry into the lexical scope of the code which called this. In order
+to have any effect this must be while the surrounding code is still being
+compiled; usually by being invoked as part of a C<BEGIN> block (or the one
+implied by a C<use> statement.)
+
+Calls to this function must be wrapped between a pair of calls to
+L</prepare_export_lexical> and L</finish_export_lexical>, between which may be
+placed one or more calls to C<export_lexical> itself.
+
+    prepare_export_lexical();
+    export_lexical(name1, sv1);
+    export_lexical(name2, sv2);
+    ...
+    finish_export_lexical();
+
+=cut
+*/
+void
+Perl_export_lexical(pTHX_ SV *name, SV *sv)
+{
+    PERL_ARGS_ASSERT_EXPORT_LEXICAL;
+
+    PADOFFSET off = pad_add_name_sv(name, padadd_STATE, 0, 0);
+    SvREFCNT_dec(PL_curpad[off]);
+    PL_curpad[off] = SvREFCNT_inc(sv);
+}
+
+/*
+=for apidoc finish_export_lexical
+
+Commits any recently exported lexical names to the caller's pad and undoes
+the effect of L</prepare_export_lexical>. See L</export_lexical> for more
+detail.
+
+=cut
+*/
+void
+Perl_finish_export_lexical(pTHX)
+{
+    PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL;
+
+    intro_my();
+
+    LEAVE;
+}
+
+/*
  * ex: set ts=8 sts=4 sw=4 et:
  */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -368,7 +368,8 @@ well.
 
 =item *
 
-XXX
+Added new API function C<export_lexical()> which does the same lexical export
+that the L<builtin/export_lexically> function does.
 
 =back
 

--- a/proto.h
+++ b/proto.h
@@ -1511,6 +1511,14 @@ PERL_CALLCONV Size_t
 Perl_expected_size(UV size);
 #define PERL_ARGS_ASSERT_EXPECTED_SIZE
 
+PERL_CALLCONV void
+Perl_export_lexical(pTHX_ SV *name, SV *sv)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+#define PERL_ARGS_ASSERT_EXPORT_LEXICAL         \
+        Perl_assert_aTHX; assert(name); assert(sv)
+
 PERL_CALLCONV bool
 Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
         Perl_attribute_nonnull(1)
@@ -1601,6 +1609,12 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_SCRIPT            \
         Perl_assert_aTHX; assert(scriptname)
+
+PERL_CALLCONV void
+Perl_finish_export_lexical(pTHX)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL  \
+        Perl_assert_aTHX
 
 PERL_CALLCONV I32
 Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
@@ -5311,6 +5325,12 @@ Perl_pregfree2(pTHX_ REGEXP *rx)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGFREE2              \
         Perl_assert_aTHX; assert(rx)
+
+PERL_CALLCONV void
+Perl_prepare_export_lexical(pTHX)
+        Perl_attribute_nonnull_aTHX;
+#define PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL \
+        Perl_assert_aTHX
 
 PERL_CALLCONV const char *
 Perl_prescan_version(pTHX_ const char *s, bool strict, const char **errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha)
@@ -9280,24 +9300,10 @@ Perl_XS_builtin_indexed(pTHX_ CV *cv)
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
-Perl_finish_export_lexical(pTHX)
-        Perl_attribute_nonnull_aTHX
-        __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
 Perl_import_builtin_bundle(pTHX_ U16 ver)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_IMPORT_BUILTIN_BUNDLE \
-        Perl_assert_aTHX
-
-PERL_CALLCONV void
-Perl_prepare_export_lexical(pTHX)
-        Perl_attribute_nonnull_aTHX
-        __attribute__visibility__("hidden");
-# define PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL \
         Perl_assert_aTHX
 
 #endif /* defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C) */


### PR DESCRIPTION
Previously these were only used internally. As they may be useful to XS modules we should export them publicly and document them.

Also, `pad.c` is a better place to find them, than `builtin.c`.

* This set of changes requires a perldelta entry, and I'll add the following when I merge it (because right now there's too many conflicts going on)

```pod
=head1 Internal Changes

=over 4

=item *

New API function C<export_lexical()> is provided, that allows XS modules to perform the same lexical export behaviour that the L</builtin> module already does.

=back
```