### PR TITLE
perlapi: Document backward compatibilty macros

### DIFF
--- a/autodoc.pl
+++ b/autodoc.pl
@@ -2072,7 +2072,7 @@ sub docout ($fh, $section_name, $element_name, $docref) {
                                         if $flags =~ /u/ && $flags !~ /[my]/;
 
             my $has_semicolon = $flags =~ /;/;
-            die "'U' and ';' flags are incompatible"
+            die "'U' and ';' flags are incompatible "
                . where_from_string($item->{file}, $item->{line_num})
                                             if $flags =~ /U/ && $has_semicolon;
 

--- a/autodoc.pl
+++ b/autodoc.pl
@@ -2095,6 +2095,10 @@ sub docout ($fh, $section_name, $element_name, $docref) {
                 }
             }
 
+            die "'B' and 'D' flags are incompatible "
+               . where_from_string($item->{file}, $item->{line_num})
+                                            if $flags =~ tr/BD// > 1;
+
             my $ret = $item->{ret_type} // "";
             my @args;
             my $this_has_pTHX = 0;

--- a/cop.h
+++ b/cop.h
@@ -1235,7 +1235,15 @@ struct context {
 #define G_WANT          3
 
 #ifndef PERL_CORE
-   /* name prior to 5.31.1 */
+
+/*
+=for apidoc ABmn||G_ARRAY
+
+A synonym for C<L</G_LIST>>, which you should use instead.
+
+=cut
+
+   name prior to 5.31.1 */
 #  define G_ARRAY  G_LIST
 #endif
 

--- a/cv.h
+++ b/cv.h
@@ -289,6 +289,14 @@ copy the flag from one CV to another; using something like
 
 #ifndef PERL_CORE
     /* Back-compatibility wrappers for its old name */
+/*
+=for apidoc  ABmn|I32|CVf_NAMED
+
+Use C<L</CVf_HasNAME_HEK>> instead
+
+=cut
+*/
+
 #  define CVf_NAMED    CVf_HasNAME_HEK
 #  define CvNAMED      CvHasNAME_HEK
 #  define CvNAMED_on   CvHasNAME_HEK_on

--- a/cv.h
+++ b/cv.h
@@ -94,7 +94,12 @@ name can be found via the L</CvGV>.
  */
 #define CvHasNAME(cv)   ((bool)SvANY(cv)->xcv_gv_u.xcv_gv)
 
-/* Back-compat */
+/*
+=for apidoc ABm|bool|CvHASGV|CV *cv
+A synonym for c<L</CvHasNAME>>
+
+=cut
+*/
 #ifndef PERL_CORE
 #  define CvHASGV(cv)  CvHasNAME(cv)
 #endif

--- a/cv.h
+++ b/cv.h
@@ -288,11 +288,18 @@ copy the flag from one CV to another; using something like
 #define CvHasNAME_HEK_off(cv)   (CvFLAGS(cv) &= ~CVf_HasNAME_HEK)
 
 #ifndef PERL_CORE
-    /* Back-compatibility wrappers for its old name */
 /*
 =for apidoc  ABmn|I32|CVf_NAMED
 
 Use C<L</CVf_HasNAME_HEK>> instead
+
+=for apidoc  ABm|HEK *|CvNAMED
+=for apidoc_item||CvNAMED_on
+=for apidoc_item||CvNAMED_off
+
+Use, respectively, C<L</CvHasNAME_HEK>>,
+C<CvHasNAME_HEK_on>,
+and C<CvHasNAME_HEK_off> instead
 
 =cut
 */

--- a/gv.h
+++ b/gv.h
@@ -236,6 +236,20 @@ Return the CV from the GV.
 #define GvONCE_FATAL_off(gv)	(GvFLAGS(gv) &= ~GVf_ONCE_FATAL)
 
 #ifndef PERL_CORE
+
+/*
+=for apidoc ABm|bool|GvIN_PAD|GV* gv
+
+Now always returns C<false>.
+
+=for apidoc  ABm||GvIN_PAD_on|GV* gv
+=for apidoc_item||GvIN_PAD_off|GV* gv
+
+Now are no-ops
+
+=cut
+*/
+
 #  define GvIN_PAD(gv)		0
 #  define GvIN_PAD_on(gv)	NOOP
 #  define GvIN_PAD_off(gv)	NOOP

--- a/gv.h
+++ b/gv.h
@@ -247,6 +247,10 @@ Now always returns C<false>.
 
 Now are no-ops
 
+=for apidoc ABmn|GV*|Nullgv
+
+Null GV pointer
+
 =cut
 */
 

--- a/handy.h
+++ b/handy.h
@@ -2865,7 +2865,12 @@ These each call C<PoisonWith(0xEF)> for catching access to freed memory.
 
 =cut */
 
-/* Maintained for backwards-compatibility only. Use newSV() instead. */
+/*
+=for apidoc ABm|SV*|NEWSV|type x|STRLEN len
+Use newSV() instead.
+
+=cut
+ */
 #ifndef PERL_CORE
 #define NEWSV(x,len)	newSV(len)
 #endif

--- a/handy.h
+++ b/handy.h
@@ -15,19 +15,26 @@
 #define PERL_HANDY_H_
 
 #ifndef PERL_CORE
+
+/*
+=for apidoc_section $casting
+=for apidoc BCmnU|type|Null|type
+
+Null pointer of type C<type>
+
+=cut
+*/
 #  define Null(type) ((type)NULL)
 
 /*
 =for apidoc_section $string
-=for apidoc AmnU||Nullch
+=for apidoc ABmnU||Nullch
 Null character pointer.  (No longer available when C<PERL_CORE> is
 defined.)
 
 =for apidoc_section $SV
-=for apidoc AmnU||Nullsv
+=for apidoc ABmnU||Nullsv
 Null SV pointer.  (No longer available when C<PERL_CORE> is defined.)
-
-=cut
 
 Below are signatures of functions from config.h which can't easily be gleaned
 from it, and are very unlikely to change

--- a/handy.h
+++ b/handy.h
@@ -3012,7 +3012,17 @@ enum mem_log_type {
 #define Newxz(v,n,t)	(v = (MEM_WRAP_CHECK_(n,t) (t*)MEM_LOG_ALLOC(n,t,safecalloc((n),sizeof(t)))))
 
 #ifndef PERL_CORE
-/* pre 5.9.x compatibility */
+/*
+=for apidoc      ABm|void|New|type x|void* ptr|int nitems|type
+=for apidoc_item    |void|Newc|type x|void* ptr|int nitems|type
+=for apidoc_item    |void|Newz|type x|void* ptr|int nitems|type
+
+Use respectively C<L</Newx>>, C<L</Newxc>>, and C<L</Newxz>>.
+
+=cut
+
+    pre 5.9.x compatibility
+*/
 #define New(x,v,n,t)	Newx(v,n,t)
 #define Newc(x,v,n,t,c)	Newxc(v,n,t,c)
 #define Newz(x,v,n,t)	Newxz(v,n,t)

--- a/hv.h
+++ b/hv.h
@@ -477,6 +477,15 @@ whether it is valid to call C<HvAUX()>.
 #define HvLAZYDEL_off(hv)	(SvFLAGS(hv) &= ~SVphv_LAZYDEL)
 
 #ifndef PERL_CORE
+
+/*
+=for apidoc ABmn|HE*|Nullhe
+
+Null HE pointer.
+
+=cut
+*/
+
 #  define Nullhe Null(HE*)
 #endif
 #define HeNEXT(he)		(he)->hent_next
@@ -512,6 +521,15 @@ whether it is valid to call C<HvAUX()>.
 #define HeSVKEY_set(he,sv)	((HeKLEN(he) = HEf_SVKEY), (HeKEY_sv(he) = sv))
 
 #ifndef PERL_CORE
+
+/*
+=for apidoc ABmn|HE*|Nullhek
+
+Null HEK pointer.
+
+=cut
+*/
+
 #  define Nullhek Null(HEK*)
 #endif
 #define HEK_BASESIZE		STRUCT_OFFSET(HEK, hek_key[0])

--- a/op.h
+++ b/op.h
@@ -1125,7 +1125,12 @@ C<sib> is non-null. For a higher-level interface, see C<L</op_sibling_splice>>.
     ((o)->op_sibparent = ((o)->op_moresib = cBOOL(sib)) ? (sib) : (parent))
 
 #if !defined(PERL_CORE) && !defined(PERL_EXT)
-/* for backwards compatibility only */
+/*
+=for apidoc ABm||OP_SIBLING|OP *o
+
+A synonym for C<L</OpSIBLING>>, which you should use instead.
+=cut
+*/
 #  define OP_SIBLING(o)		OpSIBLING(o)
 #endif
 

--- a/op.h
+++ b/op.h
@@ -586,6 +586,13 @@ typedef enum {
 #define kSVOP_sv		cSVOPx_sv(kid)
 
 #ifndef PERL_CORE
+
+/*
+=for apidoc ABmn|OP *|Nullop
+Null OP pointer.
+
+=cut
+*/
 #  define Nullop ((OP*)NULL)
 #endif
 

--- a/op.h
+++ b/op.h
@@ -713,7 +713,12 @@ least an C<UNOP>.
 
 #define LINKLIST(o) ((o)->op_next ? (o)->op_next : op_linklist((OP*)o))
 
-/* no longer used anywhere in core */
+/*
+=for apidoc ABm|void|cv_ckproto|const CV *cv|const GV *gv|const char *p
+
+=cut
+*/
+
 #ifndef PERL_CORE
 #define cv_ckproto(cv, gv, p) \
    cv_ckproto_len_flags((cv), (gv), (p), (p) ? strlen(p) : 0, 0)

--- a/op.h
+++ b/op.h
@@ -539,6 +539,13 @@ typedef enum {
 } OPclass;
 
 
+/*
+=for apidoc ABm|bool|IS_PADGV|SV* sv
+=for apidoc ABm|bool|IS_PADCONST|SV* sv
+
+=cut
+*/
+
 #ifdef USE_ITHREADS
 #  define cGVOPx_gv(o)  ((GV*)PAD_SVl(cPADOPx(o)->op_padix))
 #  ifndef PERL_CORE

--- a/pad.h
+++ b/pad.h
@@ -384,8 +384,43 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #  define PadnameLEN_set(pn, len)   (assert(!PadnameIsFULLSV(pn)), (pn)->xpadn_len = (len))
 #endif
 
-/* backward compatibility */
 #ifndef PERL_CORE
+/*
+=for apidoc ABmn||SvPAD_STATE
+
+=for apidoc ABmn||SvPAD_TYPED
+
+=for apidoc ABm||SvPAD_OUR|type pn
+
+=for apidoc ABmn||SvPAD_STATE_on
+
+=for apidoc ABm||SvPAD_TYPED_on|pn
+
+=for apidoc ABm||SvPAD_OUR_on|pn
+
+=for apidoc ABmn||SvOURSTASH
+
+=for apidoc ABmn||SvOURSTASH_set
+
+=for apidoc ABmn||SVpad_STATE
+
+=for apidoc ABmn||SVpad_TYPED
+
+=for apidoc ABmn||SVpad_OUR
+
+=for apidoc ABmn||PADNAMEt_OUTER
+
+=for apidoc ABmn||PADNAMEt_STATE
+
+=for apidoc ABmn||PADNAMEt_LVALUE
+
+=for apidoc ABmn||PADNAMEt_TYPED
+
+=for apidoc ABmn||PADNAMEt_OUR
+
+=cut
+*/
+
 #  define SvPAD_STATE           PadnameIsSTATE
 #  define SvPAD_TYPED           PadnameHasTYPE
 #  define SvPAD_OUR(pn)         cBOOL(PadnameOURSTASH(pn))

--- a/perl.h
+++ b/perl.h
@@ -282,6 +282,9 @@ Now a no-op.
 =for apidoc_item||_PERL_OBJECT_THIS
 =for apidoc_item||PERL_OBJECT_THIS_
 
+=for apidoc ABm||CALL_FPTR|*fptr
+=for apidoc ABm||MEMBER_TO_FPTR|name
+
 =cut
  */
 #  define STATIC static

--- a/perl.h
+++ b/perl.h
@@ -961,6 +961,12 @@ program could at least compile, regardless.
 But such crippled compilers are long gone, so this always expands to
 C<volatile>, and you might as well just type the actual C keyword.
 
+=for apidoc AB#||CAN_PROTOTYPE
+
+This is defined if and only if the compiler being used understands function
+prototypes.  Nowadays it is always defined, since perl won't compile at all on
+compilers without that capability.
+
 =for apidoc AB#||I_LIMITS
 
 This is defined if and only if the compiler being used has F<limits.h>.

--- a/perl.h
+++ b/perl.h
@@ -214,7 +214,7 @@ Otherwise ends a section of code already begun by a C<L</START_EXTERN_C>>.
 =for apidoc AmU|void|dTHXa|PerlInterpreter * a
 On threaded perls, set C<pTHX> to C<a>; on unthreaded perls, do nothing
 
-=for apidoc AmU|void|dTHXoa|PerlInterpreter * a
+=for apidoc ABmU|void|dTHXoa|PerlInterpreter * a
 Now a synonym for C<L</dTHXa>>.
 
 =cut
@@ -747,13 +747,18 @@ code.
 #  define pTHX_12	12
 #endif
 
+#ifndef PERL_CORE
+
 /*
 =for apidoc_section $concurrency
-=for apidoc AmnU||dVAR
-This is now a synonym for dNOOP: declare nothing
+=for apidoc ABmnU||dVAR
+
+This is now a synonym for dNOOP: declare nothing.
+It used to be part of the PERL_GLOBAL_STRUCT(_PRIVATE) feature, which no longer
+exists
 
 =for apidoc_section $XS
-=for apidoc Amn;||dMY_CXT_SV
+=for apidoc ABmn;||dMY_CXT_SV
 Now a placeholder that declares nothing
 
 =for apidoc ABmn||pTHXo
@@ -769,13 +774,9 @@ Now a placeholder that declares nothing
 =cut
 */
 
-#ifndef PERL_CORE
-    /* Backwards compatibility macro for XS code. It used to be part of the
-     * PERL_GLOBAL_STRUCT(_PRIVATE) feature, which no longer exists */
-#  define dVAR		dNOOP
+/* these are only defined for compatibility; should not be used internally. */
 
-    /* these are only defined for compatibility; should not be used internally.
-     * */
+#  define dVAR		dNOOP
 #  define dMY_CXT_SV    dNOOP
 #  ifndef pTHXo
 #    define pTHXo		pTHX

--- a/perl.h
+++ b/perl.h
@@ -967,6 +967,8 @@ This is defined if and only if the compiler being used understands function
 prototypes.  Nowadays it is always defined, since perl won't compile at all on
 compilers without that capability.
 
+=for apidoc ABT||_|...
+
 =for apidoc AB#||I_LIMITS
 
 This is defined if and only if the compiler being used has F<limits.h>.

--- a/perl.h
+++ b/perl.h
@@ -6060,9 +6060,21 @@ interpreter phase you might do:
 #define phase_name(phase) (PL_phase_names[phase])
 
 #ifndef PERL_CORE
-/* Do not use this macro. It only exists for extensions that rely on PL_dirty
- * instead of using the newer PL_phase, which provides everything PL_dirty
- * provided, and more. */
+/*
+=for apidoc_section $globals
+=for apidoc ABm|bool|PL_dirty
+Do not use this macro. It only exists for extensions that rely on PL_dirty
+instead of using the newer PL_phase, which provides everything PL_dirty
+provided, and more.
+
+=for apidoc ABmn|STRLEN|PL_amagic_generation
+Now a synonym for C<L</PL_na>>.
+
+=for apidoc ABmn|SV*|PL_encoding
+Now returns a Null SV pointer.
+
+=cut
+*/
 #  define PL_dirty cBOOL(PL_phase == PERL_PHASE_DESTRUCT)
 
 #  define PL_amagic_generation PL_na

--- a/perl.h
+++ b/perl.h
@@ -961,6 +961,24 @@ program could at least compile, regardless.
 But such crippled compilers are long gone, so this always expands to
 C<volatile>, and you might as well just type the actual C keyword.
 
+=for apidoc AB#||I_LIMITS
+
+This is defined if and only if the compiler being used has F<limits.h>.
+Nowadays it is always defined, since perl won't compile at all on compilers
+without that.
+
+=for apidoc AB#||I_STDARG
+
+This is defined if and only if the compiler being used has F<stdarg.h>.
+Nowadays it is always defined, since perl won't compile at all on compilers
+without that.
+
+=for apidoc AB#||STANDARD_C
+
+This is defined if and only if the compiler being used complies with an ANSI C
+standard.  Nowadays it is always defined, since perl only compiles on such
+compilers.
+
 =cut
 */
 #ifndef PERL_CORE

--- a/perl.h
+++ b/perl.h
@@ -285,6 +285,16 @@ Now a no-op.
 =for apidoc ABm||CALL_FPTR|*fptr
 =for apidoc ABm||MEMBER_TO_FPTR|name
 
+=for apidoc_section $compiler
+=for apidoc ABmn||STATIC
+
+This was used to declare a C variable C<static> in C compilers that
+understood that, and to do nothing in C compilers that did not, so that your
+program could compile, regardless.
+
+But such crippled compilers are long gone, so this always expands to
+C<static>, and you might as well just type the actual C keyword.
+
 =cut
  */
 #  define STATIC static
@@ -940,7 +950,19 @@ symbol would not be defined on C<L</EBCDIC>> platforms.
 #define DOSISH 1
 #endif
 
-/* These exist only for back-compat with XS modules. */
+/* These exist only for back-compat with XS modules.
+=for apidoc_section $compiler
+=for apidoc ABmn||VOL
+
+This was used to declare a C variable C<volatile> in C compilers that
+understood that, and to do nothing in C compilers that did not, so that your
+program could at least compile, regardless.
+
+But such crippled compilers are long gone, so this always expands to
+C<volatile>, and you might as well just type the actual C keyword.
+
+=cut
+*/
 #ifndef PERL_CORE
 #define VOL volatile
 #define CAN_PROTOTYPE

--- a/perl.h
+++ b/perl.h
@@ -4099,9 +4099,15 @@ EXTERN_C int perl_tsa_mutex_unlock(perl_mutex* mutex);
 #define PERL_EXIT_ABORT		0x08  /* Call abort() if Perl_my_exit() or Perl_my_failure_exit() called */
 
 #ifndef PERL_CORE
-/* format to use for version numbers in file/directory names */
-/* XXX move to Configure? */
-/* This was only ever used for the current version, and that can be done at
+/*
+=for apidoc_section $versioning
+=for apidoc ABmn|const char *|PERL_FS_VER_FMT
+Format to use for version numbers in file/directory names
+
+=cut
+
+ * XXX move to Configure?
+ * This was only ever used for the current version, and that can be done at
    compile time, as PERL_FS_VERSION, so should we just delete it?  */
 #  ifndef PERL_FS_VER_FMT
 #    define PERL_FS_VER_FMT	"%d.%d.%d"

--- a/perl.h
+++ b/perl.h
@@ -127,7 +127,15 @@ functions with no normal arguments, and used by L</C<comma_pDEPTH>> itself.
 #  endif
 #endif
 
-/* PERL_IMPLICIT_CONTEXT is a legacy synonym for MULTIPLICITY */
+/*
+=for apidoc_section $concurrency
+=for apidoc AB#||PERL_IMPLICIT_CONTEXT
+
+This is a legacy synonym for MULTIPLICITY
+
+=cut
+*/
+
 #if defined(MULTIPLICITY)               \
  && ! defined(PERL_CORE)                \
  && ! defined(PERL_IMPLICIT_CONTEXT)

--- a/perl.h
+++ b/perl.h
@@ -274,6 +274,10 @@ Now a synonym for C<L</dTHXa>>.
 =for apidoc AmD|void|CPERLscope|void x
 Now a no-op.
 
+=for apidoc ABmn||CPERLarg
+=for apidoc_item||CPERLarg_
+=for apidoc_item||_CPERLarg
+
 =cut
  */
 #  define STATIC static

--- a/perl.h
+++ b/perl.h
@@ -278,6 +278,10 @@ Now a no-op.
 =for apidoc_item||CPERLarg_
 =for apidoc_item||_CPERLarg
 
+=for apidoc ABmn||PERL_OBJECT_THIS
+=for apidoc_item||_PERL_OBJECT_THIS
+=for apidoc_item||PERL_OBJECT_THIS_
+
 =cut
  */
 #  define STATIC static

--- a/pod/perlguts.pod
+++ b/pod/perlguts.pod
@@ -3240,7 +3240,7 @@ bits.
 =head2 Background and MULTIPLICITY
 
 =for apidoc_section $concurrency
-=for apidoc Amnh||PERL_IMPLICIT_CONTEXT
+=for apidoc Amnh||MULTIPLICITY
 
 The Perl interpreter can be regarded as a closed box: it has an API
 for feeding it code or otherwise making it do things, but it also has
@@ -3257,9 +3257,6 @@ first argument. MULTIPLICITY makes multi-threaded perls possible (with the
 ithreads threading model, related to the macro USE_ITHREADS.)
 
 PERL_IMPLICIT_CONTEXT is a legacy synonym for MULTIPLICITY.
-
-=for apidoc_section $concurrency
-=for apidoc Amnh||MULTIPLICITY
 
 To see whether you have non-const data you can use a BSD (or GNU)
 compatible C<nm>:

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -483,9 +483,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     CvMETHOD
     CvMETHOD_off
     CvMETHOD_on
-    CvNAMED
-    CvNAMED_off
-    CvNAMED_on
     CvNAME_HEK_clear
     CvNAME_HEK_set
     CvNODEBUG

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -253,9 +253,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     blk_old_tmpsfloor
     blk_sub
     blk_u16
-    BmFLAGS
-    BmPREVIOUS
-    BmRARE
     BmUSEFUL
     BOM_UTF8_FIRST_BYTE
     BOM_UTF8_TAIL

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1768,11 +1768,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     PadnameOURSTASH_set
     PadnameOUTER
     PadnamePROTOCV
-    PADNAMEt_LVALUE
-    PADNAMEt_OUR
-    PADNAMEt_OUTER
-    PADNAMEt_STATE
-    PADNAMEt_TYPED
     PadnameTYPE
     PadnameTYPE_set
     padnew_CLONE
@@ -2524,25 +2519,14 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     SvOK_off_exc_UV
     SvOKp
     SvOOK_on
-    SvOURSTASH
-    SvOURSTASH_set
     SvPADMY
     SvPADMY_on
-    SvPAD_OUR
-    SVpad_OUR
-    SvPAD_OUR_on
     SvPADSTALE
     SvPADSTALE_off
     SvPADSTALE_on
-    SvPAD_STATE
-    SVpad_STATE
-    SvPAD_STATE_on
     SvPADTMP
     SvPADTMP_off
     SvPADTMP_on
-    SvPAD_TYPED
-    SVpad_TYPED
-    SvPAD_TYPED_on
     SVpav_REAL
     SVpav_REIFY
     SvPCS_IMPORTED

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1431,7 +1431,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     NewOp
     NewOpSz
     new_SV
-    NEWSV
     NEW_VERSION
     new_XNV
     new_XPVMG

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -933,9 +933,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     htoni
     htovl
     htovs
-    HvAMAGIC
-    HvAMAGIC_off
-    HvAMAGIC_on
     HvARRAY
     HvAUX
     HvAUXf_IS_CLASS

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -260,7 +260,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     BSDish
     BSD_SETPGRP
     CALL_BLOCK_HOOKS
-    CALL_FPTR
     CALLREGCOMP
     CALLREGCOMP_ENG
     CALLREGDUPE
@@ -1333,7 +1332,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     MDEREF_SHIFT
     memBEGINPs
     memBEGINs
-    MEMBER_TO_FPTR
     memENDPs
     memENDs
     memGE

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -2516,7 +2516,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     SvOKp
     SvOOK_on
     SvPADMY
-    SvPADMY_on
     SvPADSTALE
     SvPADSTALE_off
     SvPADSTALE_on

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -813,9 +813,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     GvIMPORTED_SV
     GvIMPORTED_SV_off
     GvIMPORTED_SV_on
-    GvIN_PAD
-    GvIN_PAD_off
-    GvIN_PAD_on
     GvINTRO
     GvINTRO_off
     GvINTRO_on

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -419,7 +419,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     CvAUTOLOAD
     CvAUTOLOAD_off
     CvAUTOLOAD_on
-    cv_ckproto
     CvCLONE
     CvCLONED
     CvCLONED_off

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -474,7 +474,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     CvHASEVAL
     CvHASEVAL_off
     CvHASEVAL_on
-    CvHASGV
     CvHSCXT
     CvIsMETHOD
     CvIsMETHOD_off

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1715,7 +1715,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     OpREFCNT_set
     OP_REFCNT_TERM
     OP_REFCNT_UNLOCK
-    OP_SIBLING
     OPTIMIZE_INFTY
     OP_TYPE_IS_COP_NN
     OP_TYPE_IS_NN

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1422,10 +1422,8 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     NEGATE_2IV
     NEGATE_2UV
     NEGATIVE_INDICES_VAR
-    New
     new_body_allocated
     new_body_from_arena
-    Newc
     new_NOARENA
     new_NOARENAZ
     NewOp
@@ -1435,7 +1433,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     new_XNV
     new_XPVMG
     new_XPVNV
-    Newz
     NEXT_LINE_CHAR
     NOARENA
     NOCAPTURE_PAT_MOD

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1112,8 +1112,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     isNON_BRACE_QUANTIFIER
     is_NONCHAR_utf8_safe
     IS_NUMERIC_RADIX
-    IS_PADCONST
-    IS_PADGV
     is_PATWS_safe
     is_posix_ALPHA
     is_posix_ALPHANUMERIC

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -992,7 +992,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     I8_TO_NATIVE
     I8_TO_NATIVE_UTF8
     IGNORE_PAT_MOD
-    I_LIMITS
     ILLEGAL_UTF8_BYTE
     IN_BYTES
     INCLUDE_PROTOTYPES
@@ -1142,7 +1141,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     is_STRICT_VERSION
     is_SURROGATE_utf8
     is_SURROGATE_utf8_safe
-    I_STDARG
     is_THREE_CHAR_FOLD_HEAD_latin1_safe
     is_THREE_CHAR_FOLD_HEAD_utf8_safe
     is_THREE_CHAR_FOLD_latin1_safe
@@ -2408,7 +2406,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     SSPUSHPTR
     SSPUSHUV
     Stack_off_t_MAX
-    STANDARD_C
     StashHANDLER
     Stat
     Stat_t

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -2446,9 +2446,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     SvCANEXISTDELETE
     sv_cathek
     sv_catpvn_nomg_utf8_upgrade
-    SvCOMPILED
-    SvCOMPILED_off
-    SvCOMPILED_on
     SV_CONST_RETURN
     SV_CONSTS_COUNT
     SV_COW_OTHER_PVS

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -2466,7 +2466,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     SvFAKE
     SvFAKE_off
     SvFAKE_on
-    SVf_AMAGIC
     SVf_BREAK
     SVf_FAKE
     SVf_IOK

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -287,7 +287,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     CAN64BITHASH
     CAN_COW_FLAGS
     CAN_COW_MASK
-    CAN_PROTOTYPE
     CASE_STD_PMMOD_FLAGS_PARSE_SET
     CATCH_GET
     CATCH_SET

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -456,7 +456,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     CVf_LEXICAL
     CVf_LVALUE
     CVf_METHOD
-    CVf_NAMED
     CVf_NODEBUG
     CVf_NOWARN_AMBIGUOUS
     CVf_REFCOUNTED_ANYSV

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -1455,12 +1455,7 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     NOT_REACHED
     NSIG
     ntohi
-    Null
     Nullfp
-    Nullgv
-    Nullhe
-    Nullhek
-    Nullop
     NUM_ANYOF_CODE_POINTS
     NV_BIG_ENDIAN
     NV_DIG

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -2411,7 +2411,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     STANDARD_C
     StashHANDLER
     Stat
-    STATIC
     Stat_t
     STATUS_ALL_FAILURE
     STATUS_ALL_SUCCESS
@@ -2808,7 +2807,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     vFAIL4
     VNORMAL
     VNUMIFY
-    VOL
     VSTRINGIFY
     vTHX
     VT_NATIVE

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -742,7 +742,6 @@ my %unresolved_visibility_overrides = map { $_ => 1 } qw(
     Fstat
     FULL_TRIE_STUDY
     fwrite1
-    G_ARRAY
     GCC_DIAG_IGNORE
     GCC_DIAG_IGNORE_DECL
     GCC_DIAG_IGNORE_STMT

--- a/sv.h
+++ b/sv.h
@@ -1350,6 +1350,13 @@ C<sv_force_normal> does nothing.
 #define SVs_PADMY		0
 #define SvPADMY(sv)		(!(SvFLAGS(sv) & SVs_PADTMP))
 #ifndef PERL_CORE
+/*
+=for apidoc ABm||SvPADMY_on|SV * sv
+Use C<SvPADTMP_off> instead.  (Yes, the original is C<on> and the replacement
+is C<off>.)
+
+=cut
+*/
 # define SvPADMY_on(sv)		SvPADTMP_off(sv)
 #endif
 

--- a/sv.h
+++ b/sv.h
@@ -1402,6 +1402,18 @@ object type. Exposed to perl code via Internals::SvREADONLY().
 #endif
 
 #ifndef PERL_CORE
+/*
+=for apidoc ABm|bool|SvCOMPILED|SV* sv
+
+Now always returns C<false>.
+
+=for apidoc  ABm||SvCOMPILED_on|SV* sv
+=for apidoc_item||SvCOMPILED_off|SV* sv
+Now are no-ops
+
+=cut
+*/
+
 #  define SvCOMPILED(sv)	0
 #  define SvCOMPILED_on(sv)
 #  define SvCOMPILED_off(sv)

--- a/sv.h
+++ b/sv.h
@@ -1747,6 +1747,12 @@ only be used as part of a larger operation
 #endif
 
 #ifndef PERL_CORE
+/*
+=for apidoc_section $string
+=for apidoc ABm|U32|BmFLAGS|SV* sv
+
+=cut
+*/
 #  define BmFLAGS(sv)		(SvTAIL(sv) ? FBMcf_TAIL : 0)
 #endif
 
@@ -1764,6 +1770,15 @@ only be used as part of a larger operation
 #endif
 
 #ifndef PERL_CORE
+/*
+=for apidoc_section $string
+=for apidoc   ABm|U32|BmRARE|SV* sv
+=for apidoc_item |U32|BmPREVIOUS|SV* sv
+
+These both now return 0
+
+=cut
+*/
 # define BmRARE(sv)	0
 # define BmPREVIOUS(sv)	0
 #endif

--- a/sv.h
+++ b/sv.h
@@ -1224,9 +1224,17 @@ Turns on or off the L</HvOVERLOAD> flag.
 #define HvOVERLOAD(hv)          (SvFLAGS(hv) & SVphv_OVERLOAD)
 #define HvOVERLOAD_on(hv)       (perl_assert_HV_(hv) SvFLAGS(hv) |= SVphv_OVERLOAD)
 #define HvOVERLOAD_off(hv)      (perl_assert_HV_(hv) SvFLAGS(hv) &=~ SVphv_OVERLOAD)
-/* These used to be called "AMAGIC", for "active magic", a rather vague
- * description of what we now call operator overloading. */
 #ifndef PERL_CORE
+/*
+=for apidoc ABmn|U32|SVf_AMAGIC
+
+Use C<SVphv_OVERLOAD> instead.
+"AMAGIC" is short for "active magic"; a rather vague description of what we
+now call operator overloading.
+
+=cut
+*/
+
 #  define SVf_AMAGIC            SVphv_OVERLOAD
 #  define HvAMAGIC              HvOVERLOAD
 #  define HvAMAGIC_on           HvOVERLOAD_on

--- a/sv.h
+++ b/sv.h
@@ -1232,6 +1232,17 @@ Use C<SVphv_OVERLOAD> instead.
 "AMAGIC" is short for "active magic"; a rather vague description of what we
 now call operator overloading.
 
+=for apidoc   ABm|bool|HvAMAGIC|HV * hv
+=for apidoc_item ||HvAMAGIC_on|HV * hv
+=for apidoc_item || HvAMAGIC_off|HV * hv
+
+Use, respectively,
+C<L</HvOVERLOAD>>,
+C<L</HvOVERLOAD_on>>,
+and C<L</HvOVERLOAD_off>> instead.
+"AMAGIC" is short for "active magic"; a rather vague description of what we
+now call operator overloading.
+
 =cut
 */
 


### PR DESCRIPTION
This series of commits takes advantage of the new B flag that causes perlapi to automatically have text added indicating that the respective element is for backwards-compatibility only.

This allows a modicum of documentation for these, without having to scour the code for the exact behaviors and gotchas.  This should be sufficient for most users, since they are supposed to be moving away from using these symbols anyway.  And its certainly better than no documentation at all, the current state of most of these.

These are the low hanging fruit, where I inferred that these were only for back-compat by noting that the code prohibits use of these in the core, by undefining them except for outside code.

* This set of changes does not require a perldelta entry.
