### PR TITLE
reinstate const magic vtables

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -6360,7 +6360,7 @@ EXTCONST runops_proc_t PL_runops_std
 EXTCONST runops_proc_t PL_runops_dbg
   INIT(Perl_runops_debug);
 
-#define EXT_MGVTBL EXT MGVTBL
+#define EXT_MGVTBL EXTCONST MGVTBL
 
 #define PERL_MAGIC_READONLY_ACCEPTABLE 0x40
 #define PERL_MAGIC_VALUE_MAGIC 0x80


### PR DESCRIPTION
Magic vtables were originally made const in c910fea and except for one bug that was rejected (GH #14450) has caused no reported problems that I recall (or find).

9c376794d8 which has an unrelated commit message and changes related to that commit message, removed the const-ness from magic vtables.

So this appears to have been accidentally removed.

If @ap had a reason, we can reject this.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry (there wasn't one for the 9c376794d8  change)
