### PR TITLE
thread.h: Broadcast not signal when waking lock waiters

### DIFF
--- a/thread.h
+++ b/thread.h
@@ -362,7 +362,7 @@
         DEBUG_K(PerlIO_printf(Perl_debug_log,                               \
                 "%s: %ld: 0x%p: mutex 0x%p about to signal, then write"     \
                 " unlock\n", __FILE__, (long) __LINE__, aTHX, mutex));      \
-        COND_SIGNAL(&(mutex)->wakeup);                                      \
+        COND_BROADCAST(&(mutex)->wakeup);                                      \
         MUTEX_UNLOCK(&(mutex)->lock);                                       \
         DEBUG_K(PerlIO_printf(Perl_debug_log,                               \
                 "%s: %ld: 0x%p mutex 0x%p: signalled, write unlocked\n",    \


### PR DESCRIPTION
Better throughput is possible, when a lock is released, by waking all threads waiting for it, instead of just one thread.  The POSIX Standard says this.


* This set of changes does not require a perldelta entry.
