### PR TITLE
embed.fnc lacked 'd' flag

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -1053,7 +1053,7 @@ Cp	|void	|clear_defarray |NN AV *av				\
 				|bool abandon
 Cipx	|void	|clear_defarray_simple					\
 				|NN AV *av
-p	|const COP *|closest_cop|NN const COP *cop			\
+dp	|const COP *|closest_cop|NN const COP *cop			\
 				|NULLOK const OP *o			\
 				|NULLOK const OP *curop 		\
 				|bool opnext


### PR DESCRIPTION
autodoc.pl now die's on this, which prevents later build steps

Fixes: GH #24583

