### PR TITLE
io/socket.t: workaround an apparent bug in MacOS 27 beta

### DIFF
--- a/t/io/socket.t
+++ b/t/io/socket.t
@@ -239,7 +239,7 @@ SKIP: {
 
 SKIP:
 {
-    eval { require Errno; defined &Errno::EMFILE }
+    eval { require Errno; defined &Errno::EMFILE && defined &Errno::EBADF }
       or skip "Can't load Errno or EMFILE not defined", 1;
     # stdio might return strange values in errno if it runs
     # out of FILE entries, and does on darwin
@@ -260,6 +260,15 @@ SKIP:
     }
     @socks == $sock_limit
       and skip "Didn't run out of open handles", 1;
+    local $::TODO;
+    # GH 24549
+    # Hopefully Apple will fix this before the full release of macos 27
+    # If not the osvers check will become a regexp match
+    if ($^O eq "darwin"
+        and $Config{osvers} eq "27.0.0"
+        and $! == Errno::EBADF()) {
+        $::TODO = "Darwin 27 socket() returns EBADF instead of EMFILE";
+    }
     is(0+$!, Errno::EMFILE(), "check correct errno for too many files");
 }
 


### PR DESCRIPTION
Hopefully they will fix it before the full release, if not the condition will need to be extended.

Fixes #24549

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and I haven't written it yet.