### PR TITLE
regex: fix recent bug with  fixed utf8 substr

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -1097,11 +1097,12 @@ Perl_re_intuit_start(pTHX_
              * caller will have set strpos = pos()-4; we look for the substr
              * at position pos()-4+1, which lines up with the "a" */
 
-            if (prog->anchored_substr || prog->anchored_utf8) {
+            SV *anchored_sv = utf8_target ? prog->anchored_utf8
+                                       : prog->anchored_substr;
+
+            if (anchored_sv) {
                 /* Substring at constant offset from beg-of-str... */
 
-                SV *anchored_sv = utf8_target ? prog->anchored_utf8
-                                           : prog->anchored_substr;
                 SSize_t slen = SvCUR(anchored_sv);
                 SSize_t offset = prog->substrs->data[0].min_offset;
                 char *s = HOP3c(strpos, offset, strend);

--- a/t/re/pat.t
+++ b/t/re/pat.t
@@ -28,7 +28,7 @@ skip_all_without_unicode_tables();
 my $has_locales = locales_enabled('LC_CTYPE');
 my $utf8_locale = find_utf8_ctype_locale();
 
-plan tests => 1298;  # Update this when adding/deleting tests.
+plan tests => 1300;  # Update this when adding/deleting tests.
 
 run_tests() unless caller;
 
@@ -2647,6 +2647,20 @@ SKIP:
         unlike "",             $pat,               "code in array 16 not 1";
         unlike "XAB-B-=EC",    $pat,               "code in array 16 not 2";
 
+    }
+
+    {
+        # GH #24614
+        # On an anchored patten with utf8 fixed substring, where there is
+        # no equivalent non-utf8 substring which can be compared to a
+        # non-utf8 pattern, abandon intuit rather than trying to use a
+        # non-existent substr. It was necessary to run the match twice to
+        # trigger the bug, as the sub-optimal way intuit works meant that
+        # wasn't trying on the first iteration.
+
+        for my $i (1..2) {
+            ok("pqrs" !~ m{^\x{100}.+?AB}, "GH #24614 iter $i");
+        }
     }
 
     {


### PR DESCRIPTION
GH #24614

v5.45.0-199-g63f838213c, while fixing a performance bug in the regex intuit system, introduced a NULL pointer defef under certain circumstances. In particular, where:

    - the pattern is anchored;
    - it has a fixed utf8 substring;
    - that substring can't be downgraded to non-utf8;
    - that pattern is matched against a non-utf8 string at least twice.

The cause is assuming intuit can use the fixed substring if either the utf8 or non-utf8 is present, but then using the variant relevant to the utf8-ness of the string being matched (which may be NULL).

The fix is trivial - retrieve the relevant substr SV first, and only use it if it's non-NULL.

The pattern has to be matched twice due to the way S_to_byte_substr() works: it's called the first time to attempt to downgrade the fixed and floating substrings. Because the fixed substring can't be downgraded, it returns false and intuit_start() abandons the effort. On second iteration, the floating non-utf8 substr is now present, which is enough to make intuit_start() skip calling S_to_byte_substr(). This whole area of intuit is a bit rough.

* This set of changes does not require a perldelta entry.
