### PR TITLE
config_h.SH: Reentrant API no longer experimental

### DIFF
--- a/config_h.SH
+++ b/config_h.SH
@@ -5341,7 +5341,6 @@ sed <<!GROK!THIS! >$CONFIG_H -e 's!^#undef\(.*/\)\*!/\*#define\1 \*!' -e 's!^#un
 /* USE_REENTRANT_API:
  *	This symbol, if defined, indicates that Perl should
  *	try to use the various _r versions of library functions.
- *	This is extremely experimental.
  */
 #$useithreads	USE_ITHREADS		/**/
 #$usethreads		USE_THREADS		/**/


### PR DESCRIPTION
much less "extremely experimental"

It has been the default for 25 years

commit 3d62afa2fe4f633de972ecfb12ef158a84f558f8
Author: Jarkko Hietaniemi <jhi@iki.fi>
Date:   Sun Aug 12 16:55:31 2001 +0000

  On ithreads default to use_reentrant except on naturally
  threadsafe platforms.

* This set of changes does not require a perldelta entry.
