### PR TITLE
Porting/release_schedule.pod: Add Karen Etheridge for August

### DIFF
--- a/Porting/release_schedule.pod
+++ b/Porting/release_schedule.pod
@@ -40,7 +40,7 @@ you should reset the version numbers to the next blead series.
 
   2026-07-15  5.45.0  ✓       Leon Timmermans   (tag only)
   2026-07-21  5.45.1  ✓       Paul Evans
-  2026-08-20  5.45.2          
+  2026-08-20  5.45.2          Karen Etheridge
   2026-09-20  5.45.3          
   2026-10-20  5.45.4          
   2026-11-20  5.45.5          


### PR DESCRIPTION
* This set of changes does not require a perldelta entry.