### PR TITLE
Document parts of the HEK API

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -236,6 +236,28 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvHASEVAL_on(cv)	(CvFLAGS(cv) |= CVf_HASEVAL)
 #define CvHASEVAL_off(cv)	(CvFLAGS(cv) &= ~CVf_HASEVAL)
 
+/*
+=for apidoc Am|I32|CvHasNAME_HEK|CV *cv
+=for apidoc_item CVf_HasNAME_HEK
+
+If true, indicates that this CV has a name stored I<directly> into it, which
+is accessible by L</CvNAME_HEK>. This is normally only the case for named
+lexical subroutines (i.e. those created by C<my sub ...> syntax). Named
+package subroutines do not store their name this way; instead those are
+accessible via the L</CvGV>.
+
+In normal circumstances you would not need to check this flag just to see if
+the subroutine has a name as would be recognised by a Perl developer. For
+that purpose, see L</CvGvNAME_HEK>.
+
+This macro returns the value of the flag constant directly; it may be used to
+copy the flag from one CV to another; using something like
+
+    CvFLAGS(ncv) |= CvHasNAME_HEK(ocv);
+
+=cut
+*/
+
 #define CvHasNAME_HEK(cv)       (CvFLAGS(cv) & CVf_HasNAME_HEK)
 #define CvHasNAME_HEK_on(cv)    (CvFLAGS(cv) |= CVf_HasNAME_HEK)
 #define CvHasNAME_HEK_off(cv)   (CvFLAGS(cv) &= ~CVf_HasNAME_HEK)
@@ -312,6 +334,15 @@ Helper macro to turn off the C<CvREFCOUNTED_ANYSV> flag.
 /* Flags for newXS_flags  */
 #define XS_DYNAMIC_FILENAME	0x01	/* The filename isn't static  */
 
+/*
+=for apidoc ATi|HEK *|CvNAME_HEK|CV *cv
+
+If the CV is named with a hash key structure (i.e. L</CvHasNAME_HEK> is true),
+returns the name hash key structure. If not, returns C<NULL>.
+
+=cut
+*/
+
 PERL_STATIC_INLINE HEK *
 CvNAME_HEK(CV *sv)
 {
@@ -320,8 +351,17 @@ CvNAME_HEK(CV *sv)
         : 0;
 }
 
-/* helper for the common pattern:
-   CvHasNAME_HEK(sv) ? CvNAME_HEK((CV *)sv) : GvNAME_HEK(CvGV(sv))
+/*
+=for apidoc Am|HEK *|CvGvNAME_HEK|CV *cv
+
+Attempts to return a naming hash key structure associated with the CV; either
+by using L</CvNAME_HEK> or the L</GvNAME_HEK> of its L</CvGV>.
+
+Equivalent to the otherwise-common pattern:
+
+   CvHasNAME_HEK(cv) ? CvNAME_HEK((CV *)cv) : GvNAME_HEK(CvGV(cv))
+
+=cut
 */
 #define CvGvNAME_HEK(sv) ( \
         CvHasNAME_HEK((CV*)sv) ? \

--- a/embed.fnc
+++ b/embed.fnc
@@ -3289,7 +3289,7 @@ Xp	|void	|set_numeric_standard					\
 Xp	|void	|set_numeric_underlying 				\
 				|NN const char *file			\
 				|const line_t caller_line
-Cp	|HEK *	|share_hek	|NN const char *str			\
+Adp	|HEK *	|share_hek	|NN const char *str			\
 				|SSize_t len				\
 				|U32 hash
 Tp	|Signal_t|sighandler1	|int sig
@@ -3987,7 +3987,7 @@ Adp	|SSize_t|unpackstring	|SPTR const char *pat			\
 				|EPTRge const char *strend		\
 				|U32 flags
 : Used in gv.c, hv.c
-Cp	|void	|unshare_hek	|NULLOK HEK *hek
+Adp	|void	|unshare_hek	|NULLOK HEK *hek
 Cdp	|void	|unsharepvn	|NULLOK const char *sv			\
 				|I32 len				\
 				|U32 hash

