### PR TITLE
Renamings for clarity in `op.c`

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -5109,13 +5109,10 @@ Sd	|AV *	|mro_get_linear_isa_dfs 				\
 				|U32 level
 #endif
 #if defined(PERL_IN_OP_C)
-S	|void	|apply_attrs	|NN HV *stash				\
-				|NN SV *target				\
-				|NULLOK OP *attrs
 S	|void	|apply_attrs_my |NN HV *stash				\
 				|NN OP *target				\
 				|NULLOK OP *attrs			\
-				|NN OP **imopsp
+				|NN OP **import_opsp
 RS	|I32	|assignment_type|NULLOK const OP *o
 S	|void	|bad_type_gv	|I32 n					\
 				|NN GV *gv				\
@@ -5132,6 +5129,10 @@ S	|CV *	|clear_special_blocks					\
 				|NN GV * const gv			\
 				|NN CV * const cv
 S	|void	|cop_free	|NN COP *cop
+S	|OP *	|declare_var_attributes 				\
+				|NULLOK OP *o				\
+				|NULLOK OP *attrs			\
+				|NN OP **import_opsp
 S	|OP *	|dup_attrlist	|NN OP *o
 S	|void	|find_and_forget_pmops					\
 				|NN OP *o
@@ -5142,6 +5143,10 @@ S	|OP *	|force_list	|NULLOK OP *arg 			\
 S	|void	|forget_pmop	|NN PMOP * const o
 S	|void	|gen_constant_list					\
 				|NULLOK OP *o
+S	|void	|import_attributes_module				\
+				|NN HV *stash				\
+				|NN SV *target				\
+				|NULLOK OP *attrs
 S	|void	|inplace_aassign|NN OP *o
 ST	|bool	|is_dup_mode	|NN const OP *o
 RST	|bool	|is_handle_constructor					\
@@ -5157,9 +5162,6 @@ S	|void	|move_proto_attr|NN OP **proto				\
 				|NN OP **attrs				\
 				|NN const GV *name			\
 				|bool curstash
-S	|OP *	|my_kid 	|NULLOK OP *o				\
-				|NULLOK OP *attrs			\
-				|NN OP **imopsp
 S	|OP *	|newGIVWHENOP	|NULLOK OP *cond			\
 				|NN OP *block				\
 				|I32 enter_opcode			\

--- a/embed.h
+++ b/embed.h
@@ -1453,7 +1453,6 @@
 #     define mro_get_linear_isa_dfs(a,b)        S_mro_get_linear_isa_dfs(aTHX_ a,b)
 #   endif
 #   if defined(PERL_IN_OP_C)
-#     define apply_attrs(a,b,c)                 S_apply_attrs(aTHX_ a,b,c)
 #     define apply_attrs_my(a,b,c,d)            S_apply_attrs_my(aTHX_ a,b,c,d)
 #     define assignment_type(a)                 S_assignment_type(aTHX_ a)
 #     define bad_type_gv(a,b,c,d)               S_bad_type_gv(aTHX_ a,b,c,d)
@@ -1461,12 +1460,14 @@
 #     define check_alt_hash_fields_hekify(a)    S_check_alt_hash_fields_hekify(aTHX_ a)
 #     define clear_special_blocks(a,b,c)        S_clear_special_blocks(aTHX_ a,b,c)
 #     define cop_free(a)                        S_cop_free(aTHX_ a)
+#     define declare_var_attributes(a,b,c)      S_declare_var_attributes(aTHX_ a,b,c)
 #     define dup_attrlist(a)                    S_dup_attrlist(aTHX_ a)
 #     define find_and_forget_pmops(a)           S_find_and_forget_pmops(aTHX_ a)
 #     define fold_constants(a)                  S_fold_constants(aTHX_ a)
 #     define force_list(a,b)                    S_force_list(aTHX_ a,b)
 #     define forget_pmop(a)                     S_forget_pmop(aTHX_ a)
 #     define gen_constant_list(a)               S_gen_constant_list(aTHX_ a)
+#     define import_attributes_module(a,b,c)    S_import_attributes_module(aTHX_ a,b,c)
 #     define inplace_aassign(a)                 S_inplace_aassign(aTHX_ a)
 #     define is_dup_mode                        S_is_dup_mode
 #     define is_handle_constructor              S_is_handle_constructor
@@ -1475,7 +1476,6 @@
 #     define looks_like_bool(a)                 S_looks_like_bool(aTHX_ a)
 #     define modkids(a,b)                       S_modkids(aTHX_ a,b)
 #     define move_proto_attr(a,b,c,d)           S_move_proto_attr(aTHX_ a,b,c,d)
