### PR TITLE
Permit SV-backed PADNAMEs

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2488,11 +2488,11 @@ Cdp	|CV *	|newMYSUB	|I32 floor				\
 ARdp	|OP *	|newNULLLIST
 ARdp	|OP *	|newOP		|I32 optype				\
 				|I32 flags
-ARTdpx	|PADNAMELIST *|newPADNAMELIST					\
+ARdpx	|PADNAMELIST *|newPADNAMELIST					\
 				|size_t max
-ARTdpx	|PADNAME *|newPADNAMEouter					\
+ARdpx	|PADNAME *|newPADNAMEouter					\
 				|NN PADNAME *outer
-ARTdpx	|PADNAME *|newPADNAMEpvn|NN const char *s			\
+ARdpx	|PADNAME *|newPADNAMEpvn|NN const char *s			\
 				|STRLEN len
 ARdip	|OP *	|newPADxVOP	|I32 type				\
 				|I32 flags				\

--- a/embed.fnc
+++ b/embed.fnc
@@ -2738,6 +2738,8 @@ Adpx	|PADNAME **|padnamelist_store					\
 				|NN PADNAMELIST *pnl			\
 				|SSize_t key				\
 				|NULLOK PADNAME *val
+p	|PADNAME *|padname_upgrade_sv					\
+				|NN PADNAME *pn
 
 : pad API
 ARdp	|PADLIST *|pad_new	|int flags

--- a/embed.h
+++ b/embed.h
@@ -660,9 +660,9 @@
 # define newMYSUB(a,b,c,d,e)                    Perl_newMYSUB(aTHX_ a,b,c,d,e)
 # define newNULLLIST()                          Perl_newNULLLIST(aTHX)
 # define newOP(a,b)                             Perl_newOP(aTHX_ a,b)
-# define newPADNAMELIST                         Perl_newPADNAMELIST
-# define newPADNAMEouter                        Perl_newPADNAMEouter
-# define newPADNAMEpvn                          Perl_newPADNAMEpvn
+# define newPADNAMELIST(a)                      Perl_newPADNAMELIST(aTHX_ a)
+# define newPADNAMEouter(a)                     Perl_newPADNAMEouter(aTHX_ a)
+# define newPADNAMEpvn(a,b)                     Perl_newPADNAMEpvn(aTHX_ a,b)
 # define newPADxVOP(a,b,c)                      Perl_newPADxVOP(aTHX_ a,b,c)
 # define newPMOP(a,b)                           Perl_newPMOP(aTHX_ a,b)
 # define newPROG(a)                             Perl_newPROG(aTHX_ a)

--- a/embed.h
+++ b/embed.h
@@ -1383,6 +1383,7 @@
 #   define pad_push(a,b)                        Perl_pad_push(aTHX_ a,b)
 #   define pad_swipe(a,b)                       Perl_pad_swipe(aTHX_ a,b)
 #   define padlist_store(a,b,c)                 Perl_padlist_store(aTHX_ a,b,c)
+#   define padname_upgrade_sv(a)                Perl_padname_upgrade_sv(aTHX_ a)
 #   define parse_unicode_opts(a)                Perl_parse_unicode_opts(aTHX_ a)
 #   define parser_free(a)                       Perl_parser_free(aTHX_ a)
 #   define peep(a)                              Perl_peep(aTHX_ a)

--- a/pad.c
+++ b/pad.c
@@ -2857,10 +2857,11 @@ Perl_newPADNAMEpvn(pTHX_ const char *s, STRLEN len)
     alloc = (struct padname_with_str *)alloc2;
     pn = (PADNAME *)alloc;
     PadnameREFCNT(pn) = 1;
-    PadnamePV(pn) = alloc->xpadn_str;
-    Copy(s, PadnamePV(pn), len, char);
-    *(PadnamePV(pn) + len) = '\0';
-    PadnameLEN(pn) = len;
+    char *pv = alloc->xpadn_str;
+    Copy(s, pv, len, char);
+    *(pv + len) = '\0';
+    PadnamePV_set(pn, pv);
+    PadnameLEN_set(pn, len);
     return pn;
 }
 
@@ -2884,7 +2885,7 @@ Perl_newPADNAMEouter(pTHX_ PADNAME *outer)
     PADNAME *pn;
     Newxz(pn, 1, PADNAME);
     PadnameREFCNT(pn) = 1;
