### PR TITLE
perl.h: cast locale context to PerlInterpreter *

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -6440,10 +6440,10 @@ INIT({
 #endif
 
 #ifdef USE_PERL_SWITCH_LOCALE_CONTEXT
-#  define PERL_SET_LOCALE_CONTEXT(i)                                        \
-      STMT_START {                                                          \
-          if (LIKELY(! (i)->Iveto_switch_non_tTHX_context))                 \
-                Perl_switch_locale_context(i);                              \
+#  define PERL_SET_LOCALE_CONTEXT(i)                                             \
+      STMT_START {                                                               \
+          if (LIKELY(! ((PerlInterpreter *)(i))->Iveto_switch_non_tTHX_context)) \
+              Perl_switch_locale_context(i);                                     \
       } STMT_END
 
     /* In some Configurations there may be per-thread information that is


### PR DESCRIPTION
Some modules pass a void pointer as the context (e.g. Glib, Cairo). This is fine with Perl_switch_locale_context, which implicitly converts its argument, but we need an explicit cast to PerlInterpreter * if we want to dereference it to get at Iveto_switch_non_tTHX_context.

Fixes #24597, #24598, #24599.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
