### PR TITLE
Disable SIGINFO tests for OpenBSD 8

### DIFF
--- a/ext/POSIX/t/sigaction.t
+++ b/ext/POSIX/t/sigaction.t
@@ -202,7 +202,7 @@ SKIP: {
     $skip{pid}{$^O} = $skip{uid}{$^O} = "not set for kill()"
         if (($^O.$Config{osvers}) =~ /^darwin[0-8]\./
             ||
-            ($^O.$Config{osvers}) =~ /^openbsd[0-7]\./
+            ($^O.$Config{osvers}) =~ /^openbsd[0-8]\./
             ||
             ($^O eq 'gnu')
             ||


### PR DESCRIPTION
As of OpenBSD 8, we still don't have uid and the other details returned from SIGINFO.

https://github.com/openbsd/src/commit/872cb83f470ba5906d0d512f813b7507ca5d9086

See previous versions of this change every five years.

OpenBSD 6 - https://github.com/Perl/perl5/issues/15664
OpenBSD 7 - https://github.com/Perl/perl5/issues/19483


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
