### PR TITLE
Regex compilation - static helpers for flattening nested branches

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -348,6 +348,14 @@ well.
 
 =item *
 
+During regex compilation, C<S_reg> will attempt to flatten nested BRANCH
+structures, in an attempt to give the TRIE optimizer more alternations
+to consider. The intent is that patterns that were previously compiled
+into two or more adjacent TRIE nodes might now get compiled into a single
+(or at least, fewer) TRIE node(s).
+
+=item *
+
 XXX
 
 =back

--- a/regcomp.c
+++ b/regcomp.c
@@ -1699,6 +1699,7 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
     RExC_sawback = false;
 
     RExC_seen = 0;
+    RExC_have_flattened = false;
     RExC_maxlen = 0;
     RExC_in_lookaround = false;
     RExC_seen_zerolen = *exp == '^' ? -1 : 0;
@@ -1806,6 +1807,13 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
             flags |= RESTART_PARSE;
         }
 
+        /* Branch flattening and (*THEN) nodes are incompatible. If both have
+         * been seen, trigger a reparse without any branch flattening. */
+        if (UNLIKELY(RExC_have_flattened && !RExC_unsafe_flatten
+               && (RExC_seen & REG_CUTGROUP_SEEN) )) {
+            RExC_unsafe_flatten = true;
+            flags |= RESTART_PARSE;
+        }
         /* We have that number in RExC_npar */
         RExC_total_parens = RExC_npar;
         RExC_logical_total_parens = RExC_logical_npar;
