### PR TITLE
Maintainers.pl: correct version number for podlators

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1002,7 +1002,7 @@ our %Modules = (
     },
 
     'podlators' => {
-        'DISTRIBUTION' => 'RRA/podlators-v6.0.2.tar.gz',
+        'DISTRIBUTION' => 'RRA/podlators-v6.1.0.tar.gz',
         'SYNCINFO'     => 'jkeenan on Sun Jul 14 20:06:07 2024',
         'MAIN_MODULE'  => 'Pod::Man',
         'FILES'        => q[cpan/podlators pod/perlpodstyle.pod],


### PR DESCRIPTION
The modules were upgraded to v6.1.0; the entry in %Maintainers was not. 'perl Porting/core-cpan-diff -ax' should now not report podlators.


-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
