### PR TITLE
hv.h: unclash HV_FETCH_ISSTORE and G_DISCARD

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -469,6 +469,17 @@ compute it.
 =cut
 */
 
+/* sanity check: hash action codes don't clash with G_DISCARD */
+STATIC_ASSERT_DECL(
+    (G_DISCARD & HV_DISABLE_UVAR_XKEY) == 0 &&
+    (G_DISCARD & HV_FETCH_ISSTORE) == 0 &&
+    (G_DISCARD & HV_FETCH_ISEXISTS) == 0 &&
+    (G_DISCARD & HV_FETCH_LVALUE) == 0 &&
+    (G_DISCARD & HV_FETCH_JUST_SV) == 0 &&
+    (G_DISCARD & HV_DELETE) == 0 &&
+    (G_DISCARD & HV_FETCH_EMPTY_HE) == 0
+);
+
 void *
 Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
                int flags, int action, SV *val, U32 hash)
@@ -2683,6 +2694,9 @@ are set.
 
 =cut
 */
+
+/* sanity check: HV_NAME_SETALL doesn't clash with HVhek_UTF8 */
+STATIC_ASSERT_DECL((HV_NAME_SETALL & HVhek_UTF8) == 0);
 
 void
 Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)

--- a/hv.h
+++ b/hv.h
@@ -121,7 +121,7 @@ struct xpvhv_aux {
     HE		*xhv_eiter;	/* current entry of iterator */
     I32		xhv_riter;	/* current root of iterator */
 
-/* Concerning xhv_name_count: When non-zero, xhv_name_u contains a pointer 
+/* Concerning xhv_name_count: When non-zero, xhv_name_u contains a pointer
  * to an array of HEK pointers, this being the length. The first element is
  * the name of the stash, which may be NULL. If xhv_name_count is positive,
  * then *xhv_name is one of the effective names. If xhv_name_count is nega-
@@ -707,9 +707,9 @@ struct refcounted_he {
  * Passed in PERL_MAGIC_uvar calls
  */
 #define HV_DISABLE_UVAR_XKEY	0x01
-/* We need to ensure that these don't clash with G_DISCARD, which is 2, as it
+#define HV_FETCH_ISSTORE	0x02
+/* We need to ensure that these don't clash with G_DISCARD, which is 4, as it
    is documented as being passed to hv_delete().  */
-#define HV_FETCH_ISSTORE	0x04
 #define HV_FETCH_ISEXISTS	0x08
 #define HV_FETCH_LVALUE		0x10
 #define HV_FETCH_JUST_SV	0x20


### PR DESCRIPTION
The comment in hv.h says "we need to ensure that these don't clash", but we didn't, and they did (HV_FETCH_ISSTORE == 4, G_DISCARD == 4). :-(

- Update the comment with the correct value of G_DISCARD, which is 4, not 2.
- Change HV_FETCH_ISSTORE to not clash with G_DISCARD.
- Add a static assert to make sure future flag changes don't result in flag collisions.
- Add another static assert for HV_NAME_SETALL/HVhek_UTF8 while we're at it.

Background: Commit b54b4831042e added the comment about avoiding clashes with G_DISCARD; commit 2f8edad0d37e changed G_DISCARD without updating the hash action codes, introducing a clash.

Fixes #24537.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
