### PR TITLE
Convert PL_sv_reftype_lookup to store reftype values and their lengths

### DIFF
--- a/op.c
+++ b/op.c
@@ -4497,7 +4497,7 @@ S_ref_cmp_type(pTHX_ OP * constop)
 
     /* Compare against the builtin types */
     for (unsigned int i = 0; i < 14; i++) {
-        if (strcmp(PL_sv_reftype_lookup[i], str) == 0) {
+        if (strcmp(PL_sv_reftype_lookup[i].str, str) == 0) {
             return i;
         }
     }

--- a/pp.c
+++ b/pp.c
@@ -617,8 +617,8 @@ PP(pp_ref_cmp)
                     const char * name = HEK_KEY(namehek);
 
                     if (wanted <= SVrt_INVLIST
-                        && ((I32)strlen(PL_sv_reftype_lookup[wanted]) == namelen)
-                        && memEQ(PL_sv_reftype_lookup[wanted], name, namelen)
+                        && ((I32)PL_sv_reftype_lookup[wanted].len == namelen)
+                        && memEQ(PL_sv_reftype_lookup[wanted].str, name, namelen)
                         )
                          goto matched;
 

--- a/sv.c
+++ b/sv.c
@@ -11798,21 +11798,22 @@ Perl_sv_pvutf8n_force(pTHX_ SV *const sv, STRLEN *const lp)
  * are mirrored by the SVrt_* constants defined in op_private for
  * OP_REF_CMP but also used below by Perl_sv_reftype_id.
 */
-const char * const PL_sv_reftype_lookup[PL_sv_reftype_lookup_MAX] = {
-    "UNKNOWN", /* 0 */
-    "ARRAY",   /* 1 */
-    "HASH",    /* 2 */
-    "CODE",    /* 3 */
-    "REF",     /* 5 */
-    "SCALAR",  /* 6 */
-    "GLOB",    /* 4 */
-    "REGEXP",  /* 7 */
-    "OBJECT",  /* 8 */
-    "LVALUE",  /* 9 */
-    "IO",      /* 10 */
-    "FORMAT",  /* 11 */
-    "VSTRING", /* 12 */
-    "INVLIST", /* 13 */
+
+const sv_reftype_entry PL_sv_reftype_lookup[PL_sv_reftype_lookup_MAX] = {
+    {STR_WITH_LEN("UNKNOWN")}, /* 0 */
+    {STR_WITH_LEN("ARRAY")},   /* 1 */
+    {STR_WITH_LEN("HASH")},    /* 2 */
+    {STR_WITH_LEN("CODE")},    /* 3 */
+    {STR_WITH_LEN("REF")},     /* 5 */
+    {STR_WITH_LEN("SCALAR")},  /* 6 */
+    {STR_WITH_LEN("GLOB")},    /* 4 */
+    {STR_WITH_LEN("REGEXP")},  /* 7 */
+    {STR_WITH_LEN("OBJECT")},  /* 8 */
+    {STR_WITH_LEN("LVALUE")},  /* 9 */
+    {STR_WITH_LEN("IO")},      /* 10 */
+    {STR_WITH_LEN("FORMAT")},  /* 11 */
+    {STR_WITH_LEN("VSTRING")}, /* 12 */
+    {STR_WITH_LEN("INVLIST")}, /* 13 */
 };
 
 U8
@@ -11884,7 +11885,7 @@ Perl_sv_reftype(pTHX_ const SV *const sv, const int ob)
         return SvPV_nolen_const(sv_ref(NULL, sv, ob));
     }
     else {
-        return PL_sv_reftype_lookup[ sv_reftype_id(sv) ];
+        return PL_sv_reftype_lookup[ sv_reftype_id(sv) ].str;
     }
 }
 

--- a/sv.h
+++ b/sv.h
@@ -2915,8 +2915,12 @@ macro family.
  * If external visibility is required in the future, it should be
  * via a new function rather than directly. */
 #ifdef PERL_CORE
+typedef struct {
+    const char * str;
+    STRLEN len;
+} sv_reftype_entry;
 #define PL_sv_reftype_lookup_MAX 14
-extern const char *const PL_sv_reftype_lookup[PL_sv_reftype_lookup_MAX];
+extern const sv_reftype_entry PL_sv_reftype_lookup[PL_sv_reftype_lookup_MAX];
 #endif
 
 /*


### PR DESCRIPTION
So that `pp_ref_cmp` doesn't have to determine the strlen for itself.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
