### PR TITLE
class: on error, clean up field init ops in the right CV

### DIFF
--- a/class.c
+++ b/class.c
@@ -687,6 +687,10 @@ S_class_cleanup_definition(pTHX_ HV *stash)
     SvREFCNT_dec(aux->xhv_class_subclasses_pending_seal);
     aux->xhv_class_subclasses_pending_seal = NULL;
 
+    /* need to release the saved initializer ops in the context
+       of the CV any pad entries were created in */
+    resume_compcv_final(aux->xhv_class_suspended_initfields_compcv);
+
     /* clean up the ops for defaults for fields, if any, since
        padname_free() doesn't.
     */
@@ -726,7 +730,6 @@ S_class_cleanup_definition(pTHX_ HV *stash)
     }
 
     /* field clean up */
-    resume_compcv_final(aux->xhv_class_suspended_initfields_compcv);
     SvREFCNT_dec(PL_compcv);
     Safefree(aux->xhv_class_suspended_initfields_compcv);
     aux->xhv_class_suspended_initfields_compcv = NULL;

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -438,7 +438,10 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+Cleanup of field initialization ops for an incomplete class now
+happens within the correct CV.  Previously, if an error was thrown
+with an incomplete class this would release pad entries on the wrong
+CV and eventually crash.  [GH #24616]
 
 =back
 

--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -278,3 +278,14 @@ class X :isa(Mod24517) {
 }
 EXPECT
 Class :isa attribute requires a class but "Mod24517" is not one at - line 4.
+########
+# NAME class cleanup doesn't crash GH #24616
+use strict;
+use warnings;
+use experimental 'class';
+my $r;
+class Bug;
+field $_y = $r->{foo}{bar};
+method g() { $x }
+EXPECT
+Global symbol "$x" requires explicit package name (did you forget to declare "my $x"?) at - line 7.


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
This would clean up the OPs in whatever happened to be the current CV when an exception was thrown, which could be the wrong CV.
    
This would result in pad entries being cleaned up in the wrong CV which led to crashes.
    
Fixes #24616

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
