### PR TITLE
regen/embed.pl: Examine more header files

### DIFF
--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -83,7 +83,6 @@ $skip_files{$_} = 1 for qw(
                             embed.h
                             embedvar.h
                             fakesdio.h
-                            perl_lock_definitions.h
                             nostdio.h
                             perl_langinfo.h
                             perlio.h
@@ -203,8 +202,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     ASCII_RESTRICT_PAT_MOD
     ASCII_RESTRICT_PAT_MODS
     ASCII_TO_NATIVE
-    ASCTIME_LOCK
-    ASCTIME_UNLOCK
     ASSERT_CURPAD_ACTIVE
     ASSERT_CURPAD_LEGAL
     ASSERT_IS_LITERAL
@@ -405,8 +402,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     cSVOPx
     cSVOPx_sv
     cSVOPx_svp
-    CTIME_LOCK
-    CTIME_UNLOCK
     Ctl
     CTYPE256
     cUNOP
@@ -759,41 +754,11 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     GCC_DIAG_RESTORE_DECL
     GCC_DIAG_RESTORE_STMT
     GETATARGET
-    GETENV_LOCK
-    GETENV_UNLOCK
     get_extended_os_errno
-    GETHOSTBYADDR_LOCK
-    GETHOSTBYADDR_UNLOCK
-    GETHOSTBYNAME_LOCK
-    GETHOSTBYNAME_UNLOCK
-    GETNETBYADDR_LOCK
-    GETNETBYADDR_UNLOCK
-    GETNETBYNAME_LOCK
-    GETNETBYNAME_UNLOCK
-    GETPROTOBYNAME_LOCK
-    GETPROTOBYNAME_UNLOCK
-    GETPROTOBYNUMBER_LOCK
-    GETPROTOBYNUMBER_UNLOCK
-    GETPROTOENT_LOCK
-    GETPROTOENT_UNLOCK
-    GETPWNAM_LOCK
-    GETPWNAM_UNLOCK
-    GETPWUID_LOCK
-    GETPWUID_UNLOCK
-    GETSERVBYNAME_LOCK
-    GETSERVBYNAME_UNLOCK
-    GETSERVBYPORT_LOCK
-    GETSERVBYPORT_UNLOCK
-    GETSERVENT_LOCK
-    GETSERVENT_UNLOCK
-    GETSPNAM_LOCK
-    GETSPNAM_UNLOCK
     GETTARGET
     GETTARGETSTACKED
     G_FAKINGEVAL
     GLOBAL_PAT_MOD
-    GMTIME_LOCK
-    GMTIME_UNLOCK
     G_NODEBUG
     GREEK_CAPITAL_LETTER_MU
     GREEK_SMALL_LETTER_MU
@@ -1331,8 +1296,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     LOCALE_TERM
     LOCALE_UNLOCK
     LOCAL_PATCH_COUNT
-    LOCALTIME_LOCK
-    LOCALTIME_UNLOCK
     LOCK_DOLLARZERO_MUTEX
     LOCK_LC_NUMERIC_STANDARD
     LONGDOUBLE_BIG_ENDIAN
@@ -1449,8 +1412,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     MI_INIT_WORKAROUND_PACK
     MIN_OFFUNI_VARIANT_CP
     Mkdir
-    MKTIME_LOCK
-    MKTIME_UNLOCK
     M_PAT_MODS
     msbit_pos
     MSPAGAIN
@@ -2525,10 +2486,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     STORE_LC_NUMERIC_SET_STANDARD
     strBEGINs
     Strerror
-    STRFMON_LOCK
-    STRFMON_UNLOCK
-    STRFTIME_LOCK
-    STRFTIME_UNLOCK
     STRUCT_OFFSET
     STRUCT_SV
     SUBVERSION
@@ -2766,8 +2723,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     TWO_BYTE_UTF8_TO_UNI
     TYPE_CHARS
     TYPE_DIGITS
-    TZSET_LOCK
-    TZSET_UNLOCK
     U16_MAX
     U16_MIN
     U32_MAX
@@ -3401,7 +3356,9 @@ my %undocumented_always_visible = map { $_ => 1 } qw(
 
 # The keys are files that have documentation outside the normal apidoc lines,
 # and all the definitions are assumed to exist.
-my %assume_symbols_documented_files = map { $_ => 1 } qw();
+my %assume_symbols_documented_files = map { $_ => 1 } qw(
+    perl_lock_definitions.h
+);
 
 # Keep lists of symbols to undef under various conditions.  We can initialize
 # the two ones for perl extensions with the lists above.

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -145,6 +145,8 @@ my $names_reserved_for_perl_use_re =
 # as ones that turn on a special debugging mode.
 my %per_file_definitions = (
         'perl.h'             => { 'H_PERL' => 0 },
+        'win32/config_H.gc'  => { '_config_h_' => 0 },
+        'win32/config_H.vc'  => { '_config_h_' => 0 },
 );
 
 # This is a list of symbols that are:
@@ -261,7 +263,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     BSD_GETPGRP
     BSDish
     BSD_SETPGRP
-    BYTEORDER
     CALL_BLOCK_HOOKS
     CALL_FPTR
     CALLREGCOMP
@@ -612,8 +613,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     do_exec
     DOSISH
     DOUBLE_BIG_ENDIAN
-    DOUBLE_HAS_INF
-    DOUBLE_HAS_NAN
     DOUBLE_IS_IEEE_FORMAT
     DOUBLE_IS_VAX_FLOAT
     DOUBLE_LITTLE_ENDIAN
@@ -877,13 +876,9 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     HAS_EXTRA_LONG_UTF8
     HAS_GETPGRP
     HAS_GROUP
-    HAS_HTONL
-    HAS_HTONS
     HAS_IOCTL
     HAS_KILL
     HAS_NONLATIN1_FOLD_CLOSURE
-    HAS_NTOHL
-    HAS_NTOHS
     HAS_PASSWD
     HAS_POSIX_2008_LOCALE
     HAS_PTHREAD_UNCHECKED_GETSPECIFIC_NP
@@ -1895,7 +1890,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     PP_wrapped
     PRESCAN_VERSION
     PRINTF_FORMAT_NULL_OK
-    PRIVLIB_EXP
     PRIVSHIFT
     ProgLen
     pthread_addr_t
@@ -2410,7 +2404,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     share_hek_hek
     sharepvn
     SHARP_S_SKIP
-    SH_PATH
     SHUTDOWN_TERM
     sI
     SIMPLE
@@ -3358,6 +3351,8 @@ my %undocumented_always_visible = map { $_ => 1 } qw(
 # and all the definitions are assumed to exist.
 my %assume_symbols_documented_files = map { $_ => 1 } qw(
     perl_lock_definitions.h
+    win32/config_H.gc
+    win32/config_H.vc
 );
 
 # Keep lists of symbols to undef under various conditions.  We can initialize
@@ -3370,8 +3365,10 @@ my %non_ext_undefs = %needed_by_ext;
 my %need_longs;
 
 # Create lists of headers and C files to examine.  Use all top level .c files,
-# and all top level .h files that aren't on the $skip_files list.
-my @header_list;
+# and all top level .h files that aren't on the $skip_files list.  (A couple
+# header files aren't named typically; its simplest to just add them
+# directly.)
+my @header_list = qw(win32/config_H.gc win32/config_H.vc);
 my @c_list;
 open my $mf, "<", "MANIFEST" or die "Can't open MANIFEST: $!";
 while (defined (my $file = <$mf>)) {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -169,7 +169,7 @@ my %per_file_definitions = (
 #
 # For all modules that aren't deliberately using particular names, all the
 # other symbols on it are namespace pollutants.
-my @unresolved_visibility_overrides = qw(
+my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     _
     ABORT
     ABS_IV_MIN
@@ -3150,7 +3150,7 @@ my @unresolved_visibility_overrides = qw(
 # This is a list of symbols that are used by the OS and which perl may need to
 # define or redefine, and which aren't otherwise currently detectable by this
 # program's algorithms as being such.  They are not namespace pollutants
-my @system_symbols = qw(
+my %system_symbols = map { $_ => 1 } qw(
     environ
     htonl
     htons
@@ -3178,7 +3178,7 @@ my @system_symbols = qw(
 
 # This is a list of symbols that are needed by the ext/re module, and are not
 # documented.  They become undefined for any other modules.
-my @needed_by_ext_re = qw(
+my %needed_by_ext_re = map { $_ => 1 } qw(
     FAIL_
     first_upper_bit_set_byte_number
     invlist_intersection_complement_2nd_
@@ -3191,7 +3191,7 @@ my @needed_by_ext_re = qw(
 
 # This is a list of symbols that are needed by various ext/ modules, and are
 # not documented.  They become undefined for any other modules.
-my @needed_by_ext = qw(
+my %needed_by_ext = map { $_ => 1 } qw(
     OPpPARAM_IF_FALSE
     OPpPARAM_IF_UNDEF
     OPpSELF_IN_PAD
@@ -3200,7 +3200,7 @@ my @needed_by_ext = qw(
 # This is a list of symbols that are needed to be visible everywhere and are
 # not documented, and we don't plan to document them any time soon.
 # Effectively these are symbols that would otherwise be in
-# @unresolved_visibility_overrides, but we have resolved them to here.
+# %unresolved_visibility_overrides, but we have resolved them to here.
 #
 # Think twice about adding a symbol to this list.  Would it be better to
 # instead document the symbol?  Or maybe its name could easily be changed to
@@ -3212,7 +3212,7 @@ my @needed_by_ext = qw(
 # The list has two parts, separated by a blank line.  The names in the second
 # part have a trailing underscore, indicating the intent for this symbol to
 # not be directly usable by XS code
-my @undocumented_always_visible = qw(
+my %undocumented_always_visible = map { $_ => 1 } qw(
     CVf_HasNAME_HEK
     CvHasNAME_HEK_off
     CvHasNAME_HEK_on
@@ -3398,22 +3398,6 @@ my @undocumented_always_visible = qw(
     UTF8_WARN_SUPER_BIT_POS_
     UTF8_WARN_SURROGATE_BIT_POS_
 );
-
-# Turn all the lists above into hashes
-my %unresolved_visibility_overrides;
-$unresolved_visibility_overrides{$_} = 1 for @unresolved_visibility_overrides;
-
-my %system_symbols;
-$system_symbols{$_} = 1 for @system_symbols;
-
-my %needed_by_ext_re;
-$needed_by_ext_re{$_} = 1 for @needed_by_ext_re;
-
-my %needed_by_ext;
-$needed_by_ext{$_} = 1 for @needed_by_ext;
-
-my %undocumented_always_visible;
-$undocumented_always_visible{$_} = 1 for @undocumented_always_visible;
 
 # Keep lists of symbols to undef under various conditions.  We can initialize
 # the two ones for perl extensions with the lists above.

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -859,22 +859,10 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     G_WRITING_TO_STDERR
     HADNV
     HASARENA
-    HASATTRIBUTE_ALWAYS_INLINE
-    HASATTRIBUTE_DEPRECATED
-    HASATTRIBUTE_FORMAT
-    HASATTRIBUTE_MALLOC
-    HASATTRIBUTE_NONNULL
-    HASATTRIBUTE_NORETURN
-    HASATTRIBUTE_PURE
-    HASATTRIBUTE_UNUSED
-    HASATTRIBUTE_VISIBILITY
-    HASATTRIBUTE_WARN_UNUSED_RESULT
     HAS_BUILTIN_UNREACHABLE
     HAS_C99
-    HAS_CHOWN
     HAS_EXTENDED_OS_ERRNO
     HAS_EXTRA_LONG_UTF8
-    HAS_GETPGRP
     HAS_GROUP
     HAS_IOCTL
     HAS_KILL
@@ -882,9 +870,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     HAS_PASSWD
     HAS_POSIX_2008_LOCALE
     HAS_PTHREAD_UNCHECKED_GETSPECIFIC_NP
-    HAS_SETPGRP
-    HAS_SETREGID
-    HAS_SETREUID
     HAS_UTIME
     HAS_WAIT
     hasWARNBIT
@@ -1889,7 +1874,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     PP
     PP_wrapped
     PRESCAN_VERSION
-    PRINTF_FORMAT_NULL_OK
     PRIVSHIFT
     ProgLen
     pthread_addr_t
@@ -2802,7 +2786,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     USE_PWENT_FPTR
     USE_PWENT_PTR
     USE_QUERYLOCALE
-    USE_REENTRANT_API
     USER_PROP_MUTEX_INIT
     USER_PROP_MUTEX_LOCK
     USER_PROP_MUTEX_TERM
@@ -3353,6 +3336,7 @@ my %assume_symbols_documented_files = map { $_ => 1 } qw(
     perl_lock_definitions.h
     win32/config_H.gc
     win32/config_H.vc
+    config_h.SH
 );
 
 # Keep lists of symbols to undef under various conditions.  We can initialize
@@ -5234,7 +5218,20 @@ sub find_undefs {
                 next;
             }
         }
-    }   # Done with headers
+    }   # Done with headers, except for config.h
+
+    # We can't examine config.h directly because it is not under source code
+    # control, and the outputs of this program are.  However, config_h.SH is
+    # under source control, and we can infer from it the symbols that config.h
+    # will eventually contain.  All of them are considered public.
+    my $config_name = "config_h.SH";
+    open my $config_fh, "<", $config_name or die "Can't open $config_name: $!";
+    while (<$config_fh>) {
+                    # Pattern based on manual inspection of $config_name
+        next unless / ^ \# (?: define | \$ (?: d_ )? \w+ ) \s+ (\w+) /x;
+        set_flags_visibility($1, $config_name, $., undef);
+    }
+    close $config_fh, or die "Can't close config_h.SH: $!";
 
     # Now look through the C and pod files.  Any preprocessor constraints in
     # these affect only the containing files, so no need to look for cpp
@@ -5277,10 +5274,8 @@ sub find_undefs {
         if (! defined $cpp_visibility) {
 
             # To get here we have a macro without having encountered its
-            # #define.  This can legitimately happen when that definition is
-            # in config.h, which we don't (and can't examine); or it could be
-            # the result of some flaw somewhere.  But there is no real harm
-            # done unless we are trying to restrict the external visibility.
+            # #define.  There is no real harm done unless we are trying to
+            # restrict the external visibility.
             if ($flags_visibility ne '1') {
                 warn "'$name' unexpectedly has no C preprocessor conditions"
                    . " for #defining it; found in "
@@ -5289,8 +5284,6 @@ sub find_undefs {
             }
             $cpp_visibility = 1;    # Assume worst case
 
-            # (The reason we can't examine config.h is that it is not under
-            # source code control, and the outputs of this program are.)
         }
 
         if ($cpp_visibility eq '0') {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -170,7 +170,6 @@ my %per_file_definitions = (
 # For all modules that aren't deliberately using particular names, all the
 # other symbols on it are namespace pollutants.
 my %unresolved_visibility_overrides = map { $_ => 1 } qw(
-    _
     ABORT
     ABS_IV_MIN
     ALIGNED_TYPE
@@ -3213,6 +3212,7 @@ my %needed_by_ext = map { $_ => 1 } qw(
 # part have a trailing underscore, indicating the intent for this symbol to
 # not be directly usable by XS code
 my %undocumented_always_visible = map { $_ => 1 } qw(
+    _
     CVf_HasNAME_HEK
     CvHasNAME_HEK_off
     CvHasNAME_HEK_on

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3399,6 +3399,10 @@ my %undocumented_always_visible = map { $_ => 1 } qw(
     UTF8_WARN_SURROGATE_BIT_POS_
 );
 
+# The keys are files that have documentation outside the normal apidoc lines,
+# and all the definitions are assumed to exist.
+my %assume_symbols_documented_files = map { $_ => 1 } qw();
+
 # Keep lists of symbols to undef under various conditions.  We can initialize
 # the two ones for perl extensions with the lists above.
 my %always_undefs;
@@ -4732,18 +4736,26 @@ sub set_flags_visibility {
     #       core but nowhere else
     #   1   The symbol is supposed to be visible everywhere
 
-    # Use the stored flags if new ones empty.  If those don't exist, assume
-    # visible everywhere for symbols that Perl reserves for its use, and
-    # hidden visibility for everything else.
+    # Use the stored flags if new ones empty.  Look for special handling
+    # request otherwise.
     my $flags = $raw_flags // $visibility{$name}{flags_raw};
     if (! defined $flags) {
-        if ($name =~ $names_reserved_for_perl_use_re) {
+        if ($assume_symbols_documented_files{$file}) {
+
+            # Every definition in $file is assumed to have documentation and
+            # is visible everywhere
+            $flags = 'Am';
+        }
+        elsif ($name =~ $names_reserved_for_perl_use_re) {
+
+            # Symbols that Perl reserves for its use are assumed to be
+            # everywhere visible.
             $flags = 'A';
 
             # But note that this is an assumption; so can avoid warning later.
             $visibility{$name}{flags_implicit} = 1;
         }
-        else {
+        else {  # Hidden visibility for everything else.
             $flags = 'e';
         }
     }
@@ -5204,11 +5216,14 @@ sub find_undefs {
             # Just the symbol, no arglist nor definition
             $name =~ s/ (?: \s | \( ) .* //x;
 
-            # Call the subroutine with an 'undef' third parameter for symbols
-            # reserved for Perl-use.  That tells it to consider these to be
-            # always visible unless otherwise directed
-            set_flags_visibility($name, $hdr, $line->{start_line_num}, undef)
-                                  if $name =~ $names_reserved_for_perl_use_re;
+            # Call the subroutine with an 'undef' third parameter for these
+            # reasons, to signal it to handle them specially.
+            if (   $assume_symbols_documented_files{$hdr}
+                || $name =~ $names_reserved_for_perl_use_re)
+            {
+                set_flags_visibility($name, $hdr, $line->{start_line_num},
+                                     undef);
+            }
 
             # Calculate $name's actual visibility for later use.
             my $stringified_conds = get_and_set_cpp_visibility($name, $line);


### PR DESCRIPTION
Several header-like files were not previously examined when looking for symbols that should not be visible to XS code.  These are `config.h`  and two Win32 variants of it, plus perl_lock_definitions.h

This PR also makes minor improvements, and resolves the single underbar symbol.

See #24593

* This set of changes does not require a perldelta entry.
