### PR TITLE
Clean up new clib locking

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -494,17 +494,20 @@ my %valid_sections = (
                 4) We don't know about it.
 
             See L<perlclib/Dealing with embedded perls and threads> for more
-            details.  F<regen/lock_definitions.pl> can be patched to add new
-            functions or revise existing data.
+            details.  The macro definitions are based on man pages (especially
+            Linux ones), and our experience.  We also know from experience
+            that man pages can be wrong or incomplete, and the behavior of any
+            given function may be platform dependent.  Patches to update our
+            knowledge base in F<regen/lock_definitions.pl> are welcome.
 
             For a function 'foo', the locking/unlocking macros are named
 
              PERL_FOO_LOCK
              PERL_FOO_UNLOCK
 
-            Note that just because a function is on this list, doesn't mean it
-            is a good idea for you to use it.  Some are obsolete; some are
-            implemented on only one or a few platforms; some have better
+            Note that just because a function is on the list below, doesn't
+            mean it is a good idea for you to use it.  Some are obsolete; some
+            are implemented on only one or a few platforms; some have better
             alternatives.  Before using a given lock, look it up in
             F<perl_lock_definitions.h> to see what notes and cautions are
             given for it.

--- a/perl.h
+++ b/perl.h
@@ -7544,8 +7544,8 @@ typedef struct am_table_short AMTS;
  * thread-safe, reproduced at the bottom of regen/lock_definitions.pl.
  * This is unfortunately incomplete.  It doesn't include the ones that just
  * access environment variables, for example.  Linux documents some more as
- * well; some of those might just be documentating that the Linux
- * implementation is non-compliant; or it might be it is an oversight in POSIX.
+ * well; some of those might just be documenting that the Linux implementation
+ * is non-compliant; or it might be it is an oversight in POSIX.
  *
  * The macros only work when you unlock before requesting another lock.
  * Otherwise, deadlock is possible.  The macros are crafted so that they safely

--- a/perl.h
+++ b/perl.h
@@ -2286,7 +2286,7 @@ my_snprintf()
  * that should be true only if the snprintf()/vsnprintf() are true
  * to the standard. */
 
-#define PERL_SNPRINTF_CHECK(len, max, api) STMT_START { if ((max) > 0 && (Size_t)len > (max)) Perl_croak_nocontext("panic: %s buffer overflow", STRINGIFY(api)); } STMT_END
+#define PERL_SNPRINTF_CHECK(len, max, api) STMT_START { if ((max) > 0 && (Size_t)len > (max)) croak("panic: %s buffer overflow", STRINGIFY(api)); } STMT_END
 
 #if defined(USE_LOCALE_NUMERIC) || defined(USE_QUADMATH)
 #  define my_snprintf Perl_my_snprintf