--- a/gv.h
+++ b/gv.h
@@ -43,6 +43,13 @@ the need to cast the result to the appropriate type.
 
 #define GvXPVGV(gv)	((XPVGV*)SvANY(gv))
 
+/*
+=for apidoc Am|HEK *|GvNAME_HEK|GV *gv
+Returns the package name directly as a hash key structure, or C<NULL> if
+there is no name associated.
+
+=cut
+*/
 
 #if defined (DEBUGGING) && defined(PERL_USE_GCC_BRACE_GROUPS) && !defined(__INTEL_COMPILER)
 #  define GvGP(gv)							\

--- a/hv.c
+++ b/hv.c
@@ -3295,6 +3295,15 @@ Perl_unsharepvn(pTHX_ const char *str, I32 len, U32 hash)
     unshare_hek_or_pvn (NULL, str, len, hash);
 }
 
+/*
+=for apidoc unshare_hek
+
+Decrements the reference count of the given hash key structure. If that was
+the last reference and its count has become zero, it is removed from the
+shared string table and its storage is reclaimed.
+
+=cut
+*/
 
 void
 Perl_unshare_hek(pTHX_ HEK *hek)
@@ -3399,10 +3408,31 @@ S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash)
         Safefree(str);
 }
 
-/* get a (constant) string ptr from the global string table
- * string will get added if it is not already there.
- * len and hash must both be valid for str.
- */
+/*
+=for apidoc share_hek
+
+Returns a pointer to the hash key structure entry containing the string given
+by I<str> and I<len>. If the string should be considered as opaque bytes,
+I<len> must be positive. If the string should be considered as a UTF-8 encoded
+sequence of characters, I<len> must be negative. The hash value must have been
+previously computed (using C<PERL_HASH>); do not simply pass zero here.
+
+If the string was already present in the global string table (C<PL_strtab>),
+then its reference count is incremented and the pointer to it is returned. If
+not, it is added and a pointer to the new entry with reference count 1 is
+returned. (I.e. do not think of this as a "newHEK" function; its entire
+purpose is to return shared pointers if possible).
+
+Note that it is possible the returned C<HEK> does not have the C<HEK_UTF8>
+flag set on it, even though a UTF-8 encoded sequence was given here. This
+happens in the case that the codepoints encoded by the sequence fit entirely
+within the range 0 to 255; if this happens, the string is stored as if it was
+plain bytes, but the C<HEK_WASUTF8> flag is set on it instead to indicate
+this.
+
+=cut
+*/
+
 HEK *
 Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
 {

--- a/hv.h
+++ b/hv.h
@@ -216,6 +216,10 @@ See C<L</SvSTASH>>, C<L</CvSTASH>>.
 =for apidoc Am|STRLEN|HvNAMELEN|HV *stash
 Returns the length of the stash's name.
 
+=for apidoc Am|HEK *|HvNAME_HEK|HV *stash
+Returns the package name directly as a hash key structure, or C<NULL> if
+C<stash> isn't a stash.
+
 =cut
 
 Disfavored forms of HvNAME and HvNAMELEN; suppress mention of them
@@ -245,6 +249,9 @@ Returns the actual pointer stored in the key slot of the hash entry.  The
 pointer may be either C<char*> or C<SV*>, depending on the value of
 C<HeKLEN()>.  Can be assigned to.  The C<HePV()> or C<HeSVKEY()> macros are
 usually preferable for finding the value of a key.
+
+=for apidoc Am|HEK *|HeKEY_hek|HE *he
+Returns the underlying hash key structure stored in the hash entry.
 
 =for apidoc Am|STRLEN|HeKLEN|HE* he
 If this is negative, and amounts to C<HEf_SVKEY>, it indicates the entry
@@ -298,6 +305,31 @@ C<SV*> if the hash entry contains only a C<char*> key.
 Sets the key to a given C<SV*>, taking care to set the appropriate flags to
 indicate the presence of an C<SV*> key, and returns the same
 C<SV*>.
+
+=for apidoc Am|U32|HEK_HASH|HEK *hek
+Returns the hash value associated with the given hash key structure.
+
+=for apidoc Am|I32|HEK_LEN|HEK *hek
+If non-negative, indicates the length of the string stored by the hash key
+structure. It may also be negative and equal to C<HEf_SVKEY>, indicating that
+the hash key is not in fact a string but a stored SV pointer value.
+
+=for apidoc Am|char *|HEK_KEY|HEK *hek
+If L</HEK_LEN> is non-negative, returns a pointer to the stored string. The
+length of the string is given by C<HEK_LEN>, which does not include a
+terminating NUL (C<\0>) byte which follows.
+
+If L</HEK_LEN> is negative and equal to C<HEf_SVKEY>, then C<HEK_KEY> returns
+a pointer to an SV * - i.e. its value should be treated as C<SV **>.
+
+=for apidoc Am|bool|HEK_UTF8|HEK *hek
+Returns true if the hash key structure's string should be considered as UTF-8.
+
+=for apidoc Am|bool|HEK_WASUTF8|HEK *hek
+Returns true if the hash key structure's string should be considered as plain
+bytes, but they were given as a UTF-8 encoded string to L</share_hek>. This
+happens if the encoded codepoints did not exceed the range 0 to 255, and were
+thus converted down to plain bytes.
 
 =cut
 */
@@ -372,7 +404,7 @@ whether it is valid to call C<HvAUX()>.
   ? *HvAUX(hv)->xhv_name_u.xhvnameu_names	  \
   : HvAUX(hv)->xhv_name_u.xhvnameu_name		  \
  )
