### PR TITLE
Porting/Maintainers.pm: remove note about 5.8.0 compatibility

### DIFF
--- a/Porting/Maintainers.pm
+++ b/Porting/Maintainers.pm
@@ -4,13 +4,11 @@
 
 package Maintainers;
 
+use 5.008;
 use strict;
 use warnings;
 
 use lib "Porting";
-# Please don't use post 5.008 features as this module is used by
-# Porting/makemeta, and that in turn has to be run by the perl just built.
-use 5.008;
 
 require "Maintainers.pl";
 our (%Modules, %Maintainers);
@@ -21,7 +19,7 @@ our @EXPORT_OK = qw(%Modules %Maintainers
 		show_results process_options files_to_modules
 		finish_tap_output
 		reload_manifest);
-our $VERSION = 0.14;
+our $VERSION = 0.15;
 
 require Exporter;
 


### PR DESCRIPTION
This note makes no sense to me. It was added in commit 357244ac7b88 whose message adds that the "perl just built" can be 5.8.x. That may have been true in February 2008 when the comment was added, but there haven't been any 5.8 releases since December 2008.

At first I wanted to update the note to refer to "features from any perl version still under support", but maintenance releases are made from their own branches (and we decide what changes go in those), so there really is no need to keep the code in this file backwards compatible in blead.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
