### PR TITLE
hints/cygwin: newlocale bug fixed in their 3.3.6

### DIFF
--- a/hints/cygwin.sh
+++ b/hints/cygwin.sh
@@ -106,5 +106,9 @@ lddlflags="$lddlflags $ldflags"
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64697
 d_thread_local=undef
 
-# Broken: https://sourceware.org/pipermail/cygwin/2022-August/252043.html */
-d_newlocale=undef
+case "$osvers" in
+    # https://cygwin.com/cgit/newlib-cygwin/commit/?h=cygwin-3_3-branch&id=b612db5b14728214ca09355af5d1490df2fa1c2f
+    [12].*|3.[12].*|3.3.[12345])
+        d_newlocale=undef
+        ;;
+esac


### PR DESCRIPTION
https://cygwin.com/cgit/newlib-cygwin/commit/?h=cygwin-3_3-branch&id=b612db5b14728214ca09355af5d1490df2fa1c2f


* This set of changes does not require a perldelta entry.
