### PR TITLE
hints/darwin.sh: adjust comment about readdir_r()

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -528,15 +528,8 @@ d_mkostemp=undef
 # but clang isn't wise to this, so our probe works but the build fails...
 d_thread_local=undef
 
-# from man readdir_r
-#     The readdir_r() interface is deprecated because it cannot be used
-#     correctly unless {NAME_MAX} is a fixed value.
-# This note is present in the 10.15.7 man pages, but not the 10.13.6
-# man page.
-#
-# OS X 10.15 is kernel version 19 (https://en.wikipedia.org/wiki/MacOS)
-#
-# https://man.freebsd.org/cgi/man.cgi?query=readdir_r&apropos=0&sektion=0&manpath=macOS+10.15.7&format=html
+# readdir_r() is noted as deprecated in directory(3) from Catalina onwards (10.15 / darwin 19)
+# https://github.com/apple-oss-distributions/Libc/blob/Libc-1353.11.2/gen/directory.3#L69-L74
 case "$osvers" in
     [0-9].*|1[0-8].*) ;;
     *) d_readdir_r=undef ;;


### PR DESCRIPTION
It was deprecated in the 10.15 (Libc-1353.11.2).
Not there in the directory(3) manual from macOS 10.14.6. (Libc-1272.250.1).
Point to Apple's Libc source for reference.

* This set of changes does not require a perldelta entry.
