### PR TITLE
Rename `CvNAMED` to `CvHasNAME_HEK`

### DIFF
--- a/cv.h
+++ b/cv.h
@@ -148,7 +148,7 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CVf_DYNFILE	0x1000	/* The filename is malloced  */
 #define CVf_AUTOLOAD	0x2000	/* SvPVX contains AUTOLOADed sub name  */
 #define CVf_HASEVAL	0x4000	/* contains string eval  */
-#define CVf_NAMED	0x8000  /* Has a name HEK */
+#define CVf_HasNAME_HEK 0x8000  /* Has a name HEK */
 #define CVf_LEXICAL	0x10000 /* Omit package from name */
 #define CVf_ANONCONST	0x20000 /* :const - create anonconst op */
 #define CVf_SIGNATURE   0x40000 /* CV uses a signature */
@@ -236,9 +236,17 @@ See L<perlguts/Autoloading with XSUBs>.
 #define CvHASEVAL_on(cv)	(CvFLAGS(cv) |= CVf_HASEVAL)
 #define CvHASEVAL_off(cv)	(CvFLAGS(cv) &= ~CVf_HASEVAL)
 
-#define CvNAMED(cv)		(CvFLAGS(cv) & CVf_NAMED)
-#define CvNAMED_on(cv)		(CvFLAGS(cv) |= CVf_NAMED)
-#define CvNAMED_off(cv)		(CvFLAGS(cv) &= ~CVf_NAMED)
+#define CvHasNAME_HEK(cv)       (CvFLAGS(cv) & CVf_HasNAME_HEK)
+#define CvHasNAME_HEK_on(cv)    (CvFLAGS(cv) |= CVf_HasNAME_HEK)
+#define CvHasNAME_HEK_off(cv)   (CvFLAGS(cv) &= ~CVf_HasNAME_HEK)
+
+#ifndef PERL_CORE
+    /* Back-compatibility wrappers for its old name */
+#  define CVf_NAMED    CVf_HasNAME_HEK
+#  define CvNAMED      CvHasNAME_HEK
+#  define CvNAMED_on   CvHasNAME_HEK_on
+#  define CvNAMED_off  CvHasNAME_HEK_off
+#endif
 
 #define CvLEXICAL(cv)		(CvFLAGS(cv) & CVf_LEXICAL)
 #define CvLEXICAL_on(cv)	(CvFLAGS(cv) |= CVf_LEXICAL)
