### PR TITLE
Set CvNAME_HEK on PL_compcv

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -64,7 +64,6 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvXSUBANY(sv)	((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_start_u.xcv_xsubany
 #define CvGV(sv)	Perl_CvGV(aTHX_ (CV *)(sv))
 #define CvGV_set(cv,gv)	Perl_cvgv_set(aTHX_ cv, gv)
-#define CvHASGV(cv)	cBOOL(SvANY(cv)->xcv_gv_u.xcv_gv)
 #define CvFILE(sv)	((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_file
 #ifdef USE_ITHREADS
 #  define CvFILE_set_from_cop(sv, cop)	\
@@ -78,6 +77,27 @@ See L<perlguts/Autoloading with XSUBs>.
 /* For use when you only have a XPVCV*, not a real CV*.
    Must be assert protected as in Perl_CvDEPTH before use. */
 #define CvDEPTHunsafe(sv) ((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_depth
+
+/*
+=for apidoc Am|bool|CvHasNAME|CV *cv
+
+Returns true if the CV has a name, either by having a name HEK or a GV. This
+macro does not indicate which. If additionally L</CvHasNAME_HEK> is true, then
+the name can be found in L</CvNAME_HEK>. If C<CvHasNAME_HEK> is false, the
+name can be found via the L</CvGV>.
+
+=cut
+*/
+
+/* This union is shared by both .xcv_gv and .xcv_hek, so the boolean truth of
+ * it indicates that either one is set
+ */
+#define CvHasNAME(cv)   ((bool)SvANY(cv)->xcv_gv_u.xcv_gv)
+
+/* Back-compat */
+#ifndef PERL_CORE
+#  define CvHASGV(cv)  CvHasNAME(cv)
+#endif
 
 /* these CvPADLIST/CvRESERVED asserts can be reverted one day, once stabilized */
 #define CvPADLIST(sv)	  (*(assert_(!CvISXSUB((CV*)(sv))) \

--- a/cv.h
+++ b/cv.h
@@ -399,6 +399,14 @@ Equivalent to the otherwise-common pattern:
         CvHasNAME_HEK_on(cv)						     \
     )
 
+#define CvNAME_HEK_clear(sv) (                                   \
+        CvNAME_HEK((CV *)sv)                                      \
+            ? unshare_hek(SvANY((CV *)(cv))->xcv_gv_u.xcv_hek)     \
+            : (void)0,                                              \
+        (((XPVCV*)MUTABLE_PTR(SvANY(cv)))->xcv_gv_u.xcv_hek) = NULL, \
+        CvHasNAME_HEK_off(cv)                                         \
+    )
+
 /*
 
 =for apidoc m|bool|CvWEAKOUTSIDE|CV *cv

--- a/gv.c
+++ b/gv.c
@@ -3226,7 +3226,7 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
            numifying instead of C's "+0". */
         gv = gv_fetchmeth_pvn(stash, cooky, l, -1, 0);
         cv = 0;