-/* This macro may go away without notice.  */
+
 #define HvNAME_HEK(hv) \
         (HvHasAUX(hv) && HvAUX(hv)->xhv_name_u.xhvnameu_name ? HvNAME_HEK_NN(hv) : NULL)
 #define HvHasNAME(hv) \

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -476,13 +476,11 @@ my @unresolved_visibility_overrides = qw(
     CVf_UNIQUE
     CVf_WEAKOUTSIDE
     CVf_XS_RCSTACK
-    CvGvNAME_HEK
     CvGV_set
     CvHASEVAL
     CvHASEVAL_off
     CvHASEVAL_on
     CvHASGV
-    CvHasNAME_HEK
     CvHSCXT
     CvIsMETHOD
     CvIsMETHOD_off
@@ -918,7 +916,6 @@ my @unresolved_visibility_overrides = qw(
     GvMULTI_on
     GvNAME
     GvNAME_get
-    GvNAME_HEK
     GvNAMELEN
     GvNAMELEN_get
     GvNAMEUTF8
@@ -980,7 +977,6 @@ my @unresolved_visibility_overrides = qw(
     hasWARNBIT
     HASWIDTH
     HEK_BASESIZE
-    HeKEY_hek
     HeKEY_sv
     HEKf
     HEKf256
@@ -989,16 +985,11 @@ my @unresolved_visibility_overrides = qw(
     HeKFLAGS
     HEK_FLAGS
     HEKf_QUOTEDPREFIX
-    HEK_HASH
-    HEK_KEY
-    HEK_LEN
     HeKLEN_UTF8
     HeKUTF8
-    HEK_UTF8
     HEK_UTF8_off
     HEK_UTF8_on
     HeKWASUTF8
-    HEK_WASUTF8
     HEK_WASUTF8_off
     HEK_WASUTF8_on
     HeNEXT
@@ -1095,7 +1086,6 @@ my @unresolved_visibility_overrides = qw(
     HvLAZYDEL_off
     HvLAZYDEL_on
     HvMAX
-    HvNAME_HEK
     HvNAME_HEK_NN
     HvPLACEHOLDERS
     HvPLACEHOLDERS_get


### PR DESCRIPTION
My recent PR #24617 failed CI because the newly-added functions' documentation referred to documentation I expected to exist, but it in fact did not. So here is a minimal viable set of documentation of existing functions related to the HEK API, to allow that to make sense.

* This set of changes does not require a perldelta entry.