-#     define my_kid(a,b,c)                      S_my_kid(aTHX_ a,b,c)
 #     define newGIVWHENOP(a,b,c,d,e)            S_newGIVWHENOP(aTHX_ a,b,c,d,e)
 #     define newMETHOP_internal(a,b,c,d)        S_newMETHOP_internal(aTHX_ a,b,c,d)
 #     define new_logop(a,b,c,d)                 S_new_logop(aTHX_ a,b,c,d)

--- a/op.c
+++ b/op.c
@@ -16488,9 +16488,7 @@ static const MGVTBL custom_op_register_vtbl = {
     custom_op_register_free,     /* free */
     0,                          /* copy */
     0,                          /* dup */
-#ifdef MGf_LOCAL
     0,                          /* local */
-#endif
 };
 
 

--- a/op.c
+++ b/op.c
@@ -3974,31 +3974,30 @@ S_dup_attrlist(pTHX_ OP *o)
 }
 
 static void
-S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
+S_import_attributes_module(pTHX_ HV *stash, SV *target, OP *attrs)
 {
-    PERL_ARGS_ASSERT_APPLY_ATTRS;
-    {
-        SV * const stashsv = newSVhek(HvNAME_HEK(stash));
+    PERL_ARGS_ASSERT_IMPORT_ATTRIBUTES_MODULE;
 
-        /* fake up C<use attributes $pkg,$rv,@attrs> */
+    SV * const stashsv = newSVhek(HvNAME_HEK(stash));
+
+    /* fake up C<use attributes $pkg,$rv,@attrs> */
 
 #define ATTRSMODULE "attributes"
 #define ATTRSMODULE_PM "attributes.pm"
 
-        load_module(PERL_LOADMOD_IMPORT_OPS,
-                    newSVpvs(ATTRSMODULE),
-                    NULL,
-                    op_prepend_elem(OP_LIST,
-                                    newSVOP(OP_CONST, 0, stashsv),
-                                    op_prepend_elem(OP_LIST,
-                                                    newSVOP(OP_CONST, 0,
-                                                            newRV(target)),
-                                                    dup_attrlist(attrs))));
-    }
+    load_module(
+            PERL_LOADMOD_IMPORT_OPS,
+            newSVpvs(ATTRSMODULE),
+            NULL,
+            op_prepend_elem(OP_LIST,
+                newSVOP(OP_CONST, 0, stashsv),
+                op_prepend_elem(OP_LIST,
+                    newSVOP(OP_CONST, 0, newRV(target)),
+                    dup_attrlist(attrs))));
 }
 
 static void
-S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
+S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **import_opsp)
 {
     PERL_ARGS_ASSERT_APPLY_ATTRS_MY;
 
@@ -4042,7 +4041,7 @@ S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
                                newMETHOP_named(OP_METHOD_NAMED, 0, meth)));
 
     /* Combine the ops. */
-    *imopsp = op_append_elem(OP_LIST, *imopsp, imop);
+    *import_opsp = op_append_elem(OP_LIST, *import_opsp, imop);
 }
 
 /*
@@ -4213,9 +4212,9 @@ S_cant_declare(pTHX_ OP *o)
 }
 
 static OP *
-S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
+S_declare_var_attributes(pTHX_ OP *o, OP *attrs, OP **import_opsp)
 {
-    PERL_ARGS_ASSERT_MY_KID;
+    PERL_ARGS_ASSERT_DECLARE_VAR_ATTRIBUTES;
 
     I32 type;
     const bool stately = PL_parser && PL_parser->in_my == KEY_state;
@@ -4228,7 +4227,7 @@ S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
     if (OP_TYPE_IS_OR_WAS(o, OP_LIST)) {
         OP *kid;
         for (kid = cLISTOPo->op_first; kid; kid = OpSIBLING(kid))
-            my_kid(kid, attrs, imopsp);
+            declare_var_attributes(kid, attrs, import_opsp);
         return o;
     } else if (type == OP_UNDEF || type == OP_STUB) {
         return o;
@@ -4242,11 +4241,11 @@ S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
             assert(PL_parser);
             PL_parser->in_my = KEY_NULL;
             PL_parser->in_my_stash = NULL;
-            apply_attrs(GvSTASH(gv),
-                        (type == OP_RV2SV ? GvSVn(gv) :
-                         type == OP_RV2AV ? MUTABLE_SV(GvAVn(gv)) :
-                         type == OP_RV2HV ? MUTABLE_SV(GvHVn(gv)) : MUTABLE_SV(gv)),
-                        attrs);
+            import_attributes_module(GvSTASH(gv),
+                    (type == OP_RV2SV ? GvSVn(gv) :
+                     type == OP_RV2AV ? MUTABLE_SV(GvAVn(gv)) :
+                     type == OP_RV2HV ? MUTABLE_SV(GvHVn(gv)) : MUTABLE_SV(gv)),
+                    attrs);
         }
         o->op_private |= OPpOUR_INTRO;
         return o;
@@ -4254,7 +4253,7 @@ S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
     else if (type == OP_REFGEN || type == OP_SREFGEN) {
         check_or_warn_declared_refs();
         /* Kid is a nulled OP_LIST, handled above.  */
