### PR TITLE
allow perl to build from path containing spaces

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -55,6 +55,7 @@ true)
 
 	pldlflags="$cccdlflags"
 	static_ldflags=''
+	pwd_sans_UU="`pwd | sed 's/\/UU$//'`"
 	case "${osname}${osvers}" in
 	darwin*)
 		shrpldflags="${ldflags} -dynamiclib \
@@ -63,8 +64,9 @@ true)
 			     -current_version \
 				${revision}.${patchlevel}.${subversion}"
 		case "$osvers" in
-	        1[5-9]*|[2-9]*)
-			shrpldflags="$shrpldflags -install_name `pwd -P`/\$@ -Xlinker -headerpad_max_install_names"
+		1[5-9]*|[2-9]*)
+			pwdP="`pwd -P`"
+			shrpldflags="$shrpldflags -install_name `quote "$pwdP"`/\$@ -Xlinker -headerpad_max_install_names"
 			exeldflags="-Xlinker -headerpad_max_install_names"
 			;;
 		*)
@@ -105,7 +107,7 @@ true)
 				;;
 			esac
 			shrpldflags="$shrpldflags $ldflags $perllibs $cryptlib"
-			linklibperl="-L $archlibexp/CORE -L `pwd | sed 's/\/UU$//'` -lperl"
+			linklibperl="-L $archlibexp/CORE -L `quote "$pwd_sans_UU"` -lperl"
 			linklibperl_nonshr='-lperl_nonshr'
 			;;
 		*)
@@ -117,13 +119,13 @@ true)
 				;;
 			esac
 			shrpldflags="$shrpldflags $ldflags $perllibs $cryptlib"
-			linklibperl="-L $archlibexp/CORE -L `pwd | sed 's/\/UU$//'` -lperl"
+			linklibperl="-L $archlibexp/CORE -L `quote "$pwd_sans_UU"` -lperl"
 			linklibperl_nonshr='-lperl_nonshr'
 			;;
 		esac
 		;;
 	hpux*)
-		linklibperl="-L `pwd | sed 's/\/UU$//'` -Wl,+s -Wl,+b$archlibexp/CORE -lperl"
+		linklibperl="-L `quote "$pwd_sans_UU"` -Wl,+s -Wl,+b$archlibexp/CORE -lperl"
 		;;
 	os390*)
             shrpldflags='-shared'
@@ -168,7 +170,7 @@ test -r $lib && export LD_PRELOAD="$lib $LD_PRELOAD"
 exec "$@"
 EOT
 		chmod 755 preload
-		ldlibpth="$ldlibpth `pwd`/preload `pwd`/$libperl"
+		ldlibpth="$ldlibpth `quote "$pwd"`/preload `quote "$pwd"`/$libperl"
 	    fi
 	    ;;
 	os390)	test -f /bin/env && ldlibpth="/bin/env $ldlibpth"
@@ -1093,7 +1095,7 @@ $spitshell >>$Makefile <<!GROK!THIS!
 .PHONY: makeppport
 makeppport: \$(MINIPERL_EXE) \$(CONFIGPM)
 	-@for f in Makefile.PL PPPort_pm.PL RealPPPort_xs.PL ppport_h.PL; do \
-	(cd ext/Devel-PPPort && `pwd`/run.sh ../../$(MINIPERL_EXE) -I../../lib \$\$f); \
+	(cd ext/Devel-PPPort && `quote "$pwd"`/run.sh ../../$(MINIPERL_EXE) -I../../lib \$\$f); \
 	done
 
 !GROK!THIS!

--- a/Porting/bench.pl
+++ b/Porting/bench.pl
@@ -756,7 +756,7 @@ sub process_executables_list {
                         . "seen both in --read file and on command line\n"
             if defined $label && $seen_from_reads{$label};
 
-        my $r = qx($perl -e 'print qq(ok\n)' 2>&1);
+        my $r = qx('$perl' -e 'print qq(ok\n)' 2>&1);
         die "Error: unable to execute '$perl': $r\n" if $r ne "ok\n";
 
         push @results, [ $perl, $label,  { }, '' ];
@@ -1188,7 +1188,7 @@ sub grind_run {
                             . "valgrind --tool=cachegrind  --branch-sim=yes --cache-sim=yes "
                             . "--cachegrind-out-file=/dev/null "
                             . "$OPTS{grindargs} "
-                            . "$perl $OPTS{perlargs} $args - $counts->[$j] 2>&1";
+                            . "'$perl' $OPTS{perlargs} $args - $counts->[$j] 2>&1";
                     # for debugging and error messages
                     my $id = "$test/$label "
                         . ($i ? "active" : "empty") . "/"

--- a/hints/catamount.sh
+++ b/hints/catamount.sh
@@ -106,7 +106,7 @@ Red*) ;; # E.g. "Red Storm Protocol Release 2.1.0"
    exit 1 ;;
 esac
 run=$BUILD/run.sh
-cat > $run <<'__EOF2__'
+cat > "$run" <<'__EOF2__'
 #!/bin/sh
 #
 # $run
@@ -119,7 +119,7 @@ grep "^cata: exe .* signal " .yod$$o
 rm -f .yod$$o .yod$$e
 exit $status
 __EOF2__
-chmod 755 $run
+chmod 755 "$run"
 case "`cc -V 2>&1`" in
 *catamount*) ;; # E.g. "/opt/xt-pe/1.5.41/bin/snos64/cc: INFO: catamount target is being used"
 *) echo "Could not find 'cc' for catamount, aborting."
@@ -127,7 +127,7 @@ case "`cc -V 2>&1`" in
 esac
 
 cc=$BUILD/cc.sh
-cat > $cc <<__EOF3a__
+cat > "$cc" <<__EOF3a__
 #!/bin/sh
 #
 # $0
@@ -147,9 +147,9 @@ srct=''
 exe=''
 defs='-Dmain=catamain -Dexit=cataexit -D_exit=_cataexit'
 argv=''
-BUILD=$BUILD
+BUILD='$BUILD'
 __EOF3a__
-cat >> $cc <<'__EOF3b__'
+cat >> "$cc" <<'__EOF3b__'
 case "$1" in
 --cata_o) ;;
 *) if test ! -f catalib.o
