### PR TITLE
Correct entry for Storable in %Maintainers

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1048,7 +1048,7 @@ our %Modules = (
     },
 
     'Storable' => {
-        'DISTRIBUTION' => 'NWCLARK/Storable-3.25.tar.gz',
+        'DISTRIBUTION' => 'HAARG/Storable-3.41.tar.gz',
         'FILES'        => q[dist/Storable],
         'EXCLUDED'     => [
             qr{^t/compat/},


### PR DESCRIPTION
What we were/are actually shipping is version 3.41, updated by Graham Knop.  Applying this patch removes listing of Storable in Porting/core-cpan-diff -ax, eliminating need for synch with CPAN operation.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