-    PadnamePV(pn) = PadnamePV(outer);
+    PadnamePV_set(pn, PadnamePV(outer));
     /* Not PadnameREFCNT(outer), because ‘outer’ may itself close over
        another entry.  The original pad name owns the buffer.  */
     PadnameREFCNT_inc(PADNAME_FROM_PV(PadnamePV(outer)));
@@ -2895,7 +2896,7 @@ Perl_newPADNAMEouter(pTHX_ PADNAME *outer)
         PadnameFIELDINFO(pn)->refcount++;
         PadnameFLAGS(pn) |= PADNAMEf_FIELD;
     }
-    PadnameLEN(pn) = PadnameLEN(outer);
+    PadnameLEN_set(pn, PadnameLEN(outer));
     return pn;
 }
 
@@ -2959,7 +2960,6 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
      ? newPADNAMEouter(padname_dup(PADNAME_FROM_PV(PadnamePV(src)), param))
      : newPADNAMEpvn(PadnamePV(src), PadnameLEN(src));
     ptr_table_store(PL_ptr_table, src, dst);
-    PadnameLEN(dst) = PadnameLEN(src);
     PadnameFLAGS(dst) = PadnameFLAGS(src);
     PadnameREFCNT(dst) = 0; /* The caller will increment it.  */
     PadnameTYPE   (dst) = (HV *)sv_dup_inc((SV *)PadnameTYPE(src), param);

--- a/pad.c
+++ b/pad.c
@@ -2709,7 +2709,7 @@ is allocated.
 */
 
 PADNAMELIST *
-Perl_newPADNAMELIST(size_t max)
+Perl_newPADNAMELIST(pTHX_ size_t max)
 {
     PERL_ARGS_ASSERT_NEWPADNAMELIST;
 
@@ -2844,7 +2844,7 @@ C<L</newPADNAMEouter>>.
 */
 
 PADNAME *
-Perl_newPADNAMEpvn(const char *s, STRLEN len)
+Perl_newPADNAMEpvn(pTHX_ const char *s, STRLEN len)
 {
     PERL_ARGS_ASSERT_NEWPADNAMEPVN;
 
@@ -2877,7 +2877,7 @@ C<PADNAMEf_OUTER> flag already set.
 */
 
 PADNAME *
-Perl_newPADNAMEouter(PADNAME *outer)
+Perl_newPADNAMEouter(pTHX_ PADNAME *outer)
 {
     PERL_ARGS_ASSERT_NEWPADNAMEOUTER;
 

--- a/pad.c
+++ b/pad.c
@@ -2924,8 +2924,37 @@ Perl_padname_free(pTHX_ PADNAME *pn)
                 Safefree(info);
             }
         }
+        if (PadnameIsFULLSV(pn))
+            SvREFCNT_dec(PadnameSV(pn));
         Safefree(pn);
     }
+}
+
+/*
+In-place upgrades a PADNAME so that PadnameIsFULLSV() is true. This stores an
+SV inside the padname, which is now always the one returned by PadnameSV().
+Code may use this SV as a place to attach magic.
+*/
+PADNAME *
+Perl_padname_upgrade_sv(pTHX_ PADNAME *pn)
+{
+    PERL_ARGS_ASSERT_PADNAME_UPGRADE_SV;
+
+    if(PadnameIsFULLSV(pn))
+        return pn;
+
+    SV *sv = newSV_type(SVt_PV);
+    SvLEN_set(sv, 0); /* sv does not own the buffer, it belongs to the underlying Padname */
+    SvCUR_set(sv, PadnameLEN(pn));
+    SvPVX(sv) = PadnamePV(pn);
+    SvPOK_on(sv);
+    SvUTF8_on(sv);
+    SvREADONLY_on(sv);
+
+    pn->xpadn_sv = sv;
+
+    PadnameFLAGS(pn) |= PADNAMEf_FULLSV;
+    return pn;
 }
 
 #if defined(USE_ITHREADS)
@@ -2956,9 +2985,20 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
         return dst;
     }
 
