### PR TITLE
Net-Ping: synch CPAN version 2.77 into blead underneath dist/

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4417,9 +4417,9 @@ dist/Module-CoreList/t/utils.t				Module::CoreList tests
 dist/Net-Ping/Changes			Net::Ping
 dist/Net-Ping/lib/Net/Ping.pm		Hello, anybody home?
 dist/Net-Ping/Makefile.PL		Build Net::Ping
-dist/Net-Ping/t/000_load.t
-dist/Net-Ping/t/001_new.t
-dist/Net-Ping/t/010_pingecho.t
+dist/Net-Ping/t/000_load.t		Test file related to Net::Ping
+dist/Net-Ping/t/001_new.t		Test file related to Net::Ping
+dist/Net-Ping/t/010_pingecho.t		Test file related to Net::Ping
 dist/Net-Ping/t/110_icmp_inst.t		Ping Net::Ping
 dist/Net-Ping/t/120_udp_inst.t		Ping Net::Ping
 dist/Net-Ping/t/130_tcp_inst.t		Ping Net::Ping

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -891,7 +891,7 @@ our %Modules = (
             qw(t/603_meta.t),
             qw(t/604_manifest.t),
             qw(t/appveyor-test.bat),
-
+            qr{\.github/},
         ],
     },
 

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -879,7 +879,8 @@ our %Modules = (
     },
 
     'Net::Ping' => {
-        'DISTRIBUTION' => 'RURBAN/Net-Ping-2.76.tar.gz',
+        'DISTRIBUTION' => 'RURBAN/Net-Ping-2.77.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Thu Jul 16 15:34:17 2026',
         'FILES'        => q[dist/Net-Ping],
         'EXCLUDED'     => [
             qr{^\.[awc]},

--- a/dist/Net-Ping/Changes
+++ b/dist/Net-Ping/Changes
@@ -1,5 +1,9 @@
 CHANGES
 -------
+2.77  2026-06-02 07:34:55 rurban
+      Minor
+      - Fix tests to about.com (GH #34)
+      - Replace broken cpm matrix tests with cpanm
 2.76  2025-09-08 08:39:55 rurban
       Features
       - use SOCK_DRGAM for ICMP under linux, which requires no root.

--- a/dist/Net-Ping/Makefile.PL
+++ b/dist/Net-Ping/Makefile.PL
@@ -30,11 +30,11 @@ push @extras,
         resources   => {
             # TODO: 26 old issues still open at RT
             # https://rt.cpan.org/Public/Dist/Display.html?Name=Net-Ping
-            bugtracker  => 'https://github.com/Perl/perl5/issues',
+            bugtracker  => 'https://github.com/rurban/Net-Ping/issues',
             repository  => {
                 type => 'git',
-                url => 'https://github.com/Perl/perl5.git',
-                web => 'https://github.com/Perl/perl5',
+                url => 'https://github.com/rurban/Net-Ping.git',
+                web => 'https://github.com/rurban/Net-Ping',
             },
             license     => [ 'http://dev.perl.org/licenses/' ],
         },
@@ -55,7 +55,7 @@ WriteMakefile(
     'Test::Pod'           => '1.22',
     'Test::More'          => 0,
   },
-  INSTALLDIRS => ( $] < 5.011 ? 'perl' : 'site' ),
+  INSTALLDIRS => ($ENV{PERL_CORE} ? 'perl' : 'site'),
   clean      => { FILES => 'Net-Ping-*' },
   @extras
 );
@@ -67,7 +67,13 @@ sub depend {
 README : lib/Net/Ping.pm
 	pod2text lib/Net/Ping.pm > README
 release : dist
-	git tag \$(VERSION)
+	if test \"\$(shell git rev-parse --abbrev-ref HEAD)\" != \"master\" || \\
+           test \"\$(shell git diff --raw)\" != \"\" || \\
+           test \"\$(shell git diff --cached --raw)\" != \"\" ; then \\
+          echo 'You are not on a clean master branch, aborting.'; \\
+          exit 1; \\
+	fi
+	-git tag -f \$(VERSION)
 	cpan-upload \$(DISTVNAME).tar\$(SUFFIX)
 	git push
 	git push --tags

--- a/dist/Net-Ping/t/000_load.t
+++ b/dist/Net-Ping/t/000_load.t
@@ -12,5 +12,5 @@ BEGIN {
     use_ok( 'Net::Ping' )   || print "No Net::Ping!\n";
 }
 
-note( "Testing Net::Ping $Net::Ping::VERSION, Perl $] on $^O, $^X" );
+diag( "Testing Net::Ping $Net::Ping::VERSION, Perl $] on $^O, $^X" );
 

--- a/dist/Net-Ping/t/001_new.t
+++ b/dist/Net-Ping/t/001_new.t
@@ -1,14 +1,9 @@
 use warnings;
 use strict;
-use Config;
 
 BEGIN {
   unless (my $port = getservbyname('echo', 'tcp')) {
     print "1..0 \# Skip: no echo port\n";
-    exit;
-  }
-  unless ($Config{d_getpbyname}) {
-    print "1..0 \# Skip: no getprotobyname\n";
     exit;
   }
 }

--- a/dist/Net-Ping/t/010_pingecho.t
+++ b/dist/Net-Ping/t/010_pingecho.t
@@ -1,15 +1,9 @@
 use warnings;
 use strict;
-use Config;
-
 
 BEGIN {
   unless (my $port = getservbyname('echo', 'tcp')) {
     print "1..0 \# Skip: no echo port\n";
-    exit;
-  }
-  unless ($Config{d_getpbyname}) {
-    print "1..0 \# Skip: no getprotobyname\n";
     exit;
   }
 }

--- a/dist/Net-Ping/t/200_ping_tcp.t
+++ b/dist/Net-Ping/t/200_ping_tcp.t
@@ -73,7 +73,7 @@ is($p->ping($fail_ip), 0, "Can't reach $fail_ip");
 
 if ($p->ping('google.com')) { # check for firewall
   foreach (qw(google.com www.google.com www.wisc.edu
-              yahoo.com www.yahoo.com www.about.com)) {
+              yahoo.com www.yahoo.com www.duckduckgo.com)) {
     isnt($p->ping($_), 0, "Can ping $_");
   }
 } else {

--- a/dist/Net-Ping/t/400_ping_syn.t
+++ b/dist/Net-Ping/t/400_ping_syn.t
@@ -41,7 +41,7 @@ my %webs = (
   # Hopefully all these web ports are open
   "yahoo.com." => 1,
   "www.yahoo.com." => 1,
-  "www.about.com." => 1,
+  "www.duckduckgo.com." => 1,
   "www.microsoft.com." => 1,
 );
 

--- a/dist/Net-Ping/t/410_syn_host.t
+++ b/dist/Net-Ping/t/410_syn_host.t
@@ -46,7 +46,7 @@ BEGIN {
   "www.freeservers.com." => 1,
   "yahoo.com." => 1,
   "www.yahoo.com." => 1,
-  "www.about.com." => 1,
+  "www.duckduckgo.com." => 1,
   "www.microsoft.com." => 1,
   "127.0.0.1" => 1,
 );

--- a/dist/Net-Ping/t/420_ping_syn_port.t
+++ b/dist/Net-Ping/t/420_ping_syn_port.t
@@ -97,6 +97,6 @@ is keys %contacted, 2,
   '2 servers did not acknowledge our ping'
   or diag sort keys %contacted;
 delete $contacted{$_}
-    foreach ("$fail_ip:80","$fail_ip:443", 'www.about.com:443');
+    foreach ("$fail_ip:80","$fail_ip:443", 'www.duckduckgo.com:443');
 is keys %contacted, 0,
     'The servers that did not acknowledge our ping were correct';

--- a/dist/Net-Ping/t/450_service.t
+++ b/dist/Net-Ping/t/450_service.t
@@ -78,7 +78,7 @@ is($p->ping("127.0.0.1"), 1, 'first port is reachable');
 $p->{port_num} = $port2;
 
 {
-    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390|cygwin|freebsd)$/;
+    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390|freebsd)$/;
     is($p->ping("127.0.0.1"), 1, 'second port is reachable');
 }
 
