### PR TITLE
t/run/todo.t - remove passing test for GH 16952

### DIFF
--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -338,14 +338,6 @@ TODO: {
 }
 
 TODO: {
-    todo_skip "Test needs -DDEBUGGING", 1 unless $is_debugging_build;
-    local $::TODO = 'GH 16952';
-    fresh_perl('s/d|(?{})!//.$&>0for$0,l..a0,0..0',
-               { stderr => 'devnull' });
-    is($?, 0, "No assertion failure; GH 16952");
-}
-
-TODO: {
     local $::TODO = 'GH 16971';
     fresh_perl('split(/00|0\G/, "000")',
                { stderr => 'devnull' });


### PR DESCRIPTION
af11b0c528200761891d46a7f6566aa880be45ca addressed GH#16952 and GH#24388, and included tests based on the former.

This _todo.t_ test is no longer required.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
