### PR TITLE
OP_REF_CMP - don't apply to a TARGMY reftype

### DIFF
--- a/op.c
+++ b/op.c
@@ -4532,6 +4532,7 @@ Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
     /* Check for ref/reftype $x eq/ne 'BUILTIN_TYPE' */
     OP *splice = NULL;
     U8 builtin_u8 = 0;
+    bool has_targmy;
 
     if ((OP_TYPE_IS(left, OP_REF) || OP_TYPE_IS(left, OP_REFTYPE))&& OP_TYPE_IS(right, OP_CONST)) {
         splice = left;
@@ -4541,7 +4542,12 @@ Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
         splice = right;
         builtin_u8 = S_ref_cmp_type(aTHX_ left);
       ref_seqne_check:
-        if ((type ==OP_SEQ || type == OP_SNE) && builtin_u8) {
+        /* ref() doesn't support TARGMY. reftype() does and it does
+         * very occasionally get applied - see GH#24630. */
+        has_targmy = ((PL_opargs[splice->op_type] & OA_TARGLEX)
+                                && (splice->op_private & OPpTARGET_MY));
+
+        if ((type ==OP_SEQ || type == OP_SNE) && builtin_u8 && !has_targmy) {
             U8 flags = OP_TYPE_IS(splice, OP_REFTYPE) ? OPf_SPECIAL : 0;
             if (type == OP_SNE) builtin_u8 |= OPpREF_CMP_NE;
             OP *referant = op_sibling_splice(splice,NULL,1,NULL);

--- a/t/op/ref.t
+++ b/t/op/ref.t
@@ -8,7 +8,7 @@ BEGIN {
 
 use strict qw(refs subs);
 
-plan(479);
+plan(481);
 
 # Test this first before we extend the stack with other operations.
 # This caused an asan failure due to a bad write past the end of the stack.
@@ -1032,6 +1032,7 @@ EOF
     ok( (builtin::reftype $no eq ''), "ref_cmp: (reftype \$undef eq '') is true");
     ok( (ref $rqr eq 'Regexp'), "ref_cmp: (ref qr// eq 'Regexp') is true");
     ok( (builtin::reftype $rqr eq 'REGEXP'), "ref_cmp: (reftype qr// eq 'REGEXP') is true");
+
     # GH# 24621 and adjacent bugs - reftype and ref use the same codepaths here
     my $empty = bless {}, "BADBUG";
     my $scala = bless {}, "SCALA";
@@ -1039,6 +1040,13 @@ EOF
     ok( (ref $empty ne ''),  "ref_cmp: ref ne '' for object blessed into 'BADBUG'");
     ok( (ref $scala ne 'SCALAR'),  "ref_cmp: ref ne 'SCALAR' for object blessed into 'SCALA'");
     ok( (ref $ioNULL ne 'IO'), "ref_cmp: ref ne 'IO' for object blessed into 'IO\\0X'");
+
+    # GH#24630 - ref_cmp doesn't support TARGMY, reftype might have it set
+    my $rt1; my $rt2;
+    (($rt1 = ref($rav)) eq 'HASH' or $rt eq 'ARRAY');
+    is($rt1, 'ARRAY', "ref_cmp: no clash with TARGMY for ref");
+    (($rt2 = builtin::reftype($rav)) eq 'HASH' or $rt eq 'ARRAY');
+    is($rt2, 'ARRAY', "ref_cmp: no clash with TARGMY for refype");
 }
 
 # Bit of a hack to make test.pl happy. There are 3 more tests after it leaves.


### PR DESCRIPTION
OP_REF_CMP does not currently support the TARGMY optimization, so should not replace an OP that has already had it applied.

GH#24630 provided an example of this happening, along the lines of:

    my $bool = ( ($r = reftype($x)) eq 'HASH' or $r eq 'ARRAY' );

Where the assignment into `$r` is via TARGMY on the `reftype`.

Closes #24630

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
