### PR TITLE
regexec.c - remove unnecessary logical_to_parno[] mapping

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -8301,7 +8301,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             type = OP(scan);
             n = ARG1u(scan);  /* which paren pair */
             if (rex->logical_to_parno) {
-                n = rex->logical_to_parno[n];
+                /* The compiler has already mapped this from logical to
+                 * physical; only search the other physical buffers sharing
+                 * the same logical number. */
                 do {
                     if ( RXp_LASTPAREN(rex) < n ||
                          RXp_OFFS_START(rex,n) == -1 ||

--- a/t/re/pat_advanced.t
+++ b/t/re/pat_advanced.t
@@ -1535,6 +1535,26 @@ sub run_tests {
     }
 
     {
+        my $s = "abb";
+        $s =~ s{^(?|(a)|(b)) (?|(a)|(b)) ((\2)*)}{${&}z}x;
+        is($s, "abbz", "numeric backrefs find the matching branch-reset capture");
+    }
+
+    {
+        my @tests = (
+            [qr/^(?|(a)|(b)) (?|(a)|(b)) ((\2)*)$/x, "aaa", "first physical capture"],
+            [qr/^(?|(a)|(b)) (?|(a)|(b)) ((\2)*)$/x, "bbb", "second physical capture"],
+            [qr/^(?|(a)|(b)) (?|(a)|(b)) ((\g{2})*)$/x, "abbb", "\\g{N} backreference"],
+            [qr/^(?|(a)|(b)|(c)) (?|(a)|(b)|(c)) ((\2)*)$/x, "accc", "three-way branch reset"],
+            [qr/^(?|(a)|(b)) (?|(a)|(b))\2$/x, "aaa", "backreference after branch reset"],
+            [qr/^(?|(a)|(b)) (?|(a)|(b))\1\2$/x, "aaaa", "multiple branch-reset backreferences"],
+        );
+        for my $test (@tests) {
+            like($test->[1], $test->[0], "branch reset: $test->[2]");
+        }
+    }
+
+    {
         use warnings;
         my $message = "ASCII pattern that really is UTF-8";
         my @w;


### PR DESCRIPTION
This fixes https://github.com/Perl/perl5/issues/24577

We had an unnecessary logical_to_parno[] mapping in regexec.c, given that the code in regcomp.c already does this mapping during regex compilation.

* This patch does not require a perldelta entry.
