### PR TITLE
S_maybe_targlex - do nothing when OPpPAD_STATE is set, even on EMPTYAVHV

### DIFF
--- a/op.c
+++ b/op.c
@@ -6249,7 +6249,8 @@ S_maybe_targlex(pTHX_ const U32 op_flags, OP * const kid, OP * const kkid)
         /* Can just relocate the target. */
         PADOFFSET op_targ_temp = kid->op_targ;
 
-        if (OP_TYPE_IS(kid, OP_EMPTYAVHV)) {
+        if (OP_TYPE_IS(kid, OP_EMPTYAVHV) &&
+                !(kkid->op_private & OPpPAD_STATE)) {
             kid->op_flags |= op_flags & (OPf_WANT|OPf_PARENS);
             kid->op_private |= OPpTARGET_MY |
                               (kkid->op_private & (OPpLVAL_INTRO|OPpPAD_STATE));

--- a/t/op/state.t
+++ b/t/op/state.t
@@ -9,7 +9,7 @@ BEGIN {
 
 use strict;
 
-plan tests => 170;
+plan tests => 171;
 
 # Before loading feature.pm, test it with CORE::
 ok eval 'CORE::state $x = 1;', 'CORE::state outside of feature.pm scope';
@@ -527,6 +527,15 @@ for (1,2) {
     $res = join '', gh_18630A , gh_18630A;
     is($res, "b2b2", 'ARRAY copied successfully in subroutine exit');
     is(scalar gh_18630A, 2, 'gh_18630A scalar call returns element count');
+}
+
+# [GH #24571] / [GH #24570] OP_EMPTYAVHV cannot set up the OP_ONCE tree, so
+#                           S_maybe_targlex should return without optimizing.
+
+{
+    sub got_once { state $cache = {} }
+    got_once()->{foo} = 'bar';
+    is(got_once()->{foo}, 'bar', 'gh_24571 No S_maybe_targlex breakage');
 }
 
 __DATA__


### PR DESCRIPTION
When `S_maybe_targlex` ran on a newly-created `OP_SASSIGN`, it appeared as if `OP_EMPTYAVHV` could handle the `OPpPAD_STATE` flag internally, but that only appeared to be the case because `S_maybe_targlex` would be skipped when that flag was set.

The flag check wasn't updated as it should have been when `S_maybe_targlex` was moved to run before `OP_SASSIGN` creation.

https://github.com/Perl/perl5/commit/edc77d1b36336920f654386bb10a9701c62337d0

Consequently, `S_maybe_targlex` optimized when it should not and the `OP_ONCE` structure that should have been created for `state` variable declarations was not.

This caused breakage such as https://github.com/Perl/perl5/issues/24571

This commit makes `S_maybe_targlex` return without doing any optimization when `OPpPAD_STATE` is set in the `OP_EMPTYAVHV` branch.

Closes #24571

Closes #24570

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry, it fixes a bug only just introduced.
