### PR TITLE
perlsource: fix Porting/Maintainers invocation

### DIFF
--- a/pod/perlsource.pod
+++ b/pod/perlsource.pod
@@ -185,7 +185,7 @@ violations, POD encoding issues, etc.
 =item * F<Maintainers>, F<Maintainers.pl>, and F<Maintainers.pm>
 
 These files contain information on who maintains which modules. Run
-C<perl Porting/Maintainers -M Module::Name> to find out more
+C<perl Porting/Maintainers --module Module::Name> to find out more
 information about a dual-life module.
 
 =item * F<podtidy>


### PR DESCRIPTION
The suggested '-M' option doesn't work:

    $ perl Porting/Maintainers -M ExtUtils::ParseXS
    Option m is ambiguous (maintainer, module)
    Porting/Maintainers: Usage:
        --maintainer M | --module M [--files]
                    List modules or maintainers matching the pattern M.
                    With --files, list all the files associated with them
    or
        --check | --checkmani [commit | file ... | dir ... ]
                    Check consistency of Maintainers.pl
                            with a file     checks if it has a maintainer
                            with a dir      checks all files have a maintainer
                            with a commit   checks files modified by that commit
                            no arg          checks for multiple maintainers
                   --checkmani is like --check, but only reports on unclaimed
                   files if they are in MANIFEST
    or
        --opened  | file ....
                    List the module ownership of modified or the listed files

    Matching is case-ignoring regexp, author matching is both by
    the short id and by the full name and email.  A "module" may
    not be just a module, it may be a file or files or a subdirectory.
    The options may be abbreviated to their unique prefixes

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