-    dst = PadnameOUTER(src)
-     ? newPADNAMEouter(padname_dup(PADNAME_FROM_PV(PadnamePV(src)), param))
-     : newPADNAMEpvn(PadnamePV(src), PadnameLEN(src));
+    if(PadnameOUTER(src))
+        /* Cloning an outer padname just makes a capture of the outer part
+         * regardless of whether it is SV-backed
+         */
+        dst = newPADNAMEouter(padname_dup(PADNAME_FROM_PV(PadnamePV(src)), param));
+    else {
+        dst = newPADNAMEpvn(PadnamePV(src), PadnameLEN(src));
+
+        if(PadnameIsFULLSV(src)) {
+            char *pnpv = PadnamePV(dst);
+            dst->xpadn_sv = sv_dup_inc(src->xpadn_sv, param);
+            SvPVX(dst->xpadn_sv) = pnpv;
+        }
+    }
     ptr_table_store(PL_ptr_table, src, dst);
     PadnameFLAGS(dst) = PadnameFLAGS(src);
     PadnameREFCNT(dst) = 0; /* The caller will increment it.  */

--- a/pad.h
+++ b/pad.h
@@ -247,7 +247,8 @@ The length of the name.
 Whether PadnamePV is in UTF-8.  Currently, this is always true.
 
 =for apidoc Amx|SV *|PadnameSV|PADNAME * pn
-Returns the pad name as a mortal SV.
+Returns the pad name as a mortal SV. The returned SV is marked C<SvREADONLY>;
+the caller must not attempt to modify it.
 
 =for apidoc m|bool|PadnameIsOUR|PADNAME * pn
 Whether this is an "our" variable.
@@ -341,7 +342,7 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameLEN(pn)		(pn)->xpadn_len
 #define PadnameUTF8(pn)		1
 #define PadnameSV(pn) \
-        newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8)
+        newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8|SVf_READONLY|SVf_PROTECT)
 #define PadnameFLAGS(pn)	(pn)->xpadn_flags
 #define PadnameIsOUR(pn)	cBOOL((pn)->xpadn_ourstash)
 #define PadnameOURSTASH(pn)	(pn)->xpadn_ourstash

--- a/pad.h
+++ b/pad.h
@@ -58,7 +58,10 @@ struct padnamelist {
 struct padname_fieldinfo;
 
 #define PADNAME_BASE_ \
-    char *	xpadn_pv;		\
+    union {                             \
+        char *	xpadn_pv;		\
+        SV *    xpadn_sv;               \
+    };                                  \
     HV *	xpadn_ourstash;		\
     union {				\
         HV *	xpadn_typestash;	\
@@ -247,8 +250,12 @@ The length of the name.
 Whether PadnamePV is in UTF-8.  Currently, this is always true.
 
 =for apidoc Amx|SV *|PadnameSV|PADNAME * pn
-Returns the pad name as a mortal SV. The returned SV is marked C<SvREADONLY>;
-the caller must not attempt to modify it.
+Returns the pad name as a maybe-mortal SV. The returned SV is marked
+C<SvREADONLY>; the caller must not attempt to modify it.
+
+The returned SV might be mortal, or it might be owned by the pad name itself.
+Either way, the caller should not attempt to take ownership of it or call
+C<SvREFCNT_dec> on it.
 
 =for apidoc m|bool|PadnameIsOUR|PADNAME * pn
 Whether this is an "our" variable.
@@ -338,11 +345,11 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadARRAY(pad)		AvARRAY(pad)
 #define PadMAX(pad)		AvFILLp(pad)
 
-#define PadnamePV(pn)		((pn)->xpadn_pv + 0)
-#define PadnameLEN(pn)		((pn)->xpadn_len + 0)
+#define PadnamePV(pn)		(PadnameIsFULLSV(pn) ? SvPVX((pn)->xpadn_sv) : (pn)->xpadn_pv)
+#define PadnameLEN(pn)		(PadnameIsFULLSV(pn) ? SvCUR((pn)->xpadn_sv) : (pn)->xpadn_len)
 #define PadnameUTF8(pn)		1
 #define PadnameSV(pn) \
-        newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8|SVf_READONLY|SVf_PROTECT)
+        (PadnameIsFULLSV(pn) ? (pn)->xpadn_sv : newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8|SVf_READONLY|SVf_PROTECT))
 #define PadnameFLAGS(pn)	(pn)->xpadn_flags
 #define PadnameIsOUR(pn)	cBOOL((pn)->xpadn_ourstash)
 #define PadnameOURSTASH(pn)	(pn)->xpadn_ourstash
@@ -359,6 +366,7 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadnameIsSTATE(pn)	(PadnameFLAGS(pn) & PADNAMEf_STATE)
 #define PadnameLVALUE(pn)	(PadnameFLAGS(pn) & PADNAMEf_LVALUE)
 #define PadnameIsFIELD(pn)	(PadnameFLAGS(pn) & PADNAMEf_FIELD)
