### PR TITLE
hints/darwin.sh: Use mkostemp from Sierra onwards

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -521,8 +521,13 @@ case "$osvers" in
 esac
 
 # mkostemp() was autodetected as present but found to not be linkable
-# on 15.6.0.  Unknown what other OS versions are affected.
-d_mkostemp=undef
+# on El Capitan (10.11.6/darwin 15.6.0).
+# It is documented as available from Sierra (10.12/darwin 16) in mkostemp(3).
+case "$osvers" in
+    [1-9].*|1[0-5].*)
+        d_mkostemp=undef
+        ;;
+esac
 
 # Apparently the MACH-O format can't support _Thread_local in shared objects,
 # but clang isn't wise to this, so our probe works but the build fails...

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -370,6 +370,11 @@ L</Modules and Pragmata> section.
 
 XXX
 
+=item MacOS (Darwin)
+
+Use of mkostemp(3) enabled on macOS 10.12 Sierra (Darwin 16) and newer,
+where it is available.
+
 =back
 
 =head1 Internal Changes


### PR DESCRIPTION
It's found defined in `unistd.h` in El Capitan but guarded off with availability macros to indicate it's available from 10.12.
I guess that's where the issue arose with it being detected and not being able to link to it.

Tested with Perl 5.44.0 on OS X El Capitan 10.11 (darwin 15) with test suite passing.
Tested with Perl 5.44.0 on macOS Sierra 10.12 (darwin 16) with test suite passing.
Tested with blead on macOS 12 (darwin 21) with test suite passing.

* This set of changes requires a perldelta entry, and it is included.
