### PR TITLE
autodoc.pl: Generate missing pod for back-compat symbols

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -1851,9 +1851,21 @@ sub docout ($fh, $section_name, $element_name, $docref) {
     my $flags = $item0->{flags};
 
     if ($pod !~ /\S/) {
-        die "Empty pod for $element_name ("
-           . where_from_string($item0->{file}, $item0->{line_num})
-           . ')';
+        if ($flags !~ /B/) {
+            die "Empty pod for $element_name ("
+              . where_from_string($item0->{file}, $item0->{line_num})
+              . ')';
+        }
+        else {
+            # We accept empty pod for backwards compatibilty-only elements.  
+            # Doing so allows a modicum of documentation without us having to
+            # work at figuring out what to say for something that shouldn't be
+            # being used anyway.
+            $pod = <<~EOT;
+                No further documentation is currently available.
+                Patches welcome.
+                EOT
+        }
     }
 
     print $fh "\n=over $description_indent\n";

--- a/perl.h
+++ b/perl.h
@@ -756,6 +756,16 @@ This is now a synonym for dNOOP: declare nothing
 =for apidoc Amn;||dMY_CXT_SV
 Now a placeholder that declares nothing
 
+=for apidoc ABmn||pTHXo
+
+=for apidoc ABmn||pTHXo_
+
+=for apidoc ABmn||aTHXo
+
+=for apidoc ABmn||aTHXo_
+
+=for apidoc ABmn||dTHXo
+
 =cut
 */
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -214,7 +214,6 @@ my @unresolved_visibility_overrides = qw(
     ASSERT_NOT_PTR
     assert_not_ROK
     aTHXa
-    aTHXo
     aTHXx
     AT_LEAST_ASCII_RESTRICTED
     AT_LEAST_UNI_SEMANTICS
@@ -650,7 +649,6 @@ my @unresolved_visibility_overrides = qw(
     dTARG
     dTARGETSTACKED
     dTHX_DEBUGGING
-    dTHXo
     dTHXs
     dTHXx
     dTOPiv
@@ -2012,7 +2010,6 @@ my @unresolved_visibility_overrides = qw(
     pTHX_9
     pTHX__FORMAT
     pTHX_FORMAT
-    pTHXo
     pTHX__VALUE
     pTHX_VALUE
     pTHXx
@@ -3053,7 +3050,6 @@ my @unresolved_visibility_overrides = qw(
     ZAPHOD32_WARN4
     ZAPHOD32_WARN5
     ZAPHOD32_WARN6
-    aTHXo_
     aTHXx_
     BASE_TWO_BYTE_HI_
     BASE_TWO_BYTE_LO_
@@ -3164,7 +3160,6 @@ my @unresolved_visibility_overrides = qw(
     __PATCHLEVEL_H_INCLUDED__
     PLATFORM_SYS_INIT_
     PLATFORM_SYS_TERM_
-    pTHXo_
     pTHX__VALUE_
     pTHX_VALUE_
     pTHXx_


### PR DESCRIPTION
It's a pain to write documentation.  That helps explain why We have >3K undocumented symbols visible to the outside world.

With symbols that are retained just for backwards compatibility, that may well be all that a module maintainer needs to know: Don't use it for new code.  And that pod can be automatically generated.

This commit adds that ability and uses it for 4 symbols.  There are dozens more that could benefit from this, but I'm starting with just these to get people's reactions.


* This set of changes does not require a perldelta entry.