+#define PadnameIsFULLSV(pn)     (PadnameFLAGS(pn) & PADNAMEf_FULLSV)
 
 #define PadnameLVALUE_on(pn)    (PadnameFLAGS(pn) |= PADNAMEf_LVALUE)
 #define PadnameIsSTATE_on(pn)   (PadnameFLAGS(pn) |= PADNAMEf_STATE)
@@ -369,10 +377,11 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PADNAMEf_TYPED      0x08    /* for B; unused by core */
 #define PADNAMEf_OUR        0x10    /* for B; unused by core */
 #define PADNAMEf_FIELD      0x20    /* field var */
+#define PADNAMEf_FULLSV     0x80    /* padname stored in SVt_PV in xpadn_sv */
 
 #ifdef PERL_CORE
-#  define PadnamePV_set(pn, pv)     ((pn)->xpadn_pv = (pv))
-#  define PadnameLEN_set(pn, len)   ((pn)->xpadn_len = (len))
+#  define PadnamePV_set(pn, pv)     (assert(!PadnameIsFULLSV(pn)), (pn)->xpadn_pv = (pv))
+#  define PadnameLEN_set(pn, len)   (assert(!PadnameIsFULLSV(pn)), (pn)->xpadn_len = (len))
 #endif
 
 /* backward compatibility */

--- a/pad.h
+++ b/pad.h
@@ -338,8 +338,8 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadARRAY(pad)		AvARRAY(pad)
 #define PadMAX(pad)		AvFILLp(pad)
 
-#define PadnamePV(pn)		(pn)->xpadn_pv
-#define PadnameLEN(pn)		(pn)->xpadn_len
+#define PadnamePV(pn)		((pn)->xpadn_pv + 0)
+#define PadnameLEN(pn)		((pn)->xpadn_len + 0)
 #define PadnameUTF8(pn)		1
 #define PadnameSV(pn) \
         newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8|SVf_READONLY|SVf_PROTECT)
@@ -369,6 +369,11 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PADNAMEf_TYPED      0x08    /* for B; unused by core */
 #define PADNAMEf_OUR        0x10    /* for B; unused by core */
 #define PADNAMEf_FIELD      0x20    /* field var */
+
+#ifdef PERL_CORE
+#  define PadnamePV_set(pn, pv)     ((pn)->xpadn_pv = (pv))
+#  define PadnameLEN_set(pn, len)   ((pn)->xpadn_len = (len))
+#endif
 
 /* backward compatibility */
 #ifndef PERL_CORE

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -422,6 +422,12 @@ L<perlclib/Dealing with embedded perls and threads>.
 During compiletime of a named subroutine, the name of the new sub
 currently being compiled is now accessible via C<CvNAME_HEK(PL_compcv)>.
 
+=item *
+
+A new internal function, C<padname_upgrade_sv()> attaches an SV onto a
+PADNAME instance, which is used to store the name string of that padname.
+This SV can be used by code that wishes to attach magic onto the padname.
+
 =back
 
 =head1 Selected Bug Fixes

--- a/proto.h
+++ b/proto.h
@@ -5129,6 +5129,14 @@ Perl_padname_free(pTHX_ PADNAME *pn)
         Perl_assert_aTHX; assert(pn)
 
 PERL_CALLCONV PADNAME *
+Perl_padname_upgrade_sv(pTHX_ PADNAME *pn)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
+        __attribute__visibility__("hidden");
+#define PERL_ARGS_ASSERT_PADNAME_UPGRADE_SV     \
+        Perl_assert_aTHX; assert(pn)
+
+PERL_CALLCONV PADNAME *
 Perl_padnamelist_fetch(PADNAMELIST *pnl, SSize_t key)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;

--- a/proto.h
+++ b/proto.h
@@ -4373,23 +4373,27 @@ Perl_newOP(pTHX_ I32 optype, I32 flags)
         Perl_assert_aTHX
 
 PERL_CALLCONV PADNAMELIST *
-Perl_newPADNAMELIST(size_t max)
+Perl_newPADNAMELIST(pTHX_ size_t max)
+        Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
-#define PERL_ARGS_ASSERT_NEWPADNAMELIST
+#define PERL_ARGS_ASSERT_NEWPADNAMELIST         \
+        Perl_assert_aTHX
 
 PERL_CALLCONV PADNAME *