@@ -133,7 +133,7 @@ SKIP: {
 
   {
     local $TODO = "Believed not to work on $^O"
-      if $^O =~ /^(?:hpux|MSWin32|os390|cygwin|freebsd)$/;
+      if $^O =~ /^(?:hpux|MSWin32|os390|freebsd)$/;
     is($p->ack(), '127.0.0.1', 'IP should be reachable');
   }
 }

--- a/dist/Net-Ping/t/500_ping_icmp.t
+++ b/dist/Net-Ping/t/500_ping_icmp.t
@@ -22,11 +22,11 @@ my $is_devel = $ENV{PERL_CORE} || -d ".git" ? 1 : 0;
 $ENV{TEST_PING_HOST} = "127.0.0.1" if $ENV{NO_NETWORK_TESTING};
 # Note this rawsocket test code is considered anti-social in p5p and was removed in
 # their variant.
-# See https://www.nntp.perl.org/group/perl.perl5.porters/2016/11/msg240707.html
+# See See https://www.nntp.perl.org/group/perl.perl5.porters/2016/11/msg240707.html
 # Problem is that ping_icmp needs root perms, and previous bugs were
 # never caught. So I rather execute it via sudo in the core test suite
 # and on devel CPAN dirs, than not at all and risk further bitrot of this API.