-        if (gv && (cv = GvCV(gv)) && CvHASGV(cv)) {
+        if (gv && (cv = GvCV(gv)) && CvHasNAME(cv)) {
             const HEK * const gvhek = CvGvNAME_HEK(cv);
             const HEK * const stashek =
                 HvNAME_HEK(CvHasNAME_HEK(cv) ? CvSTASH(cv) : GvSTASH(CvGV(cv)));

--- a/op.c
+++ b/op.c
@@ -12089,8 +12089,8 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
             }
 
             SvPOK_off(cv);
-            CvFLAGS(cv) = CvFLAGS(PL_compcv) | existing_builtin_attrs
-                                             | CvHasNAME_HEK(cv);
+            CvFLAGS(cv) = (CvFLAGS(PL_compcv) & ~CVf_HasNAME_HEK) |
+                    existing_builtin_attrs | CvHasNAME_HEK(cv);
             CvOUTSIDE(cv) = CvOUTSIDE(PL_compcv);
             CvOUTSIDE_SEQ(cv) = CvOUTSIDE_SEQ(PL_compcv);
             CvPADLIST_set(cv,CvPADLIST(PL_compcv));
@@ -12122,6 +12122,9 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
     }
     else {
         cv = PL_compcv;
+        if(name && CvHasNAME_HEK(cv))
+            CvNAME_HEK_clear(cv);
+
         if (name && isGV(gv)) {
             GvCV_set(gv, cv);
             GvCVGEN(gv) = 0;

--- a/op.c
+++ b/op.c
@@ -12144,7 +12144,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
     assert(cv);
     assert(SvREFCNT((SV*)cv) != 0);
 
-    if (!CvHASGV(cv)) {
+    if (!CvHasNAME(cv)) {
         if (isGV(gv))
             CvGV_set(cv, gv);
         else {

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -417,6 +417,11 @@ to update our knowledge base are welcome.
 More detail can be found in
 L<perlclib/Dealing with embedded perls and threads>.
 
+=item *
+
+During compiletime of a named subroutine, the name of the new sub
+currently being compiled is now accessible via C<CvNAME_HEK(PL_compcv)>.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2410,7 +2410,7 @@ PP_wrapped(pp_caller, MAXARG, 0)
         RETURN;
     if (CxTYPE(cx) == CXt_SUB || CxTYPE(cx) == CXt_FORMAT) {
         /* So is ccstack[dbcxix]. */
-        if (CvHASGV(dbcx->blk_sub.cv)) {
+        if (CvHasNAME(dbcx->blk_sub.cv)) {
             PUSHs(cv_name(dbcx->blk_sub.cv, 0, 0));
             PUSHs(boolSV(CxHASARGS(cx)));
         }

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -6323,10 +6323,10 @@ static void
 S_croak_undefined_subroutine(pTHX_ CV const *cv, GV const *gv)
 {
     if (cv) {
-        if (CvLEXICAL(cv) && CvHASGV(cv))
+        if (CvLEXICAL(cv) && CvHasNAME(cv))
             croak("Undefined subroutine &%" SVf " called",
                        SVfARG(cv_name((CV*)cv, NULL, 0)));
-        else /* pp_entersub triggers when (CvANON(cv) || !CvHASGV(cv)) */
+        else /* pp_entersub triggers when (CvANON(cv) || !CvHasNAME(cv)) */
             croak("Undefined subroutine called");
     } else { /* pp_entersub triggers when (!cv) after `try_autoload` */
         SV *sub_name = newSV_type_mortal(SVt_PV);
@@ -6440,9 +6440,9 @@ PP(pp_entersub)
         GV* autogv;
 
         /* anonymous or undef'd function leaves us no recourse */
-        if (CvLEXICAL(cv) && CvHASGV(cv))
+        if (CvLEXICAL(cv) && CvHasNAME(cv))
             S_croak_undefined_subroutine(aTHX_ cv, NULL);
-        if (CvANON(cv) || !CvHASGV(cv))
+        if (CvANON(cv) || !CvHasNAME(cv))
             S_croak_undefined_subroutine(aTHX_ cv, NULL);
 
         /* autoloaded stub? */

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -500,6 +500,7 @@ my @unresolved_visibility_overrides = qw(
     CvNAMED
     CvNAMED_off
     CvNAMED_on
+    CvNAME_HEK_clear
     CvNAME_HEK_set
     CvNODEBUG
     CvNODEBUG_off

--- a/toke.c
+++ b/toke.c
@@ -13540,7 +13540,16 @@ Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
     PERL_ARGS_ASSERT_INIT_NAMED_CV;
 
     if (nameop->op_type == OP_CONST) {
-        const char *const name = SvPV_nolen_const(((SVOP*)nameop)->op_sv);
+        SV *namesv = ((SVOP*)nameop)->op_sv;
+        STRLEN namlen;
+        const char *const name = SvPV_const(namesv, namlen);
+        bool name_is_utf8 = SvUTF8(namesv);
+
+        U32 hash;
+        PERL_HASH(hash, name, namlen);
+        CvNAME_HEK_set(cv, share_hek(
+            name, name_is_utf8 ? -(SSize_t)namlen : (SSize_t)namlen, hash));
+
         if (   strEQ(name, "BEGIN")
             || strEQ(name, "END")
             || strEQ(name, "INIT")


### PR DESCRIPTION
This addition makes it possible for code invoked during compiletime that interacts with a sub currently being compiled to actually learn the name of that subroutine. This name may be of interest to, for example, XS modules that provide extension attributes on subroutines (as part of an upcoming feature being developed).
    
Prior to this change, during compilation of a named sub, no code would be able to see the name of the sub being compiled. It was stored only in the parser stack, inaccessible to even other bits of perl core, and definitely not visible to XS modules.

* This set of changes may require a perldelta entry, and it is included