@@ -307,16 +315,16 @@ Helper macro to turn off the C<CvREFCOUNTED_ANYSV> flag.
 PERL_STATIC_INLINE HEK *
 CvNAME_HEK(CV *sv)
 {
-    return CvNAMED(sv)
+    return CvHasNAME_HEK(sv)
         ? ((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_gv_u.xcv_hek
         : 0;
 }
 
 /* helper for the common pattern:
-   CvNAMED(sv) ? CvNAME_HEK((CV *)sv) : GvNAME_HEK(CvGV(sv))
+   CvHasNAME_HEK(sv) ? CvNAME_HEK((CV *)sv) : GvNAME_HEK(CvGV(sv))
 */
 #define CvGvNAME_HEK(sv) ( \
-        CvNAMED((CV*)sv) ? \
+        CvHasNAME_HEK((CV*)sv) ? \
             ((XPVCV*)MUTABLE_PTR(SvANY((SV*)sv)))->xcv_gv_u.xcv_hek\
             : GvNAME_HEK(CvGV( (SV*) sv)) \
         )
@@ -328,7 +336,7 @@ CvNAME_HEK(CV *sv)
             ? unshare_hek(SvANY((CV *)(cv))->xcv_gv_u.xcv_hek)	  \
             : (void)0,						   \
         ((XPVCV*)MUTABLE_PTR(SvANY(cv)))->xcv_gv_u.xcv_hek = (hek), \
-        CvNAMED_on(cv)						     \
+        CvHasNAME_HEK_on(cv)						     \
     )
 
 /*

--- a/dump.c
+++ b/dump.c
@@ -2359,23 +2359,23 @@ const struct flag_to_name second_sv_flags_names[] = {
 };
 
 const struct flag_to_name cv_flags_names[] = {
-    {CVf_ANON, "ANON,"},
-    {CVf_UNIQUE, "UNIQUE,"},
-    {CVf_CLONE, "CLONE,"},
-    {CVf_CLONED, "CLONED,"},
-    {CVf_CONST, "CONST,"},
-    {CVf_NODEBUG, "NODEBUG,"},
-    {CVf_LVALUE, "LVALUE,"},
+    {CVf_ANON,             "ANON,"},
+    {CVf_UNIQUE,           "UNIQUE,"},
+    {CVf_CLONE,            "CLONE,"},
+    {CVf_CLONED,           "CLONED,"},
+    {CVf_CONST,            "CONST,"},
+    {CVf_NODEBUG,          "NODEBUG,"},
+    {CVf_LVALUE,           "LVALUE,"},
     {CVf_NOWARN_AMBIGUOUS, "NOWARN_AMBIGUOUS,"},
-    {CVf_WEAKOUTSIDE, "WEAKOUTSIDE,"},
-    {CVf_CVGV_RC, "CVGV_RC,"},
-    {CVf_DYNFILE, "DYNFILE,"},
-    {CVf_AUTOLOAD, "AUTOLOAD,"},
-    {CVf_HASEVAL, "HASEVAL,"},
-    {CVf_SLABBED, "SLABBED,"},
-    {CVf_NAMED, "NAMED,"},
-    {CVf_LEXICAL, "LEXICAL,"},
-    {CVf_ISXSUB, "ISXSUB,"},
+    {CVf_WEAKOUTSIDE,      "WEAKOUTSIDE,"},
+    {CVf_CVGV_RC,          "CVGV_RC,"},
+    {CVf_DYNFILE,          "DYNFILE,"},
+    {CVf_AUTOLOAD,         "AUTOLOAD,"},
+    {CVf_HASEVAL,          "HASEVAL,"},
+    {CVf_SLABBED,          "SLABBED,"},
+    {CVf_HasNAME_HEK,      "HasNAME_HEK,"},
+    {CVf_LEXICAL,          "LEXICAL,"},
+    {CVf_ISXSUB,           "ISXSUB,"},
     {CVf_ANONCONST,        "ANONCONST,"},
     {CVf_SIGNATURE,        "SIGNATURE,"},
     {CVf_REFCOUNTED_ANYSV, "REFCOUNTED_ANYSV,"},
@@ -3036,7 +3036,7 @@ Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bo
                                          (IV)CvXSUBANY(sv).any_i32);
             }
         }
-        if (CvNAMED(sv))
+        if (CvHasNAME_HEK(sv))
             dump_indent(level, file, "  NAME = \"%s\"\n",
                                         HEK_KEY(CvNAME_HEK((CV *)sv)));
         else do_gvgv_dump(level, file, "  GVGV::GV", CvGV(sv));

--- a/ext/B/B.pm
+++ b/ext/B/B.pm
@@ -20,7 +20,7 @@ sub import {
 # walkoptree comes from B.xs
 
 BEGIN {
-    $B::VERSION = '1.92';
+    $B::VERSION = '1.93';
     @B::EXPORT_OK = ();
 
     # Our BOOT code needs $VERSION set, and will append to @EXPORT_OK.
@@ -93,6 +93,9 @@ our @specialsv_name = qw(Nullsv &PL_sv_undef &PL_sv_yes &PL_sv_no
 {
     no warnings 'once';
     *CVf_METHOD = \&CVf_NOWARN_AMBIGUOUS;
+    *CVf_NAMED  = \&CVf_HasNAME_HEK;
+
+    push @B::EXPORT_OK, qw( CVf_METHOD CVf_NAMED );
 }
 
 {

--- a/ext/B/B.xs
+++ b/ext/B/B.xs
@@ -2192,7 +2192,7 @@ SV *
 NAME_HEK(cv)
 	B::CV cv
     CODE:
-	RETVAL = CvNAMED(cv) ? newSVhek(CvNAME_HEK(cv)) : &PL_sv_undef;
+	RETVAL = CvHasNAME_HEK(cv) ? newSVhek(CvNAME_HEK(cv)) : &PL_sv_undef;
     OUTPUT:
 	RETVAL
 

--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -364,8 +364,8 @@ do_test('reference to named subroutine without prototype',
   RV = $ADDR
   SV = PVCV\\($ADDR\\) at $ADDR
     REFCNT = (3|4)
-    FLAGS = \\((?:HASEVAL(?:,NAMED)?)?\\)	# $] < 5.015 || !thr
-    FLAGS = \\(DYNFILE(?:,HASEVAL(?:,NAMED)?)?\\) # $] >= 5.015 && thr
+    FLAGS = \\((?:HASEVAL(?:,(?:NAMED|HasNAME_HEK))?)?\\)         # $] < 5.015 || !thr
+    FLAGS = \\(DYNFILE(?:,HASEVAL(?:,(?:NAMED|HasNAME_HEK))?)?\\) # $] >= 5.015 && thr
     COMP_STASH = $ADDR\\t"main"
     START = $ADDR ===> \\d+
     ROOT = $ADDR

--- a/gv.c
+++ b/gv.c
@@ -246,7 +246,7 @@ Perl_cvgv_set(pTHX_ CV* cv, GV* gv)
 {
     PERL_ARGS_ASSERT_CVGV_SET;
 
-    GV * const oldgv = CvNAMED(cv) ? NULL : SvANY(cv)->xcv_gv_u.xcv_gv;
+    GV * const oldgv = CvHasNAME_HEK(cv) ? NULL : SvANY(cv)->xcv_gv_u.xcv_gv;
     HEK *hek;
 
     if (oldgv == gv)
@@ -266,7 +266,7 @@ Perl_cvgv_set(pTHX_ CV* cv, GV* gv)
         CvLEXICAL_off(cv);
     }
 
-    CvNAMED_off(cv);
+    CvHasNAME_HEK_off(cv);
     SvANY(cv)->xcv_gv_u.xcv_gv = gv;
     assert(!CvCVGV_RC(cv));
 
@@ -308,12 +308,12 @@ Perl_cvgv_from_hek(pTHX_ CV *cv)
         gv_init_pvn(gv, CvSTASH(cv), HEK_KEY(CvNAME_HEK(cv)),
                 HEK_LEN(CvNAME_HEK(cv)),
                 SVf_UTF8 * cBOOL(HEK_UTF8(CvNAME_HEK(cv))));
-    if (!CvNAMED(cv)) { /* gv_init took care of it */
+    if (!CvHasNAME_HEK(cv)) { /* gv_init took care of it */
         assert (SvANY(cv)->xcv_gv_u.xcv_gv == gv);
         return gv;
     }
     unshare_hek(CvNAME_HEK(cv));
