### PR TITLE
Replace comment lines of = signs with -

### DIFF
--- a/locale.c
+++ b/locale.c
@@ -1521,7 +1521,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
 #  undef OVERRIDE_AND_SAVEPV
 #endif
 
-/*==========================================================================
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  * Here starts the code that gives a uniform interface to its callers, hiding
  * the differences between platforms.
  *
@@ -1537,7 +1537,7 @@ S_parse_LC_ALL_string(pTHX_ const char * string,
                                     ((const char *) setlocale(cat, locale))
 #endif
 
-/*==========================================================================
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  * Here is the main posix layer.  It is the same as the base one unless the
  * system is lacking LC_ALL, or there are categories that we ignore, but that
  * the system libc knows about */
@@ -1666,7 +1666,7 @@ S_posix_setlocale_with_complications(pTHX_ const int cat,
 #endif
 
 /* End of posix layer
- *==========================================================================
+ *-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  *
  * The next layer up is to catch vagaries and bugs in the libc setlocale return
  * value.  The return is not guaranteed to be stable.
@@ -1860,7 +1860,7 @@ S_stdize_locale(pTHX_ const int category,
 
 /* End of stdize_locale layer
  *
- * ==========================================================================
+ * -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  *
  * The next many lines form several implementations of a layer above the
  * close-to-the-metal 'posix' and 'stdized' macros.  They are used to present a
@@ -1905,7 +1905,7 @@ S_stdize_locale(pTHX_ const int category,
  * but each may be a mortalized copy.  If you need something stable across
  * calls, you need to savepv() the result yourself.
  *
- *===========================================================================*/
+ *-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 #if    (! defined(USE_LOCALE_THREADS) && ! defined(USE_POSIX_2008_LOCALE))    \
     || (  defined(WIN32) && defined(USE_THREAD_SAFE_LOCALE))
@@ -1953,7 +1953,7 @@ S_setlocale_i(pTHX_ const int category, const char * locale)
 
 #  endif
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 #elif   defined(USE_LOCALE_THREADS)                 \
    && ! defined(USE_THREAD_SAFE_LOCALE)
 
@@ -2019,7 +2019,7 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char * locale)
 #  define TOGGLE_LOCK(i)    POSIX_SETLOCALE_LOCK
 #  define TOGGLE_UNLOCK(i)  POSIX_SETLOCALE_UNLOCK
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 #elif defined(USE_POSIX_2008_LOCALE)
 #  ifndef LC_ALL
@@ -2639,14 +2639,14 @@ S_bool_setlocale_2008_i(pTHX_
     return false;
 }
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 #else
 #  error Unexpected Configuration
 #endif   /* End of the various implementations of the setlocale and
             querylocale macros used in the remainder of this program */
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 /* Each implementation above is based on two fundamental macros #defined above:
  *  1) either a querylocale_r or a querylocale_i
@@ -2723,7 +2723,7 @@ S_bool_setlocale_2008_i(pTHX_
 #  error No bool_setlocale() form defined
 #endif
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 /* Most of the cases in this file just toggle the locale briefly; but there are
  * a few instances where a longer toggled interval, over multiple operations,
@@ -2835,7 +2835,7 @@ S_update_PL_curlocales_i(pTHX_
 
 #  endif  /* Need PL_curlocales[] */
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 #if defined(USE_LOCALE)
 
@@ -9200,7 +9200,7 @@ Perl_init_i18nl10n(pTHX_ int printwarn)
 
     new_LC_ALL("C", true /* Don't shortcut */);
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
     /* Now ready to override the initialization with the values that the user
      * wants.  This is done in the global locale as explained in the
@@ -10570,7 +10570,7 @@ Perl_strxfrm(pTHX_ SV * src)
 #  define WHICH_LC_INDEX LC_MESSAGES_INDEX_
 #endif
 
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 /* First set of implementations, when have strerror_l() */
 
 #if defined(USE_POSIX_2008_LOCALE) && defined(HAS_STRERROR_L)
@@ -10661,7 +10661,7 @@ Perl_my_strerror(pTHX_ const int errnum, utf8ness_t * utf8ness)
     return errstr;
 }
 #  endif    /* Above is using strerror_l */
-/*===========================================================================*/
+/*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 #else       /* Below is not using strerror_l */
 #  if ! defined(USE_LOCALE_CTYPE) && ! defined(USE_LOCALE_MESSAGES)
 

--- a/perl.h
+++ b/perl.h
@@ -114,8 +114,8 @@ functions with no normal arguments, and used by L</C<comma_pDEPTH>> itself.
 #  define HAS_C99 1
 #endif
 