@@ -242,7 +242,7 @@ case "$exe" in
    esac
    ;;
 esac
-cc -I$BUILD $argv 2> .cc$$e > .cc$$o
+cc -I"$BUILD" $argv 2> .cc$$e > .cc$$o
 status=$?
 egrep -v 'catamount target|'$$'\.c:$' .cc$$e 1>&2
 case "`grep "is not implemented" .cc$$e`" in
@@ -262,7 +262,7 @@ then
 fi
 exit $status
 __EOF3b__
-chmod 755 $cc
+chmod 755 "$cc"
 
 cat >cata.h<<__EOF6__
 #ifndef CATA_H

--- a/hints/cygwin.sh
+++ b/hints/cygwin.sh
@@ -15,8 +15,8 @@ test -z "$cc" && cc='gcc'
 if test -z "$plibpth"
 then
     plibpth=`gcc -print-file-name=libc.a`
-    plibpth=`dirname $plibpth`
-    plibpth=`cd $plibpth && pwd`
+    plibpth=`dirname "$plibpth"`
+    plibpth=`cd "$plibpth" && pwd`
 fi
 so='dll'
 # - eliminate -lc, implied by gcc and a symlink to libcygwin.a

--- a/hints/linux-android.sh
+++ b/hints/linux-android.sh
@@ -199,7 +199,7 @@ run=$run-$targetrun
 to=$to-$targetto
 from=$from-$targetfrom
 
-$cat >$run <<EOF
+$cat >"$run" <<EOF
 #!/bin/sh
 doexit="echo \\\$? >$targetdir/output.status"
 env=''
@@ -226,7 +226,7 @@ esac
 exe=\$1
 shift
 args=\$@
-$to \$exe > /dev/null 2>&1
+"$to" \$exe > /dev/null 2>&1
 
 # send copy results to /dev/null as otherwise it outputs speed stats which gets in our way.
 # sometimes there is no $?, I dunno why? we then get Cross/run-adb-shell: line 39: exit: XX: numeric argument required
@@ -234,9 +234,9 @@ adb -s $targethost shell "sh -c '(cd \$cwd && \$env ; \$exe \$args > $targetdir/
 
 rm output.stdout output.stderr output.status 2>/dev/null
 
-$from output.stdout
-$from output.stderr
-$from output.status
+"$from" output.stdout
+"$from" output.stderr
+"$from" output.status
 
 # We get back Ok\r\n on android for some reason, grrr:
 $cat output.stdout | $tr -d '\r'
@@ -252,15 +252,15 @@ rm output.stdout output.stderr output.status
 exit \$result_status
 
 EOF
-$chmod a+rx $run
+$chmod a+rx "$run"
 
-$cat >$targetmkdir <<EOF
+$cat >"$targetmkdir" <<EOF
 #!/bin/sh
 adb -s $targethost shell "mkdir -p \$@"
 EOF
-$chmod a+rx $targetmkdir
+$chmod a+rx "$targetmkdir"
 
-$cat >$to <<EOF
+$cat >"$to" <<EOF
 #!/bin/sh
 for f in \$@
 do
@@ -275,9 +275,9 @@ do
 done
 exit 0
 EOF
-$chmod a+rx $to
+$chmod a+rx "$to"
 
-$cat >$from <<EOF
+$cat >"$from" <<EOF
 #!/bin/sh
 for f in \$@
 do
@@ -286,7 +286,7 @@ do
 done
 exit 0
 EOF
-$chmod a+rx $from
+$chmod a+rx "$from"
 
 fi # Cross-compiling with adb
 
@@ -314,7 +314,7 @@ ldflags="$ldflags -L/system/lib"
 ;;
 esac
 
-osvers="`$run getprop ro.build.version.release`"
+osvers="`"$run" getprop ro.build.version.release`"
 
 # We want osname to be linux-android during Configure,
 # but plain 'android' afterwards.
@@ -324,7 +324,7 @@ case "$src" in
         ;;
 esac
 
-$cat <<'EOO' >> $pwd/config.arch
+$cat <<'EOO' >> "$pwd/config.arch"
 
 osname='android'
 eval "libpth='$libpth /system/lib /vendor/lib'"

