### PR TITLE
ExtUtils::ParseXS: make filename hack work with linenumbers => 0

### DIFF
--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS.pm
@@ -376,13 +376,8 @@ sub process_file {
   }
   $self->{out_filename} = $cfile;
 
-  if ($self->{config_WantLineNumbers}) {
-    tie(*PSEUDO_STDOUT, 'ExtUtils::ParseXS::CountLines', $cfile, $Options{output});
-    select PSEUDO_STDOUT;
-  }
-  else {
-    select $Options{output};
-  }
+  tie(*PSEUDO_STDOUT, 'ExtUtils::ParseXS::CountLines', $cfile, $Options{output});
+  select PSEUDO_STDOUT;
 
   $self->{typemaps_object} = process_typemaps( $Options{typemap}, $pwd );
 
@@ -410,7 +405,7 @@ sub process_file {
 
   chdir($orig_cwd);
   select($orig_fh);
-  untie *PSEUDO_STDOUT if tied *PSEUDO_STDOUT;
+  untie *PSEUDO_STDOUT;
   close $self->{in_fh};
 
   return 1;

--- a/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
+++ b/dist/ExtUtils-ParseXS/lib/ExtUtils/ParseXS/Node.pm
@@ -1655,9 +1655,8 @@ sub as_code {
 
     # Emit the boot_Foo__Bar() C function / XSUB
 
-    my $set_file = '';
-    my $reset_file = '';
-    if ($pxs->{config_WantLineNumbers}) {
+    my ($set_file, $reset_file);
+    {
         (my $module = $pxs->{MODULE_cname}) =~ tr/_/:/;
         my $fake_file = "$pxs->{out_filename} in $module";
         $set_file = 'ExtUtils::ParseXS::CountLines'->file_marker($fake_file);

--- a/dist/ExtUtils-ParseXS/t/003-parse-file-scope-keywords.t
+++ b/dist/ExtUtils-ParseXS/t/003-parse-file-scope-keywords.t
@@ -212,7 +212,7 @@ EOF
                 |
 EOF
 
-            [  0, qr{^\s*#line \d+ \Q"(output) in Foo::Bar"\E}m,
+            [  0, qr{^\s*\#line \d+ \Q"(output) in Foo::Bar"\E}m,
                 "includes correct module name"
             ],
         ],
@@ -220,6 +220,25 @@ EOF
     );
 
     test_many($preamble, 'boot_Foo__Bar', \@test_fns);
+
+    @test_fns = (
+        [
+            'file name in XS handshake (linenumbers off)',
+            Q(<<'EOF'),
+                |MODULE = Foo::Bar PACKAGE = Foo::Bar::Util
+                |
+                |PROTOTYPES:  DISABLE
+                |
+EOF
+
+            [  0, qr{^\s*\#line \d+ \Q"(output) in Foo::Bar"\E}m,
+                "includes correct module name"
+            ],
+        ],
+
+    );
+
+    test_many($preamble, 'boot_Foo__Bar', \@test_fns, [ linenumbers => 0 ]);
 }
 
 {


### PR DESCRIPTION
We now always pipe our output through ExtUtils::ParseXS::CountLines (so we can always get the current output line number), but this should make no difference to normal output, which checks `config_WantLineNumbers` before actually switching to a different file with a custom `#line` directive. Which is to say, the documented behavior of `linenumbers => 0` should remain unchanged.

Follow-up to PR #24651.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