-/* =========================================================================
- * The defines from here to the following ===== line are unfortunately
+/* -------------------------------------------------------------------------
+ * The defines from here to the following ----- line are unfortunately
  * duplicated in makedef.pl, and changes here MUST also be made there */
 
 /* See L<perlguts/"The Perl API"> for detailed notes on
@@ -155,7 +155,7 @@ functions with no normal arguments, and used by L</C<comma_pDEPTH>> itself.
 #endif
 
 /* end of makedef.pl logic duplication.  But there are other groups below.
- * ========================================================================= */
+ * ------------------------------------------------------------------------- */
 
 /*
 =for apidoc_section $directives
@@ -1155,8 +1155,8 @@ violations are fatal.
 #   include <xlocale.h>
 #endif
 
-/* =========================================================================
- * The defines from here to the following ===== line are unfortunately
+/* -------------------------------------------------------------------------
+ * The defines from here to the following ----- line are unfortunately
  * duplicated in makedef.pl, and changes here MUST also be made there */
 
 /* If not forbidden, we enable locale handling if either 1) the POSIX 2008
@@ -1185,7 +1185,7 @@ violations are fatal.
 #endif
 
 /* end of makedef.pl logic duplication.  But there are other groups below.
- * ========================================================================= */
+ * ------------------------------------------------------------------------- */
 
 /* Even if not using locales, this header should be #included so as to #define
  * some symbols which avoid #ifdefs to get things to compile.  But make sure
@@ -1255,8 +1255,8 @@ typedef enum {
                                   { 12, 11, 10, 9, 8, 7, 5, 4, 3, 2, 1, 0 }
 #    define  PERL_LC_ALL_SEPARATOR "/ = /"
 #  endif
-/* =========================================================================
- * The defines from here to the following ===== line are unfortunately
+/* -------------------------------------------------------------------------
+ * The defines from here to the following ----- line are unfortunately
  * duplicated in makedef.pl, and changes here MUST also be made there */
 
 #  if defined(USE_THREADS) && ! defined(NO_LOCALE_THREADS)
@@ -1349,7 +1349,7 @@ typedef enum {
 #endif
 
 /* end of makedef.pl logic duplication
- * ========================================================================= */
+ * ------------------------------------------------------------------------- */
 
 #ifdef PERL_CORE
 

--- a/perlio.c
+++ b/perlio.c
@@ -323,7 +323,7 @@ Perl_boot_core_PerlIO(pTHX)
 #endif
 
 
-/*======================================================================================*/
+/*--------------------------------------------------------------------------------------*/
 /*
  * Implement all the PerlIO interface ourselves.
  */
@@ -5486,7 +5486,7 @@ Perl_PerlIO_restore_errno(pTHX_ PerlIO *f)
 #undef HAS_FGETPOS
 
 
-/*======================================================================================*/
+/*--------------------------------------------------------------------------------------*/
 /*
  * Now some functions in terms of above which may be needed even if we are
  * not in true PerlIO mode

--- a/regcomp.c
+++ b/regcomp.c
@@ -146,7 +146,7 @@ EXTERN_C const struct regexp_engine wild_reg_engine;
 #include "regcomp_internal.h"
 #include "feature.h"
 
-/* =========================================================
+/* ---------------------------------------------------------
  * BEGIN edit_distance stuff.
  *
  * This calculates how many single character changes of any type are needed to
@@ -289,7 +289,7 @@ S_edit_distance(const UV* src,
 }
 
 /* END of edit_distance() stuff
- * ========================================================= */
+ * --------------------------------------------------------- */
 
 #ifdef PERL_RE_BUILD_AUX
 /* add a data member to the struct reg_data attached to this regex, it should

--- a/sv.c
+++ b/sv.c
@@ -128,7 +128,7 @@
 static const char S_destroy[] = "DESTROY";
 #define S_destroy_len (sizeof(S_destroy)-1)
 
-/* ============================================================================
+/* ----------------------------------------------------------------------------
 
 An SV (or AV, HV, etc.) is allocated in two parts: the head (struct
 sv, av, hv...) contains type and reference count information, and for
@@ -223,7 +223,7 @@ Public API:
 
 =cut
 
- * ========================================================================= */
+ * ------------------------------------------------------------------------- */
 
 /*
  * "A time to plant, and a time to uproot what was planted..."
@@ -14785,7 +14785,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
     SvTAINT(sv);
 }
 
-/* =========================================================================
+/* -------------------------------------------------------------------------
 
 =for apidoc_section $embedding
 
@@ -14799,7 +14799,7 @@ During the course of a cloning, a hash table is used to map old addresses
 to new addresses.  The table is created and manipulated with the
 ptr_table_* functions.
 
- * =========================================================================*/
+ * -------------------------------------------------------------------------*/
 
 
 #if defined(USE_ITHREADS)


### PR DESCRIPTION
When handling a git merge or rebase conflict, it is common to search in conflicted files for the conflict marker, which likely consists of at least seven '=' signs in a row. These comment lines often come up as false matches in these files (especially in `sv.c` which is often in conflict between nontrivial feature branches). Removing these comments makes it easier to search for those markers.

* This set of changes does not require a perldelta entry.