### PR TITLE
sv_set_undef(): preserve the SVs_TEMP flag

### DIFF
--- a/ext/XS-APItest/APItest_misc_runtime.xs
+++ b/ext/XS-APItest/APItest_misc_runtime.xs
@@ -105,3 +105,30 @@ valid_identifier(SV *s)
 
 const char *
 svtypename(U8 type)
+
+int
+test_sv_set_undef()
+    ALIAS:
+      XS::APItest::test_sv_set_undef = 1
+      XS::APItest::test_sv_set_PL_sv_undef = 2
+      XS::APItest::test_sv_setiv_temp = 3
+    CODE:
+        SV *sv = sv_newmortal();
+        if (!SvTEMP(sv))
+            XSRETURN_UNDEF;
+        switch (ix) {
+        case 1:
+            sv_set_undef(sv);
+            break;
+        /* other setters for comparison */
+        case 2:
+            sv_setsv(sv, &PL_sv_undef);
+            break;
+        case 3:
+            sv_setiv(sv, 0);
+            break;
+        }
+        RETVAL = SvTEMP(sv) ? 1 : 2;
+    OUTPUT:
+        RETVAL
+

--- a/ext/XS-APItest/t/sv.t
+++ b/ext/XS-APItest/t/sv.t
@@ -13,4 +13,8 @@ is(svtypename(SVt_PVMG), "PVMG");
 is(svtypename(SVt_PVGV), "PVGV");
 is(svtypename(123),      undef);
 
+is(test_sv_set_undef(), 1, "sv_set_undef() preserves temp");
+is(test_sv_set_PL_sv_undef(), 1, "sv_setsv(..., &PL_sv_undef) preserves temp");
+is(test_sv_setiv_temp(), 1, "sv_setiv(..., 0) preserves temp");
+
 done_testing();

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -449,6 +449,12 @@ happens within the correct CV.  Previously, if an error was thrown
 with an incomplete class this would release pad entries on the wrong
 CV and eventually crash.  [GH #24616]
 
+=item *
+
+sv_set_undef() no longer blindly clears the C<SVs_TEMP> flag.  This
+could break code that expected to detect mortal SVs, like constant
+folding.  [GH #24661]
+
 =back
 
 =head1 Known Problems

--- a/sv.c
+++ b/sv.c
@@ -5335,16 +5335,12 @@ Perl_sv_set_undef(pTHX_ SV *sv)
         }
 
         if (SvROK(sv)) {
-            if (SvWEAKREF(sv))
-                sv_unref_flags(sv, 0);
-            else {
-                SV *rv = SvRV(sv);
-                SvFLAGS(sv) = type; /* quickly turn off all flags */
-                SvREFCNT_dec_NN(rv);
-                return;
-            }
+            sv_unref_flags(sv, 0);
+            assert(!SvOK(sv));
+            return;
         }
-        SvFLAGS(sv) = type; /* quickly turn off all flags */
+
+        SvOK_off(sv);
         return;
     }
 


### PR DESCRIPTION
sv_set_undef() would clear the SVs_TEMP and other flags if the SV was SvTYPE() <= SVt_IV, breaking code that checks for SVs_TEMP, suah as constant folding.

Found while trying to replace sv_setsv(TARG, &PL_sv_undef) with sv_set_undef(TARG) and failing.



-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it will be included once I have a ticket number.