@@ -3036,6 +3044,199 @@ S_reg_la_OPFAIL(pTHX_ RExC_state_t *pRExC_state, U32 flags,
     RExC_seen |= flags;
     RExC_in_lookaround = true;
     return 0; /* keep parsing! */
+}
+
+/* Helper for S_flatten_inner_branches
+ * Skips over any leading NOTHING/OPTIMIZED nodes.
+ */
+PERL_STATIC_INLINE regnode *
+S_content_head(pTHX_ regnode *wrapper)
+{
+    regnode *node = REGNODE_AFTER(wrapper);
+    while (OP(node) == NOTHING || OP(node) == OPTIMIZED) {
+        regnode *nx = regnext(node);
+        if (UNLIKELY(!nx))
+            break;
+        node = nx;
+    }
+    return node;
+}
+
+/* S_flatten_inner_branches */
+static void
+S_flatten_inner_branches(pTHX_ RExC_state_t *pRExC_state, regnode *first_outer_br,
+                               regnode *ender, U32 depth)
+{
+
+    PERL_UNUSED_VAR(depth); /* Used for DEBUG_PARSE_r output */
+    DECLARE_AND_GET_RE_DEBUG_FLAGS;
+
+    regnode *prev_outer_br = NULL;
+    regnode *outer_br  = first_outer_br;
+
+    while (outer_br && OP(outer_br) == BRANCH) {
+        /* Get next outer BRANCH node - or the tail */
+        regnode *outer_successor = regnext(outer_br);
+        /* Follow REGNODE_AFTER(outer_br) to see what's inside this BRANCH */
+        regnode *first_inner_br = S_content_head(aTHX_ outer_br);
+
+        if (OP(first_inner_br) != BRANCH) { /* Not a nested BRANCH */
+            prev_outer_br = outer_br; outer_br = outer_successor; continue;
+        }
+
+        /* There is a set of inner BRANCH regnodes. Walk them to find the
+         * final one in the chain, checking for conditions (such as empty
+         * branch contents) that could corrupt the regex if flattened. */
+        regnode *last_inner_br = first_inner_br;
+         /* Note: This loop could check if flattening has a good chance of
+         * building bigger tries, or would result in offsets > U16_MAX, but
+         * with the anticipated move to 32 bit offsets, it shouldn't matter.
+         * If this code does create oversized offsets in the meantime, the
+         * surrounding code will reparse using BRANCHJ. */
+        bool unsafe = false;
+        while (1) {
+            regnode *inner_content = S_content_head(aTHX_ last_inner_br);
+            const U8 type = REGNODE_TYPE(OP(inner_content));
+            if (type == NOTHING) { /* Note: OPTIMIZED also has type == NOTHING */
+                unsafe = true; break;
+            }
+
+            if (OP(regnext(last_inner_br)) != BRANCH)
+                break;
+            last_inner_br = regnext(last_inner_br);
+        }
+        if (unsafe) {
+            prev_outer_br = outer_br; outer_br = outer_successor; continue;
+        }
+
+        /* It may not be safe to flatten if the regnode following the final
+         * inner BRANCH isn't a TAIL. Flattening is definitely not safe if
+         * the tail doesn't point to the expected outer TAIL. */
+        regnode *inner_ender = regnext(last_inner_br);
+        if (UNLIKELY(OP(inner_ender) != TAIL) || regnext(inner_ender) != ender) {
+            prev_outer_br = outer_br; outer_br = outer_successor; continue;
+        }
+
+        /* By this point, there is an inner BRANCH and it seems safe to
+         * flatten it. This is done by manipulating regnode offsets. */
+        const regnode_offset last_inner_off      = REGNODE_OFFSET(last_inner_br);
+        const regnode_offset outer_successor_off = REGNODE_OFFSET(outer_successor);
+        const regnode_offset first_inner_br_off  = REGNODE_OFFSET(first_inner_br);
+        const regnode_offset prev_outer_br_off = (prev_outer_br) ? REGNODE_OFFSET(prev_outer_br) : 0;
+
+        /* However, we cannot reliably tell if there is an outer *THEN yet to
+         * be parsed, in which case flattening could mess up the matching logic.
+         * If REG_CUTGROUP_SEEN was set during parsing, Perl_op_re_compile will
+         * check if RExC_have_flattened was also set, and if so, it triggers a
+         * reparse with no flattening. */
+        RExC_have_flattened = true;
+
+#ifdef DEBUGGING
+        U64 my_nalt = 0;
+        SV *debug_string = NULL;
+
+        DEBUG_PARSE_r({
+            debug_string = newSV_type(SVt_PV);
+        });
+#endif
+        /* Walk the inner BRANCH regnodes in turn. */
+        for (regnode *inner_br = first_inner_br; OP(inner_br) == BRANCH; inner_br = regnext(inner_br)) {
+            regnode *content_tail = S_content_head(aTHX_ inner_br);
+            assert(content_tail);
+#ifdef DEBUGGING
+            regnode *content_head = content_tail;
+#endif
+            /* Walk the regnodes within a single inner BRANCH to
+             * find the local tail (content_tail). */
+            regnode *nx = regnext(content_tail);
+            while (nx && nx != inner_ender && content_tail != ender) {
+                content_tail = nx;
+                nx = regnext(content_tail);
+            }
+            /* The inner tail shouldn't be an outer regnode. */
+            assert(content_tail != ender);
+
+            /* Flatten this inner BRANCH by effectively hoisting the
+             * contents to the level of the outer BRANCH. */
+            if (nx == inner_ender) {
+                const regnode_offset tail_off  = REGNODE_OFFSET(content_tail);
+                const regnode_offset ender_off = REGNODE_OFFSET(ender);
+
+                DEBUG_PARSE_r({
+                    if (my_nalt == 1) sv_catpvs(debug_string, "|");
+                    /* Not trying exhaustively to find an EXACT to report */
+                    U8 first_op = OP(content_head);
+                    regnode *lbl = (REGNODE_TYPE(first_op) == EXACT) ? content_head : NULL;
+
+                    DEBUG_PARSE_MSG("fltn");
+                    if (lbl) {
+                        re_printf("~ EXACT <%.*s> (brnc %" UVuf ") "
+                            "attach to TAIL (%" UVuf ")\n",
+                            (int) STR_LEN(lbl), STRING(lbl),
+                            (UV) REGNODE_OFFSET(lbl), (UV) ender_off);
+                        if (my_nalt < 2) {
+                            sv_catpvn(debug_string, STRING(lbl), STR_LEN(lbl));
+                        }
+                    } else {
+                        regprop(RExC_rx, RExC_mysv1, content_tail, NULL, pRExC_state);
+                        re_printf(" ~ route %s tail (%" UVuf
+                            ") to ender (%" UVuf ")\n",
+                            SvPV_nolen_const(RExC_mysv1),
+                            (UV) tail_off, (UV) ender_off);
+                        if (my_nalt < 2) {
+                            sv_catsv(debug_string, RExC_mysv1);
+                        }
+                    }
+                    my_nalt++;
+                });
+                /* Point the final regnode within the inner BRANCH to the
+                 * common outer TAIL regnode. */
+                NEXT_OFF_set(content_tail, ender_off - tail_off);
+            }
+        }
+
+        DEBUG_PARSE_r({
+            if (my_nalt > 2)
+                sv_catpvs(debug_string, "|...");
+            DEBUG_PARSE_MSG("fltn");
+            re_printf("~ %" UVuf " inner brnc%s (%" SVf ") lifted\n",
+                  my_nalt, (my_nalt == 1 ? "" : "s"), debug_string);
+
+            SvREFCNT_dec(debug_string);
+        });
+
+        /* Ensure that BRANCH takes up 2 units of space, as the
+         * following OP fixups assume that to be the case. */
+        assert(REGNODE_AFTER(outer_br) == outer_br + 2);
+
+        /* Fix up the relevant outer BRANCH regnode */
+        if (prev_outer_br) {
+            NEXT_OFF_set(prev_outer_br, first_inner_br_off - prev_outer_br_off);
+            OP(outer_br) = OPTIMIZED;
+            NEXT_OFF_set(outer_br, 0);
+        } else {
+            OP(outer_br) = NOTHING;
+
+            const regnode_offset outer_br_off = REGNODE_OFFSET(outer_br);
+            assert(first_inner_br_off >= outer_br_off);
+            NEXT_OFF_set(outer_br, first_inner_br_off - outer_br_off);
+        }
+
+        regnode *detritus = outer_br + NODE_STEP_REGNODE;
+        OP(detritus) = OPTIMIZED;
+        NEXT_OFF_set(detritus, 0);
+
+        /* Fix up the inner branch. */
+        NEXT_OFF_set(last_inner_br, outer_successor_off - last_inner_off);
+
+        /* .. and the inner content tail. */
+        OP(inner_ender) = OPTIMIZED; /* inner_ender was likely a TAIL node */
+        NEXT_OFF_set(inner_ender, 0);
+
+        /* Ready to go round again. */
+        outer_br = first_inner_br;
+        continue;
+    }
 }
 
 /* Below are the main parsing routines.
@@ -4448,6 +4649,25 @@ S_reg(pTHX_ RExC_state_t *pRExC_state, I32 paren, I32 *flagp, U32 depth)
                         is_nothing = 0;
                 }
             }
+
+            /* Note: the difference betweem BRANCH and BRANCHJ may disappear
+             * if/when the regex engine uses 32 bit offsets everywhere. */
+            if (! RExC_use_BRANCHJ
+                && ! RExC_unsafe_flatten
+                && (
+                    OP(REGNODE_p(ender)) == TAIL
+                 || OP(REGNODE_p(ender)) == END))
+            {
+                assert(OP(REGNODE_p(ret)) == BRANCH);
+                /* If there is a nested branch that can be safely hoisted
+                 * up to this branch's level, do so to flatten the pattern.
+                 * This will hopefully allow make_trie to fold in more
+                 * alternations and otherwise avoid the need to deepen the
+                 * state stack. */
+                (void) S_flatten_inner_branches(aTHX_ pRExC_state,
+                               REGNODE_p(ret), REGNODE_p(ender), depth);
+            }
+
             if (is_nothing) {
                 regnode * ret_as_regnode = REGNODE_p(ret);
                 br = REGNODE_TYPE(OP(ret_as_regnode)) != BRANCH

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -160,6 +160,8 @@ struct RExC_state_t {
     HV         *unlexed_names;
     SV          *runtime_code_qr;       /* qr with the runtime code blocks */
     bool        use_BRANCHJ;
+    bool        have_flattened;
+    bool        unsafe_flatten;
     bool        sWARN_EXPERIMENTAL__VLB;
     bool        sWARN_EXPERIMENTAL__REGEX_SETS;
     /* DEBUGGING only fields, keep these LAST so that we do not
@@ -257,6 +259,8 @@ struct RExC_state_t {
 #define RExC_warn_text (pRExC_state->warn_text)
 #define RExC_in_script_run      (pRExC_state->in_script_run)
 #define RExC_use_BRANCHJ        (pRExC_state->use_BRANCHJ)
+#define RExC_have_flattened          (pRExC_state->have_flattened)
+#define RExC_unsafe_flatten          (pRExC_state->unsafe_flatten)
 #define RExC_warned_WARN_EXPERIMENTAL__VLB (pRExC_state->sWARN_EXPERIMENTAL__VLB)
 #define RExC_warned_WARN_EXPERIMENTAL__REGEX_SETS (pRExC_state->sWARN_EXPERIMENTAL__REGEX_SETS)
 #define RExC_unlexed_names (pRExC_state->unlexed_names)

--- a/t/re/opt.t
+++ b/t/re/opt.t
@@ -274,3 +274,16 @@ abc(*ACCEPT)xyz	3	0+abc	-	-
 # Must not have stclass=[x]
 (*ACCEPT)xyz	0	-	-	-
 (a(*ACCEPT)){2}	1	0+a	-	-
+
+# Nested branches that should be flattened
+(?:mat3|mat4)|mat1|mat2	4	0+mat	-	-	flattened single nested branch
+^(?:mat1|mat2|(?:mat3|mat4)|mat5|(?:mat6|mat7))$	4	0+mat	-	noscan,anchor SBOL	flattened multiple, simple branches
+(?:foo|bar|(?:baz|bop|bing)|zoop)	3	-	-	stclass=~AHOCORASICKC-EXACT\[bfz\]	flattened multiple branches
+(?:(?:frog|fan)|fog)|(?:farce|(?:forge|flambe))	3	0+f	-	-	flattened multiple, deeper branches
+
+(?:(?:cat|dog|fish)|bird)x	4	-	3:4+x	-	flattened trie, trailing literal floats
+(?:(?:(?:a|b)|(?:c|d))|(?:(?:e|f)|(?:g|h)))z	2	1+z	-	-	single-char trie, trailing literal anchored
+(?:(?:(?:aa|ab|ac)|(?:ba|bb|bc))|(?:(?:ca|cb|cc)|(?:da|db|dc)))e	3	2+e	-	-	two-char trie, trailing literal anchored
+
+# Nested branches that should not be flattened
+(?:(?:(?:|x)|(?:|y))|(?:(?:|z)|w))q	1	-	0:1+q	-	empty alternatives; prefix is zero-width, literal floats

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2205,6 +2205,19 @@ ABCF|BCD[Ee]|C[Gg]	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
 /\F[A]B\Ec/	abc	y	$&	abc	-	Straddling \F [ \E ] works
 /\U[a]B\Ec/	ABc	y	$&	ABc	-	Straddling \U [ \E ] works
 
+# Flattening of nested branches should not change capture groups
+/^(?:(?:(a)|(b))|(?:(c)|(d)))e$/	ce	y	$3-$1	c-	-	Flatten 1
+/^(?:(?:(a)|(b))|(?:(c)|(d)))e$/	be	y	$2	b	-	Flatten 2
+/^(?:(?:(a)|(b))|(?:(c)|(d)))e$/	ae	y	$1	a	-	Flatten 3
+/^(?:(?:(a)|(b))|(?:(c)|(d)))e$/	de	y	$4	d	-	Flatten 4
+/^((?:(a)|(b))|(?:(c)|(d)))e$/	ce	y	$1-$4	c-c	-	Flatten out
+/^(?:(?:(?:(a)|(b))|(?:(c)|(d)))|(?:(e)|(f)))g$/	cg	y	$3	c	-	Flatten deep
+
+# Nested branch flattening is not compatible with *THEN
+(?:zz|(?:a(*THEN)b|c)|d)	a	n	$&	a	-	(*THEN) stays nested (no match)
+(?:zz|(?:a(*THEN)b|c)|d)	d	y	$&	d	-	(*THEN) stays nested (match)
+(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	aab	n	-	-	-	(Don't) flatten *THEN
+
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment
 # vim: softtabstop=0 noexpandtab


### PR DESCRIPTION
This commit attempts to flatten BRANCHes within a BRANCH, mostly for the
benefit of conversion of EXACT alternations into fewer TRIE nodes.

For example, prior to this commit, the following pattern:

    /mat|mat2|(?:mat3|mat4)|mat5|(?:mat6|mat7)/

would compile to:

     1: TRIEC-EXACT[m] (35)
        <mat> (35)
        <mat2> (35)
        <mat> (13)
    13: TRIE-EXACT[34] (35)
        <3>
        <4>
        <mat5> (35)
        <mat> (28)
    28: TRIE-EXACT[67] (35)
        <6>
        <7>
    35: END (0)

now it compiles to:

     1: EXACT <mat> (3)
     3: TRIE-EXACT[2-7] (35)
        <>
        <2>
        <3>
        <4>
        <5>
        <6>
        <7>
    35: END (0)

The commit only flattens branches where the branch tails directly match.

_Update: Following the suggestion to implement in `S_reg`, more complicated examples get flattened than was the case with the original attempt._

Notes:

_1. While a person might not write that sort of branching pattern,
it could arise from combining RE pieces, otherwise programatically
generating a pattern, or (potentially) from earlier parsing of
non-explicit branches into BRANCH regnodes._
 
_2. I'm no regex engine guru. There may be a better way / place to
do this, or the implementation might be as suboptimal as my
understanding of regcomp._ _In particular, I was unsure if or how
to apply to BRANCHJ regnodes._

_3. Also, any suggestions for improving the tests would be
welcomed!_

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and it is included.
