### PR TITLE
add and use STRLEN_MAX

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -2462,6 +2462,7 @@ typedef UVTYPE UV;
 
 #define Size_t_MAX (~(Size_t)0)
 #define SSize_t_MAX (SSize_t)(~(Size_t)0 >> 1)
+#define STRLEN_MAX (~(STRLEN)0)
 
 /*
 =for apidoc_section $integer

--- a/perlio.c
+++ b/perlio.c
@@ -1130,7 +1130,7 @@ PerlIOScalar_read(pTHX_ PerlIO *f, void *vbuf, Size_t count)
          * be the case on other 64-bit platforms.
          */
 #if Off_t_size >= Size_t_size
-        assert(len < ((~(STRLEN)0) >> 1));
+        assert(len < (STRLEN_MAX >> 1));
         if ((Off_t)len <= s->posn)
 	    return 0;
 #else

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3242,6 +3242,7 @@ my %undocumented_always_visible = map { $_ => 1 } qw(
     MGf_MGv2
     PADNAMEf_FULLSV
     PadnameIsFULLSV
+    STRLEN_MAX
 
     assert_scalar_or_IO_
     DEBUG__

--- a/regexec.c
+++ b/regexec.c
@@ -9246,9 +9246,9 @@ NULL
 
                     /* Only do the calculations and enable the cache if it
                      * won't overflow. This test is equivalent to:
-                     *    ((len + 1) * n  + 7) <= max(STRLEN)
+                     *    ((len + 1) * n  + 7) <= STRLEN_MAX
                      */
-                    if (len < ((~(STRLEN)0) - 7)/n) {
+                    if (len < (STRLEN_MAX - 7)/n) {
                         reginfo->poscache_maxiter = (len + 1) * n;
                         reginfo->poscache_iter = reginfo->poscache_maxiter;
                     }

--- a/sv.c
+++ b/sv.c
@@ -14280,7 +14280,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
                 elen = va_arg(*args, UV);
                 /* if utf8 length is larger than 0x7ffff..., then it might
                  * have been a signed value that wrapped */
-                if (elen  > ((~(STRLEN)0) >> 1)) {
+                if (elen  > (STRLEN_MAX >> 1)) {
                     assert(0); /* in DEBUGGING build we want to crash */
                     elen = 0; /* otherwise we want to treat this as an empty string */
                 }
@@ -15101,7 +15101,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV *const sv, const char *const pat, const STRLEN p
             char *s;
 
             /* signed value that's wrapped? */
-            assert(elen  <= ((~(STRLEN)0) >> 1));
+            assert(elen  <= (STRLEN_MAX >> 1));
 
             /* if zeros is non-zero, then it represents filler between
              * elen and precis. So adding elen and zeros together will


### PR DESCRIPTION
There are already definitions present for Size_t_MAX etc, but for some reason STRLEN_MAX was missing. Add it, and use it in obvious places.

* This set of changes does not require a perldelta entry.