--- a/lib/h2xs.t
+++ b/lib/h2xs.t
@@ -167,7 +167,7 @@ while (my ($args, $version, $expectation) = splice @tests, 0, 3) {
   # h2xs warns about what it is writing hence the (possibly unportable)
   # 2>&1 dupe:
   # does it run?
-  my $prog = "$^X $lib $extracted_program $args $dupe";
+  my $prog = "\"$^X\" $lib $extracted_program $args $dupe";
   @result = `$prog`;
   cmp_ok ($?, "==", 0, "running $prog ");
   $result = join("",@result);

--- a/mkppport
+++ b/mkppport
@@ -134,7 +134,7 @@ sub readlist($list)
 sub run
 {
   my @args = ("-I" . File::Spec->catdir((File::Spec->updir) x 2, 'lib'), @_);
-  my $run = $perl =~ m/\s/ ? qq("$perl") : $perl;
+  my $run = $perl;
   for (@args) {
     $_ = qq("$_") if $^O eq 'VMS' && /^[^"]/;
     $run .= " $_";

--- a/t/base/term.t
+++ b/t/base/term.t
@@ -17,7 +17,7 @@ else {print "not ok 1\n";}
 
 # check `` processing
 
-$x = `$^X -le "print 'hi there'"`;
+$x = `"$^X" -le "print 'hi there'"`;
 if ($x eq "hi there\n") {print "ok 2\n";} else {print "not ok 2\n";}
 
 # check $#array

--- a/t/io/dup.t
+++ b/t/io/dup.t
@@ -29,7 +29,7 @@ print STDOUT "ok 2\n";
 print STDERR "ok 3\n";
 
 # Since some systems don't have echo, we use Perl.
-$echo = qq{$^X -le "print q(ok %d)"};
+$echo = qq{"$^X" -le "print q(ok %d)"};
 
 $cmd = sprintf $echo, 4;
 print `$cmd`;

--- a/t/io/open.t
+++ b/t/io/open.t
@@ -91,7 +91,7 @@ my $afile = tempfile();
 }
 {
     ok( open(my $f, '-|', <<EOC),     'open -|' );
-    $Perl -e "print qq(a row\\n); print qq(another row\\n)"
+    "$Perl" -e "print qq(a row\\n); print qq(another row\\n)"
 EOC
 
     ok_cloexec($f);
@@ -101,7 +101,7 @@ EOC
 }
 {
     ok( open(my $f, '|-', <<EOC),     'open |-' );
-    $Perl -pe "s/^not //"
+    "$Perl" -pe "s/^not //"
 EOC
 
     ok_cloexec($f);
@@ -197,7 +197,7 @@ ok( -s $afile < 20,                     '       -s' );
 
 {
     ok( open(local $f, '-|', <<EOC),  'open local $f, "-|", ...' );
-    $Perl -e "print qq(a row\\n); print qq(another row\\n)"
+    "$Perl" -e "print qq(a row\\n); print qq(another row\\n)"
 EOC
     ok_cloexec($f);
     my @rows = <$f>;
@@ -208,7 +208,7 @@ EOC
 
 {
     ok( open(local $f, '|-', <<EOC),  'open local $f, "|-", ...' );
-    $Perl -pe "s/^not //"
+    "$Perl" -pe "s/^not //"
 EOC
 
     ok_cloexec($f);
@@ -232,14 +232,14 @@ like( $@, qr/Bad filehandle:\s+$afile/,          '       right error' );
 {
     local *F;
     for (1..2) {
-	ok( open(F, qq{$Perl -le "print 'ok'"|}), 'open to pipe' );
+	ok( open(F, qq{"$Perl" -le "print 'ok'"|}), 'open to pipe' );
 	ok_cloexec(\*F);
 	is(scalar <F>, "ok\n",  '       readline');
 	ok( close F,            '       close' );
     }
 
     for (1..2) {
-	ok( open(F, "-|", qq{$Perl -le "print 'ok'"}), 'open -|');
+	ok( open(F, "-|", qq{"$Perl" -le "print 'ok'"}), 'open -|');
 	ok_cloexec(\*F);
 	is( scalar <F>, "ok\n", '       readline');
 	ok( close F,            '       close' );
@@ -390,7 +390,7 @@ is($@, '', 'no "Modification of a read-only value" when closing');
 {
     package p73626;
     sub TIESCALAR { bless {} }
-    sub FETCH { "$Perl -e 1"}
+    sub FETCH { qq["$Perl" -e 1]}
 
     tie my $p, 'p73626';
 

--- a/t/io/openpid.t
+++ b/t/io/openpid.t
@@ -24,7 +24,7 @@ $SIG{HUP} = 'DEFAULT';
 $SIG{HUP} = 'IGNORE' if $^O eq 'interix';
 
 my $perl = which_perl();
-$perl .= qq[ "-I../lib"];
+$perl = qq["$perl" "-I../lib"];
 
 my @perl = ( which_perl(), "-I../lib" );
 

--- a/t/io/pipe.t
+++ b/t/io/pipe.t
@@ -176,7 +176,7 @@ SKIP: {
           if $^O eq 'posix-bc';
 
         local $SIG{PIPE} = 'IGNORE';
-        open NIL, qq{|$Perl -e "exit 0"} or die "open failed: $!";
+        open NIL, qq{|"$Perl" -e "exit 0"} or die "open failed: $!";
         sleep 5;
         if (print NIL 'foo') {
             # If print was allowed we had better get an error on close
@@ -190,7 +190,7 @@ SKIP: {
     {
         # check that errno gets forced to 0 if the piped program exited 
         # non-zero
-        open NIL, qq{|$Perl -e "exit 23";} or die "fork failed: $!";
+        open NIL, qq{|"$Perl" -e "exit 23";} or die "fork failed: $!";
         $! = 1;
         ok(!close NIL,  'close failure on non-zero piped exit');
         is($!, '',      '       errno');
@@ -230,7 +230,7 @@ SKIP: {
 # check that status is unaffected by implicit close
 {
     local(*NIL);
-    open NIL, qq{|$Perl -e "exit 23"} or die "fork failed: $!";
+    open NIL, qq{|"$Perl" -e "exit 23"} or die "fork failed: $!";
     $? = 42;
     # NIL implicitly closed here
 }
@@ -261,7 +261,7 @@ SKIP: {
 \$SIG{ALRM}=sub{die};
 alarm 1;
 \$Perl = q\0$Perl\0;
-my \$cmd = qq(\$Perl -e "sleep 3");
+my \$cmd = qq("\$Perl" -e "sleep 3");
 my \$pid = open my \$fh, "|\$cmd" or die "\$!\n";
 close \$fh;
 PROG

--- a/t/io/through.t
+++ b/t/io/through.t
@@ -71,22 +71,22 @@ sub testpipe ($$$$$$) {
   my $fh;
   if ($how_w eq 'print') {	# AUTOFLUSH???
     # Should be shell-neutral:
-    open $fh, '-|', qq[$Perl -we "$set_out;print for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
+    open $fh, '-|', qq["$Perl" -we "$set_out;print for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
   } elsif ($how_w eq 'print/flush') {
     # shell-neutral and miniperl-enabled autoflush? qq(\x24\x7c) eq '$|'
     if ($::IS_ASCII) {
-        open $fh, '-|', qq[$Perl -we "$set_out;eval qq(\\x24\\x7c = 1) or die;print for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
+        open $fh, '-|', qq["$Perl" -we "$set_out;eval qq(\\x24\\x7c = 1) or die;print for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
     }
     else {
-        open $fh, '-|', qq[$Perl -we "$set_out;eval qq(\\x5b\\x4f = 1) or die;print for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
+        open $fh, '-|', qq["$Perl" -we "$set_out;eval qq(\\x5b\\x4f = 1) or die;print for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
     }
   } elsif ($how_w eq 'syswrite') {
     ### How to protect \$_
     if ($::IS_ASCII) {
-        open $fh, '-|', qq[$Perl -we "$set_out;eval qq(sub w {syswrite STDOUT, \\x24_} 1) or die; w() for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
+        open $fh, '-|', qq["$Perl" -we "$set_out;eval qq(sub w {syswrite STDOUT, \\x24_} 1) or die; w() for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
     }
     else {
-        open $fh, '-|', qq[$Perl -we "$set_out;eval qq(sub w {syswrite STDOUT, \\x5B_} 1) or die; w() for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
+        open $fh, '-|', qq["$Perl" -we "$set_out;eval qq(sub w {syswrite STDOUT, \\x5B_} 1) or die; w() for grep length, split /(.{1,$write_c})/s, qq($quoted)"] or die "open: $!";
     }
   } else {
     die "Unrecognized write: '$how_w'";
@@ -129,10 +129,10 @@ sub testfile ($$$$$$) {
 # shell-neutral and miniperl-enabled autoflush? qq(\x24\x7c) eq '$|'
 my $fh;
 if ($::IS_ASCII) {
-    open $fh, '-|', qq[$Perl -we "eval qq(\\x24\\x7c = 1) or die; binmode STDOUT; sleep 1, print for split //, qq(a\nb\n\nc\n\n\n)"] or die "open: $!";
+    open $fh, '-|', qq["$Perl" -we "eval qq(\\x24\\x7c = 1) or die; binmode STDOUT; sleep 1, print for split //, qq(a\nb\n\nc\n\n\n)"] or die "open: $!";
 }
 else {
-    open $fh, '-|', qq[$Perl -we "eval qq(\\x5B\\x4f = 1) or die; binmode STDOUT; sleep 1, print for split //, qq(a\nb\n\nc\n\n\n)"] or die "open: $!";
+    open $fh, '-|', qq["$Perl" -we "eval qq(\\x5B\\x4f = 1) or die; binmode STDOUT; sleep 1, print for split //, qq(a\nb\n\nc\n\n\n)"] or die "open: $!";
 }
 ok(1, 'open pipe');
 binmode $fh, q(:crlf);

--- a/t/lib/warnings/doio
+++ b/t/lib/warnings/doio
@@ -60,10 +60,10 @@
 __END__
 # doio.c [Perl_do_open9]
 use warnings 'io' ;
-open(F, '|'."$^X -e 1|");
+open(F, "|\"$^X\" -e 1|");
 close(F);
 no warnings 'io' ;
-open(G, '|'."$^X -e 1|");
+open(G, "|\"$^X\" -e 1|");
 close(G);
 EXPECT
 Can't open bidirectional pipe at - line 3.

--- a/t/lib/warnings/op
+++ b/t/lib/warnings/op
@@ -1135,7 +1135,7 @@ Format FRED redefined at - line 5.
 ########
 # op.c
 use warnings 'exec' ;
-exec "$^X -e 1" ; 
+exec "\"$^X\" -e 1" ;
 my $a
 EXPECT
 Statement unlikely to be reached at - line 4.
@@ -1143,7 +1143,7 @@ Statement unlikely to be reached at - line 4.
 ########
 # op.c, no warning if exec isn't a statement.
 use warnings 'exec' ;
-$a || exec "$^X -e 1" ;
+$a || exec "\"$^X\" -e 1" ;
 my $a
 EXPECT
 ########
@@ -1177,7 +1177,7 @@ Can't use 'defined(%hash)' (Maybe you should just omit the defined()?) at - line
 ########
 # op.c
 no warnings 'exec' ;
-exec "$^X -e 1" ; 
+exec "\"$^X\" -e 1" ;
 my $a
 EXPECT
 

--- a/t/op/alarm.t
+++ b/t/op/alarm.t
@@ -38,7 +38,7 @@ eval {
     local $SIG{ALRM} = sub { $end_time = time; die "ALARM!\n" };
     $start_time = time;
     alarm 3;
-    system(qq{$Perl -e "sleep 6"});
+    system(qq{"$Perl" -e "sleep 6"});
     $end_time = time;
     alarm 0;
 };
@@ -57,7 +57,7 @@ is( $@, "ALARM!\n",             'alarm w/$SIG{ALRM} vs system()' );
 
 {
     local $SIG{"ALRM"} = sub { die };
-    eval { alarm(1); my $x = qx($Perl -e "sleep 3"); alarm(0); };
+    eval { alarm(1); my $x = qx("$Perl" -e "sleep 3"); alarm(0); };
     chomp (my $foo = "foo\n");
     ok($foo eq "foo", '[perl #33928] chomp() fails after alarm(), `sleep`');
 }

--- a/t/op/die_exit.t
+++ b/t/op/die_exit.t
@@ -64,10 +64,10 @@ foreach my $test (@tests) {
     my($bang, $query, $code) = @$test;
     $code ||= 'die;';
     if ($^O eq 'MSWin32' || $^O eq 'VMS') {
-        system(qq{$^X -e "\$! = $bang; \$? = $query; $code"});
+        system(qq{"$^X" -e "\$! = $bang; \$? = $query; $code"});
     }
     else {
-        system(qq{$^X -e '\$! = $bang; \$? = $query; $code'});
+        system(qq{"$^X" -e '\$! = $bang; \$? = $query; $code'});
     }
     my $exit = $?;
 

--- a/t/op/exec.t
+++ b/t/op/exec.t
@@ -45,13 +45,13 @@ SKIP: {
     skip("bug/feature of pdksh", 2) if $^O eq 'os2';
 
     my $tnum = curr_test();
-    $exit = system qq{$Perl -le "print q{ok $tnum - interp system(EXPR)"}};
+    $exit = system qq{"$Perl" -le "print q{ok $tnum - interp system(EXPR)"}};
     next_test();
     is( $exit, 0, '  exited 0' );
 }
 
 my $tnum = curr_test();
-$exit = system qq{$Perl -le "print q{ok $tnum - split & direct system(EXPR)"}};
+$exit = system qq{"$Perl" -le "print q{ok $tnum - split & direct system(EXPR)"}};
 next_test();
 is( $exit, 0, '  exited 0' );
 
@@ -68,7 +68,7 @@ is( $exit, 0, '  exited 0' );
 # Some basic piped commands.  Some OS's have trouble with "helpfully"
 # putting newlines on the end of piped output.  So we split this into
 # newline insensitive and newline sensitive tests.
-my $echo_out = `$Perl -e "print 'ok'" | $Perl -le "print <STDIN>"`;
+my $echo_out = `"$Perl" -e "print 'ok'" | "$Perl" -le "print <STDIN>"`;
 $echo_out =~ s/\n\n/\n/g;
 is( $echo_out, "ok\n", 'piped echo emulation');
 
@@ -77,19 +77,19 @@ is( $echo_out, "ok\n", 'piped echo emulation');
     # piped output.
     local $TODO = 'VMS sticks newlines on everything' if $Is_VMS;
 
-    is( scalar `$Perl -e "print 'ok'"`,
+    is( scalar `"$Perl" -e "print 'ok'"`,
         "ok", 'no extra newlines on ``' );
 
-    is( scalar `$Perl -e "print 'ok'" | $Perl -e "print <STDIN>"`, 
+    is( scalar `"$Perl" -e "print 'ok'" | "$Perl" -e "print <STDIN>"`,
         "ok", 'no extra newlines on pipes');
 
-    is( scalar `$Perl -le "print 'ok'" | $Perl -le "print <STDIN>"`, 
+    is( scalar `"$Perl" -le "print 'ok'" | "$Perl" -le "print <STDIN>"`,
         "ok\n\n", 'doubled up newlines');
 
-    is( scalar `$Perl -e "print 'ok'" | $Perl -le "print <STDIN>"`, 
+    is( scalar `"$Perl" -e "print 'ok'" | "$Perl" -le "print <STDIN>"`,
         "ok\n", 'extra newlines on inside pipes');
 
-    is( scalar `$Perl -le "print 'ok'" | $Perl -e "print <STDIN>"`, 
+    is( scalar `"$Perl" -le "print 'ok'" | "$Perl" -e "print <STDIN>"`,
         "ok\n", 'extra newlines on outgoing pipes');
 
     {
@@ -100,10 +100,10 @@ is( $echo_out, "ok\n", 'piped echo emulation');
 }
 
 
-is( system(qq{$Perl -e "exit 0"}), 0,     'Explicit exit of 0' );
+is( system(qq{"$Perl" -e "exit 0"}), 0,     'Explicit exit of 0' );
 
 my $exit_one = $vms_exit_mode ? 4 << 8 : 1 << 8;
-is( system(qq{$Perl "-I../lib" -e "use vmsish qw(hushed); exit 1"}), $exit_one,
+is( system(qq{"$Perl" "-I../lib" -e "use vmsish qw(hushed); exit 1"}), $exit_one,
     'Explicit exit of 1' );
 
 $rc = system { "lskdfj" } "lskdfj";
@@ -120,17 +120,17 @@ unless ( ok( $! == 2  or  $! =~ /\bno\b.*\bfile/i or
 }
 
 
-is( `$Perl -le "print 'ok'"`,   "ok\n",     'basic ``' );
+is( `"$Perl" -le "print 'ok'"`,   "ok\n",     'basic ``' );
 is( <<`END`,                    "ok\n",     '<<`HEREDOC`' );
-$Perl -le "print 'ok'"
+"$Perl" -le "print 'ok'"
 END
 
 is( <<~`END`,                   "ok\n",     '<<~`HEREDOC`' );
-  $Perl -le "print 'ok'"
+  "$Perl" -le "print 'ok'"
   END
 
 {
-    sub rpecho { qq($Perl -le "print '$_[0]'") }
+    sub rpecho { qq("$Perl" -le "print '$_[0]'") }
     is scalar(readpipe(rpecho("b"))), "b\n",
 	"readpipe with one argument in scalar context";
     is join(",", "a", readpipe(rpecho("b")), "c"), "a,b\n,c",

--- a/t/op/fork.t
+++ b/t/op/fork.t
@@ -31,7 +31,7 @@ SKIP: {
 	unless $probe eq 'good';
 
     my $out = qx{
-        $shell -c 'ulimit -u 1; exec $^X -e "
+        $shell -c 'ulimit -u 1; exec "$^X" -e "
             print((() = fork) == 1 ? q[ok] : q[not ok])
         "'
     };
@@ -255,10 +255,10 @@ $| = 1;
 $\ = "\n";
 my $getenv;
 if ($^O eq 'MSWin32') {
-    $getenv = qq[$^X -e "print \$ENV{TST}"];
+    $getenv = qq["$^X" -e "print \$ENV{TST}"];
 }
 else {
-    $getenv = qq[$^X -e 'print \$ENV{TST}'];
+    $getenv = qq["$^X" -e 'print \$ENV{TST}'];
 }
 $ENV{TST} = 'foo';
 if (fork) {

--- a/t/op/lex_assign.t
+++ b/t/op/lex_assign.t
@@ -17,7 +17,7 @@ $runme = $^X;
 %h = (1..6);
 $aref = \@a;
 $href = \%h;
-open OP, qq{$runme -le "print 'aaa Ok ok' for 1..100"|};
+open OP, qq{"$runme" -le "print 'aaa Ok ok' for 1..100"|};
 $chopit = 'aaaaaa';
 @chopar = (113 .. 119);
 $posstr = '123456';
@@ -262,7 +262,7 @@ done_testing();
 __END__
 ref $xref			# ref
 ref $cstr			# ref nonref
-`$runme -e "print qq[1\\n]"`				# backtick skip(MSWin32)
+`"$runme" -e "print qq[1\\n]"`				# backtick skip(MSWin32)
 `$undefed`			# backtick undef skip(MSWin32)
 '???'				# glob  (not currently OA_TARGLEX)
 <OP>				# readline
@@ -389,7 +389,7 @@ readlink 'non-existent', 'non-existent1' # readlink
 '???'				# fork
 '???'				# wait
 '???'				# waitpid
-system "$runme -e 0"		# system skip(VMS)
+system $runme, "-e", "0"	# system skip(VMS)
 '???'				# exec
 '???'				# kill
 getppid				# getppid

--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -126,7 +126,7 @@ SKIP: {
     sub FETCH { $next_test + pop }
     tie my @tn, __PACKAGE__;
 
-    open( CMDPIPE, "|-", $PERL);
+    open( CMDPIPE, "|-", $PERL, "-");
 
     print CMDPIPE "\$t1 = $tn[1]; \$t2 = $tn[2];\n", <<'END';
 
@@ -149,7 +149,7 @@ END
 
     close CMDPIPE;
 
-    open( CMDPIPE, "|-", $PERL);
+    open( CMDPIPE, "|-", $PERL, "-");
     print CMDPIPE "\$t3 = $tn[3];\n", <<'END';
 
     { package X;
@@ -180,7 +180,7 @@ END
     $todo = ($Config{usecrosscompile} ? '# TODO: Not sure whats going on here when cross-compiling' : '');
     print $? & 0xFF ? "ok $tn[4]$todo\n" : "not ok $tn[4]$todo\n";
 
-    open(CMDPIPE, "|-", $PERL);
+    open(CMDPIPE, "|-", $PERL, "-");
     print CMDPIPE <<'END';
 
     sub PVBM () { 'foo' }
@@ -244,9 +244,9 @@ is((keys %h)[0], "foo\034bar");
 }
 
 # $?, $@, $$
-system qq[$PERL "-I../lib" -e "use vmsish qw(hushed); exit(0)"];
+system qq["$PERL" "-I../lib" -e "use vmsish qw(hushed); exit(0)"];
 is $?, 0;
-system qq[$PERL "-I../lib" -e "use vmsish qw(hushed); exit(1)"];
+system qq["$PERL" "-I../lib" -e "use vmsish qw(hushed); exit(1)"];
 isnt $?, 0;
 
 eval { die "foo\n" };
@@ -312,7 +312,7 @@ $$ = $pid; # Tests below use $$
 	$headmaybe = <<EOH ;
 \@rem ='
 \@echo off
-$perl -x \%0
+"$perl" -x \%0
 goto endofperl
 \@rem ';
 EOH
@@ -349,20 +349,21 @@ print "\$^X is $^X, \$0 is $0\n";
 EOF
     ok close(SCRIPT) or diag $!;
     ok chmod(0755, $script) or diag $!;
-    $_ = $Is_VMS ? `$perl $script` : `$script`;
-    s/\.exe//i if $Is_Cygwin or $Is_os2;
-    s{is perl}{is $perl}; # for systems where $^X is only a basename
-    s{\\}{/}g;
-    if ($Is_MSWin32 || $Is_os2) {
-	is uc $_, uc $s1;
-    } else {
-  SKIP:
-     {
-	  skip "# TODO: Hit bug posix-2058; exec does not setup argv[0] correctly." if ($^O eq "vos");
-	  is $_, $s1;
-     }
+    SKIP: {
+        skip "can't test shebang because path to executable contains spaces"
+            if !$Is_VMS && $perl =~ / / && $headmaybe eq '';
+        $_ = $Is_VMS ? `$perl $script` : `"$script"`;
+        s/\.exe//i if $Is_Cygwin or $Is_os2;
+        s{is perl}{is $perl}; # for systems where $^X is only a basename
+        s{\\}{/}g;
+        if ($Is_MSWin32 || $Is_os2) {
+            is uc $_, uc $s1;
+        } else {
+            skip "# TODO: Hit bug posix-2058; exec does not setup argv[0] correctly." if ($^O eq "vos");
+            is $_, $s1;
+        }
     }
-    $_ = `$perl $script`;
+    $_ = `"$perl" "$script"`;
     s/\.exe//i if $Is_os2 or $Is_Cygwin;
     s{\\}{/}g;
     if ($Is_MSWin32 || $Is_os2) {

--- a/t/op/srand.t
+++ b/t/op/srand.t
@@ -54,9 +54,9 @@ ok( !eq_array(\@first_run, \@second_run),
 # This test checks whether Perl called srand for you.
 {
     local $ENV{PERL_RAND_SEED};
-    @first_run  = `$^X -le "print int rand 100 for 1..100"`;
+    @first_run  = `"$^X" -le "print int rand 100 for 1..100"`;
     sleep(1); # in case our srand() is too time-dependent
-    @second_run = `$^X -le "print int rand 100 for 1..100"`;
+    @second_run = `"$^X" -le "print int rand 100 for 1..100"`;
 }
 
 ok( !eq_array(\@first_run, \@second_run), 'srand() called automatically');

--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -39,9 +39,10 @@ elsif( $ENV{GITHUB_ACTIONS} && length $ENV{GITHUB_BASE_REF} ) {
 
     # gives the history of the branch being merged, excluding what it is
     # merged into
-    $revision_range = '"HEAD^1..HEAD^2"'
+    $revision_range = 'HEAD^1..HEAD^2'
         if $branch_head;
 }
 
-exec("$^X Porting/updateAUTHORS.pl --source_dir=$source_dir --validate $revision_range");
+exec $^X, 'Porting/updateAUTHORS.pl', "--source_dir=$source_dir", '--validate', $revision_range;
+die "$^X: $!";
 # EOF

--- a/t/porting/bench.t
+++ b/t/porting/bench.t
@@ -28,14 +28,14 @@ skip_all "no valgrind" unless -x '/bin/valgrind' || -x '/usr/bin/valgrind';
 # Address sanitizer clashes horribly with cachegrind
 skip_all "not with ASAN" if $Config{ccflags} =~ /sanitize=address/;
 # If this takes more than 15 second then something is very wrong
-skip_all "cachegrind broken" if system "( ulimit -c 0; ulimit -t 15; valgrind -q --tool=cachegrind --cachegrind-out-file=/dev/null $^X -e0 ) 2>/dev/null";
+skip_all "cachegrind broken" if system "( ulimit -c 0; ulimit -t 15; valgrind -q --tool=cachegrind --cachegrind-out-file=/dev/null '$^X' -e0 ) 2>/dev/null";
 
 
 my $bench_pl = "Porting/bench.pl";
 
 ok -e $bench_pl, "$bench_pl exists and is executable";
 
-my $bench_cmd = "$^X -Ilib $bench_pl";
+my $bench_cmd = "'$^X' -Ilib $bench_pl";
 
 my ($out, $cmd);
 
@@ -404,7 +404,7 @@ my $resultfile2 = tempfile(); # benchmark results for 2 perls
 # the -j 2 is to minimally exercise its parallel facility.
 
 note("running cachegrind for 1st perl; may be slow...");
-$out = qx($bench_cmd -j 2 --write=$resultfile1 --tests=call::sub::empty $^X=p0 2>&1);
+$out = qx($bench_cmd -j 2 --write=$resultfile1 --tests=call::sub::empty '$^X'=p0 2>&1);
 is $out, "", "--write should produce no output (1 perl)";
 ok -s $resultfile1, "--write should create a non-empty results file (1 perl)";
 
@@ -412,7 +412,7 @@ ok -s $resultfile1, "--write should create a non-empty results file (1 perl)";
 # perls' functionality.
 
 note("running cachegrind for 2nd perl; may be slow...");
-$out = qx($bench_cmd -j 2 --read=$resultfile1 --write=$resultfile2 $^X=p1 2>&1);
+$out = qx($bench_cmd -j 2 --read=$resultfile1 --write=$resultfile2 '$^X'=p1 2>&1);
 is $out, "", "--write should produce no output (2 perls)"
     or diag("got: $out");
 ok -s $resultfile2, "--write should create a non-empty results file (2 perls)";
@@ -531,7 +531,7 @@ like $out, $format_qrs{percent2}, "2 reads; overlapping test sets";
 # A read defines what benchmarks to run
 
 note("running cachegrind on 1 perl; may be slow...");
-$out = qx($bench_cmd --read=t/porting/bench/callsub.json --tests=call::sub::empty $^X=p1 2>&1);
+$out = qx($bench_cmd --read=t/porting/bench/callsub.json --tests=call::sub::empty '$^X'=p1 2>&1);
 $out =~ s{^\./perl}{p0}m;
 $out =~ s{\Q./perl}{    p0};
 like $out, $format_qrs{percent2}, "1 read; 1 generate";
@@ -551,8 +551,8 @@ $bench_cmd
     --tests=call::sub::empty
     --autolabel
     --perlargs=-Ilib
-    $^X --args='-Ifoo/bar -Mstrict' --env='FOO=foo'
-    $^X --args='-Ifoo/bar'          --env='BAR=bar' --env='BAZ=baz'
+    '$^X' --args='-Ifoo/bar -Mstrict' --env='FOO=foo'
+    '$^X' --args='-Ifoo/bar'          --env='BAR=bar' --env='BAZ=baz'
     2>&1
 EOF
 $cmd =~ s/\n\s+/ /g;

--- a/t/porting/bench_selftest.t
+++ b/t/porting/bench_selftest.t
@@ -7,4 +7,5 @@ use strict;
 chdir '..' if -f 'test.pl' && -f 'thread_it.pl';
 require './t/test.pl';
 
-system "$^X -I. -MTestInit Porting/bench.pl --action=selftest";
+exec $^X, qw(-I. -MTestInit Porting/bench.pl --action=selftest);
+die "$^X: $!";

--- a/t/porting/checkcfgvar.t
+++ b/t/porting/checkcfgvar.t
@@ -32,4 +32,5 @@ if ( $Config{usecrosscompile} ) {
   skip_all( "Not all files are available during cross-compilation" );
 }
 
-system "$^X -Ilib Porting/checkcfgvar.pl --tap";
+exec $^X, qw(-Ilib Porting/checkcfgvar.pl --tap);
+die "$^X: $!";

--- a/t/porting/cmp_version.t
+++ b/t/porting/cmp_version.t
@@ -28,4 +28,5 @@ require './t/test.pl';
 my $source = find_git_or_skip('all');
 chdir $source or die "Can't chdir to $source: $!";
 
-system "$^X Porting/cmpVERSION.pl --tap";
+exec $^X, qw(Porting/cmpVERSION.pl --tap);
+die "$^X: $!";

--- a/t/porting/cpphdrcheck.t
+++ b/t/porting/cpphdrcheck.t
@@ -79,7 +79,7 @@ my $perl_headers = <<'HEADERS';
 
 HEADERS
 
-$ccflags .= " " . join " ", map { "-I$_" }
+$ccflags .= " " . join " ", map { qq("-I$_") }
   File::Spec->catdir($cwd, ".."),
   # win32 has special config.h handling during the build
   File::Spec->catdir($cwd, "..", "lib", "CORE");

--- a/t/porting/perlfunc.t
+++ b/t/porting/perlfunc.t
@@ -38,4 +38,5 @@ if ( ord("A") == 193) {
     exit 0;
 }
 
-system "$^X ext/Pod-Functions/Functions_pm.PL --tap pod/perlfunc.pod";
+exec $^X, qw(ext/Pod-Functions/Functions_pm.PL --tap pod/perlfunc.pod);
+die "$^X: $!";

--- a/t/porting/regen.t
+++ b/t/porting/regen.t
@@ -129,7 +129,7 @@ my @errors;
 foreach my $prog (@progs) {
     my $args = qq[-Ilib $prog --tap];
     note("./perl $args");
-    my $command = "$^X $args";
+    my $command = qq["$^X" $args];
     if (system $command) { # if it exits with an error...
         $command=~s/\s*--tap//;
         push @errors, $prog eq "regen.pl"

--- a/t/porting/test_testlist.t
+++ b/t/porting/test_testlist.t
@@ -21,13 +21,13 @@ $ENV{PERL_TORTURE_TEST} = 1;
 $ENV{PERL_TEST_MEMORY} = 1;
 $ENV{PERL_BENCHMARK} = 1;
 
-for my $file (`$^X t/harness -dumptests`) {
+for my $file (`"$^X" t/harness -dumptests`) {
     chomp $file;
     $all{$file}++;
     $th{$file}++;
 }
 
-for my $file (`$^X t/TEST -dumptests`) {
+for my $file (`"$^X" t/TEST -dumptests`) {
     chomp $file;
     $all{$file}++;
     delete $th{$file} or $tt{$file}++;

--- a/t/run/cloexec.t
+++ b/t/run/cloexec.t
@@ -83,7 +83,7 @@ plan(tests => 22);
 sub test_not_inherited {
     my $expected_fd = shift;
     ok( -f $tmpfile2, "tmpfile '$tmpfile2' exists" );
-    my $cmd = qq{$Perl -e $quote$Child_prog$quote $expected_fd};
+    my $cmd = qq{"$Perl" -e $quote$Child_prog$quote $expected_fd};
     # Expect 'Bad file descriptor' or similar to be written to STDERR.
     local *SAVERR; open SAVERR, ">&STDERR";  # save original STDERR
     open STDERR, ">$tmperr" or die "open '$tmperr': $!";
@@ -103,7 +103,7 @@ sub test_not_inherited {
 sub test_inherited {
     my $expected_fd = shift;
     ok( -f $tmpfile1, "tmpfile '$tmpfile1' exists" );
-    my $cmd = qq{$Perl -e $quote$Child_prog$quote $expected_fd};
+    my $cmd = qq{"$Perl" -e $quote$Child_prog$quote $expected_fd};
     my $out = `$cmd`;
     my $rc  = $? >> 8;
     cmp_ok( $rc, '==', 0,

--- a/t/run/locale.t
+++ b/t/run/locale.t
@@ -719,7 +719,7 @@ SKIP: {   # GH #20054
     fresh_perl_like(<<~EOT,
                         local \$ENV{LC_ALL} = "This is not a legal locale name";
                         local \$ENV{LANG} = "Nor this neither";
-                        system "\$^X -e1";
+                        system \$^X, "-e1";
                     EOT
                     qr/Falling back to the $fallback locale/,
                     {}, "check that illegal startup environment falls back");

--- a/t/run/script.t
+++ b/t/run/script.t
@@ -11,7 +11,7 @@ my $Perl = which_perl();
 
 my $filename = tempfile();
 
-$x = `$Perl -le "print 'ok';"`;
+$x = `"$Perl" -le "print 'ok';"`;
 
 is($x, "ok\n", "Got expected 'perl -le' output");
 
@@ -19,10 +19,10 @@ open(try,">$filename") || (die "Can't open temp file.");
 print try 'print "ok\n";'; print try "\n";
 close try or die "Could not close: $!";
 
-$x = `$Perl $filename`;
+$x = `"$Perl" $filename`;
 
 is($x, "ok\n", "Got expected output of command from script");
 
-$x = `$Perl <$filename`;
+$x = `"$Perl" <$filename`;
 
 is($x, "ok\n", "Got expected output of command read from script");

--- a/t/run/switches.t
+++ b/t/run/switches.t
@@ -188,7 +188,7 @@ SWTEST
     close $f or die "Could not close: $!";
     $r = runperl(
 	progfile    => $filename,
-	args	    => [ '-x=foo -y' ],
+	args	    => [ '-x=foo', '-y' ],
     );
     is( $r, 'foo1', '-s on the shebang line' );
 }

--- a/t/run/switcht.t
+++ b/t/run/switcht.t
@@ -22,14 +22,14 @@ my $Tmsg = 'while running with -t switch';
 
 is( ${^TAINT}, -1, '${^TAINT} == -1' );
 
-my $out = `$Perl -le "print q(Hello)"`;
+my $out = `"$Perl" -le "print q(Hello)"`;
 is( $out, "Hello\n",                      '`` worked' );
 like( $warning, qr/^Insecure .* $Tmsg/, '    taint warn' );
 
 {
     no warnings 'taint';
     $warning = '';
-    my $out = `$Perl -le "print q(Hello)"`;
+    my $out = `"$Perl" -le "print q(Hello)"`;
     is( $out, "Hello\n",                      '`` worked' );
     is( $warning, '',                       '   no warnings "taint"' );
 }

--- a/t/test.pl
+++ b/t/test.pl
@@ -723,6 +723,7 @@ sub _create_runperl { # Create the string to qx in runperl().
     if ($runperl =~ m/\s/) {
         $runperl = qq{"$runperl"};
     }
+    my $perl_exe = $runperl;
     #- this allows, for example, to set PERL_RUNPERL_DEBUG=/usr/bin/valgrind
     if ($ENV{PERL_RUNPERL_DEBUG}) {
 	$runperl = "$ENV{PERL_RUNPERL_DEBUG} $runperl";
@@ -779,11 +780,11 @@ sub _create_runperl { # Create the string to qx in runperl().
 	$args{stdin} =~ s/\r/\\r/g;
 
 	if ($is_mswin || $is_vms) {
-	    $runperl = qq{$Perl -e "print qq(} .
+	    $runperl = qq{$perl_exe -e "print qq(} .
 		$args{stdin} . q{)" | } . $runperl;
 	}
 	else {
-	    $runperl = qq{$Perl -e 'print qq(} .
+	    $runperl = qq{$perl_exe -e 'print qq(} .
 		$args{stdin} . q{)' | } . $runperl;
 	}
     } elsif (exists $args{stdin}) {

--- a/t/test.pl
+++ b/t/test.pl
@@ -709,10 +709,11 @@ sub _quote_args {
     my ($runperl, $args) = @_;
 
     foreach (@$args) {
-	# In VMS protect with doublequotes because otherwise
-	# DCL will lowercase -- unless already doublequoted.
-       $_ = q(").$_.q(") if $is_vms && !/^\"/ && length($_) > 0;
-       $runperl = $runperl . ' ' . $_;
+        my $arg = $_;
+        # In VMS protect with doublequotes because otherwise
+        # DCL will lowercase -- unless already doublequoted.
+        $arg = q(").$arg.q(") if $is_vms && $arg !~ /^\"/ && length($arg) > 0;
+        $runperl = $runperl . ' ' . $arg;
     }
     return $runperl;
 }

--- a/t/test.pl
+++ b/t/test.pl
@@ -712,7 +712,7 @@ sub _quote_args {
         my $arg = $_;
         # In VMS protect with doublequotes because otherwise
         # DCL will lowercase -- unless already doublequoted.
-        $arg = q(").$arg.q(") if $is_vms && $arg !~ /^\"/ && length($arg) > 0;
+        $arg = q(").$arg.q(") if ($is_vms || $arg =~ /\s/) && $arg !~ /^\"/ && length($arg) > 0;
         $runperl = $runperl . ' ' . $arg;
     }
     return $runperl;


### PR DESCRIPTION
Fix the basic build if the path to the source directory contains spaces (mainly `mkppport` and `Makefile.SH`). This is not a complete fix: Platform-specific hints may still contain unguarded uses of `pwd` / `$PWD`.

A few tests are also fixed, in particular porting tests. (Many other tests still fail, but this is better than nothing.)

See #24670.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