@@ -5235,9 +5235,8 @@ contexts in C, and in all contexts in C++.
 #  define Perl_assert(what)                                                 \
         ((what)                                                             \
          ? ((void) 0)                                                       \
-         : (Perl_croak_nocontext("Assertion %s failed:"                     \
-                                 " file \"" __FILE__ "\", line %" LINE_Tf,  \
-                                 STRINGIFY(what), (line_t) __LINE__),       \
+         : (croak("Assertion %s failed: file \"" __FILE__ "\", line %"      \
+                  LINE_Tf, STRINGIFY(what), (line_t) __LINE__),             \
             (void) 0))
 #  define Perl_assert_(what)    assert(what),
 #else
@@ -6608,9 +6607,9 @@ INIT({
                     "%s: %" LINE_Tf ": locking " name "; new lock depth=1;" \
                     " this thread reader count=%d\n",                       \
                     __FILE__, (line_t) __LINE__, rcounter));                \
-            if (xcounter < 0) (Perl_croak_nocontext("panic: "               \
-                              "%s: %" LINE_Tf ": locking " name "; new lock"\
-                              " depth=%d; this thread reader count=%d\n",   \
+            if (xcounter < 0) (croak("panic: %s: %" LINE_Tf ": locking "    \
+                               name "; new lock depth=%d; this thread"      \
+                               " reader count=%d\n",                        \
                               __FILE__, (line_t) __LINE__, xcounter,        \
                               rcounter));                                   \
                                                                             \
@@ -6624,10 +6623,9 @@ INIT({
                         (mutex)->readers_count));                           \
             }                                                               \
             else {                                                          \
-                Perl_croak_nocontext("panic: %s: %" LINE_Tf ": attempting"  \
-                                     " to convert non-exclusive lock on "   \
-                                     name " to exclusive\n",                \
-                                     __FILE__, (line_t) __LINE__);          \
+                croak("panic: %s: %" LINE_Tf ": attempting to convert"      \
+                      " non-exclusive lock on name to exclusive\n",         \
+                      __FILE__, (line_t) __LINE__);                         \
             }                                                               \
                                                                             \
             xcounter = 1;                                                   \
@@ -6647,10 +6645,9 @@ INIT({
                     "mutex " name ": all threads reader count is %zd\n",    \
                     (mutex)->readers_count));                               \
             if (cond_to_panic_if_already_locked) {                          \
-                Perl_croak_nocontext("panic: %s: %" LINE_Tf ": attempting"  \
-                                     " to lock " name " incompatibly: %s\n",\
-                                     __FILE__, (line_t) __LINE__,           \
-                                STRINGIFY(cond_to_panic_if_already_locked));\
+                croak("panic: %s: %" LINE_Tf ": attempting to lock " name   \
+                      " incompatibly: %s\n", __FILE__, (line_t) __LINE__,   \
+                      STRINGIFY(cond_to_panic_if_already_locked));          \
             }                                                               \
         }                                                                   \
         CLANG_DIAG_RESTORE                                                  \
@@ -6670,10 +6667,9 @@ INIT({
                     __FILE__, (line_t) __LINE__, rcounter));                \
         }                                                                   \
         else if (xcounter <= 0) {                                           \
-            Perl_croak_nocontext("panic: %s: %" LINE_Tf ": attempting to"   \
-                                 " unlock already unlocked " name           \
-                                 "; depth was %d\n",                        \
-                                 __FILE__, (line_t) __LINE__, xcounter);    \
+            croak("panic: %s: %" LINE_Tf ": attempting to unlock already"   \
+                  " unlocked " name "; depth was %d\n",                     \
+                  __FILE__, (line_t) __LINE__, xcounter);                   \
         }                                                                   \
         else {                                                              \
             xcounter--;                                                     \
@@ -6692,7 +6688,7 @@ INIT({
             DEBUG_K(PerlIO_printf(Perl_debug_log,                           \
                     "%s: %" LINE_Tf ": read locking " name "; no writers\n",\
                     __FILE__, (line_t) __LINE__));                          \
-            if (xcounter != 0) Perl_croak_nocontext("panic: %s: %" LINE_Tf  \
+            if (xcounter != 0) croak("panic: %s: %" LINE_Tf                 \
                                     ": read locking " name "; writers=%d\n",\
                                     __FILE__, (line_t) __LINE__, xcounter); \
             PERL_READ_LOCK(mutex);                                          \
@@ -6720,10 +6716,11 @@ INIT({
     STMT_START {                                                            \
         CLANG_DIAG_IGNORE(-Wthread-safety)                                  \
         if (xcounter <= 0) {    /* No exclusive lock */                     \
-            if (xcounter != 0) Perl_croak_nocontext("panic: %s: %" LINE_Tf  \
-                            ": read unlocking " name "; writers=%d; this"   \
-                            " thread reader count=%d\n",                    \
-                           __FILE__, (line_t) __LINE__, xcounter, rcounter);\
+            if (xcounter != 0) croak("panic: %s: %" LINE_Tf  ": read"       \
+                                     " unlocking " name "; writers=%d;"     \
+                                     " this thread reader count=%d\n",      \
+                                     __FILE__, (line_t) __LINE__, xcounter, \
+                                     rcounter);                             \
             DEBUG_K(PerlIO_printf(Perl_debug_log,                           \
                     "%s: %" LINE_Tf ": read unlocking " name "; no writers;"\
                     " this thread reader count=%d\n",                       \
@@ -6747,11 +6744,9 @@ INIT({
                     xcounter, rcounter));                                   \
         }                                                                   \
         else {                                                              \
-            Perl_croak_nocontext("panic: %s: %" LINE_Tf ": attempting to"   \
-                                 " read unlock already unlocked " name      \
-                                 "; readers count was %zd\n",               \
-                                 __FILE__, (line_t) __LINE__,               \
-                                 (mutex)->readers_count);                   \
+            croak("panic: %s: %" LINE_Tf ": attempting to read unlock"      \
+                  " already unlocked " name "; readers count was %zd\n",    \
+                  __FILE__, (line_t) __LINE__, (mutex)->readers_count);     \
         }                                                                   \
         CLANG_DIAG_RESTORE                                                  \
     } STMT_END

--- a/pod/perlclib.pod
+++ b/pod/perlclib.pod
@@ -905,7 +905,7 @@ next item.
 
 Use them with mutexes.
 
-Since v5.44, perl furnishes wrapper macros to make many of the above calls
+Since v5.46, perl furnishes wrapper macros to make many of the above calls
 thread-safe.  If you surround a function call with the macros designed
 for it that are found in F<perl_lock_definitions.h>, you automatically
 make it thread-safe, as long as all other executing threads have done
@@ -926,12 +926,12 @@ C<PERL_TZSET_UNLOCK> macros to wrap C<tzset> with, making it
 thread-safe.
 
 There are a few functions that are callable from Perl code that use
-mutexes somewhat prior to v5.44.  You can call them to get thread-safety
+mutexes somewhat prior to v5.46.  You can call them to get thread-safety
 a little further back if you use L<perlcall> to access them.  An example
 is C<tzset>.
 
 Otherwise, you can say that your module is thread-safe when used with
-perls 5.44 or later.
+perls 5.46 or later.
 
 =item *
 
@@ -1269,7 +1269,7 @@ the global locale are affected.  Almost all the locale-related functions
 in the list directly under L</Dealing with embedded perls and threads>
 have undefined behavior if another thread interrupts their execution and
 changes the locale.  Under threads, another thread could do exactly that.
-Starting in v5.44, if all threads wrap those function calls with the
+Starting in v5.46, if all threads wrap those function calls with the
 locking macros designed for each and found in F<perl_lock_definitions.h>,
 that interruption doesn't happen.  But, the thread may still find itself
 executing in an unexpected locale, with bad results.


### PR DESCRIPTION
In #24098, I neglected to update the code based on events that happened after it was decided to defer it to 5.45.  So this PR updates the target release date, fixes a typo, and changes to use plain `croak` instead of `Perl_croak_nocontext` which are now equivalent, but weren't at the time.  

* A perldelta entry is included