-Perl_newPADNAMEouter(PADNAME *outer)
-        Perl_attribute_nonnull(1)
+Perl_newPADNAMEouter(pTHX_ PADNAME *outer)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPADNAMEOUTER        \
-        assert(outer)
+        Perl_assert_aTHX; assert(outer)
 
 PERL_CALLCONV PADNAME *
-Perl_newPADNAMEpvn(const char *s, STRLEN len)
-        Perl_attribute_nonnull(1)
+Perl_newPADNAMEpvn(pTHX_ const char *s, STRLEN len)
+        Perl_attribute_nonnull_aTHX
+        Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPADNAMEPVN          \
-        assert(s)
+        Perl_assert_aTHX; assert(s)
 
 PERL_CALLCONV OP *
 Perl_newPMOP(pTHX_ I32 type, I32 flags)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3322,6 +3322,8 @@ my @undocumented_always_visible = qw(
     KEY_UNITCHECK
     MAX_UNICODE_UTF8_BYTES
     MGf_MGv2
+    PADNAMEf_FULLSV
+    PadnameIsFULLSV
 
     assert_scalar_or_IO_
     DEBUG__

--- a/sv.c
+++ b/sv.c
@@ -10912,7 +10912,8 @@ characters) into it.  The reference count for the
 SV is set to 1.  Note that if C<len> is zero, Perl will create a zero length
 string.  You are responsible for ensuring that the source string is at least
 C<len> bytes long.  If the C<s> argument is NULL the new SV will be undefined.
-Currently the only flag bits accepted are C<SVf_UTF8> and C<SVs_TEMP>.
+Currently the only flag bits accepted are C<SVf_UTF8>, C<SVs_TEMP>,
+C<SVf_READONLY> and C<SVf_PROTECT>.
 If C<SVs_TEMP> is set, then C<sv_2mortal()> is called on the result before
 returning.  If C<SVf_UTF8> is set, C<s>
 is considered to be in UTF-8 and the
@@ -10934,7 +10935,7 @@ Perl_newSVpvn_flags(pTHX_ const char *const s, const STRLEN len, const U32 flags
 
     /* All the flags we don't support must be zero.
        And we're new code so I'm going to assert this from the start.  */
-    assert(!(flags & ~(SVf_UTF8|SVs_TEMP)));
+    assert(!(flags & ~(SVf_UTF8|SVs_TEMP|SVf_READONLY|SVf_PROTECT)));
     sv = newSV_type(SVt_PV);
     sv_setpvn_fresh(sv,s,len);
 

--- a/sv.c
+++ b/sv.c
@@ -17904,7 +17904,7 @@ Perl_init_constants(pTHX)
     SvIV_set(&PL_sv_zero, 0);
     SvNV_set(&PL_sv_zero, 0);
 
-    PadnamePV(&PL_padname_const) = (char *)PL_No;
+    PadnamePV_set(&PL_padname_const, (char *)PL_No);
 
     assert(SvIMMORTAL_INTERP(&PL_sv_yes));
     assert(SvIMMORTAL_INTERP(&PL_sv_undef));


### PR DESCRIPTION
Back before perl 5.20 pads were just AVs, containing a padname list that was just an AV, whose pad names were just string-shaped SVs. Then a whole new set of custom C-level data structures were created for padlists, pads, and padnames that are not based on SVs. This creates problems if you wish to treat a padname in a way that only SVs can be treated - for example, attaching magic to them.

A key requirement of my upcoming "attributes v2" branch is attaching magic on padnames that are used to represent signature variables, fields of object classes, and so on. These are made much simpler if padnames can (at least by special request) have an associated SV, to which such magic can be attached. In combination with my newly-merged "magic v2" branch, this PR would allow creation of a "padname magic v2 shape", which would permit trigger functions at various times related to the lifetime of the *concept* of a variable, such as the definition of a subroutine parameter or object class field. This is quite different to the existing scalar variable magic which can only be applied to actual concrete variables; such as holders for actual parameters during the lifetime of one invocation of a function or instance of object.

* This set of changes requires a perldelta entry, and I will include the following when it gets merged:

```pod
=head1 Internal Changes

=over 4

=item *

A new internal function, C<padname_upgrade_sv()> attaches an SV onto a
PADNAME instance, which is used to store the name string of that padname.
This SV can be used by code that wishes to attach magic onto the padname.

=back
```