-        my_kid(cUNOPo->op_first, attrs, imopsp);
+        declare_var_attributes(cUNOPo->op_first, attrs, import_opsp);
         return o;
     }
     else if (type != OP_PADSV &&
@@ -4276,7 +4275,7 @@ S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
         stash = PAD_COMPNAME_TYPE(o->op_targ);
         if (!stash)
             stash = PL_curstash;
-        apply_attrs_my(stash, o, attrs, imopsp);
+        apply_attrs_my(stash, o, attrs, import_opsp);
     }
     o->op_flags |= OPf_MOD;
     o->op_private |= OPpLVAL_INTRO;
@@ -4306,7 +4305,7 @@ Perl_my_attrs(pTHX_ OP *o, OP *attrs)
     if (attrs)
         SAVEFREEOP(attrs);
     rops = NULL;
-    o = my_kid(o, attrs, &rops);
+    o = declare_var_attributes(o, attrs, &rops);
     if (rops) {
         if (maybe_scalar && o->op_type == OP_PADSV) {
             o = scalar(op_append_list(OP_LIST, rops, o));
@@ -11457,7 +11456,7 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
   attrs:
     if (attrs) {
         /* Need to do a C<use attributes $stash_of_cv,\&cv,@attrs>. */
-        apply_attrs(PL_curstash, MUTABLE_SV(cv), attrs);
+        import_attributes_module(PL_curstash, MUTABLE_SV(cv), attrs);
     }
 
     if (block) {
@@ -12078,7 +12077,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
                         : PL_curstash;
         if (!name)
             SAVEFREESV(cv);
-        apply_attrs(stash, MUTABLE_SV(cv), attrs);
+        import_attributes_module(stash, MUTABLE_SV(cv), attrs);
         if (!name)
             SvREFCNT_inc_simple_void_NN(cv);
     }

--- a/proto.h
+++ b/proto.h
@@ -10893,23 +10893,14 @@ S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
 #endif /* defined(PERL_IN_MRO_C) */
 #if defined(PERL_IN_OP_C)
 static void
-S_apply_attrs(pTHX_ HV *stash, SV *target, OP *attrs)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_2);
-# define PERL_ARGS_ASSERT_APPLY_ATTRS           \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
-        assert(target)
-
-static void
-S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **imopsp)
+S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **import_opsp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS_MY        \
         Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
-        assert(target); assert(imopsp)
+        assert(target); assert(import_opsp)
 
 static I32
 S_assignment_type(pTHX_ const OP *o)
@@ -10961,6 +10952,13 @@ S_cop_free(pTHX_ COP *cop)
         Perl_assert_aTHX; assert(cop)
 
 static OP *
+S_declare_var_attributes(pTHX_ OP *o, OP *attrs, OP **import_opsp)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_3);
+# define PERL_ARGS_ASSERT_DECLARE_VAR_ATTRIBUTES \
+        Perl_assert_aTHX; assert(import_opsp)
+
+static OP *
 S_dup_attrlist(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
@@ -10999,6 +10997,15 @@ S_gen_constant_list(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_GEN_CONSTANT_LIST     \
         Perl_assert_aTHX
+
+static void
+S_import_attributes_module(pTHX_ HV *stash, SV *target, OP *attrs)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        Perl_attribute_nonnull(pTHX_2);
+# define PERL_ARGS_ASSERT_IMPORT_ATTRIBUTES_MODULE \
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        assert(target)
 
 static void
 S_inplace_aassign(pTHX_ OP *o)
@@ -11047,13 +11054,6 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MOVE_PROTO_ATTR       \
         Perl_assert_aTHX; assert(proto); assert(attrs); assert(name)
-
-static OP *
-S_my_kid(pTHX_ OP *o, OP *attrs, OP **imopsp)
-        Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_3);
-# define PERL_ARGS_ASSERT_MY_KID                \
-        Perl_assert_aTHX; assert(imopsp)
 
 static OP *
 S_newGIVWHENOP(pTHX_ OP *cond, OP *block, I32 enter_opcode, I32 leave_opcode, PADOFFSET entertarg)


### PR DESCRIPTION
While I was working on `op.c` for attributes-v2, I was getting confused at weirdly named things. Here I've renamed a bunch of them so their purpose is more clear.

I've also removed an `#ifdef` wrapping that is pointless, because the thing it is guarded by is always defined.