### PR TITLE
pp_ref_cmp - improve correctness of package name comparisons

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -616,13 +616,16 @@ PP(pp_ref_cmp)
                 if ((U32)namelen <= 7) { /* Is it 0-7 chars long? */
                     const char * name = HEK_KEY(namehek);
 
-                    if (wanted <= SVrt_INVLIST && (strncmp(PL_sv_reftype_lookup[wanted],name, namelen) == 0))
+                    if (wanted <= SVrt_INVLIST
+                        && ((I32)strlen(PL_sv_reftype_lookup[wanted]) == namelen)
+                        && memEQ(PL_sv_reftype_lookup[wanted], name, namelen)
+                        )
                          goto matched;
 
                     if (namelen == 6 && (wanted == OPpREF_CMP_REGEXP_PKG && memEQs(name, 6, "Regexp")))
                          goto matched;
 
-                    if (namelen == 6 && wanted == OPpREF_CMP_EMPTYSTR)
+                    if (namelen == 0 && wanted == OPpREF_CMP_EMPTYSTR)
                          goto matched;
                 }
             }

--- a/t/op/ref.t
+++ b/t/op/ref.t
@@ -8,7 +8,7 @@ BEGIN {
 
 use strict qw(refs subs);
 
-plan(476);
+plan(479);
 
 # Test this first before we extend the stack with other operations.
 # This caused an asan failure due to a bad write past the end of the stack.
@@ -1032,7 +1032,13 @@ EOF
     ok( (builtin::reftype $no eq ''), "ref_cmp: (reftype \$undef eq '') is true");
     ok( (ref $rqr eq 'Regexp'), "ref_cmp: (ref qr// eq 'Regexp') is true");
     ok( (builtin::reftype $rqr eq 'REGEXP'), "ref_cmp: (reftype qr// eq 'REGEXP') is true");
-
+    # GH# 24621 and adjacent bugs - reftype and ref use the same codepaths here
+    my $empty = bless {}, "BADBUG";
+    my $scala = bless {}, "SCALA";
+    my $ioNULL= bless {}, "IO\0X";
+    ok( (ref $empty ne ''),  "ref_cmp: ref ne '' for object blessed into 'BADBUG'");
+    ok( (ref $scala ne 'SCALAR'),  "ref_cmp: ref ne 'SCALAR' for object blessed into 'SCALA'");
+    ok( (ref $ioNULL ne 'IO'), "ref_cmp: ref ne 'IO' for object blessed into 'IO\\0X'");
 }
 
 # Bit of a hack to make test.pl happy. There are 3 more tests after it leaves.


### PR DESCRIPTION
f7504b2b932ed510a2d733413e7848d452cb840f streamlined SV ref type comparisons but introduced two types of bug.

* A copy/paste error caused #24621, as the `OPpREF_CMP_EMPTYSTR` check erroneously fired for package length of six instead of zero.

* Package names that are truncated versions of the builtin types, or contained embedded nulls, were improperly compared.

This commit fixes the above and adds tests.

Closes #24621 

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
