### PR TITLE
Reduce the number of reallocations from Perl_sv_add_backref

### DIFF
--- a/av.c
+++ b/av.c
@@ -151,9 +151,28 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp,
 
             if (key <= newmax)
                 goto resized;
-#endif 
+#endif
             /* overflow-safe version of newmax = key + *maxp/5 */
             newmax = *maxp / 5;
+
+            if (newmax < 5) { /* This is a feels-about-right number. */
+                /* The newmax growth factor isn't making a meaningful
+                 * contribution yet. However, if an array has elements
+                 * added one-at-a-time, this means that it could undergo
+                 * multiple Renew() calls to add 1-2 elements at a time
+                 * until newmax helps to minimize that kind of churn.
+                 *
+                 * One example is Perl_sv_add_backreference, where if an
+                 * array has to be resized once, there's a very good
+                 * chance of it being resized multiple times in the
+                 * absence of a small-growth adjustment.
+                 *
+                 * This is an attempt at such an adjustment:
+                 */
+                 if (key - *maxp < 8)
+                     key = *maxp + 8; /* A feels-about-right number. */
+            }
+
             newmax = (key > SSize_t_MAX - newmax)
                         ? SSize_t_MAX : key + newmax;
           resize:


### PR DESCRIPTION
When `Perl_sv_add_backref` has to grow an AV beyond the minimum size, or subsequently extend the AV, there there is a good chance of further calls to add yet more backrefs to the same AV. If the AV is grown to only add one or two more backrefs, there is the potential for multiple small reallocations of the same AV to occur, which isn't great for efficient compilation.

Note that when AV sizes are small:
* The growth factor in `av_extend_guts` won't meaningfully contribute.
* Most `realloc()` implementations will only add space for 1-2 elements.

For example, instrumenting _blead_ and running
`./perl -Ilib -e 'use strict; use warnings'` shows:
```
Reallocating for main: 3 to 4
Reallocating for main: 4 to 5
Reallocating for main: 5 to 6
Reallocating for main: 7 to 8
Reallocating for main: 9 to 10
Reallocating for main: 11 to 12
Reallocating for UNIVERSAL: 3 to 4
Reallocating for UNIVERSAL: 4 to 5
Reallocating for version: 3 to 4
Reallocating for version: 4 to 5
Reallocating for version: 5 to 6
Reallocating for version: 7 to 8
Reallocating for version: 9 to 10
Reallocating for version: 11 to 12
Reallocating for version: 14 to 15
Reallocating for version: 17 to 18
Reallocating for version: 21 to 22
Reallocating for version: 26 to 27
Reallocating for utf8: 3 to 4
Reallocating for utf8: 4 to 5
Reallocating for utf8: 5 to 6
Reallocating for main: 14 to 15
Reallocating for re: 3 to 4
Reallocating for main: 17 to 18
Reallocating for Tie::Hash::NamedCapture: 3 to 4
Reallocating for Tie::Hash::NamedCapture: 4 to 5
Reallocating for Tie::Hash::NamedCapture: 5 to 6
Reallocating for Tie::Hash::NamedCapture: 7 to 8
Reallocating for Tie::Hash::NamedCapture: 9 to 10
Reallocating for builtin: 3 to 4
Reallocating for builtin: 4 to 5
Reallocating for builtin: 5 to 6
Reallocating for builtin: 7 to 8
Reallocating for builtin: 9 to 10
Reallocating for builtin: 11 to 12
Reallocating for builtin: 14 to 15
Reallocating for builtin: 17 to 18
Reallocating for Internals: 3 to 4
Reallocating for main: 21 to 22
Reallocating for main: 26 to 27
Reallocating for main: 32 to 33
Reallocating for main: 39 to 40
Reallocating for strict: 3 to 4
Reallocating for strict: 4 to 5
Reallocating for strict: 5 to 6
Reallocating for strict: 7 to 8
Reallocating for strict: 9 to 10
Reallocating for warnings: 3 to 4
Reallocating for warnings: 4 to 5
Reallocating for warnings: 5 to 6
Reallocating for warnings: 7 to 8
Reallocating for warnings: 9 to 10
Reallocating for warnings: 11 to 12
Reallocating for warnings: 14 to 15
Reallocating for warnings: 17 to 18
Reallocating for warnings: 21 to 22
Reallocating for main: 47 to 48
Reallocating for warnings: 26 to 27
Reallocating for warnings: 32 to 33
Reallocating for warnings: 39 to 40
Reallocating for warnings: 47 to 48
```

Requesting that the AV instead be grown by enough to contain several more elements helps to reduce the number of reallocations, whilst not dramatically wasting memory:
```
Reallocating for main: 3 to 11
Reallocating for main: 11 to 19
Reallocating for UNIVERSAL: 3 to 11
Reallocating for version: 3 to 11
Reallocating for version: 11 to 19
Reallocating for version: 21 to 29
Reallocating for utf8: 3 to 11
Reallocating for re: 3 to 11
Reallocating for Tie::Hash::NamedCapture: 3 to 11
Reallocating for builtin: 3 to 11
Reallocating for builtin: 11 to 19
Reallocating for Internals: 3 to 11
Reallocating for main: 21 to 29
Reallocating for main: 33 to 41
Reallocating for strict: 3 to 11
Reallocating for warnings: 3 to 11
Reallocating for warnings: 11 to 19
Reallocating for warnings: 21 to 29
Reallocating for main: 47 to 55
Reallocating for warnings: 33 to 41
Reallocating for warnings: 47 to 55
```

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