-if (0 && !Net::Ping::_isroot()) {
+if (!Net::Ping::_isroot()) {
     my $file = __FILE__;
     my $lib = $ENV{PERL_CORE} ? '-I../../lib' : '-Mblib';
     if ($is_devel and $Config{ccflags} =~ /fsanitize=address/ and $^O eq 'linux') {
@@ -55,7 +55,7 @@ if (0 && !Net::Ping::_isroot()) {
 
 SKIP: {
   skip "icmp ping requires root privileges.", 2
-    if !Net::Ping::_isroot() or $^O eq 'MSWin32';
+    if ($^O ne 'Linux' and !Net::Ping::_isroot()) or $^O eq 'MSWin32';
   my $p = new Net::Ping "icmp";
   is($p->message_type(), 'echo', "default icmp message type is 'echo'");
   # message_type fails on wrong message type

--- a/dist/Net-Ping/t/501_ping_icmpv6.t
+++ b/dist/Net-Ping/t/501_ping_icmpv6.t
@@ -20,7 +20,7 @@ BEGIN {
 
 my $is_devel = $ENV{PERL_CORE} || -d ".git" ? 1 : 0;
 $ENV{TEST_PING6_HOST} = "::1" if $ENV{NO_NETWORK_TESTING};
-if (0 && !Net::Ping::_isroot()) {
+if (!Net::Ping::_isroot()) {
     my $file = __FILE__;
     my $lib = $ENV{PERL_CORE} ? '-I../../lib' : '-Mblib';
     # -n prevents from asking for a password. rather fail then


### PR DESCRIPTION
If we run `perl Porting/core-cpan-diff -ax`, we are told that the CPAN version of the Net-Ping library is newer than what we have in blead.
```
Net::Ping:
    Perl: RURBAN/Net-Ping-2.76.tar.gz
    CPAN: RURBAN/Net-Ping-2.77.tar.gz
```
However, the governance of this library is ... complicated.  We're currently treating Net-Ping as a "blead-first" library, which means it sits underneath `dist/` in our distribution.  However, at https://metacpan.org/pod/Net::Ping#AUTHORS we see:
```
Current maintainers:
  perl11 (for cperl, with IPv6 support and more)
  p5p    (for perl5)
```
So synching the latest CPAN version into blead cannot be done cleanly by `Porting/sync-with-cpan Net::Ping`.  So this is the result of a hack.  In reviewing this pull request, please examine the changes to Porting/Maintainers.pl and to dist/Net-Ping/Makefile.PL.


-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