-    CvNAMED_off(cv);
+    CvHasNAME_HEK_off(cv);
     SvANY(cv)->xcv_gv_u.xcv_gv = gv;
     if (svp && *svp) SvREFCNT_inc_simple_void_NN(gv);
     CvCVGV_RC_on(cv);
@@ -531,7 +531,7 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
         /* Not actually a constant.  Just a regular sub.  */
         CV * const cv = (CV *)has_constant;
         GvCV_set(gv,cv);
-        if (CvNAMED(cv) && CvSTASH(cv) == stash && (
+        if (CvHasNAME_HEK(cv) && CvSTASH(cv) == stash && (
                CvNAME_HEK(cv) == GvNAME_HEK(gv)
             || (  HEK_LEN(CvNAME_HEK(cv)) == HEK_LEN(GvNAME_HEK(gv))
                && HEK_FLAGS(CvNAME_HEK(cv)) != HEK_FLAGS(GvNAME_HEK(gv))
@@ -1485,7 +1485,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
      * use that, but for lack of anything better we will use the sub's
      * original package to look up $AUTOLOAD.
      */
-    varstash = CvNAMED(cv) ? CvSTASH(cv) : GvSTASH(CvGV(cv));
+    varstash = CvHasNAME_HEK(cv) ? CvSTASH(cv) : GvSTASH(CvGV(cv));
     vargv = *(GV**)hv_fetch(varstash, S_autoload, S_autolen, TRUE);
     ENTER;
 
@@ -3229,7 +3229,7 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
         if (gv && (cv = GvCV(gv)) && CvHASGV(cv)) {
             const HEK * const gvhek = CvGvNAME_HEK(cv);
             const HEK * const stashek =
-                HvNAME_HEK(CvNAMED(cv) ? CvSTASH(cv) : GvSTASH(CvGV(cv)));
+                HvNAME_HEK(CvHasNAME_HEK(cv) ? CvSTASH(cv) : GvSTASH(CvGV(cv)));
             if (memEQs(HEK_KEY(gvhek), HEK_LEN(gvhek), "nil")
              && stashek
              && memEQs(HEK_KEY(stashek), HEK_LEN(stashek), "overload")) {
@@ -4401,7 +4401,7 @@ Perl_gv_try_downgrade(pTHX_ GV *gv)
         (void)hv_deletehek(stash, gvnhek, G_DISCARD);
     } else if (GvMULTI(gv) && cv && SvREFCNT(cv) == 1 &&
             !SvOBJECT(cv) && !SvMAGICAL(cv) && !SvREADONLY(cv) &&
-            CvSTASH(cv) == stash && !CvNAMED(cv) && CvGV(cv) == gv &&
+            CvSTASH(cv) == stash && !CvHasNAME_HEK(cv) && CvGV(cv) == gv &&
             CvCONST(cv) && !CvNOWARN_AMBIGUOUS(cv) && !CvLVALUE(cv) && !CvUNIQUE(cv) &&
             !CvNODEBUG(cv) && !CvCLONE(cv) && !CvCLONED(cv) && !CvANON(cv) &&
             (namehek = GvNAME_HEK(gv)) &&

--- a/inline.h
+++ b/inline.h
@@ -241,7 +241,7 @@ Perl_CvGV(pTHX_ CV *sv)
 {
     PERL_ARGS_ASSERT_CVGV;
 
-    return CvNAMED(sv)
+    return CvHasNAME_HEK(sv)
         ? Perl_cvgv_from_hek(aTHX_ sv)
         : ((XPVCV*)MUTABLE_PTR(SvANY(sv)))->xcv_gv_u.xcv_gv;
 }

--- a/mg.c
+++ b/mg.c
@@ -4233,7 +4233,7 @@ Perl_perly_sighandler(int sig, Siginfo_t *sip PERL_UNUSED_DECL,
     if (!cv || !CvROOT(cv)) {
         const HEK * const hek = gv
                         ? GvENAME_HEK(gv)
-                        : cv && CvNAMED(cv)
+                        : cv && CvHasNAME_HEK(cv)
                            ? CvNAME_HEK(cv)
                            : cv && CvGV(cv) ? GvENAME_HEK(CvGV(cv)) : NULL;
         if (hek)

--- a/op.c
+++ b/op.c
@@ -11095,7 +11095,7 @@ Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p,
             sv_catpvs(name, "::");
             if (SvROK(gv)) {
                 assert (SvTYPE(SvRV_const(gv)) == SVt_PVCV);
-                assert (CvNAMED(SvRV_const(gv)));
+                assert (CvHasNAME_HEK(SvRV_const(gv)));
                 sv_cathek(name, CvNAME_HEK(MUTABLE_CV(SvRV_const(gv))));
             }
             else sv_catsv(name, (SV *)gv);
@@ -11363,7 +11363,7 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         cv = *spot;
     else {
         assert (*spot && SvTYPE(*spot) == SVt_PVCV);
-        if (CvNAMED(*spot))
+        if (CvHasNAME_HEK(*spot))
             hek = CvNAME_HEK(*spot);
         else {
             U32 hash;
@@ -11479,7 +11479,7 @@ Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         if (block) {
             bool free_file = CvFILE(cv) && CvDYNFILE(cv);
             cv_flags_t preserved_flags =
-                CvFLAGS(cv) & (CVf_BUILTIN_ATTRS|CVf_NAMED);
+                CvFLAGS(cv) & (CVf_BUILTIN_ATTRS|CVf_HasNAME_HEK);
             PADLIST *const temp_padl = CvPADLIST(cv);
             CV *const temp_cv = CvOUTSIDE(cv);
             const cv_flags_t other_flags =
@@ -12090,7 +12090,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
 
             SvPOK_off(cv);
             CvFLAGS(cv) = CvFLAGS(PL_compcv) | existing_builtin_attrs
-                                             | CvNAMED(cv);
+                                             | CvHasNAME_HEK(cv);
             CvOUTSIDE(cv) = CvOUTSIDE(PL_compcv);
             CvOUTSIDE_SEQ(cv) = CvOUTSIDE_SEQ(PL_compcv);
             CvPADLIST_set(cv,CvPADLIST(PL_compcv));
@@ -12187,7 +12187,7 @@ Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs,
   attrs:
     if (attrs) {
         /* Need to do a C<use attributes $stash_of_cv,\&cv,@attrs>. */
-        HV *stash = name && !CvNAMED(cv) && GvSTASH(CvGV(cv))
+        HV *stash = name && !CvHasNAME_HEK(cv) && GvSTASH(CvGV(cv))
                         ? GvSTASH(CvGV(cv))
                         : PL_curstash;
         if (!name)
@@ -15501,7 +15501,7 @@ Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags)
         return (CV*)gv;
     }
     else if (flags & RV2CVOPCV_MAYBE_NAME_GV) {
-        if (CvLEXICAL(cv) || CvNAMED(cv))
+        if (CvLEXICAL(cv) || CvHasNAME_HEK(cv))
             return NULL;
         if (!CvANON(cv) || !gv)
             gv = CvGV(cv);
@@ -16209,7 +16209,7 @@ Perl_ck_subr(pTHX_ OP *o)
                ideal for lexical subs, as its stringification will include
                the package.  But it is the best we can do.  */
             if (ckflags & CALL_CHECKER_REQUIRE_GV) {
-                if (!CvANON(cv) && (!CvNAMED(cv) || CvNAME_HEK(cv)))
+                if (!CvANON(cv) && (!CvHasNAME_HEK(cv) || CvNAME_HEK(cv)))
                     namegv = CvGV(cv);
             }
             else namegv = MUTABLE_GV(cv);

--- a/pad.c
+++ b/pad.c
@@ -371,9 +371,9 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
     SvPOK_off(MUTABLE_SV(cv));		/* forget prototype */
     sv_unmagic((SV *)cv, PERL_MAGIC_checkcall);
     if (!(flags & CV_UNDEF_KEEP_NAME)) {
-        if (CvNAMED(&cvbody)) {
+        if (CvHasNAME_HEK(&cvbody)) {
             CvNAME_HEK_set(&cvbody, NULL);
-            CvNAMED_off(&cvbody);
+            CvHasNAME_HEK_off(&cvbody);
         }
         else CvGV_set(cv, NULL);
     }
@@ -492,7 +492,7 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
      * ref status of CvOUTSIDE and CvGV, and ANON, NAMED and
      * LEXICAL, which are used to determine the sub's name.  */
     CvFLAGS(&cvbody) &= (CVf_WEAKOUTSIDE|CVf_CVGV_RC|CVf_ANON|CVf_LEXICAL
-                   |CVf_NAMED);
+                   |CVf_HasNAME_HEK);
 }
 
 /*
@@ -2289,7 +2289,7 @@ S_cv_clone(pTHX_ CV *proto, CV *cv, CV *outside, HV *cloned)
 
     CvFILE(cv)		= CvDYNFILE(proto) ? savepv(CvFILE(proto))
                                            : CvFILE(proto);
-    if (CvNAMED(proto))
+    if (CvHasNAME_HEK(proto))
          CvNAME_HEK_set(cv, share_hek_hek(CvNAME_HEK(proto)));
     else CvGV_set(cv,CvGV(proto));
     CvSTASH_set(cv, CvSTASH(proto));
@@ -2382,7 +2382,7 @@ Perl_cv_name(pTHX_ CV *cv, SV *sv, U32 flags)
     {
         SV * const retsv = sv ? (sv) : sv_newmortal();
         if (SvTYPE(cv) == SVt_PVCV) {
-            if (CvNAMED(cv)) {
+            if (CvHasNAME_HEK(cv)) {
                 if (CvLEXICAL(cv) || flags & CV_NAME_NOTQUAL)
                     sv_sethek(retsv, CvNAME_HEK(cv));
                 else {

--- a/pp.c
+++ b/pp.c
@@ -1066,7 +1066,7 @@ PP(pp_undef)
                        SVfARG(CvANON((const CV *)sv)
                          ? newSVpvs_flags("(anonymous)", SVs_TEMP)
                          : newSVhek_mortal(
-                            CvNAMED(sv)
+                            CvHasNAME_HEK(sv)
                              ? CvNAME_HEK((CV *)sv)
                              : GvENAME_HEK(CvGV((const CV *)sv))
                            )

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -482,6 +482,7 @@ my @unresolved_visibility_overrides = qw(
     CvHASEVAL_off
     CvHASEVAL_on
     CvHASGV
+    CvHasNAME_HEK
     CvHSCXT
     CvIsMETHOD
     CvIsMETHOD_off
@@ -3533,6 +3534,9 @@ my @needed_by_ext = qw(
 # part have a trailing underscore, indicating the intent for this symbol to
 # not be directly usable by XS code
 my @undocumented_always_visible = qw(
+    CVf_HasNAME_HEK
+    CvHasNAME_HEK_off
+    CvHasNAME_HEK_on
     DEBUG_A
     DEBUG_A_FLAG
     DEBUG_A_TEST

--- a/sv.c
+++ b/sv.c
@@ -7599,7 +7599,7 @@ S_anonymise_cv_maybe(pTHX_ GV *gv, CV* cv)
     assert(GvGP(gv));
     assert(!CvANON(cv));
     assert(CvGV(cv) == gv);
-    assert(!CvNAMED(cv));
+    assert(!CvHasNAME_HEK(cv));
 
     /* will the CV shortly be freed by gp_free() ? */
     if (GvCV(gv) == cv && GvGP(gv)->gp_refcnt < 2 && SvREFCNT(cv) < 2) {
@@ -16245,7 +16245,7 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
                 }
                 assert(!CvSLABBED(dsv));
                 if (CvDYNFILE(dsv)) CvFILE(dsv) = SAVEPV(CvFILE(dsv));
-                if (CvNAMED(dsv))
+                if (CvHasNAME_HEK(dsv))
                     SvANY((CV *)dsv)->xcv_gv_u.xcv_hek =
                         hek_dup(CvNAME_HEK((CV *)ssv), param);
                 /* don't dup if copying back - CvGV isn't refcounted, so the

--- a/universal.c
+++ b/universal.c
@@ -394,7 +394,7 @@ Perl_croak_xs_usage(const CV *const cv, const char *const params)
     PERL_ARGS_ASSERT_CROAK_XS_USAGE;
 
     /* Avoid CvGV as it requires aTHX.  */
-    const GV *gv = CvNAMED(cv) ? NULL : cv->sv_any->xcv_gv_u.xcv_gv;
+    const GV *gv = CvHasNAME_HEK(cv) ? NULL : cv->sv_any->xcv_gv_u.xcv_gv;
 
     if (gv) got_gv: {
         const HV *const stash = GvSTASH(gv);

--- a/util.c
+++ b/util.c
@@ -6850,7 +6850,7 @@ Perl_dtrace_probe_call(pTHX_ CV *cv, bool is_call)
     const COP  *start;
     line_t      line;
 
-    if (CvNAMED(cv)) {
+    if (CvHasNAME_HEK(cv)) {
         HEK *hek = CvNAME_HEK(cv);
         func = HEK_KEY(hek);
     }


### PR DESCRIPTION
The previous name was misleading; most CVs have "a name", by way of the GvNAME_HEK of their CvGV. This flag indicated the unusual case of a CV not having a CvGV but instead having a name directly set with a HEK stored directly in the CV.

Rather than write all that in the upcoming documentation for it, I decided it nicer and less misleading to just rename the flag and associated macros to a more meaningful one. This follows the new pattern of putting "Is" or "Has" in title case in the macro name, which tends to be more readable (and is less likely to be misread as "HASH").

* I don't feel that this set of changes requires a perldelta entry because none of the affected items are *officially* part of the documented API (yet)