### PR TITLE
Add autodoc flag B to denote back-compat only

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -75,14 +75,14 @@ use strict;
 use warnings;
 
 my $known_flags_re =
-         qr/[ aA bC dD eE fF h iI mM nN oO pP rR sS T uU v W xX y ;@\#? ] /xx;
+       qr/[ aA bB C dD eE fF h iI mM nN oO pP rR sS T uU v W xX y ;@\#? ] /xx;
 
 # Flags that don't apply to this program, like implementation details.
 my $irrelevant_flags_re = qr/[ ab eE iI P rR X? ]/xx;
 
 # Only certain flags dealing with what gets displayed, are acceptable for
 # apidoc_item
-my $item_flags_re = qr/[dD fF mM nN oO pT uU Wx;]/xx;
+my $item_flags_re = qr/[B dD fF mM nN oO pT uU Wx;]/xx;
 
 # Only certain flags are acceptable for apidoc_flag
 my $flag_flags_re = qr/[ A C dD eE h m n p u X ] /xx;
@@ -1862,6 +1862,7 @@ sub docout ($fh, $section_name, $element_name, $docref) {
     my @where_froms;
     my @deprecated;
     my @experimental;
+    my @back_compat;
     my @xrefs;
 
     for (my $i = 0; $i < @items; $i++) {
@@ -1879,6 +1880,7 @@ sub docout ($fh, $section_name, $element_name, $docref) {
 
             push @deprecated,   "C<$name>" if $item->{flags} =~ /D/;
             push @experimental, "C<$name>" if $item->{flags} =~ /x/;
+            push @back_compat, "C<$name>" if $item->{flags} =~ /B/;
         }
 
         # While we're going though the items, construct a nice list of where
@@ -1930,7 +1932,7 @@ sub docout ($fh, $section_name, $element_name, $docref) {
     print $fh format_pod_indexes(\@xrefs);
     print $fh "\n" if @xrefs;
 
-    for my $which (\@deprecated, \@experimental) {
+    for my $which (\@deprecated, \@experimental, \@back_compat) {
         next unless $which->@*;
 
         my $is;
@@ -1966,11 +1968,19 @@ sub docout ($fh, $section_name, $element_name, $docref) {
                 new code; remove $it from existing code.
                 EOT
         }
-        else {
+        elsif ($which == \@experimental) {
             print $fh <<~"EOT";
 
                 NOTE: $list $is B<experimental> and may change or be
                 removed without notice.
+                EOT
+        }
+        else {
+            $list = ucfirst($list) if $list =~ /form/;
+            print $fh <<~"EOT";
+
+                $list $is provided for backwards compatibility with
+                existing code, and should not be used for new code.
                 EOT
         }
     }

--- a/embed.fnc
+++ b/embed.fnc
@@ -501,6 +501,11 @@
 :
 :          proto.h: add __attribute__malloc__
 :
+:   'B'  Provided for backward compatibility. This is used for elements that
+:        exist only or mainly because existing code uses them, but new code
+:        should not.  The only current effect of this flag is to add a note for
+:        the item in perlapi or perlintern.
+:
 :   'b'  Binary backward compatibility. This is used for functions which are
 :        kept only to not have to change legacy applications that call them. If
 :        there are no such legacy applications in a Perl installation for all

--- a/embed.fnc
+++ b/embed.fnc
@@ -4097,7 +4097,7 @@ ATdmp	|bool	|utf8_to_uv	|SPTR const U8 * const s		\
 				|NULLOK Size_t *advance_p
 ADbdp	|UV	|utf8_to_uvchr	|NN const U8 *s 			\
 				|NULLOK STRLEN *retlen
-AMdip	|UV	|utf8_to_uvchr_buf					\
+ABMdip	|UV	|utf8_to_uvchr_buf					\
 				|SPTR const U8 *s			\
 				|EPTRge const U8 *send			\
 				|NULLOK STRLEN *retlen

--- a/embed.fnc
+++ b/embed.fnc
@@ -2784,9 +2784,9 @@ ATdo	|void	|perl_free	|NN PerlInterpreter *my_perl
 
 Cop	|const char *|PerlIO_context_layers				\
 				|NULLOK const char *mode
-ATdo	|const char *|Perl_langinfo					\
+ABTdo	|const char *|Perl_langinfo					\
 				|const nl_item item
-ATdo	|const char *|Perl_langinfo8					\
+ABTdo	|const char *|Perl_langinfo8					\
 				|const nl_item item			\
 				|NN utf8ness_t *utf8ness
 p	|int	|PerlLIO_dup2_cloexec					\

--- a/embed.fnc
+++ b/embed.fnc
@@ -2355,7 +2355,7 @@ Xp	|I32	|my_stat_flags	|NULLOK const U32 flags
 p	|const char *|my_strerror					\
 				|const int errnum			\
 				|NN utf8ness_t *utf8ness
-Adfp	|char * |my_strftime	|NN const char *fmt			\
+ABdfp	|char * |my_strftime	|NN const char *fmt			\
 				|int sec				\
 				|int min				\
 				|int hour				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -3245,15 +3245,15 @@ p	|OP *	|sawparens	|NULLOK OP *o
 p	|OP *	|scalar 	|NULLOK OP *o
 : Used in pp_ctl.c
 p	|OP *	|scalarvoid	|NN OP *arg
-Adp	|NV	|scan_bin	|NN const char *start			\
+ABdp	|NV	|scan_bin	|NN const char *start			\
 				|STRLEN len				\
 				|NN STRLEN *retlen
-Adp	|NV	|scan_hex	|NN const char *start			\
+ABdp	|NV	|scan_hex	|NN const char *start			\
 				|STRLEN len				\
 				|NN STRLEN *retlen
 Cp	|char * |scan_num	|NN const char *start			\
 				|NN YYSTYPE *lvalp
-Adp	|NV	|scan_oct	|NN const char *start			\
+ABdp	|NV	|scan_oct	|NN const char *start			\
 				|STRLEN len				\
 				|NN STRLEN *retlen
 

--- a/handy.h
+++ b/handy.h
@@ -1128,7 +1128,7 @@ C<isWORDCHAR_LC>, C<isWORDCHAR_LC_uvchr>, C<isWORDCHAR_LC_utf8>, and
 C<isWORDCHAR_LC_utf8_safe> are also as described there, but additionally
 include the platform's native underscore.
 
-=for apidoc Am|bool|isALNUM         |UV ch
+=for apidoc ABm|bool|isALNUM         |UV ch
 =for apidoc_item  ||isALNUM_A       |UV ch
 =for apidoc_item  ||isALNUM_LC      |UV ch
 =for apidoc_item  ||isALNUM_LC_uvchr|UV ch

--- a/handy.h
+++ b/handy.h
@@ -140,7 +140,7 @@ definitely a reference SV that refers to an SV of the right type.
 
 /*
 =for apidoc_section $casting
-=for apidoc Am|bool|cBOOL|bool expr
+=for apidoc ABm|bool|cBOOL|bool expr
 
 Cast-to-bool.  When Perl was able to be compiled on pre-C99 compilers, a
 C<(bool)> cast didn't necessarily do the right thing, so this macro was

--- a/numeric.c
+++ b/numeric.c
@@ -846,15 +846,15 @@ Other compromises kick in only when the result is within a digit of overflowing.
 /*
 =for apidoc scan_bin
 
-For backwards compatibility.  Use C<grok_bin> instead.
+Use C<grok_bin> instead.
 
 =for apidoc scan_hex
 
-For backwards compatibility.  Use C<grok_hex> instead.
+Use C<grok_hex> instead.
 
 =for apidoc scan_oct
 
-For backwards compatibility.  Use C<grok_oct> instead.
+Use C<grok_oct> instead.
 
 =cut
  */

--- a/perl.h
+++ b/perl.h
@@ -5184,8 +5184,8 @@ Gid_t getegid (void);
         __FILE__, (line_t) __LINE__));
 /*
 =for apidoc_section $directives
-=for apidoc     ATmp|void|assert_|bool expr
-=for apidoc_item  Tm|    |__ASSERT_
+=for apidoc    ABTmp|void|assert_|bool expr
+=for apidoc_item BTm|    |__ASSERT_
 
 These are synonymous, used to wrap the libc C<assert()> call in comma
 expressions in macro expansions, but you probably don't want to use them nor

--- a/pp.h
+++ b/pp.h
@@ -79,7 +79,7 @@ L<perlcall>.
 Declares a local copy of perl's stack pointer for the XSUB, available via
 the C<SP> macro.  See C<L</SP>>.
 
-=for apidoc mn;||djSP
+=for apidoc Bmn;||djSP
 
 Declare Just C<SP>.  This is actually identical to C<dSP>, and declares
 a local copy of perl's stack pointer, available via the C<SP> macro.

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4016,7 +4016,7 @@ sub generate_proto_h {
         my ($flags, $ret_type, $plain_func, $args, $assertions ) =
                         @{$embed}{qw(flags return_type name args assertions)};
         if ($flags =~
-             m/([^ aA b C dD eE fF h iI mM nN oO pP Rr sS T uU v W xX ; ])/xx)
+            m/([^ aA bB C dD eE fF h iI mM nN oO pP Rr sS T uU v W xX ; ])/xx)
         {
             die_at_end "flag $1 is not legal (for function $plain_func)";
         }
@@ -4042,6 +4042,8 @@ sub generate_proto_h {
             die_at_end "$plain_func: b flag without M flag requires D flag"
                                             if $flags !~ /M/ && $flags !~ /D/;
         }
+        die_at_end "$plain_func: b and B flags are mutually exclusive"
+                                                     if $flags =~ tr/bB// > 1;
 
         my $C_required_flags = '[pIimbs]';
         die_at_end


### PR DESCRIPTION
When the flags for an element contain 'B', a note will be
automatically added to its entry to the effect that it should not be
used for new code

Apply this flag to various macros and functions that exist only for back compat reasons.

* This set of changes does not require a perldelta entry.
