### PR TITLE
 Allow declaring a parameter UNUSED

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -224,8 +224,14 @@
 :   You may also add explicit asserts at the end of a function entry.
 :
 :   Sections below give more details of each item.  For readability,
-:   constraints are split into two sections, one for pointer parameters, and
-:   one for the rest.
+:   modifiers are split into three sections, first for ones that apply to any
+:   kind of parameter; second for constraints on pointer parameters, and
+:   third for the rest.
+:
+: *** Modifiers that apply to any parameter
+:
+:   UNUSED  Declare that this parameter is unused by the called function.  See
+:           the "UNUSED" entry in perlintern.
 :
 : *** Pointer parameter constraint modifiers
 :
@@ -4244,7 +4250,7 @@ Adprt	|void	|vcroak 	|NULLOK const char *pat 		\
 				|NULLOK va_list *args
 Adpt	|void	|vdeb		|NN const char *pat			\
 				|NULLOK va_list *args
-Adpt	|void	|vfatal_warner	|U32 err				\
+Adpt	|void	|vfatal_warner	|U32 err  UNUSED			\
 				|NN const char *pat			\
 				|NULLOK va_list *args
 Adpt	|char * |vform		|NN const char *pat			\

--- a/embed.fnc
+++ b/embed.fnc
@@ -192,49 +192,51 @@
 :   will be sorted asciibetically.  (This all can cause hassles if the rules
 :   change between when you make changes here and when you rebase.)
 :
-: AUTOMATIC PARAMETER SANITY CHECKING
+: FUNCTION PARAMETER MODIFIERS
 :
-:   For each function entry in this file, regen/embed.pl, generates a macro
-:   that performs parameter sanity validation.  If the function is named
-:   'foo()', the generated macro will be named 'PERL_ARGS_ASSERT_FOO'.  You
-:   should place a call to that macro in foo() before any other code.  It will
-:   automatically expand to whatever checking is currently generated for 'foo'
-:   (often none).  These are mostly in the form of assert() calls, so they
-:   are only activated for DEBUGGING builds.  But for non-DEBUGGING builds,
-:   pointer parameters that must not point to NULL have a compiler directive
-:   that means the same as GCC and Clang's '__attribute__nonnull__' generated
-:   for them for compilers that we know understand it.
+:   For each pararmeter in each function entry in this file, you can add
+:   modifiers that declare something about it beyond its C type.  The current
+:   ones are listed in this section.
+
+:   Some modifiers always have an effect; others only in DEBUGGING builds.
+:   Currently, the effect is limited to changing the function declaration in
+:   proto.h and/or the contents of a customized macro that regen/embed.pl
+:   generates for every function listed in this file.  A porting test enforces
+:   that each function listed here calls its respective macro.  If the function
+:   is named 'foo()', the generated macro will be named 'PERL_ARGS_ASSERT_FOO'.
 :
-:   A porting test enforces that an ARGS_ASSERT macro has been included in all
-:   new functions added to this file.  Each call should be at the top of your
-:   function so that the sanity checks have passed before anything tries to use
-:   an argument.
+:   The macro could very well expand to nothing, or it could have, for example,
+:   assert() sanity validation statements about the various parameters, as
+:   determined by the modifiers specified in this file and/or by other logic
+:   that we deem appropriate.  You should place a call to that macro in foo()
+:   before any other code, so that the asserts are executed before the
+:   parameter is used.
 :
-:   The contents of ARGS_ASSERT are determined by
-:       1)  constraints you give in this file for an argument.  Historically,
-:           each such constraint has been positioned between the '|' that marks
-:           the beginning of a parameter definition, and the the definition
-:           itself, like
-:               |NN const char * const name
-:           But it can come anywhere in the definition, and some prefer it to
-:           come at the end, as it modifies the argument.
-:               |const char * const name NN
-:       2)  the internal logic used by code that reads this file.
-:       3)  explicit asserts that you add in this file.
+:   The modifiers are placed in this file anywhere in the parameter
+:   description.  Historically, each modifier has been positioned between the
+:   '|' that marks the beginning of a parameter definition, and the the
+:   definition itself, like
+:       |NN const char * const name
+:   But it can come anywhere in the definition, and some prefer it to come at
+:   the end, as it modifies the argument.
+:       |const char * const name NN
+:
+:   You may also add explicit asserts at the end of a function entry.
 :
 :   Sections below give more details of each item.  For readability,
 :   constraints are split into two sections, one for pointer parameters, and
 :   one for the rest.
 :
-: *** Pointer Parameter Constraints
+: *** Pointer parameter constraint modifiers
 :
-:   Every pointer parameter must have a constraint; one of the following:
+:   Every pointer parameter must have a modifier constraint; one of the
+:   following:
 :
 :   NN      means the called function is expecting this pointer parameter to be
 :           non-NULL, and likely is not equipped to handle it being NULL.
 :   NULLOK  means the called function definitely can handle this parameter
 :           being NULL.  The reason you need to specify this at all is to tell
-:           future maintainers that you have considered the question about the
+:           future maintainers that you have considered this question about the
 :           parameter, and you have determined that this is the answer.
 :   SPTR    means that not only must this pointer parameter be non-NULL, it
 :           points to a position in a character string, which the called

--- a/embed.h
+++ b/embed.h
@@ -67,6 +67,7 @@
 #     undef OPpSELF_IN_PAD
 #     undef PREVENT_LVALUE
 #     undef TRIE_JUMP_TYPE_MAX
+#     undef UNUSED
 #     undef utf16_to_utf8
 #     undef utf16_to_utf8_reversed
 #   endif /* !defined(PERL_EXT) */

--- a/perl.h
+++ b/perl.h
@@ -519,6 +519,11 @@ C<static>, and you might as well just type the actual C keyword.
 #endif
 #ifdef HASATTRIBUTE_UNUSED
 #  define __attribute__unused__             __attribute__((unused))
+
+   /* If available, use the attribute instead of PERL_UNUSED_ARG */
+#  define PERL_UNUSED_ARG_FOR_ARGS_ASSERT(a)
+#else
+#  define PERL_UNUSED_ARG_FOR_ARGS_ASSERT(a)  PERL_UNUSED_ARG(a)
 #endif
 #ifdef HASATTRIBUTE_WARN_UNUSED_RESULT
 #  define __attribute__warn_unused_result__ __attribute__((warn_unused_result))
@@ -575,6 +580,37 @@ C<static>, and you might as well just type the actual C keyword.
 #ifndef __attribute__uninitialized__
 #  define __attribute__uninitialized__
 #endif
+
+/*
+=for apidoc_section $compiler
+=for apidoc EmnU||UNUSED
+
+Add this symbol following a formal parameter in both a function's definition,
+and its F<embed.fnc> entry to indicate that, while this parameter is passed to
+the function, the function doesn't actually use it.
+
+Perl will arrange for the suppression of any warnings the compiler would
+otherwise raise about the parameter being present but not used, which it would
+if there are no code paths through the function that reference the parameter.
+
+If there are Configurations where the parameter actually does get used, it is
+better practice to not use this mechanism, but to instead use
+L<C<PERL_UNUSED_ARG>|perlapi/PERL_UNUSED_ARG> in the conditionally compiled
+sections that don't use it.
+
+You need to add C<UNUSED> in both places.  If you forget one, there are likely
+platforms on which the warning won't be suppressed.
+
+An example is:
+ : embed.fnc entry
+ Adpt|void|vfatal_warner|U32 err UNUSED|const char *pat|va_list *args
+
+ // First line of function defintion
+ Perl_vfatal_warner(pTHX_ U32 err UNUSED,const char*pat,va_list*args){
+
+=cut
+*/
+#define UNUSED __attribute__unused__
 
 /* Some OS warn on NULL format to printf */
 #ifdef PRINTF_FORMAT_NULL_OK

--- a/proto.h
+++ b/proto.h
@@ -40,20 +40,22 @@ Perl_Gv_AMupdate(pTHX_ HV *stash, bool destructing)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_AMUPDATE            \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(stash);    \
+                 assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV const char *
 Perl_PerlIO_context_layers(pTHX_ const char *mode)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PERLIO_CONTEXT_LAYERS  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlLIO_dup2_cloexec(pTHX_ int oldfd, int newfd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_DUP2_CLOEXEC   \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlLIO_dup_cloexec(pTHX_ int oldfd)
@@ -61,7 +63,7 @@ Perl_PerlLIO_dup_cloexec(pTHX_ int oldfd)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_DUP_CLOEXEC    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
@@ -70,7 +72,7 @@ Perl_PerlLIO_open3_cloexec(pTHX_ const char *file, int flag, int perm)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_OPEN3_CLOEXEC  \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
@@ -79,7 +81,7 @@ Perl_PerlLIO_open_cloexec(pTHX_ const char *file, int flag)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PERLLIO_OPEN_CLOEXEC   \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV const char *
 Perl_langinfo(const nl_item item);
@@ -89,13 +91,13 @@ PERL_CALLCONV const char *
 Perl_langinfo8(const nl_item item, utf8ness_t *utf8ness)
         Perl_attribute_nonnull(2);
 #define PERL_ARGS_ASSERT_PERL_LANGINFO8         \
-        assert(utf8ness)
+    STMT_START { assert(utf8ness); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_localeconv(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PERL_LOCALECONV        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV const char *
 Perl_setlocale(const int category, const char *locale);
@@ -106,20 +108,20 @@ Perl_Slab_Alloc(pTHX_ size_t sz)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SLAB_ALLOC             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_Slab_Free(pTHX_ void *op)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SLAB_FREE              \
-        Perl_assert_aTHX; assert(op)
+    STMT_START { Perl_assert_aTHX; assert(op); } STMT_END
 
 PERL_CALLCONV void
 Perl_SvREFCNT_dec_set_NULL(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SVREFCNT_DEC_SET_NULL  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
@@ -128,14 +130,14 @@ Perl_abort_execution(pTHX_ SV *msg_sv, const char * const name)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ABORT_EXECUTION        \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV LOGOP *
 Perl_alloc_LOGOP(pTHX_ I32 type, OP *first, OP *other)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ALLOC_LOGOP            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_allocmy(pTHX_ const char * const name, const STRLEN len, const U32 flags)
@@ -143,14 +145,14 @@ Perl_allocmy(pTHX_ const char * const name, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ALLOCMY                \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_amagic_applies(pTHX_ SV *sv, int method, int flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_APPLIES         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir)
@@ -158,27 +160,27 @@ Perl_amagic_call(pTHX_ SV *left, SV *right, int method, int dir)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AMAGIC_CALL            \
-        Perl_assert_aTHX; assert(left); assert(right)
+    STMT_START { Perl_assert_aTHX; assert(left); assert(right); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_amagic_deref_call(pTHX_ SV *ref, int method)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AMAGIC_DEREF_CALL      \
-        Perl_assert_aTHX; assert(ref)
+    STMT_START { Perl_assert_aTHX; assert(ref); } STMT_END
 
 PERL_CALLCONV bool
 Perl_amagic_is_enabled(pTHX_ int method)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AMAGIC_IS_ENABLED      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_api_version_assert(size_t interp_size, void *v_my_perl, const char *api_version)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_API_VERSION_ASSERT     \
-        assert(api_version)
+    STMT_START { assert(api_version); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
@@ -187,7 +189,7 @@ Perl_apply(pTHX_ I32 type, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_APPLY                  \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+    STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV void
 Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, STRLEN len)
@@ -196,17 +198,19 @@ Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_APPLY_ATTRS_STRING     \
-        Perl_assert_aTHX; assert(stashpv); assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
-        assert(attrstr)
+    STMT_START { Perl_assert_aTHX; assert(stashpv); assert(cv);             \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                 assert(attrstr);                                           \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_apply_builtin_cv_attributes(pTHX_ CV *cv, OP *attrlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_APPLY_BUILTIN_CV_ATTRIBUTES \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_atfork_child(void);
@@ -225,14 +229,18 @@ Perl_av_arylen_p(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ARYLEN_P            \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_clear(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_CLEAR               \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val)
@@ -240,7 +248,7 @@ Perl_av_create_and_push(pTHX_ AV ** const avp, SV * const val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_PUSH     \
-        Perl_assert_aTHX; assert(avp); assert(val)
+    STMT_START { Perl_assert_aTHX; assert(avp); assert(val); } STMT_END
 
 PERL_CALLCONV SV **
 Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val)
@@ -248,20 +256,23 @@ Perl_av_create_and_unshift_one(pTHX_ AV ** const avp, SV * const val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_CREATE_AND_UNSHIFT_ONE \
-        Perl_assert_aTHX; assert(avp); assert(val)
+    STMT_START { Perl_assert_aTHX; assert(avp); assert(val); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_av_delete(pTHX_ AV *av, SSize_t key, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_DELETE              \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_dump(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_AV_DUMP                \
-        Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_av_exists(pTHX_ AV *av, SSize_t key)
@@ -269,14 +280,18 @@ Perl_av_exists(pTHX_ AV *av, SSize_t key)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_EXISTS              \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_extend(pTHX_ AV *av, SSize_t key)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_EXTEND              \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV ***arrayp)
@@ -286,8 +301,9 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV *
         Perl_attribute_nonnull(pTHX_5)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_EXTEND_GUTS         \
-        Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV);  \
-        assert(maxp); assert(allocp); assert(arrayp)
+    STMT_START { Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV);  \
+                 assert(maxp); assert(allocp); assert(arrayp);             \
+    } STMT_END
 
 PERL_CALLCONV SV **
 Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
@@ -295,21 +311,27 @@ Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_FETCH               \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_fill(pTHX_ AV *av, SSize_t fill)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_FILL                \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV IV *
 Perl_av_iter_p(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_ITER_P              \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_av_len(pTHX_ AV *av)
@@ -317,7 +339,9 @@ Perl_av_len(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_LEN                 \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV AV *
 Perl_av_make(pTHX_ SSize_t size, SV **strp)
@@ -325,7 +349,7 @@ Perl_av_make(pTHX_ SSize_t size, SV **strp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_MAKE                \
-        Perl_assert_aTHX; assert(strp)
+    STMT_START { Perl_assert_aTHX; assert(strp); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
@@ -333,14 +357,18 @@ Perl_av_nonelem(pTHX_ AV *av, SSize_t ix)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_NONELEM             \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_av_pop(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_POP                 \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_push(pTHX_ AV *av, SV *val)
@@ -348,15 +376,18 @@ Perl_av_push(pTHX_ AV *av, SV *val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_PUSH                \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
-        assert(val)
+    STMT_START { Perl_assert_aTHX; assert(av);                 \
+                 assert(SvTYPE(av) == SVt_PVAV); assert(val);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_reify(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_REIFY               \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_av_shift(pTHX_ AV *av)
@@ -364,28 +395,36 @@ Perl_av_shift(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_AV_SHIFT               \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV SV **
 Perl_av_store(pTHX_ AV *av, SSize_t key, SV *val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_STORE               \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_undef(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNDEF               \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_av_unshift(pTHX_ AV *av, SSize_t num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_AV_UNSHIFT             \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
@@ -395,63 +434,63 @@ Perl_bind_match(pTHX_ I32 type, OP *left, OP *right)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BIND_MATCH             \
-        Perl_assert_aTHX; assert(left); assert(right)
+    STMT_START { Perl_assert_aTHX; assert(left); assert(right); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_block_end(pTHX_ I32 floor, OP *seq)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_BLOCK_END              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV U8
 Perl_block_gimme(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_BLOCK_GIMME            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_block_start(pTHX_ int full)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_BLOCK_START            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_blockhook_register(pTHX_ BHK *hk)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_BLOCKHOOK_REGISTER     \
-        Perl_assert_aTHX; assert(hk)
+    STMT_START { Perl_assert_aTHX; assert(hk); } STMT_END
 
 PERL_CALLCONV void
 Perl_boot_core_PerlIO(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_PERLIO       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_boot_core_UNIVERSAL(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_UNIVERSAL    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_boot_core_builtin(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_BUILTIN      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_boot_core_mro(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BOOT_CORE_MRO          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
@@ -461,13 +500,15 @@ Perl_build_infix_plugin(pTHX_ OP *lhs, OP *rhs, void *tokendata)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_BUILD_INFIX_PLUGIN     \
-        Perl_assert_aTHX; assert(lhs); assert(rhs); assert(tokendata)
+    STMT_START { Perl_assert_aTHX; assert(lhs); assert(rhs);  \
+                 assert(tokendata);                           \
+    } STMT_END
 
 PERL_CALLCONV const char *
 Perl_byte_dump_string_(pTHX_ const U8 * const start, const STRLEN len, const bool format)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_BYTE_DUMP_STRING_      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
@@ -475,7 +516,7 @@ Perl_bytes_cmp_utf8(pTHX_ const U8 *b, STRLEN blen, const U8 *u, STRLEN ulen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_BYTES_CMP_UTF8         \
-        Perl_assert_aTHX; assert(b); assert(u)
+    STMT_START { Perl_assert_aTHX; assert(b); assert(u); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p)
@@ -484,7 +525,8 @@ Perl_bytes_from_utf8(pTHX_ const U8 *s, STRLEN *lenp, bool *is_utf8p)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_BYTES_FROM_UTF8        \
-        Perl_assert_aTHX; assert(s); assert(lenp); assert(is_utf8p)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(lenp); assert(is_utf8p);  \
+    } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me)
@@ -492,7 +534,7 @@ Perl_bytes_to_utf8_free_me(pTHX_ const U8 *s, STRLEN *lenp, void **free_me)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_BYTES_TO_UTF8_FREE_ME  \
-        Perl_assert_aTHX; assert(s); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(lenp); } STMT_END
 
 PERL_CALLCONV bool
 Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
@@ -500,7 +542,8 @@ Perl_c9strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_C9STRICT_UTF8_TO_UV    \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
+    STMT_START { assert(s); assert(e); assert(cp_p); assert(s <= e);  \
+    } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
@@ -508,48 +551,50 @@ Perl_call_argv(pTHX_ const char *sub_name, I32 flags, char **argv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CALL_ARGV              \
-        Perl_assert_aTHX; assert(sub_name); assert(argv)
+    STMT_START { Perl_assert_aTHX; assert(sub_name); assert(argv);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_call_atexit(pTHX_ ATEXIT_t fn, void *ptr)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_CALL_ATEXIT            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_CALL_LIST              \
-        Perl_assert_aTHX; assert(paramList);  \
-        assert(SvTYPE(paramList) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(paramList);    \
+                 assert(SvTYPE(paramList) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_call_method(pTHX_ const char *methname, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_METHOD            \
-        Perl_assert_aTHX; assert(methname)
+    STMT_START { Perl_assert_aTHX; assert(methname); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_call_pv(pTHX_ const char *sub_name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_PV                \
-        Perl_assert_aTHX; assert(sub_name)
+    STMT_START { Perl_assert_aTHX; assert(sub_name); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_call_sv(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CALL_SV                \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV const PERL_CONTEXT *
 Perl_caller_cx(pTHX_ I32 level, const PERL_CONTEXT **dbcxp)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_CALLER_CX              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV Malloc_t
 Perl_calloc(MEM_SIZE elements, MEM_SIZE size)
@@ -564,7 +609,7 @@ Perl_cando(pTHX_ Mode_t mode, bool effective, const Stat_t *statbufp)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CANDO                  \
-        Perl_assert_aTHX; assert(statbufp)
+    STMT_START { Perl_assert_aTHX; assert(statbufp); } STMT_END
 
 PERL_CALLCONV I32
 Perl_cast_i32(NV f)
@@ -592,7 +637,7 @@ Perl_check_utf8_print(pTHX_ const U8 *s, const STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CHECK_UTF8_PRINT       \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
@@ -602,15 +647,16 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_CORE  \
-        Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
-        assert(protosv)
+    STMT_START { Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
+                 assert(protosv);                                       \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_list(pTHX_ OP *entersubop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_LIST  \
-        Perl_assert_aTHX; assert(entersubop)
+    STMT_START { Perl_assert_aTHX; assert(entersubop); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
@@ -619,8 +665,9 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO \
-        Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
-        assert(protosv)
+    STMT_START { Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
+                 assert(protosv);                                       \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
@@ -629,22 +676,23 @@ Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protos
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO_OR_LIST \
-        Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
-        assert(protosv)
+    STMT_START { Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
+                 assert(protosv);                                       \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER              \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_ck_warner_d(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_CK_WARNER_D            \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV bool
 Perl_ckwarn(pTHX_ U32 w)
@@ -663,7 +711,9 @@ Perl_clear_defarray(pTHX_ AV *av, bool abandon)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CLEAR_DEFARRAY         \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV const COP *
 Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop, bool opnext)
@@ -671,7 +721,7 @@ Perl_closest_cop(pTHX_ const COP *cop, const OP *o, const OP *curop, bool opnext
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CLOSEST_COP            \
-        Perl_assert_aTHX; assert(cop)
+    STMT_START { Perl_assert_aTHX; assert(cop); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
@@ -680,7 +730,7 @@ Perl_cmpchain_extend(pTHX_ I32 type, OP *ch, OP *right)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_EXTEND        \
-        Perl_assert_aTHX; assert(ch)
+    STMT_START { Perl_assert_aTHX; assert(ch); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_cmpchain_finish(pTHX_ OP *ch)
@@ -689,7 +739,7 @@ Perl_cmpchain_finish(pTHX_ OP *ch)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_FINISH        \
-        Perl_assert_aTHX; assert(ch)
+    STMT_START { Perl_assert_aTHX; assert(ch); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
@@ -697,7 +747,7 @@ Perl_cmpchain_start(pTHX_ I32 type, OP *left, OP *right)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CMPCHAIN_START         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV const char *
 Perl_cntrl_to_mnemonic(const U8 c)
@@ -709,28 +759,28 @@ Perl_cop_disable_warning(pTHX_ COP *cop, int warn_bit)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_DISABLE_WARNING    \
-        Perl_assert_aTHX; assert(cop)
+    STMT_START { Perl_assert_aTHX; assert(cop); } STMT_END
 
 PERL_CALLCONV void
 Perl_cop_enable_warning(pTHX_ COP *cop, int warn_bit)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_ENABLE_WARNING     \
-        Perl_assert_aTHX; assert(cop)
+    STMT_START { Perl_assert_aTHX; assert(cop); } STMT_END
 
 PERL_CALLCONV const char *
 Perl_cop_fetch_label(pTHX_ COP * const cop, STRLEN *len, U32 *flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_FETCH_LABEL        \
-        Perl_assert_aTHX; assert(cop)
+    STMT_START { Perl_assert_aTHX; assert(cop); } STMT_END
 
 PERL_CALLCONV bool
 Perl_cop_has_warning(pTHX_ const COP *cop, int warn_bit)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_COP_HAS_WARNING        \
-        Perl_assert_aTHX; assert(cop)
+    STMT_START { Perl_assert_aTHX; assert(cop); } STMT_END
 
 PERL_CALLCONV void
 Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 flags)
@@ -738,7 +788,7 @@ Perl_cop_store_label(pTHX_ COP * const cop, const char *label, STRLEN len, U32 f
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_COP_STORE_LABEL        \
-        Perl_assert_aTHX; assert(cop); assert(label)
+    STMT_START { Perl_assert_aTHX; assert(cop); assert(label); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code, int * const opnum)
@@ -746,7 +796,7 @@ Perl_core_prototype(pTHX_ SV *sv, const char *name, const int code, int * const 
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORE_PROTOTYPE         \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_coresub_op(pTHX_ SV * const coreargssv, const int code, const int opnum)
@@ -754,7 +804,7 @@ Perl_coresub_op(pTHX_ SV * const coreargssv, const int code, const int opnum)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CORESUB_OP             \
-        Perl_assert_aTHX; assert(coreargssv)
+    STMT_START { Perl_assert_aTHX; assert(coreargssv); } STMT_END
 
 PERL_CALLCONV void
 Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
@@ -762,7 +812,7 @@ Perl_create_eval_scope(pTHX_ OP *retop, SV **sp, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CREATE_EVAL_SCOPE      \
-        Perl_assert_aTHX; assert(sp)
+    STMT_START { Perl_assert_aTHX; assert(sp); } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_croak(pTHX_ const char *pat, ...)
@@ -794,7 +844,7 @@ Perl_croak_no_mem_ext(const char *context, STRLEN len)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CROAK_NO_MEM_EXT       \
-        assert(context)
+    STMT_START { assert(context); } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_no_modify(void)
@@ -812,7 +862,7 @@ Perl_croak_sv(pTHX_ SV *baseex)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_CROAK_SV               \
-        Perl_assert_aTHX; assert(baseex)
+    STMT_START { Perl_assert_aTHX; assert(baseex); } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_croak_xs_usage(const CV * const cv, const char * const params)
@@ -820,7 +870,7 @@ Perl_croak_xs_usage(const CV * const cv, const char * const params)
         Perl_attribute_nonnull(2)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_CROAK_XS_USAGE         \
-        assert(cv); assert(params)
+    STMT_START { assert(cv); assert(params); } STMT_END
 
 PERL_CALLCONV Signal_t
 Perl_csighandler1(int sig);
@@ -834,7 +884,7 @@ PERL_CALLCONV regexp_engine const *
 Perl_current_re_engine(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_CURRENT_RE_ENGINE      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV XOPRETANY
 Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
@@ -842,7 +892,7 @@ Perl_custom_op_get_field(pTHX_ const OP *o, const xop_flags_enum field)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_CUSTOM_OP_GET_FIELD    \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
@@ -850,22 +900,23 @@ Perl_custom_op_register(pTHX_ Perl_ppaddr_t ppaddr, const XOP *xop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_CUSTOM_OP_REGISTER     \
-        Perl_assert_aTHX; assert(ppaddr); assert(xop)
+    STMT_START { Perl_assert_aTHX; assert(ppaddr); assert(xop); } STMT_END
 
 PERL_CALLCONV void
 Perl_cv_ckproto_len_flags(pTHX_ const CV *cv, const GV *gv, const char *p, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_CKPROTO_LEN_FLAGS   \
-        Perl_assert_aTHX; assert(cv)
+    STMT_START { Perl_assert_aTHX; assert(cv); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_cv_clone(pTHX_ CV *proto)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_CLONE               \
-        Perl_assert_aTHX; assert(proto);  \
-        assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(proto);                                 \
+                 assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV CV *
 Perl_cv_clone_into(pTHX_ CV *proto, CV *target)
@@ -874,10 +925,11 @@ Perl_cv_clone_into(pTHX_ CV *proto, CV *target)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_CLONE_INTO          \
-        Perl_assert_aTHX; assert(proto);  \
-        assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM);  \
-        assert(target);  \
-        assert(SvTYPE(target) == SVt_PVCV || SvTYPE(target) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(proto);                                   \
+                 assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM);    \
+                 assert(target);                                                    \
+                 assert(SvTYPE(target) == SVt_PVCV || SvTYPE(target) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_cv_const_sv(const CV * const cv)
@@ -895,8 +947,9 @@ Perl_cv_forget_slab(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_FORGET_SLAB         \
-        Perl_assert_aTHX;  \
-        assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX;                                                 \
+                 assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
@@ -905,9 +958,10 @@ Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER    \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
-        assert(ckfun_p); assert(ckobj_p)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                 assert(ckfun_p); assert(ckobj_p);                          \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfun_p, SV **ckobj_p, U32 *ckflags_p)
@@ -917,16 +971,17 @@ Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfu
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER_FLAGS \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
-        assert(ckfun_p); assert(ckobj_p); assert(ckflags_p)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                 assert(ckfun_p); assert(ckobj_p); assert(ckflags_p);       \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_cv_name(pTHX_ CV *cv, SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_NAME                \
-        Perl_assert_aTHX; assert(cv)
+    STMT_START { Perl_assert_aTHX; assert(cv); } STMT_END
 
 PERL_CALLCONV void
 Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
@@ -935,9 +990,10 @@ Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER    \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
-        assert(ckfun); assert(ckobj)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                 assert(ckfun); assert(ckobj);                              \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj, U32 ckflags)
@@ -946,17 +1002,19 @@ Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj,
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER_FLAGS \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
-        assert(ckfun); assert(ckobj)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                 assert(ckfun); assert(ckobj);                              \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cv_undef(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_UNDEF               \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
@@ -964,47 +1022,51 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_UNDEF_FLAGS         \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV GV *
 Perl_cvgv_from_hek(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_FROM_HEK          \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cvgv_set(pTHX_ CV *cv, GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_SET               \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVSTASH_SET            \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV);               \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_cx_dump(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CX_DUMP                \
-        Perl_assert_aTHX; assert(cx)
+    STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_CALLCONV I32
 Perl_cxinc(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_CXINC                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_deb(pTHX_ const char *pat, ...)
@@ -1012,46 +1074,46 @@ Perl_deb(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_DEB                    \
-        Perl_assert_aTHX; assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_deb_stack_all(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DEB_STACK_ALL          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_debop(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DEBOP                  \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_debprofdump(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DEBPROFDUMP            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_debstack(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DEBSTACK               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_debstackptrs(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DEBSTACKPTRS           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_debug_hash_seed(pTHX_ bool via_debug_h)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DEBUG_HASH_SEED        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
@@ -1060,20 +1122,20 @@ Perl_defelem_target(pTHX_ SV *sv, MAGIC *mg)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DEFELEM_TARGET         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_defer_error(pTHX_ SV *err)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DEFER_ERROR            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_delete_eval_scope(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DELETE_EVAL_SCOPE      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen)
@@ -1083,8 +1145,10 @@ Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_e
         Perl_attribute_nonnull(4)
         Perl_attribute_nonnull(6);
 #define PERL_ARGS_ASSERT_DELIMCPY               \
-        assert(to); assert(to_end); assert(from); assert(from_end);  \
-        assert(retlen); assert(to <= to_end); assert(from <= from_end)
+    STMT_START { assert(to); assert(to_end); assert(from); assert(from_end);  \
+                 assert(retlen); assert(to <= to_end);                        \
+                 assert(from <= from_end);                                    \
+    } STMT_END
 
 PERL_CALLCONV char *
 Perl_delimcpy_no_escape(char *to, const char *to_end, const char *from, const char *from_end, const int delim, I32 *retlen)
@@ -1094,14 +1158,16 @@ Perl_delimcpy_no_escape(char *to, const char *to_end, const char *from, const ch
         Perl_attribute_nonnull(4)
         Perl_attribute_nonnull(6);
 #define PERL_ARGS_ASSERT_DELIMCPY_NO_ESCAPE     \
-        assert(to); assert(to_end); assert(from); assert(from_end);  \
-        assert(retlen); assert(to <= to_end); assert(from <= from_end)
+    STMT_START { assert(to); assert(to_end); assert(from); assert(from_end);  \
+                 assert(retlen); assert(to <= to_end);                        \
+                 assert(from <= from_end);                                    \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_despatch_signals(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DESPATCH_SIGNALS       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die(pTHX_ const char *pat, ...)
@@ -1115,7 +1181,7 @@ Perl_die_sv(pTHX_ SV *baseex)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_DIE_SV                 \
-        Perl_assert_aTHX; assert(baseex)
+    STMT_START { Perl_assert_aTHX; assert(baseex); } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_die_unwind(pTHX_ SV *msv)
@@ -1124,7 +1190,7 @@ Perl_die_unwind(pTHX_ SV *msv)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DIE_UNWIND             \
-        Perl_assert_aTHX; assert(msv)
+    STMT_START { Perl_assert_aTHX; assert(msv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp, int fd, int do_report)
@@ -1133,13 +1199,13 @@ Perl_do_aexec5(pTHX_ SV *really, SV **mark, SV **sp, int fd, int do_report)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_AEXEC5              \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+    STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_close(pTHX_ GV *gv, bool is_explicit)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DO_CLOSE               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
@@ -1147,7 +1213,7 @@ Perl_do_dump_pad(pTHX_ I32 level, PerlIO *file, PADLIST *padlist, int full)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_DUMP_PAD            \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_eof(pTHX_ GV *gv)
@@ -1155,7 +1221,7 @@ Perl_do_eof(pTHX_ GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_EOF                 \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
@@ -1163,7 +1229,7 @@ Perl_do_gv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GV_DUMP             \
-        Perl_assert_aTHX; assert(file); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(file); assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
@@ -1171,7 +1237,7 @@ Perl_do_gvgv_dump(pTHX_ I32 level, PerlIO *file, const char *name, GV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_GVGV_DUMP           \
-        Perl_assert_aTHX; assert(file); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(file); assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
@@ -1179,8 +1245,9 @@ Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_HV_DUMP             \
-        Perl_assert_aTHX; assert(file); assert(name);  \
-        assert(!sv || SvTYPE(sv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(file); assert(name);  \
+                 assert(!sv || SvTYPE(sv) == SVt_PVHV);         \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
@@ -1190,15 +1257,16 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_DO_JOIN                \
-        Perl_assert_aTHX; assert(sv); assert(delim); assert(mark);  \
-        assert(sp)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(delim); assert(mark);  \
+                 assert(sp);                                                 \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_MAGIC_DUMP          \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV I32
 Perl_do_ncmp(pTHX_ SV * const left, SV * const right)
@@ -1208,14 +1276,14 @@ Perl_do_ncmp(pTHX_ SV * const left, SV * const right)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_NCMP                \
-        Perl_assert_aTHX; assert(left); assert(right)
+    STMT_START { Perl_assert_aTHX; assert(left); assert(right); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_op_dump(pTHX_ I32 level, PerlIO *file, const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OP_DUMP             \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp)
@@ -1223,7 +1291,7 @@ Perl_do_open(pTHX_ GV *gv, const char *name, I32 len, int as_raw, int rawmode, i
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OPEN                \
-        Perl_assert_aTHX; assert(gv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(gv); assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, SV **svp, U32 num)
@@ -1232,7 +1300,7 @@ Perl_do_open6(pTHX_ GV *gv, const char *oname, STRLEN len, PerlIO *supplied_fp, 
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_OPEN6               \
-        Perl_assert_aTHX; assert(gv); assert(oname)
+    STMT_START { Perl_assert_aTHX; assert(gv); assert(oname); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int rawperm, Stat_t *statbufp)
@@ -1241,7 +1309,7 @@ Perl_do_open_raw(pTHX_ GV *gv, const char *oname, STRLEN len, int rawmode, int r
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_OPEN_RAW            \
-        Perl_assert_aTHX; assert(gv); assert(oname)
+    STMT_START { Perl_assert_aTHX; assert(gv); assert(oname); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode, int rawperm, PerlIO *supplied_fp, SV **svp, I32 num)
@@ -1249,14 +1317,14 @@ Perl_do_openn(pTHX_ GV *gv, const char *oname, I32 len, int as_raw, int rawmode,
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_OPENN               \
-        Perl_assert_aTHX; assert(gv); assert(oname)
+    STMT_START { Perl_assert_aTHX; assert(gv); assert(oname); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_pmop_dump(pTHX_ I32 level, PerlIO *file, const PMOP *pm)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_PMOP_DUMP           \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
@@ -1264,7 +1332,7 @@ Perl_do_print(pTHX_ SV *sv, PerlIO *fp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_PRINT               \
-        Perl_assert_aTHX; assert(fp)
+    STMT_START { Perl_assert_aTHX; assert(fp); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_do_readline(pTHX)
@@ -1272,14 +1340,14 @@ Perl_do_readline(pTHX)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_READLINE            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_do_seek(pTHX_ GV *gv, Off_t pos, int whence)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_SEEK                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
@@ -1287,14 +1355,14 @@ Perl_do_sprintf(pTHX_ SV *sv, SSize_t len, SV **sarg)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_SPRINTF             \
-        Perl_assert_aTHX; assert(sv); assert(sarg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(sarg); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_sv_dump(pTHX_ I32 level, PerlIO *file, SV *sv, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_DO_SV_DUMP             \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV Off_t
 Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
@@ -1302,7 +1370,7 @@ Perl_do_sysseek(pTHX_ GV *gv, Off_t pos, int whence)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_SYSSEEK             \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV Off_t
 Perl_do_tell(pTHX_ GV *gv)
@@ -1311,7 +1379,7 @@ Perl_do_tell(pTHX_ GV *gv)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_TELL                \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV Size_t
 Perl_do_trans(pTHX_ SV *sv)
@@ -1319,14 +1387,14 @@ Perl_do_trans(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_TRANS               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV I16
 Perl_do_uniprop_match(const char * const key, const U16 key_len)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_DO_UNIPROP_MATCH       \
-        assert(key)
+    STMT_START { assert(key); } STMT_END
 
 PERL_CALLCONV UV
 Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
@@ -1334,7 +1402,7 @@ Perl_do_vecget(pTHX_ SV *sv, STRLEN offset, int size)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECGET              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_vecset(pTHX_ SV *sv)
@@ -1342,7 +1410,7 @@ Perl_do_vecset(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VECSET              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
@@ -1352,7 +1420,8 @@ Perl_do_vop(pTHX_ I32 optype, SV *sv, SV *left, SV *right)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DO_VOP                 \
-        Perl_assert_aTHX; assert(sv); assert(left); assert(right)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(left); assert(right);  \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_dofile(pTHX_ OP *term, I32 force_builtin)
@@ -1360,7 +1429,7 @@ Perl_dofile(pTHX_ OP *term, I32 force_builtin)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DOFILE                 \
-        Perl_assert_aTHX; assert(term)
+    STMT_START { Perl_assert_aTHX; assert(term); } STMT_END
 
 PERL_CALLCONV bool
 Perl_doing_taint(int argc, char **argv, char **env)
@@ -1372,13 +1441,13 @@ Perl_doref(pTHX_ OP *o, I32 type, bool set_op_ref)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DOREF                  \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_dounwind(pTHX_ I32 cxix)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DOUNWIND               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV U8
 Perl_dowantarray(pTHX)
@@ -1386,45 +1455,45 @@ Perl_dowantarray(pTHX)
         __attribute__deprecated__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_DOWANTARRAY            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_drand48_init_r(perl_drand48_t *random_state, U32 seed)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_DRAND48_INIT_R         \
-        assert(random_state)
+    STMT_START { assert(random_state); } STMT_END
 
 PERL_CALLCONV double
 Perl_drand48_r(perl_drand48_t *random_state)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_DRAND48_R              \
-        assert(random_state)
+    STMT_START { assert(random_state); } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_all(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DUMP_ALL               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_all_perl(pTHX_ bool justperl)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_ALL_PERL          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_eval(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DUMP_EVAL              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_form(pTHX_ const GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_FORM              \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char *pat, ...)
@@ -1433,14 +1502,14 @@ Perl_dump_indent(pTHX_ I32 level, PerlIO *file, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__format__(__printf__,pTHX_3,pTHX_4);
 #define PERL_ARGS_ASSERT_DUMP_INDENT            \
-        Perl_assert_aTHX; assert(file); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(file); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_packsubs(pTHX_ const HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS          \
-        Perl_assert_aTHX; assert(stash)
+    STMT_START { Perl_assert_aTHX; assert(stash); } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
@@ -1448,14 +1517,14 @@ Perl_dump_packsubs_perl(pTHX_ const HV *stash, bool justperl)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_PACKSUBS_PERL     \
-        Perl_assert_aTHX; assert(stash)
+    STMT_START { Perl_assert_aTHX; assert(stash); } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_sub(pTHX_ const GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_DUMP_SUB               \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
@@ -1463,7 +1532,7 @@ Perl_dump_sub_perl(pTHX_ const GV *gv, bool justperl)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_DUMP_SUB_PERL          \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
@@ -1471,13 +1540,13 @@ Perl_dump_vindent(pTHX_ I32 level, PerlIO *file, const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DUMP_VINDENT           \
-        Perl_assert_aTHX; assert(file); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(file); assert(pat); } STMT_END
 
 PERL_CALLCONV char  *
 Perl_dup_warnings(pTHX_ char *warnings)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_DUP_WARNINGS           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_emulate_cop_io(pTHX_ const COP * const c, SV * const sv)
@@ -1485,21 +1554,21 @@ Perl_emulate_cop_io(pTHX_ const COP * const c, SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_EMULATE_COP_IO         \
-        Perl_assert_aTHX; assert(c); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(c); assert(sv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_eval_pv(pTHX_ const char *p, I32 croak_on_error)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_PV                \
-        Perl_assert_aTHX; assert(p)
+    STMT_START { Perl_assert_aTHX; assert(p); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_eval_sv(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_EVAL_SV                \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV Size_t
 Perl_expected_size(UV size);
@@ -1511,7 +1580,7 @@ Perl_export_lexical(pTHX_ SV *name, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_EXPORT_LEXICAL         \
-        Perl_assert_aTHX; assert(name); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(name); assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
@@ -1519,21 +1588,22 @@ Perl_extended_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_EXTENDED_UTF8_TO_UV    \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
+    STMT_START { assert(s); assert(e); assert(cp_p); assert(s <= e);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_FATAL_WARNER           \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_fbm_compile(pTHX_ SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_FBM_COMPILE            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U32 flags)
@@ -1543,21 +1613,22 @@ Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FBM_INSTR              \
-        Perl_assert_aTHX; assert(big); assert(bigend); assert(littlestr);  \
-        assert(big <= bigend)
+    STMT_START { Perl_assert_aTHX; assert(big); assert(bigend);  \
+                 assert(littlestr); assert(big <= bigend);       \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_filter_add(pTHX_ filter_t funcp, SV *datasv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_FILTER_ADD             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_filter_del(pTHX_ filter_t funcp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_FILTER_DEL             \
-        Perl_assert_aTHX; assert(funcp)
+    STMT_START { Perl_assert_aTHX; assert(funcp); } STMT_END
 
 PERL_CALLCONV I32
 Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
@@ -1565,21 +1636,21 @@ Perl_filter_read(pTHX_ int idx, SV *buf_sv, int maxlen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FILTER_READ            \
-        Perl_assert_aTHX; assert(buf_sv)
+    STMT_START { Perl_assert_aTHX; assert(buf_sv); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_find_lexical_cv(pTHX_ PADOFFSET off)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_LEXICAL_CV        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV CV *
 Perl_find_runcv(pTHX_ U32 *db_seqp)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FIND_RUNCV             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV CV *
 Perl_find_runcv_where(pTHX_ U8 cond, IV arg, U32 *db_seqp)
@@ -1587,13 +1658,13 @@ Perl_find_runcv_where(pTHX_ U8 cond, IV arg, U32 *db_seqp)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_RUNCV_WHERE       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_find_rundefsv(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_FIND_RUNDEFSV          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const * const search_ext, I32 flags)
@@ -1601,13 +1672,13 @@ Perl_find_script(pTHX_ const char *scriptname, bool dosearch, const char * const
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FIND_SCRIPT            \
-        Perl_assert_aTHX; assert(scriptname)
+    STMT_START { Perl_assert_aTHX; assert(scriptname); } STMT_END
 
 PERL_CALLCONV void
 Perl_finish_export_lexical(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_FINISH_EXPORT_LEXICAL  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
@@ -1615,7 +1686,7 @@ Perl_foldEQ_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_FOLDEQ_UTF8            \
-        Perl_assert_aTHX; assert(s1); assert(s2)
+    STMT_START { Perl_assert_aTHX; assert(s1); assert(s2); } STMT_END
 
 PERL_CALLCONV I32
 Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2, U32 flags)
@@ -1623,7 +1694,7 @@ Perl_foldEQ_utf8_flags(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const c
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_FOLDEQ_UTF8_FLAGS      \
-        Perl_assert_aTHX; assert(s1); assert(s2)
+    STMT_START { Perl_assert_aTHX; assert(s1); assert(s2); } STMT_END
 
 PERL_CALLCONV void
 Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname)
@@ -1631,14 +1702,14 @@ Perl_forbid_outofblock_ops(pTHX_ OP *o, const char *blockname)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_FORBID_OUTOFBLOCK_OPS  \
-        Perl_assert_aTHX; assert(o); assert(blockname)
+    STMT_START { Perl_assert_aTHX; assert(o); assert(blockname); } STMT_END
 
 PERL_CALLCONV void
 Perl_force_locale_unlock(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FORCE_LOCALE_UNLOCK    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * const e, U32 flags, const bool die_here)
@@ -1646,27 +1717,28 @@ Perl_force_out_malformed_utf8_message_(pTHX_ const U8 * const p, const U8 * cons
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_FORCE_OUT_MALFORMED_UTF8_MESSAGE_ \
-        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(p < e);  \
+    } STMT_END
 
 PERL_CALLCONV char *
 Perl_form(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_FORM                   \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_free_tied_hv_pool(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_FREE_TIED_HV_POOL      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_free_tmps(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_FREE_TMPS              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_get_and_check_backslash_N_name(pTHX_ const char *s, const char *e, const bool is_utf8, const char **error_msg)
@@ -1676,37 +1748,39 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char *s, const char *e, const bo
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME \
-        Perl_assert_aTHX; assert(s); assert(e); assert(error_msg);  \
-        assert(s <= e)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(e); assert(error_msg);  \
+                 assert(s <= e);                                             \
+    } STMT_END
 
 PERL_CALLCONV AV *
 Perl_get_av(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_AV                 \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_get_cv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CV                 \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_get_cvn_flags(pTHX_ const char *name, STRLEN len, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_CVN_FLAGS          \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GET_DB_SUB             \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV const char *
 Perl_get_deprecated_property_msg(const Size_t warning_offset)
@@ -1724,14 +1798,14 @@ Perl_get_hash_seed(pTHX_ unsigned char * const seed_buffer)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GET_HASH_SEED          \
-        Perl_assert_aTHX; assert(seed_buffer)
+    STMT_START { Perl_assert_aTHX; assert(seed_buffer); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_get_hv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_HV                 \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV const char *
 Perl_get_no_modify(pTHX)
@@ -1741,7 +1815,7 @@ Perl_get_no_modify(pTHX)
         __attribute__pure__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GET_NO_MODIFY          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char **
 Perl_get_op_descs(pTHX)
@@ -1750,7 +1824,7 @@ Perl_get_op_descs(pTHX)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_OP_DESCS           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char **
 Perl_get_op_names(pTHX)
@@ -1759,7 +1833,7 @@ Perl_get_op_names(pTHX)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_OP_NAMES           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV U32 *
 Perl_get_opargs(pTHX)
@@ -1769,7 +1843,7 @@ Perl_get_opargs(pTHX)
         __attribute__pure__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GET_OPARGS             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PPADDR_t *
 Perl_get_ppaddr(pTHX)
@@ -1778,14 +1852,14 @@ Perl_get_ppaddr(pTHX)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_GET_PPADDR             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_get_prop_definition(pTHX_ const int table_index)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GET_PROP_DEFINITION    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV const char * const *
 Perl_get_prop_values(const int table_index)
@@ -1796,40 +1870,40 @@ PERL_CALLCONV REGEXP *
 Perl_get_re_arg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GET_RE_ARG             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_get_sv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GET_SV                 \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV int
 Perl_getcwd_sv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GETCWD_SV              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_gp_free(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GP_FREE                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV GP *
 Perl_gp_ref(pTHX_ GP *gp)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GP_REF                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_grok_atoUV(const char *pv, UV *valptr, const char **endptr)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 #define PERL_ARGS_ASSERT_GROK_ATOUV             \
-        assert(pv); assert(valptr)
+    STMT_START { assert(pv); assert(valptr); } STMT_END
 
 PERL_CALLCONV UV
 Perl_grok_bin_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *approximation, uint_fast8_t base, const U32 lookup_bit, const char prefix)
@@ -1838,7 +1912,9 @@ Perl_grok_bin_hex(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GROK_BIN_HEX           \
-        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(len_p);  \
+                 assert(flags);                                   \
+    } STMT_END
 
 PERL_CALLCONV int
 Perl_grok_infnan(pTHX_ const char **sp, const char *send)
@@ -1846,22 +1922,23 @@ Perl_grok_infnan(pTHX_ const char **sp, const char *send)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GROK_INFNAN            \
-        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send);  \
-        assert(*sp <= send)
+    STMT_START { Perl_assert_aTHX; assert(sp); assert(*sp); assert(send);  \
+                 assert(*sp <= send);                                      \
+    } STMT_END
 
 PERL_CALLCONV int
 Perl_grok_number(pTHX_ const char *pv, STRLEN len, UV *valuep)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER            \
-        Perl_assert_aTHX; assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(pv); } STMT_END
 
 PERL_CALLCONV int
 Perl_grok_number_flags(pTHX_ const char *pv, STRLEN len, UV *valuep, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GROK_NUMBER_FLAGS      \
-        Perl_assert_aTHX; assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(pv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
@@ -1870,8 +1947,9 @@ Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GROK_NUMERIC_RADIX     \
-        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send);  \
-        assert(*sp <= send)
+    STMT_START { Perl_assert_aTHX; assert(sp); assert(*sp); assert(send);  \
+                 assert(*sp <= send);                                      \
+    } STMT_END
 
 PERL_CALLCONV UV
 Perl_grok_uint_by_base(pTHX_ const char * const start, STRLEN *len_p, I32 *flags, NV *approximation, uint_fast8_t base, const U32 lookup_bit, uint_fast8_t offset)
@@ -1880,37 +1958,39 @@ Perl_grok_uint_by_base(pTHX_ const char * const start, STRLEN *len_p, I32 *flags
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GROK_UINT_BY_BASE      \
-        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(len_p);  \
+                 assert(flags);                                   \
+    } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_AVadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GV_AVADD               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_HVadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GV_HVADD               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_IOadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GV_IOADD               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_SVadd(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GV_SVADD               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_add_by_type(pTHX_ GV *gv, svtype type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GV_ADD_BY_TYPE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
@@ -1918,7 +1998,7 @@ Perl_gv_autoload_pv(pTHX_ HV *stash, const char *namepv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PV         \
-        Perl_assert_aTHX; assert(namepv)
+    STMT_START { Perl_assert_aTHX; assert(namepv); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
@@ -1926,7 +2006,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_PVN        \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_autoload_sv(pTHX_ HV *stash, SV *namesv, U32 flags)
@@ -1934,14 +2014,16 @@ Perl_gv_autoload_sv(pTHX_ HV *stash, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_AUTOLOAD_SV         \
-        Perl_assert_aTHX; assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(namesv); } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_check(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_CHECK               \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(stash);    \
+                 assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_gv_const_sv(pTHX_ GV *gv)
@@ -1949,13 +2031,13 @@ Perl_gv_const_sv(pTHX_ GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_CONST_SV            \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_dump(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_GV_DUMP                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
@@ -1963,7 +2045,7 @@ Perl_gv_efullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_EFULLNAME3          \
-        Perl_assert_aTHX; assert(sv); assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
@@ -1971,77 +2053,77 @@ Perl_gv_efullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_EFULLNAME4          \
-        Perl_assert_aTHX; assert(sv); assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(gv); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchfile(pTHX_ const char *name)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE           \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchfile_flags(pTHX_ const char * const name, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHFILE_FLAGS     \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH           \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_AUTOLOAD  \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pv(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV        \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pv_autoload(pTHX_ HV *stash, const char *name, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PV_AUTOLOAD \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pvn(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN       \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_pvn_autoload(pTHX_ HV *stash, const char *name, STRLEN len, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_PVN_AUTOLOAD \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_sv(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV        \
-        Perl_assert_aTHX; assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(namesv); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmeth_sv_autoload(pTHX_ HV *stash, SV *namesv, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETH_SV_AUTOLOAD \
-        Perl_assert_aTHX; assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(namesv); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name)
@@ -2049,7 +2131,7 @@ Perl_gv_fetchmethod(pTHX_ HV *stash, const char *name)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD         \
-        Perl_assert_aTHX; assert(stash); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(stash); assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
@@ -2057,7 +2139,7 @@ Perl_gv_fetchmethod_autoload(pTHX_ HV *stash, const char *name, I32 autoload)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_AUTOLOAD \
-        Perl_assert_aTHX; assert(stash); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(stash); assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
@@ -2065,7 +2147,7 @@ Perl_gv_fetchmethod_pv_flags(pTHX_ HV *stash, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PV_FLAGS \
-        Perl_assert_aTHX; assert(stash); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(stash); assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN len, U32 flags)
@@ -2073,7 +2155,7 @@ Perl_gv_fetchmethod_pvn_flags(pTHX_ HV *stash, const char *name, const STRLEN le
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_PVN_FLAGS \
-        Perl_assert_aTHX; assert(stash); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(stash); assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
@@ -2081,28 +2163,28 @@ Perl_gv_fetchmethod_sv_flags(pTHX_ HV *stash, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FETCHMETHOD_SV_FLAGS \
-        Perl_assert_aTHX; assert(stash); assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(stash); assert(namesv); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchpv(pTHX_ const char *nambeg, I32 flags, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPV             \
-        Perl_assert_aTHX; assert(nambeg)
+    STMT_START { Perl_assert_aTHX; assert(nambeg); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchpvn_flags(pTHX_ const char *nambeg, STRLEN len, I32 flags, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHPVN_FLAGS      \
-        Perl_assert_aTHX; assert(nambeg)
+    STMT_START { Perl_assert_aTHX; assert(nambeg); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_fetchsv(pTHX_ SV *name, I32 flags, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_FETCHSV             \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
@@ -2110,7 +2192,7 @@ Perl_gv_fullname3(pTHX_ SV *sv, const GV *gv, const char *prefix)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FULLNAME3           \
-        Perl_assert_aTHX; assert(sv); assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
@@ -2118,14 +2200,16 @@ Perl_gv_fullname4(pTHX_ SV *sv, const GV *gv, const char *prefix, bool keepmain)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_FULLNAME4           \
-        Perl_assert_aTHX; assert(sv); assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(gv); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_gv_handler(pTHX_ HV *stash, I32 id)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GV_HANDLER             \
-        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX;                             \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
@@ -2133,8 +2217,9 @@ Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT                \
-        Perl_assert_aTHX; assert(gv);  \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(gv);                               \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
@@ -2142,8 +2227,9 @@ Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PV             \
-        Perl_assert_aTHX; assert(gv);  \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(gv);                               \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flags)
@@ -2151,8 +2237,9 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PVN            \
-        Perl_assert_aTHX; assert(gv);  \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(gv);                               \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
@@ -2160,8 +2247,9 @@ Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_SV             \
-        Perl_assert_aTHX; assert(gv);  \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(gv);                                 \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(namesv);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
@@ -2169,14 +2257,14 @@ Perl_gv_name_set(pTHX_ GV *gv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GV_NAME_SET            \
-        Perl_assert_aTHX; assert(gv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(gv); assert(name); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_gv_override(pTHX_ const char * const name, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_OVERRIDE            \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_setref(pTHX_ SV * const dsv, SV * const ssv)
@@ -2185,35 +2273,35 @@ Perl_gv_setref(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_GV_SETREF              \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_gv_stashpv(pTHX_ const char *name, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPV             \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_gv_stashpvn(pTHX_ const char *name, U32 namelen, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHPVN            \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_gv_stashsv(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_STASHSV             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_gv_try_downgrade(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_GV_TRY_DOWNGRADE       \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV struct xpvhv_aux *
 Perl_hv_auxalloc(pTHX_ HV *hv)
@@ -2221,7 +2309,9 @@ Perl_hv_auxalloc(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_AUXALLOC            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV AV **
 Perl_hv_backreferences_p(pTHX_ HV *hv)
@@ -2229,7 +2319,9 @@ Perl_hv_backreferences_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_BACKREFERENCES_P    \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_hv_bucket_ratio(pTHX_ HV *hv)
@@ -2237,60 +2329,72 @@ Perl_hv_bucket_ratio(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_BUCKET_RATIO        \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_clear(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_CLEAR               \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_clear_placeholders(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_CLEAR_PLACEHOLDERS  \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void *
 Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int flags, int action, SV *val, U32 hash)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_COMMON              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV HV *
 Perl_hv_copy_hints_hv(pTHX_ HV * const ohv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_COPY_HINTS_HV       \
-        Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_delayfree_ent(pTHX_ HV *notused, HE *entry)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_DELAYFREE_ENT       \
-        Perl_assert_aTHX; assert(!notused || SvTYPE(notused) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX;                                 \
+                 assert(!notused || SvTYPE(notused) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_hv_delete(pTHX_ HV *hv, const char *key, I32 klen, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_HV_DELETE              \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+                 assert(key);                                              \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_hv_delete_ent(pTHX_ HV *hv, SV *keysv, I32 flags, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_HV_DELETE_ENT          \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
-        assert(keysv)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+                 assert(keysv);                                            \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_dump(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_DUMP                \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV HE **
 Perl_hv_eiter_p(pTHX_ HV *hv)
@@ -2298,14 +2402,18 @@ Perl_hv_eiter_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_EITER_P             \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_eiter_set(pTHX_ HV *hv, HE *eiter)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_EITER_SET           \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
@@ -2314,8 +2422,9 @@ Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_ADD           \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(name)
+    STMT_START { Perl_assert_aTHX; assert(hv);                  \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(name);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
@@ -2324,8 +2433,9 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_DELETE        \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(name)
+    STMT_START { Perl_assert_aTHX; assert(hv);                  \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(name);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_hv_exists(pTHX_ HV *hv, const char *key, I32 klen)
@@ -2333,7 +2443,9 @@ Perl_hv_exists(pTHX_ HV *hv, const char *key, I32 klen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_EXISTS              \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+                 assert(key);                                              \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
@@ -2341,43 +2453,53 @@ Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_EXISTS_ENT          \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
-        assert(keysv)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+                 assert(keysv);                                            \
+    } STMT_END
 
 PERL_CALLCONV SV **
 Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_HV_FETCH               \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+                 assert(key);                                              \
+    } STMT_END
 
 PERL_CALLCONV HE *
 Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_HV_FETCH_ENT           \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
-        assert(keysv)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+                 assert(keysv);                                            \
+    } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_hv_fill(pTHX_ HV * const hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_FILL                \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_free_ent(pTHX_ HV *notused, HE *entry)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_FREE_ENT            \
-        Perl_assert_aTHX; assert(!notused || SvTYPE(notused) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX;                                 \
+                 assert(!notused || SvTYPE(notused) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV I32
 Perl_hv_iterinit(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_ITERINIT            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV char *
 Perl_hv_iterkey(pTHX_ HE *entry, I32 *retlen)
@@ -2386,7 +2508,7 @@ Perl_hv_iterkey(pTHX_ HE *entry, I32 *retlen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERKEY             \
-        Perl_assert_aTHX; assert(entry); assert(retlen)
+    STMT_START { Perl_assert_aTHX; assert(entry); assert(retlen); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_hv_iterkeysv(pTHX_ HE *entry)
@@ -2394,7 +2516,7 @@ Perl_hv_iterkeysv(pTHX_ HE *entry)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERKEYSV           \
-        Perl_assert_aTHX; assert(entry)
+    STMT_START { Perl_assert_aTHX; assert(entry); } STMT_END
 
 PERL_CALLCONV HE *
 Perl_hv_iternext(pTHX_ HV *hv)
@@ -2402,7 +2524,9 @@ Perl_hv_iternext(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXT            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV HE *
 Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
@@ -2410,7 +2534,9 @@ Perl_hv_iternext_flags(pTHX_ HV *hv, I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXT_FLAGS      \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
@@ -2420,8 +2546,9 @@ Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXTSV          \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(key); assert(retlen)
+    STMT_START { Perl_assert_aTHX; assert(hv);                                 \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(retlen);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
@@ -2430,29 +2557,36 @@ Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERVAL             \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(entry)
+    STMT_START { Perl_assert_aTHX; assert(hv);                   \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(entry);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_ksplit(pTHX_ HV *hv, IV newmax)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_KSPLIT              \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_magic(pTHX_ HV *hv, GV *gv, int how)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_MAGIC               \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_name_set(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_NAME_SET            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV I32
 Perl_hv_placeholders_get(pTHX_ const HV *hv)
@@ -2460,7 +2594,7 @@ Perl_hv_placeholders_get(pTHX_ const HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_GET    \
-        Perl_assert_aTHX; assert(hv)
+    STMT_START { Perl_assert_aTHX; assert(hv); } STMT_END
 
 PERL_CALLCONV SSize_t *
 Perl_hv_placeholders_p(pTHX_ HV *hv)
@@ -2468,14 +2602,18 @@ Perl_hv_placeholders_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_P      \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_placeholders_set(pTHX_ HV *hv, I32 ph)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_PLACEHOLDERS_SET    \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
@@ -2483,14 +2621,18 @@ Perl_hv_pushkv(pTHX_ HV *hv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_PUSHKV              \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_rand_set(pTHX_ HV *hv, U32 new_xhv_rand)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RAND_SET            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV I32 *
 Perl_hv_riter_p(pTHX_ HV *hv)
@@ -2498,14 +2640,18 @@ Perl_hv_riter_p(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_RITER_P             \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_riter_set(pTHX_ HV *hv, I32 riter)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_HV_RITER_SET           \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_hv_scalar(pTHX_ HV *hv)
@@ -2513,37 +2659,44 @@ Perl_hv_scalar(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_SCALAR              \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(hv);    \
+                 assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV **
 Perl_hv_store(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_STORE               \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV HE *
 Perl_hv_store_ent(pTHX_ HV *hv, SV *key, SV *val, U32 hash)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_STORE_ENT           \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV **
 Perl_hv_store_flags(pTHX_ HV *hv, const char *key, I32 klen, SV *val, U32 hash, int flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_STORE_FLAGS         \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_undef(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_UNDEF               \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_undef_flags(pTHX_ HV *hv, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_HV_UNDEF_FLAGS         \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV I32
 Perl_ibcmp(pTHX_ const char *a, const char *b, I32 len)
@@ -2553,7 +2706,7 @@ Perl_ibcmp(pTHX_ const char *a, const char *b, I32 len)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IBCMP                  \
-        Perl_assert_aTHX; assert(a); assert(b)
+    STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_CALLCONV I32
 Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
@@ -2563,7 +2716,7 @@ Perl_ibcmp_locale(pTHX_ const char *a, const char *b, I32 len)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IBCMP_LOCALE           \
-        Perl_assert_aTHX; assert(a); assert(b)
+    STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_CALLCONV I32
 Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2, char **pe2, UV l2, bool u2)
@@ -2571,7 +2724,7 @@ Perl_ibcmp_utf8(pTHX_ const char *s1, char **pe1, UV l1, bool u1, const char *s2
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_IBCMP_UTF8             \
-        Perl_assert_aTHX; assert(s1); assert(s2)
+    STMT_START { Perl_assert_aTHX; assert(s1); assert(s2); } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct Perl_custom_infix **def)
@@ -2579,7 +2732,8 @@ Perl_infix_plugin_standard(pTHX_ char *operator_ptr, STRLEN operator_len, struct
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_INFIX_PLUGIN_STANDARD  \
-        Perl_assert_aTHX; assert(operator_ptr); assert(def)
+    STMT_START { Perl_assert_aTHX; assert(operator_ptr); assert(def);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_init_argv_symbols(pTHX_ int argc, char **argv)
@@ -2587,34 +2741,34 @@ Perl_init_argv_symbols(pTHX_ int argc, char **argv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_ARGV_SYMBOLS      \
-        Perl_assert_aTHX; assert(argv)
+    STMT_START { Perl_assert_aTHX; assert(argv); } STMT_END
 
 PERL_CALLCONV void
 Perl_init_constants(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_CONSTANTS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_init_dbargs(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_DBARGS            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_init_debugger(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_DEBUGGER          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_init_i18nl10n(pTHX_ int printwarn)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_INIT_I18NL10N          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
@@ -2622,29 +2776,30 @@ Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_INIT_NAMED_CV          \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
-        assert(nameop)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                 assert(nameop);                                            \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_init_stacks(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_INIT_STACKS            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_init_tm(pTHX_ struct tm *ptm)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_INIT_TM                \
-        Perl_assert_aTHX; assert(ptm)
+    STMT_START { Perl_assert_aTHX; assert(ptm); } STMT_END
 
 PERL_CALLCONV void
 Perl_init_uniprops(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INIT_UNIPROPS          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_instr(const char *big, const char *little)
@@ -2653,13 +2808,13 @@ Perl_instr(const char *big, const char *little)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_INSTR                  \
-        assert(big); assert(little)
+    STMT_START { assert(big); assert(little); } STMT_END
 
 PERL_CALLCONV U32
 Perl_intro_my(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_INTRO_MY               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV Size_t
 Perl_inverse_folds_(pTHX_ const UV cp, U32 *first_folds_to, const U32 **remaining_folds_to)
@@ -2668,7 +2823,9 @@ Perl_inverse_folds_(pTHX_ const UV cp, U32 *first_folds_to, const U32 **remainin
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_INVERSE_FOLDS_         \
-        Perl_assert_aTHX; assert(first_folds_to); assert(remaining_folds_to)
+    STMT_START { Perl_assert_aTHX; assert(first_folds_to);  \
+                 assert(remaining_folds_to);                \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_invert(pTHX_ OP *cmd)
@@ -2676,7 +2833,7 @@ Perl_invert(pTHX_ OP *cmd)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INVERT                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_invmap_dump(pTHX_ SV *invlist, UV *map)
@@ -2685,7 +2842,7 @@ Perl_invmap_dump(pTHX_ SV *invlist, UV *map)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_INVMAP_DUMP            \
-        Perl_assert_aTHX; assert(invlist); assert(map)
+    STMT_START { Perl_assert_aTHX; assert(invlist); assert(map); } STMT_END
 
 PERL_CALLCONV bool
 Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
@@ -2693,69 +2850,69 @@ Perl_io_close(pTHX_ IO *io, GV *gv, bool is_explicit, bool warn_on_fail)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_IO_CLOSE               \
-        Perl_assert_aTHX; assert(io)
+    STMT_START { Perl_assert_aTHX; assert(io); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_c9strict_utf8_string(const U8 *s, STRLEN len)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_c9strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOC \
-        assert(s); assert(ep)
+    STMT_START { assert(s); assert(ep); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_in_locale_category_(pTHX_ const bool compiling, const int category)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_IS_IN_LOCALE_CATEGORY_ \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_is_lvalue_sub(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_LVALUE_SUB          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_strict_utf8_string(const U8 *s, STRLEN len)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING  \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_strict_utf8_string_loc(const U8 *s, STRLEN len, const U8 **ep)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOC \
-        assert(s); assert(ep)
+    STMT_START { assert(s); assert(ep); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_uni_FOO_(pTHX_ const U8 classnum, const UV c)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UNI_FOO_            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_uni_perl_idcont_(pTHX_ UV c)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UNI_PERL_IDCONT_    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_uni_perl_idstart_(pTHX_ UV c)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UNI_PERL_IDSTART_   \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e, const bool require_partial)
@@ -2764,7 +2921,7 @@ Perl_is_utf8_FF_helper_(const U8 * const s0, const U8 * const e, const bool requ
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IS_UTF8_FF_HELPER_     \
-        assert(s0); assert(e); assert(s0 < e)
+    STMT_START { assert(s0); assert(e); assert(s0 < e); } STMT_END
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_FOO_(pTHX_ const U8 classnum, const U8 *p, const U8 * const e)
@@ -2773,14 +2930,16 @@ Perl_is_utf8_FOO_(pTHX_ const U8 classnum, const U8 *p, const U8 * const e)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_FOO_           \
-        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(p < e);  \
+    } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_is_utf8_char_buf(const U8 *buf, const U8 *buf_end)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 #define PERL_ARGS_ASSERT_IS_UTF8_CHAR_BUF       \
-        assert(buf); assert(buf_end); assert(buf <= buf_end)
+    STMT_START { assert(buf); assert(buf_end); assert(buf <= buf_end);  \
+    } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_is_utf8_char_helper_(const U8 * const s, const U8 *e, const U32 flags)
@@ -2789,19 +2948,19 @@ Perl_is_utf8_char_helper_(const U8 * const s, const U8 *e, const U32 flags)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IS_UTF8_CHAR_HELPER_   \
-        assert(s); assert(e); assert(s < e)
+    STMT_START { assert(s); assert(e); assert(s < e); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_utf8_fixed_width_buf_flags(const U8 * const s, STRLEN len, const U32 flags)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_FLAGS \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_utf8_fixed_width_buf_loc_flags(const U8 * const s, STRLEN len, const U8 **ep, const U32 flags)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOC_FLAGS \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
@@ -2810,7 +2969,8 @@ Perl_is_utf8_perl_idcont_(pTHX_ const U8 *p, const U8 * const e)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_PERL_IDCONT_   \
-        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(p < e);  \
+    } STMT_END
 
 PERL_CALLCONV Size_t
 Perl_is_utf8_perl_idstart_(pTHX_ const U8 *p, const U8 * const e)
@@ -2819,28 +2979,29 @@ Perl_is_utf8_perl_idstart_(pTHX_ const U8 *p, const U8 * const e)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_PERL_IDSTART_  \
-        Perl_assert_aTHX; assert(p); assert(e); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(p < e);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_utf8_string(const U8 *s, STRLEN len)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_IS_UTF8_STRING         \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_utf8_string_loc(const U8 *s, const STRLEN len, const U8 **ep)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC     \
-        assert(s); assert(ep)
+    STMT_START { assert(s); assert(ep); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_utf8_string_loc_flags(const U8 *s, STRLEN len, const U8 **ep, const U32 flags)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOC_FLAGS \
-        assert(s); assert(ep)
+    STMT_START { assert(s); assert(ep); } STMT_END
 
 PERL_CALLCONV bool
 Perl_is_utf8_valid_partial_char(const U8 * const s0, const U8 * const e)
@@ -2849,7 +3010,7 @@ Perl_is_utf8_valid_partial_char(const U8 * const s0, const U8 * const e)
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_IS_UTF8_VALID_PARTIAL_CHAR \
-        assert(s0); assert(e); assert(s0 < e)
+    STMT_START { assert(s0); assert(e); assert(s0 < e); } STMT_END
 
 PERL_CALLCONV bool
 Perl_isinfnan(NV nv)
@@ -2863,7 +3024,7 @@ Perl_isinfnansv(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_ISINFNANSV             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_jmaybe(pTHX_ OP *o)
@@ -2871,7 +3032,7 @@ Perl_jmaybe(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_JMAYBE                 \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV I32
 Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
@@ -2881,7 +3042,7 @@ Perl_keyword(pTHX_ const char *name, I32 len, bool all_keywords)
         __attribute__pure__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_KEYWORD                \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV int
 Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **op_ptr)
@@ -2889,7 +3050,8 @@ Perl_keyword_plugin_standard(pTHX_ char *keyword_ptr, STRLEN keyword_len, OP **o
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_KEYWORD_PLUGIN_STANDARD \
-        Perl_assert_aTHX; assert(keyword_ptr); assert(op_ptr)
+    STMT_START { Perl_assert_aTHX; assert(keyword_ptr); assert(op_ptr);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int filter)
@@ -2897,104 +3059,105 @@ Perl_leave_adjust_stacks(pTHX_ SV **from_sp, SV **to_sp, U8 gimme, int filter)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_LEAVE_ADJUST_STACKS    \
-        Perl_assert_aTHX; assert(from_sp); assert(to_sp)
+    STMT_START { Perl_assert_aTHX; assert(from_sp); assert(to_sp);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_leave_scope(pTHX_ I32 base)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEAVE_SCOPE            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_lex_bufutf8(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEX_BUFUTF8            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_discard_to(pTHX_ char *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_DISCARD_TO         \
-        Perl_assert_aTHX; assert(ptr)
+    STMT_START { Perl_assert_aTHX; assert(ptr); } STMT_END
 
 PERL_CALLCONV char *
 Perl_lex_grow_linestr(pTHX_ STRLEN len)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEX_GROW_LINESTR       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_lex_next_chunk(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEX_NEXT_CHUNK         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_lex_peek_unichar(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEX_PEEK_UNICHAR       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_read_space(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEX_READ_SPACE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_read_to(pTHX_ char *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_READ_TO            \
-        Perl_assert_aTHX; assert(ptr)
+    STMT_START { Perl_assert_aTHX; assert(ptr); } STMT_END
 
 PERL_CALLCONV I32
 Perl_lex_read_unichar(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEX_READ_UNICHAR       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_start(pTHX_ SV *line, PerlIO *rsfp, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_LEX_START              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_stuff_pv(pTHX_ const char *pv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PV           \
-        Perl_assert_aTHX; assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(pv); } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_stuff_pvn(pTHX_ const char *pv, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_PVN          \
-        Perl_assert_aTHX; assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(pv); } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_stuff_sv(pTHX_ SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_STUFF_SV           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_lex_unstuff(pTHX_ char *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_LEX_UNSTUFF            \
-        Perl_assert_aTHX; assert(ptr)
+    STMT_START { Perl_assert_aTHX; assert(ptr); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_list(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_LIST                   \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV HV *
 Perl_load_charnames(pTHX_ SV *char_name, const char *context, const STRLEN context_len, const char **error_msg)
@@ -3004,15 +3167,16 @@ Perl_load_charnames(pTHX_ SV *char_name, const char *context, const STRLEN conte
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_LOAD_CHARNAMES         \
-        Perl_assert_aTHX; assert(char_name); assert(context);  \
-        assert(error_msg)
+    STMT_START { Perl_assert_aTHX; assert(char_name); assert(context);  \
+                 assert(error_msg);                                     \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_LOAD_MODULE            \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_locale_panic(const char *msg, const line_t immediate_caller_line, const char * const higher_caller_file, const line_t higher_caller_line)
@@ -3020,7 +3184,7 @@ Perl_locale_panic(const char *msg, const line_t immediate_caller_line, const cha
         Perl_attribute_nonnull(3)
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_LOCALE_PANIC           \
-        assert(msg); assert(higher_caller_file)
+    STMT_START { assert(msg); assert(higher_caller_file); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_localize(pTHX_ OP *o, I32 lex)
@@ -3028,14 +3192,14 @@ Perl_localize(pTHX_ OP *o, I32 lex)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_LOCALIZE               \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV UV
 Perl_long_valid_utf8_to_uv(const U8 * const s, const U8 * const e)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 #define PERL_ARGS_ASSERT_LONG_VALID_UTF8_TO_UV  \
-        assert(s); assert(e); assert(s < e)
+    STMT_START { assert(s); assert(e); assert(s < e); } STMT_END
 
 PERL_CALLCONV I32
 Perl_looks_like_number(pTHX_ SV * const sv)
@@ -3043,7 +3207,7 @@ Perl_looks_like_number(pTHX_ SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_LOOKS_LIKE_NUMBER      \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
@@ -3052,7 +3216,7 @@ Perl_magic_clear_all_env(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEAR_ALL_ENV    \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_cleararylen_p(pTHX_ SV *sv, MAGIC *mg)
@@ -3061,7 +3225,7 @@ Perl_magic_cleararylen_p(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARARYLEN_P    \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearenv(pTHX_ SV *sv, MAGIC *mg)
@@ -3070,7 +3234,7 @@ Perl_magic_clearenv(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARENV         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearhint(pTHX_ SV *sv, MAGIC *mg)
@@ -3079,7 +3243,7 @@ Perl_magic_clearhint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHINT        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearhints(pTHX_ SV *sv, MAGIC *mg)
@@ -3088,7 +3252,7 @@ Perl_magic_clearhints(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHINTS       \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
@@ -3096,7 +3260,7 @@ Perl_magic_clearhook(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOK        \
-        Perl_assert_aTHX; assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearhookall(pTHX_ SV *sv, MAGIC *mg)
@@ -3104,7 +3268,7 @@ Perl_magic_clearhookall(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARHOOKALL     \
-        Perl_assert_aTHX; assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
@@ -3112,7 +3276,7 @@ Perl_magic_clearisa(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARISA         \
-        Perl_assert_aTHX; assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
@@ -3121,7 +3285,7 @@ Perl_magic_clearpack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARPACK        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_clearsig(pTHX_ SV *sv, MAGIC *mg)
@@ -3130,7 +3294,7 @@ Perl_magic_clearsig(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_CLEARSIG         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv, const char *name, I32 namlen)
@@ -3140,13 +3304,14 @@ Perl_magic_copycallchecker(pTHX_ SV *sv, MAGIC *mg, SV *nsv, const char *name, I
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_COPYCALLCHECKER  \
-        Perl_assert_aTHX; assert(sv); assert(mg); assert(nsv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); assert(nsv);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_magic_dump(pTHX_ const MAGIC *mg)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MAGIC_DUMP             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
@@ -3155,7 +3320,7 @@ Perl_magic_existspack(pTHX_ SV *sv, const MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_EXISTSPACK       \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
@@ -3164,7 +3329,7 @@ Perl_magic_freearylen_p(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEARYLEN_P     \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_freedestruct(pTHX_ SV *sv, MAGIC *mg)
@@ -3173,7 +3338,7 @@ Perl_magic_freedestruct(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEDESTRUCT     \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
@@ -3182,7 +3347,7 @@ Perl_magic_freemglob(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEMGLOB        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
@@ -3191,7 +3356,7 @@ Perl_magic_freeovrld(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEOVRLD        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
@@ -3200,7 +3365,7 @@ Perl_magic_freeutf8(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_FREEUTF8         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
@@ -3209,7 +3374,7 @@ Perl_magic_get(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GET              \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
@@ -3218,7 +3383,7 @@ Perl_magic_getarylen(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETARYLEN        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
@@ -3227,7 +3392,7 @@ Perl_magic_getdebugvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETDEBUGVAR      \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getdefelem(pTHX_ SV *sv, MAGIC *mg)
@@ -3236,7 +3401,7 @@ Perl_magic_getdefelem(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETDEFELEM       \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
@@ -3245,7 +3410,7 @@ Perl_magic_getnkeys(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETNKEYS         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
@@ -3254,7 +3419,7 @@ Perl_magic_getpack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETPACK          \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
@@ -3263,7 +3428,7 @@ Perl_magic_getpos(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETPOS           \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
@@ -3272,7 +3437,7 @@ Perl_magic_getsig(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETSIG           \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
@@ -3281,7 +3446,7 @@ Perl_magic_getsubstr(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETSUBSTR        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_gettaint(pTHX_ SV *sv, MAGIC *mg)
@@ -3290,7 +3455,7 @@ Perl_magic_gettaint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETTAINT         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
@@ -3299,7 +3464,7 @@ Perl_magic_getuvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETUVAR          \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
@@ -3308,7 +3473,7 @@ Perl_magic_getvec(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_GETVEC           \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_killbackrefs(pTHX_ SV *sv, MAGIC *mg)
@@ -3317,7 +3482,7 @@ Perl_magic_killbackrefs(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_KILLBACKREFS     \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, U32 argc, ...)
@@ -3327,7 +3492,8 @@ Perl_magic_methcall(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, U32 argc
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_METHCALL         \
-        Perl_assert_aTHX; assert(sv); assert(mg); assert(meth)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); assert(meth);  \
+    } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
@@ -3337,7 +3503,8 @@ Perl_magic_nextpack(pTHX_ SV *sv, MAGIC *mg, SV *key)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_NEXTPACK         \
-        Perl_assert_aTHX; assert(sv); assert(mg); assert(key)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); assert(key);  \
+    } STMT_END
 
 PERL_CALLCONV U32
 Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
@@ -3346,7 +3513,7 @@ Perl_magic_regdata_cnt(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATA_CNT      \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
@@ -3355,7 +3522,7 @@ Perl_magic_regdatum_get(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATUM_GET     \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV_NON_VOID_NO_RET(int) int
 Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
@@ -3365,7 +3532,7 @@ Perl_magic_regdatum_set(pTHX_ SV *sv, MAGIC *mg)
         __attribute__noreturn__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_REGDATUM_SET     \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
@@ -3374,8 +3541,9 @@ Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SCALARPACK       \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(hv);                \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(mg);  \
+    } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
@@ -3384,7 +3552,7 @@ Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SET              \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
@@ -3393,7 +3561,7 @@ Perl_magic_set_all_env(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SET_ALL_ENV      \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
@@ -3402,7 +3570,7 @@ Perl_magic_setarylen(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETARYLEN        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
@@ -3411,7 +3579,7 @@ Perl_magic_setdbline(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDBLINE        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
@@ -3420,7 +3588,7 @@ Perl_magic_setdebugvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDEBUGVAR      \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
@@ -3429,7 +3597,7 @@ Perl_magic_setdefelem(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETDEFELEM       \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
@@ -3438,7 +3606,7 @@ Perl_magic_setenv(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETENV           \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
@@ -3447,7 +3615,7 @@ Perl_magic_sethint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHINT          \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
@@ -3455,7 +3623,7 @@ Perl_magic_sethook(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHOOK          \
-        Perl_assert_aTHX; assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_sethookall(pTHX_ SV *sv, MAGIC *mg)
@@ -3464,7 +3632,7 @@ Perl_magic_sethookall(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETHOOKALL       \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
@@ -3473,7 +3641,7 @@ Perl_magic_setisa(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETISA           \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
@@ -3482,7 +3650,7 @@ Perl_magic_setlvref(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETLVREF         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setmglob(pTHX_ SV *sv, MAGIC *mg)
@@ -3491,7 +3659,7 @@ Perl_magic_setmglob(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETMGLOB         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setnkeys(pTHX_ SV *sv, MAGIC *mg)
@@ -3500,7 +3668,7 @@ Perl_magic_setnkeys(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETNKEYS         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setnonelem(pTHX_ SV *sv, MAGIC *mg)
@@ -3509,7 +3677,7 @@ Perl_magic_setnonelem(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETNONELEM       \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
@@ -3518,7 +3686,7 @@ Perl_magic_setpack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETPACK          \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
@@ -3527,7 +3695,7 @@ Perl_magic_setpos(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETPOS           \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
@@ -3536,7 +3704,7 @@ Perl_magic_setregexp(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETREGEXP        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
@@ -3544,7 +3712,7 @@ Perl_magic_setsig(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSIG           \
-        Perl_assert_aTHX; assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setsigall(pTHX_ SV *sv, MAGIC *mg)
@@ -3553,7 +3721,7 @@ Perl_magic_setsigall(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSIGALL        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
@@ -3562,7 +3730,7 @@ Perl_magic_setsubstr(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETSUBSTR        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
@@ -3571,7 +3739,7 @@ Perl_magic_settaint(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETTAINT         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setutf8(pTHX_ SV *sv, MAGIC *mg)
@@ -3580,7 +3748,7 @@ Perl_magic_setutf8(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETUTF8          \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
@@ -3589,7 +3757,7 @@ Perl_magic_setuvar(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETUVAR          \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
@@ -3598,7 +3766,7 @@ Perl_magic_setvec(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SETVEC           \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV U32
 Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
@@ -3607,7 +3775,7 @@ Perl_magic_sizepack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SIZEPACK         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
@@ -3616,7 +3784,7 @@ Perl_magic_wipepack(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_WIPEPACK         \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_magicv2_localize_copy(pTHX_ SV *nsv, SV *osv, MAGIC *omg)
@@ -3625,7 +3793,8 @@ Perl_magicv2_localize_copy(pTHX_ SV *nsv, SV *osv, MAGIC *omg)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MAGICV2_LOCALIZE_COPY  \
-        Perl_assert_aTHX; assert(nsv); assert(osv); assert(omg)
+    STMT_START { Perl_assert_aTHX; assert(nsv); assert(osv); assert(omg);  \
+    } STMT_END
 
 PERL_CALLCONV Malloc_t
 Perl_malloc(MEM_SIZE nbytes)
@@ -3637,27 +3806,27 @@ PERL_CALLCONV Stack_off_t *
 Perl_markstack_grow(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MARKSTACK_GROW         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_mbtowc_(pTHX_ const wchar_t *pwc, const char *s, const Size_t len)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MBTOWC_                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_mess(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_MESS                   \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_mess_sv(pTHX_ SV *basemsg, bool consume)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MESS_SV                \
-        Perl_assert_aTHX; assert(basemsg)
+    STMT_START { Perl_assert_aTHX; assert(basemsg); } STMT_END
 
 PERL_CALLCONV Free_t
 Perl_mfree(Malloc_t where);
@@ -3668,7 +3837,7 @@ Perl_mg_clear(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_CLEAR               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV int
 Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen)
@@ -3676,7 +3845,7 @@ Perl_mg_copy(pTHX_ SV *sv, SV *nsv, const char *key, I32 klen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MG_COPY                \
-        Perl_assert_aTHX; assert(sv); assert(nsv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(nsv); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_mg_find(const SV *sv, int type)
@@ -3689,7 +3858,7 @@ Perl_mg_find_mglob(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_MG_FIND_MGLOB          \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_mg_findext(const SV *sv, int type, const MGVTBL *vtbl)
@@ -3701,28 +3870,28 @@ Perl_mg_free(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE                \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_mg_free_type(pTHX_ SV *sv, int how)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREE_TYPE           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_mg_freeext(pTHX_ SV *sv, int how, const MGVTBL *vtbl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_FREEEXT             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV int
 Perl_mg_get(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_GET                 \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
@@ -3731,93 +3900,95 @@ Perl_mg_localize(pTHX_ SV *sv, SV *nsv, bool setmagic)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MG_LOCALIZE            \
-        Perl_assert_aTHX; assert(sv); assert(nsv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(nsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_mg_magical(SV *sv)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_MG_MAGICAL             \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_mg_ptr_store(pTHX_ MAGIC *mg, const void *ptr, STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_PTR_STORE           \
-        Perl_assert_aTHX; assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_mg_set(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SET                 \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV I32
 Perl_mg_size(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MG_SIZE                \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_mini_mktime(struct tm *ptm)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_MINI_MKTIME            \
-        assert(ptm)
+    STMT_START { assert(ptm); } STMT_END
 
 PERL_CALLCONV int
 Perl_mode_from_discipline(pTHX_ const char *s, STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MODE_FROM_DISCIPLINE   \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void *
 Perl_more_bodies(pTHX_ const svtype sv_type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MORE_BODIES            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_more_sv(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MORE_SV                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV const char *
 Perl_moreswitches(pTHX_ const char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MORESWITCHES           \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV void
 Perl_mortal_destructor_sv(pTHX_ SV *coderef, SV *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MORTAL_DESTRUCTOR_SV   \
-        Perl_assert_aTHX; assert(coderef)
+    STMT_START { Perl_assert_aTHX; assert(coderef); } STMT_END
 
 PERL_CALLCONV void
 Perl_mortal_svfunc_x(pTHX_ SVFUNC_t f, SV *p)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MORTAL_SVFUNC_X        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV const struct mro_alg *
 Perl_mro_get_from_name(pTHX_ SV *name)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_FROM_NAME      \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV AV *
 Perl_mro_get_linear_isa(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA     \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(stash);    \
+                 assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which)
@@ -3825,7 +3996,7 @@ Perl_mro_get_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_GET_PRIVATE_DATA   \
-        Perl_assert_aTHX; assert(smeta); assert(which)
+    STMT_START { Perl_assert_aTHX; assert(smeta); assert(which); } STMT_END
 
 PERL_CALLCONV void
 Perl_mro_isa_changed_in(pTHX_ HV *stash)
@@ -3833,36 +4004,45 @@ Perl_mro_isa_changed_in(pTHX_ HV *stash)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MRO_ISA_CHANGED_IN     \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(stash);    \
+                 assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV struct mro_meta *
 Perl_mro_meta_init(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_META_INIT          \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(stash);    \
+                 assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_mro_method_changed_in(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_METHOD_CHANGED_IN  \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(stash);    \
+                 assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash, const GV * const gv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_PACKAGE_MOVED      \
-        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
-        assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(gv)
+    STMT_START { Perl_assert_aTHX;                                   \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV);        \
+                 assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV);  \
+                 assert(gv);                                         \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_mro_register(pTHX_ const struct mro_alg *mro)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MRO_REGISTER           \
-        Perl_assert_aTHX; assert(mro)
+    STMT_START { Perl_assert_aTHX; assert(mro); } STMT_END
 
 PERL_CALLCONV void
 Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name)
@@ -3870,7 +4050,7 @@ Perl_mro_set_mro(pTHX_ struct mro_meta * const meta, SV * const name)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MRO_SET_MRO            \
-        Perl_assert_aTHX; assert(meta); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(meta); assert(name); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_alg * const which, SV * const data)
@@ -3879,29 +4059,32 @@ Perl_mro_set_private_data(pTHX_ struct mro_meta * const smeta, const struct mro_
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_SET_PRIVATE_DATA   \
-        Perl_assert_aTHX; assert(smeta); assert(which); assert(data)
+    STMT_START { Perl_assert_aTHX; assert(smeta); assert(which);  \
+                 assert(data);                                    \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_multiconcat_stringify(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MULTICONCAT_STRINGIFY  \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MULTIDEREF_STRINGIFY   \
-        Perl_assert_aTHX; assert(o);  \
-        assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(o);                                      \
+                 assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV NV
 Perl_my_atof(pTHX_ const char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MY_ATOF                \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV char *
 Perl_my_atof2(pTHX_ const char *orig, NV *value)
@@ -3909,7 +4092,7 @@ Perl_my_atof2(pTHX_ const char *orig, NV *value)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF2               \
-        Perl_assert_aTHX; assert(orig); assert(value)
+    STMT_START { Perl_assert_aTHX; assert(orig); assert(value); } STMT_END
 
 PERL_CALLCONV char *
 Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len)
@@ -3917,7 +4100,7 @@ Perl_my_atof3(pTHX_ const char *orig, NV *value, const STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_MY_ATOF3               \
-        Perl_assert_aTHX; assert(orig); assert(value)
+    STMT_START { Perl_assert_aTHX; assert(orig); assert(value); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_my_attrs(pTHX_ OP *o, OP *attrs)
@@ -3925,13 +4108,13 @@ Perl_my_attrs(pTHX_ OP *o, OP *attrs)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_ATTRS               \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_my_clearenv(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MY_CLEARENV            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_my_dirfd(DIR *dir);
@@ -3942,20 +4125,20 @@ Perl_my_exit(pTHX_ U32 status)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_MY_EXIT                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_my_failure_exit(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
 #define PERL_ARGS_ASSERT_MY_FAILURE_EXIT        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_my_fflush_all(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MY_FFLUSH_ALL          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV Pid_t
 Perl_my_fork(void);
@@ -3965,7 +4148,7 @@ PERL_CALLCONV I32
 Perl_my_lstat_flags(pTHX_ const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MY_LSTAT_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_my_mkostemp_cloexec(char *templte, int flags)
@@ -3973,7 +4156,7 @@ Perl_my_mkostemp_cloexec(char *templte, int flags)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_MKOSTEMP_CLOEXEC    \
-        assert(templte)
+    STMT_START { assert(templte); } STMT_END
 
 PERL_CALLCONV int
 Perl_my_mkstemp_cloexec(char *templte)
@@ -3981,7 +4164,7 @@ Perl_my_mkstemp_cloexec(char *templte)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_MKSTEMP_CLOEXEC     \
-        assert(templte)
+    STMT_START { assert(templte); } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
@@ -3989,13 +4172,13 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MY_POPEN_LIST          \
-        Perl_assert_aTHX; assert(mode); assert(args)
+    STMT_START { Perl_assert_aTHX; assert(mode); assert(args); } STMT_END
 
 PERL_CALLCONV void
 Perl_my_setenv(pTHX_ const char *nam, const char *val)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MY_SETENV              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
@@ -4003,7 +4186,7 @@ Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
         Perl_attribute_nonnull(3)
         __attribute__format__(__printf__,3,4);
 #define PERL_ARGS_ASSERT_MY_SNPRINTF            \
-        assert(buffer); assert(format)
+    STMT_START { assert(buffer); assert(format); } STMT_END
 
 PERL_CALLCONV int
 Perl_my_socketpair(int family, int type, int protocol, int fd[2]);
@@ -4013,7 +4196,7 @@ PERL_CALLCONV I32
 Perl_my_stat_flags(pTHX_ const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_MY_STAT_FLAGS          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV const char *
 Perl_my_strerror(pTHX_ const int errnum, utf8ness_t *utf8ness)
@@ -4021,7 +4204,7 @@ Perl_my_strerror(pTHX_ const int errnum, utf8ness_t *utf8ness)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_STRERROR            \
-        Perl_assert_aTHX; assert(utf8ness)
+    STMT_START { Perl_assert_aTHX; assert(utf8ness); } STMT_END
 
 PERL_CALLCONV char *
 Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, int mon, int year, int wday, int yday, int isdst)
@@ -4029,54 +4212,54 @@ Perl_my_strftime(pTHX_ const char *fmt, int sec, int min, int hour, int mday, in
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__strftime__,pTHX_1,0);
 #define PERL_ARGS_ASSERT_MY_STRFTIME            \
-        Perl_assert_aTHX; assert(fmt)
+    STMT_START { Perl_assert_aTHX; assert(fmt); } STMT_END
 
 PERL_CALLCONV NV
 Perl_my_strtod(const char * const s, char **e)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_MY_STRTOD              \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV void
 Perl_my_unexec(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MY_UNEXEC              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_my_vsnprintf(char *buffer, const Size_t len, const char *format, va_list ap)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_MY_VSNPRINTF           \
-        assert(buffer); assert(format)
+    STMT_START { assert(buffer); assert(format); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newANONATTRSUB(pTHX_ I32 floor, OP *proto, OP *attrs, OP *block)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWANONATTRSUB         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newANONHASH(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWANONHASH            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newANONLIST(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWANONLIST            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newANONSUB(pTHX_ I32 floor, OP *proto, OP *block)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWANONSUB             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newARGDEFELEMOP(pTHX_ I32 flags, OP *expr, I32 argindex)
@@ -4084,33 +4267,33 @@ Perl_newARGDEFELEMOP(pTHX_ I32 flags, OP *expr, I32 argindex)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWARGDEFELEMOP        \
-        Perl_assert_aTHX; assert(expr)
+    STMT_START { Perl_assert_aTHX; assert(expr); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newASSIGNOP(pTHX_ I32 flags, OP *left, I32 optype, OP *right)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWASSIGNOP            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newATTRSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWATTRSUB             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newATTRSUB_x(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block, bool o_is_gv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWATTRSUB_X           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV AV *
 Perl_newAV(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAV                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newAVREF(pTHX_ OP *o)
@@ -4118,49 +4301,51 @@ Perl_newAVREF(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVREF               \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV AV *
 Perl_newAV_alloc_x(pTHX_ SSize_t size)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAV_ALLOC_X          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV AV *
 Perl_newAV_alloc_xz(pTHX_ SSize_t size)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAV_ALLOC_XZ         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV AV *
 Perl_newAV_mortal(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAV_MORTAL           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV AV *
 Perl_newAVav(pTHX_ AV *oav)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVAV                \
-        Perl_assert_aTHX; assert(!oav || SvTYPE(oav) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(!oav || SvTYPE(oav) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV AV *
 Perl_newAVhv(pTHX_ HV *ohv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWAVHV                \
-        Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newBINOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWBINOP               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
@@ -4168,26 +4353,30 @@ Perl_newCONDOP(pTHX_ I32 flags, OP *first, OP *trueop, OP *falseop)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWCONDOP              \
-        Perl_assert_aTHX; assert(first)
+    STMT_START { Perl_assert_aTHX; assert(first); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newCONSTSUB(pTHX_ HV *stash, const char *name, SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWCONSTSUB            \
-        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX;                             \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newCONSTSUB_flags(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags, SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWCONSTSUB_FLAGS      \
-        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX;                             \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newCVREF(pTHX_ I32 flags, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWCVREF               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
@@ -4195,20 +4384,20 @@ Perl_newDEFEROP(pTHX_ I32 flags, OP *block)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWDEFEROP             \
-        Perl_assert_aTHX; assert(block)
+    STMT_START { Perl_assert_aTHX; assert(block); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newDEFSVOP(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWDEFSVOP             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_newFORM(pTHX_ I32 floor, OP *o, OP *block)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWFORM                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
@@ -4216,7 +4405,7 @@ Perl_newFOROP(pTHX_ I32 flags, OP *sv, OP *expr, OP *block, OP *cont)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWFOROP               \
-        Perl_assert_aTHX; assert(expr)
+    STMT_START { Perl_assert_aTHX; assert(expr); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newGIVENOP(pTHX_ OP *cond, OP *block, PADOFFSET defsv_off)
@@ -4225,14 +4414,14 @@ Perl_newGIVENOP(pTHX_ OP *cond, OP *block, PADOFFSET defsv_off)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGIVENOP             \
-        Perl_assert_aTHX; assert(cond); assert(block)
+    STMT_START { Perl_assert_aTHX; assert(cond); assert(block); } STMT_END
 
 PERL_CALLCONV GP *
 Perl_newGP(pTHX_ GV * const gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWGP                  \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newGVOP(pTHX_ I32 type, I32 flags, GV *gv)
@@ -4240,21 +4429,21 @@ Perl_newGVOP(pTHX_ I32 type, I32 flags, GV *gv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVOP                \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newGVREF(pTHX_ I32 type, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVREF               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV GV *
 Perl_newGVgen(pTHX_ const char *pack)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWGVGEN               \
-        Perl_assert_aTHX; assert(pack)
+    STMT_START { Perl_assert_aTHX; assert(pack); } STMT_END
 
 PERL_CALLCONV GV *
 Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
@@ -4262,14 +4451,14 @@ Perl_newGVgen_flags(pTHX_ const char *pack, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWGVGEN_FLAGS         \
-        Perl_assert_aTHX; assert(pack)
+    STMT_START { Perl_assert_aTHX; assert(pack); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_newHV(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHV                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newHVREF(pTHX_ OP *o)
@@ -4277,35 +4466,36 @@ Perl_newHVREF(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVREF               \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_newHVhv(pTHX_ HV *ohv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWHVHV                \
-        Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(!ohv || SvTYPE(ohv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV IO *
 Perl_newIO(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWIO                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newLISTOP(pTHX_ I32 type, I32 flags, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLISTOP              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newLISTOPn(pTHX_ I32 type, I32 flags, ...)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLISTOPN             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
@@ -4314,7 +4504,7 @@ Perl_newLOGOP(pTHX_ I32 optype, I32 flags, OP *first, OP *other)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOGOP               \
-        Perl_assert_aTHX; assert(first); assert(other)
+    STMT_START { Perl_assert_aTHX; assert(first); assert(other); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newLOOPEX(pTHX_ I32 type, OP *label)
@@ -4322,7 +4512,7 @@ Perl_newLOOPEX(pTHX_ I32 type, OP *label)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPEX              \
-        Perl_assert_aTHX; assert(label)
+    STMT_START { Perl_assert_aTHX; assert(label); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
@@ -4330,7 +4520,7 @@ Perl_newLOOPOP(pTHX_ I32 flags, I32 debuggable, OP *expr, OP *block)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWLOOPOP              \
-        Perl_assert_aTHX; assert(expr)
+    STMT_START { Perl_assert_aTHX; assert(expr); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP *dynamic_meth)
@@ -4338,7 +4528,7 @@ Perl_newMETHOP(pTHX_ I32 type, I32 flags, OP *dynamic_meth)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP              \
-        Perl_assert_aTHX; assert(dynamic_meth)
+    STMT_START { Perl_assert_aTHX; assert(dynamic_meth); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newMETHOP_named(pTHX_ I32 type, I32 flags, SV * const_meth)
@@ -4346,35 +4536,35 @@ Perl_newMETHOP_named(pTHX_ I32 type, I32 flags, SV * const_meth)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWMETHOP_NAMED        \
-        Perl_assert_aTHX; assert(const_meth)
+    STMT_START { Perl_assert_aTHX; assert(const_meth); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newMYSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *attrs, OP *block)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWMYSUB               \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newNULLLIST(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWNULLLIST            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newOP(pTHX_ I32 optype, I32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWOP                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PADNAMELIST *
 Perl_newPADNAMELIST(pTHX_ size_t max)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPADNAMELIST         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PADNAME *
 Perl_newPADNAMEouter(pTHX_ PADNAME *outer)
@@ -4382,7 +4572,7 @@ Perl_newPADNAMEouter(pTHX_ PADNAME *outer)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPADNAMEOUTER        \
-        Perl_assert_aTHX; assert(outer)
+    STMT_START { Perl_assert_aTHX; assert(outer); } STMT_END
 
 PERL_CALLCONV PADNAME *
 Perl_newPADNAMEpvn(pTHX_ const char *s, STRLEN len)
@@ -4390,28 +4580,28 @@ Perl_newPADNAMEpvn(pTHX_ const char *s, STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPADNAMEPVN          \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newPMOP(pTHX_ I32 type, I32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPMOP                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_newPROG(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWPROG                \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newPVOP(pTHX_ I32 type, I32 flags, char *pv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWPVOP                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
@@ -4420,7 +4610,7 @@ Perl_newRANGE(pTHX_ I32 flags, OP *left, OP *right)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRANGE               \
-        Perl_assert_aTHX; assert(left); assert(right)
+    STMT_START { Perl_assert_aTHX; assert(left); assert(right); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newRV(pTHX_ SV * const sv)
@@ -4428,21 +4618,21 @@ Perl_newRV(pTHX_ SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWRV                  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newSLICEOP(pTHX_ I32 flags, OP *subscript, OP *listop)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSLICEOP             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSTATEOP             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newSTUB(pTHX_ GV *gv, bool fake)
@@ -4450,20 +4640,20 @@ Perl_newSTUB(pTHX_ GV *gv, bool fake)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWSTUB                \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newSUB(pTHX_ I32 floor, OP *o, OP *proto, OP *block)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NEWSUB                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSV(pTHX_ const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSV                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
@@ -4471,7 +4661,7 @@ Perl_newSVOP(pTHX_ I32 type, I32 flags, SV *sv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVOP                \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newSVREF(pTHX_ OP *o)
@@ -4479,21 +4669,21 @@ Perl_newSVREF(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVREF               \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSV_false(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSV_FALSE            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSV_true(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSV_TRUE             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
@@ -4502,56 +4692,58 @@ Perl_newSVavdefelem(pTHX_ AV *av, SSize_t ix, bool extendible)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWSVAVDEFELEM         \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVbool(pTHX_ const bool bool_val)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVBOOL              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVhek(pTHX_ const HEK * const hek)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVHEK               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVhek_mortal(pTHX_ const HEK * const hek)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVHEK_MORTAL        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSViv(pTHX_ const IV i)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVIV                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVnv(pTHX_ const NV n)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVNV                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpv(pTHX_ const char * const s, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPV                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpv_share(pTHX_ const char *s, U32 hash)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPV_SHARE          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpvf(pTHX_ const char * const pat, ...)
@@ -4560,49 +4752,49 @@ Perl_newSVpvf(pTHX_ const char * const pat, ...)
         __attribute__warn_unused_result__
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_NEWSVPVF               \
-        Perl_assert_aTHX; assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(pat); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpvn(pTHX_ const char * const s, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpvn_flags(pTHX_ const char * const s, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpvn_share(pTHX_ const char *s, I32 len, U32 hash)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVN_SHARE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpvz(pTHX_ const STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVPVZ               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVrv(pTHX_ SV * const rv, const char * const classname)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEWSVRV                \
-        Perl_assert_aTHX; assert(rv)
+    STMT_START { Perl_assert_aTHX; assert(rv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVsv(pTHX_ SV * const old)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVSV                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
@@ -4610,21 +4802,21 @@ Perl_newSVsv_flags_NN(pTHX_ SV * const old, I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVSV_FLAGS_NN       \
-        Perl_assert_aTHX; assert(old)
+    STMT_START { Perl_assert_aTHX; assert(old); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVsv_nomg(pTHX_ SV * const old)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVSV_NOMG           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVuv(pTHX_ const UV u)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWSVUV                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
@@ -4634,22 +4826,23 @@ Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWTRYCATCHOP          \
-        Perl_assert_aTHX; assert(tryblock); assert(catchvar);  \
-        assert(catchblock)
+    STMT_START { Perl_assert_aTHX; assert(tryblock); assert(catchvar);  \
+                 assert(catchblock);                                    \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newUNOP(pTHX_ I32 type, I32 flags, OP *first)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWUNOP                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newUNOP_AUX(pTHX_ I32 type, I32 flags, OP *first, UNOP_AUX_item *aux)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWUNOP_AUX            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newWHENOP(pTHX_ OP *cond, OP *block)
@@ -4657,14 +4850,14 @@ Perl_newWHENOP(pTHX_ OP *cond, OP *block)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWWHENOP              \
-        Perl_assert_aTHX; assert(block)
+    STMT_START { Perl_assert_aTHX; assert(block); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newWHILEOP(pTHX_ I32 flags, I32 debuggable, LOOP *loop, OP *expr, OP *block, OP *cont, I32 has_my)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWWHILEOP             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename)
@@ -4672,7 +4865,8 @@ Perl_newXS(pTHX_ const char *name, XSUBADDR_t subaddr, const char *filename)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS                  \
-        Perl_assert_aTHX; assert(subaddr); assert(filename)
+    STMT_START { Perl_assert_aTHX; assert(subaddr); assert(filename);  \
+    } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr)
@@ -4680,7 +4874,7 @@ Perl_newXS_deffile(pTHX_ const char *name, XSUBADDR_t subaddr)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_NEWXS_DEFFILE          \
-        Perl_assert_aTHX; assert(name); assert(subaddr)
+    STMT_START { Perl_assert_aTHX; assert(name); assert(subaddr); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const filename, const char * const proto, U32 flags)
@@ -4688,7 +4882,8 @@ Perl_newXS_flags(pTHX_ const char *name, XSUBADDR_t subaddr, const char * const 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_NEWXS_FLAGS            \
-        Perl_assert_aTHX; assert(subaddr); assert(filename)
+    STMT_START { Perl_assert_aTHX; assert(subaddr); assert(filename);  \
+    } STMT_END
 
 PERL_CALLCONV CV *
 Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, const char * const filename, const char * const proto, SV ** const_svp, U32 flags)
@@ -4696,7 +4891,7 @@ Perl_newXS_len_flags(pTHX_ const char *name, STRLEN len, XSUBADDR_t subaddr, con
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEWXS_LEN_FLAGS        \
-        Perl_assert_aTHX; assert(subaddr)
+    STMT_START { Perl_assert_aTHX; assert(subaddr); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_new_block_statement(pTHX_ OP *block, OP *cont)
@@ -4704,28 +4899,28 @@ Perl_new_block_statement(pTHX_ OP *block, OP *cont)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEW_BLOCK_STATEMENT    \
-        Perl_assert_aTHX; assert(block)
+    STMT_START { Perl_assert_aTHX; assert(block); } STMT_END
 
 PERL_CALLCONV PERL_SI *
 Perl_new_stackinfo(pTHX_ I32 stitems, I32 cxitems)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEW_STACKINFO          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PERL_SI *
 Perl_new_stackinfo_flags(pTHX_ I32 stitems, I32 cxitems, UV flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEW_STACKINFO_FLAGS    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_new_version(pTHX_ SV *ver)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_NEW_VERSION            \
-        Perl_assert_aTHX; assert(ver)
+    STMT_START { Perl_assert_aTHX; assert(ver); } STMT_END
 
 PERL_CALLCONV char *
 Perl_new_warnings_bitfield(pTHX_ char *buffer, const char * const bits, STRLEN size)
@@ -4733,7 +4928,7 @@ Perl_new_warnings_bitfield(pTHX_ char *buffer, const char * const bits, STRLEN s
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEW_WARNINGS_BITFIELD  \
-        Perl_assert_aTHX; assert(bits)
+    STMT_START { Perl_assert_aTHX; assert(bits); } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
@@ -4741,7 +4936,7 @@ Perl_nextargv(pTHX_ GV *gv, bool nomagicopen)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NEXTARGV               \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_ninstr(const char *big, const char *bigend, const char *little, const char *lend)
@@ -4752,8 +4947,9 @@ Perl_ninstr(const char *big, const char *bigend, const char *little, const char 
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_NINSTR                 \
-        assert(big); assert(bigend); assert(little); assert(lend);  \
-        assert(big <= bigend); assert(little <= lend)
+    STMT_START { assert(big); assert(bigend); assert(little); assert(lend);  \
+                 assert(big <= bigend); assert(little <= lend);              \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_no_bareword_filehandle(pTHX_ const char *fhname)
@@ -4761,7 +4957,7 @@ Perl_no_bareword_filehandle(pTHX_ const char *fhname)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NO_BAREWORD_FILEHANDLE \
-        Perl_assert_aTHX; assert(fhname)
+    STMT_START { Perl_assert_aTHX; assert(fhname); } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_noperl_die(const char *pat, ...)
@@ -4769,7 +4965,7 @@ Perl_noperl_die(const char *pat, ...)
         __attribute__noreturn__
         __attribute__format__(__printf__,1,2);
 #define PERL_ARGS_ASSERT_NOPERL_DIE             \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_noshutdownhook(void);
@@ -4779,14 +4975,14 @@ PERL_CALLCONV int
 Perl_nothreadhook(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_NOTHREADHOOK           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_notify_parser_that_encoding_changed(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_NOTIFY_PARSER_THAT_ENCODING_CHANGED \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_oopsAV(pTHX_ OP *o)
@@ -4795,7 +4991,7 @@ Perl_oopsAV(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OOPSAV                 \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_oopsHV(pTHX_ OP *o)
@@ -4804,134 +5000,134 @@ Perl_oopsHV(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OOPSHV                 \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_append_elem(pTHX_ I32 optype, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_APPEND_ELEM         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_append_list(pTHX_ I32 optype, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_APPEND_LIST         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OPclass
 Perl_op_class(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_CLASS               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_op_clear(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_CLEAR               \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_contextualize(pTHX_ OP *o, I32 context)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_CONTEXTUALIZE       \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_convert_list(pTHX_ I32 optype, I32 flags, OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_OP_CONVERT_LIST        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_op_dump(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_DUMP                \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_force_list(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_FORCE_LIST          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_op_free(pTHX_ OP *arg)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_FREE                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_linklist(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_LINKLIST            \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_lvalue(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_LVALUE              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_lvalue_flags(pTHX_ OP *o, I32 type, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_LVALUE_FLAGS        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_op_null(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_OP_NULL                \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_parent(OP *o)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_OP_PARENT              \
-        assert(o)
+    STMT_START { assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_prepend_elem(pTHX_ I32 optype, OP *first, OP *last)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_PREPEND_ELEM        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_op_refcnt_lock(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_REFCNT_LOCK         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_op_refcnt_unlock(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_REFCNT_UNLOCK       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_scope(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_SCOPE               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP *insert)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_OP_SIBLING_SPLICE      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_unscope(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_OP_UNSCOPE             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
@@ -4940,7 +5136,8 @@ Perl_op_wrap_finally(pTHX_ OP *block, OP *finally)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_OP_WRAP_FINALLY        \
-        Perl_assert_aTHX; assert(block); assert(finally)
+    STMT_START { Perl_assert_aTHX; assert(block); assert(finally);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
@@ -4949,7 +5146,7 @@ Perl_opdump_printf(pTHX_ struct Perl_OpDumpContext *ctx, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_OPDUMP_PRINTF          \
-        Perl_assert_aTHX; assert(ctx); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(ctx); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_output_non_portable(pTHX_ const U8 shift)
@@ -4962,7 +5159,7 @@ Perl_package(pTHX_ OP *name, OP *version)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PACKAGE                \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, SV **endlist)
@@ -4973,44 +5170,49 @@ Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, 
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_PACKLIST               \
-        Perl_assert_aTHX; assert(cat); assert(pat); assert(patend);  \
-        assert(beglist); assert(endlist); assert(pat <= patend);  \
-        assert(*patend == '\0')
+    STMT_START { Perl_assert_aTHX; assert(cat); assert(pat); assert(patend);  \
+                 assert(beglist); assert(endlist); assert(pat <= patend);     \
+                 assert(*patend == '\0');                                     \
+    } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_anon(pTHX_ CV *func, I32 optype)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_ANON           \
-        Perl_assert_aTHX; assert(func);  \
-        assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(func);                                \
+                 assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_name_pv(pTHX_ const char *name, const U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PV        \
-        Perl_assert_aTHX; assert(name);  \
-        assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
-        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(name);                       \
+                 assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
+                 assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV);    \
+    } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN       \
-        Perl_assert_aTHX; assert(namepv);  \
-        assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
-        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(namepv);                     \
+                 assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
+                 assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV);    \
+    } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_SV        \
-        Perl_assert_aTHX; assert(name);  \
-        assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
-        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(name);                       \
+                 assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
+                 assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV);    \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_add_weakref(pTHX_ CV *func)
@@ -5018,42 +5220,43 @@ Perl_pad_add_weakref(pTHX_ CV *func)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_ADD_WEAKREF        \
-        Perl_assert_aTHX; assert(func);  \
-        assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(func);                                \
+                 assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_alloc(pTHX_ I32 optype, U32 tmptype)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PAD_ALLOC              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_block_start(pTHX_ int full)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_BLOCK_START        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pv(pTHX_ const char *name, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PV          \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_PVN         \
-        Perl_assert_aTHX; assert(namepv)
+    STMT_START { Perl_assert_aTHX; assert(namepv); } STMT_END
 
 PERL_CALLCONV PADOFFSET
 Perl_pad_findmy_sv(pTHX_ SV *name, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_FINDMY_SV          \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
@@ -5063,51 +5266,52 @@ Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_FIXUP_INNER_ANONS  \
-        Perl_assert_aTHX; assert(padlist); assert(old_cv);  \
-        assert(SvTYPE(old_cv) == SVt_PVCV || SvTYPE(old_cv) == SVt_PVFM);  \
-        assert(new_cv);  \
-        assert(SvTYPE(new_cv) == SVt_PVCV || SvTYPE(new_cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(padlist); assert(old_cv);                 \
+                 assert(SvTYPE(old_cv) == SVt_PVCV || SvTYPE(old_cv) == SVt_PVFM);  \
+                 assert(new_cv);                                                    \
+                 assert(SvTYPE(new_cv) == SVt_PVCV || SvTYPE(new_cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_free(pTHX_ PADOFFSET po)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_FREE               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_pad_leavemy(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_LEAVEMY            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PADLIST *
 Perl_pad_new(pTHX_ int flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PAD_NEW                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_push(pTHX_ PADLIST *padlist, int depth)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_PUSH               \
-        Perl_assert_aTHX; assert(padlist)
+    STMT_START { Perl_assert_aTHX; assert(padlist); } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_swipe(pTHX_ PADOFFSET po, bool refadjust)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_SWIPE              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_tidy(pTHX_ padtidy_type type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PAD_TIDY               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PAD **
 Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
@@ -5115,14 +5319,14 @@ Perl_padlist_store(pTHX_ PADLIST *padlist, I32 key, PAD *val)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PADLIST_STORE          \
-        Perl_assert_aTHX; assert(padlist)
+    STMT_START { Perl_assert_aTHX; assert(padlist); } STMT_END
 
 PERL_CALLCONV void
 Perl_padname_free(pTHX_ PADNAME *pn)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAME_FREE           \
-        Perl_assert_aTHX; assert(pn)
+    STMT_START { Perl_assert_aTHX; assert(pn); } STMT_END
 
 PERL_CALLCONV PADNAME *
 Perl_padname_upgrade_sv(pTHX_ PADNAME *pn)
@@ -5130,58 +5334,58 @@ Perl_padname_upgrade_sv(pTHX_ PADNAME *pn)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PADNAME_UPGRADE_SV     \
-        Perl_assert_aTHX; assert(pn)
+    STMT_START { Perl_assert_aTHX; assert(pn); } STMT_END
 
 PERL_CALLCONV PADNAME *
 Perl_padnamelist_fetch(PADNAMELIST *pnl, SSize_t key)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PADNAMELIST_FETCH      \
-        assert(pnl)
+    STMT_START { assert(pnl); } STMT_END
 
 PERL_CALLCONV void
 Perl_padnamelist_free(pTHX_ PADNAMELIST *pnl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_FREE       \
-        Perl_assert_aTHX; assert(pnl)
+    STMT_START { Perl_assert_aTHX; assert(pnl); } STMT_END
 
 PERL_CALLCONV PADNAME **
 Perl_padnamelist_store(pTHX_ PADNAMELIST *pnl, SSize_t key, PADNAME *val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PADNAMELIST_STORE      \
-        Perl_assert_aTHX; assert(pnl)
+    STMT_START { Perl_assert_aTHX; assert(pnl); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_arithexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_ARITHEXPR        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_barestmt(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_BARESTMT         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_block(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_BLOCK            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_fullexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_FULLEXPR         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_fullstmt(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_FULLSTMT         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_parse_ident_msg(pTHX_ const char *s, const char *end, bool is_utf8, HV **failure_details, U32 flags)
@@ -5189,37 +5393,38 @@ Perl_parse_ident_msg(pTHX_ const char *s, const char *end, bool is_utf8, HV **fa
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PARSE_IDENT_MSG        \
-        Perl_assert_aTHX; assert(s); assert(end); assert(s < end)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(end); assert(s < end);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_parse_label(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_LABEL            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_listexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_LISTEXPR         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_stmtseq(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_STMTSEQ          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_subsignature(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_SUBSIGNATURE     \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_parse_termexpr(pTHX_ U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PARSE_TERMEXPR         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV U32
 Perl_parse_unicode_opts(pTHX_ const char **popt)
@@ -5227,7 +5432,7 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSE_UNICODE_OPTS     \
-        Perl_assert_aTHX; assert(popt)
+    STMT_START { Perl_assert_aTHX; assert(popt); } STMT_END
 
 PERL_CALLCONV void
 Perl_parser_free(pTHX_ const yy_parser *parser)
@@ -5235,14 +5440,14 @@ Perl_parser_free(pTHX_ const yy_parser *parser)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PARSER_FREE            \
-        Perl_assert_aTHX; assert(parser)
+    STMT_START { Perl_assert_aTHX; assert(parser); } STMT_END
 
 PERL_CALLCONV void
 Perl_peep(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PEEP                   \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PerlInterpreter *
 perl_alloc(void);
@@ -5252,31 +5457,31 @@ PERL_CALLCONV void
 perl_construct(PerlInterpreter *my_perl)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_PERL_CONSTRUCT         \
-        assert(my_perl)
+    STMT_START { assert(my_perl); } STMT_END
 
 PERL_CALLCONV int
 perl_destruct(PerlInterpreter *my_perl)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_PERL_DESTRUCT          \
-        assert(my_perl)
+    STMT_START { assert(my_perl); } STMT_END
 
 PERL_CALLCONV void
 perl_free(PerlInterpreter *my_perl)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_PERL_FREE              \
-        assert(my_perl)
+    STMT_START { assert(my_perl); } STMT_END
 
 PERL_CALLCONV int
 perl_parse(PerlInterpreter *my_perl, XSINIT_t xsinit, int argc, char **argv, char **env)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_PERL_PARSE             \
-        assert(my_perl)
+    STMT_START { assert(my_perl); } STMT_END
 
 PERL_CALLCONV int
 perl_run(PerlInterpreter *my_perl)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_PERL_RUN               \
-        assert(my_perl)
+    STMT_START { assert(my_perl); } STMT_END
 
 PERL_CALLCONV Signal_t
 Perl_perly_sighandler(int sig, Siginfo_t *info, void *uap, bool safe);
@@ -5286,13 +5491,13 @@ PERL_CALLCONV const char *
 Perl_phase_name(pTHX_ enum perl_phase phase)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PHASE_NAME             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_pmop_dump(pTHX_ PMOP *pm)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PMOP_DUMP              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
@@ -5301,13 +5506,13 @@ Perl_pmruntime(pTHX_ OP *o, OP *expr, OP *repl, UV flags, I32 floor)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PMRUNTIME              \
-        Perl_assert_aTHX; assert(o); assert(expr)
+    STMT_START { Perl_assert_aTHX; assert(o); assert(expr); } STMT_END
 
 PERL_CALLCONV void
 Perl_pop_scope(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_POP_SCOPE              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
@@ -5315,14 +5520,14 @@ Perl_populate_isa(pTHX_ const char *name, STRLEN len, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_POPULATE_ISA           \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV REGEXP *
 Perl_pregcomp(pTHX_ SV * const pattern, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGCOMP               \
-        Perl_assert_aTHX; assert(pattern)
+    STMT_START { Perl_assert_aTHX; assert(pattern); } STMT_END
 
 PERL_CALLCONV I32
 Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *screamer, U32 nosave)
@@ -5333,35 +5538,36 @@ Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *st
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 #define PERL_ARGS_ASSERT_PREGEXEC               \
-        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend);  \
-        assert(strbeg); assert(screamer); assert(strbeg <= stringarg);  \
-        assert(stringarg <= strend)
+    STMT_START { Perl_assert_aTHX; assert(prog); assert(stringarg);         \
+                 assert(strend); assert(strbeg); assert(screamer);          \
+                 assert(strbeg <= stringarg); assert(stringarg <= strend);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_pregfree(pTHX_ REGEXP *r)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PREGFREE               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_pregfree2(pTHX_ REGEXP *rx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PREGFREE2              \
-        Perl_assert_aTHX; assert(rx)
+    STMT_START { Perl_assert_aTHX; assert(rx); } STMT_END
 
 PERL_CALLCONV void
 Perl_prepare_export_lexical(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PREPARE_EXPORT_LEXICAL \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV const char *
 Perl_prescan_version(pTHX_ const char *s, bool strict, const char **errstr, bool *sqv, int *ssaw_decimal, int *swidth, bool *salpha)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PRESCAN_VERSION        \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV void *
 Perl_ptr_table_fetch(pTHX_ PTR_TBL_t * const tbl, const void * const sv)
@@ -5369,27 +5575,27 @@ Perl_ptr_table_fetch(pTHX_ PTR_TBL_t * const tbl, const void * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PTR_TABLE_FETCH        \
-        Perl_assert_aTHX; assert(tbl)
+    STMT_START { Perl_assert_aTHX; assert(tbl); } STMT_END
 
 PERL_CALLCONV void
 Perl_ptr_table_free(pTHX_ PTR_TBL_t * const tbl)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PTR_TABLE_FREE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PTR_TBL_t *
 Perl_ptr_table_new(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_PTR_TABLE_NEW          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_ptr_table_split(pTHX_ PTR_TBL_t * const tbl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PTR_TABLE_SPLIT        \
-        Perl_assert_aTHX; assert(tbl)
+    STMT_START { Perl_assert_aTHX; assert(tbl); } STMT_END
 
 PERL_CALLCONV void
 Perl_ptr_table_store(pTHX_ PTR_TBL_t * const tbl, const void * const oldsv, void * const newsv)
@@ -5397,13 +5603,13 @@ Perl_ptr_table_store(pTHX_ PTR_TBL_t * const tbl, const void * const oldsv, void
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_PTR_TABLE_STORE        \
-        Perl_assert_aTHX; assert(tbl); assert(newsv)
+    STMT_START { Perl_assert_aTHX; assert(tbl); assert(newsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_push_scope(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_PUSH_SCOPE             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim)
@@ -5411,14 +5617,14 @@ Perl_pv_display(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pv
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_DISPLAY             \
-        Perl_assert_aTHX; assert(dsv); assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(pv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_pv_escape(pTHX_ SV *dsv, char const * const str, const STRLEN count, STRLEN max, STRLEN * const escaped, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_ESCAPE              \
-        Perl_assert_aTHX; assert(str)
+    STMT_START { Perl_assert_aTHX; assert(str); } STMT_END
 
 PERL_CALLCONV char *
 Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const STRLEN max, char const * const start_color, char const * const end_color, const U32 flags)
@@ -5426,7 +5632,7 @@ Perl_pv_pretty(pTHX_ SV *dsv, char const * const str, const STRLEN count, const 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_PRETTY              \
-        Perl_assert_aTHX; assert(dsv); assert(str)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(str); } STMT_END
 
 PERL_CALLCONV char *
 Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV flags)
@@ -5434,26 +5640,26 @@ Perl_pv_uni_display(pTHX_ SV *dsv, const U8 *spv, STRLEN len, STRLEN pvlim, UV f
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_PV_UNI_DISPLAY         \
-        Perl_assert_aTHX; assert(dsv); assert(spv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(spv); } STMT_END
 
 PERL_CALLCONV void
 Perl_qerror(pTHX_ SV *err)
         Perl_attribute_nonnull_aTHX
         __attribute__deprecated__;
 #define PERL_ARGS_ASSERT_QERROR                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_rcpv_copy(pTHX_ char * const pv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_RCPV_COPY              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_rcpv_free(pTHX_ char * const pv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_RCPV_FREE              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_rcpv_new(pTHX_ const char * const pv, STRLEN len, U32 flags)
@@ -5461,14 +5667,14 @@ Perl_rcpv_new(pTHX_ const char * const pv, STRLEN len, U32 flags)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_RCPV_NEW               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV REGEXP *
 Perl_re_compile(pTHX_ SV * const pattern, U32 orig_rx_flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_COMPILE             \
-        Perl_assert_aTHX; assert(pattern)
+    STMT_START { Perl_assert_aTHX; assert(pattern); } STMT_END
 
 PERL_CALLCONV char *
 Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg, char *strpos, char *strend, const U32 flags, re_scream_pos_data *data)
@@ -5478,22 +5684,24 @@ Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_RE_INTUIT_START        \
-        Perl_assert_aTHX; assert(rx); assert(strbeg); assert(strpos);  \
-        assert(strend); assert(strbeg <= strpos); assert(strpos <= strend)
+    STMT_START { Perl_assert_aTHX; assert(rx); assert(strbeg);              \
+                 assert(strpos); assert(strend); assert(strbeg <= strpos);  \
+                 assert(strpos <= strend);                                  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_re_intuit_string(pTHX_ REGEXP * const r)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RE_INTUIT_STRING       \
-        Perl_assert_aTHX; assert(r)
+    STMT_START { Perl_assert_aTHX; assert(r); } STMT_END
 
 PERL_CALLCONV REGEXP *
 Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count, OP *expr, const regexp_engine *eng, REGEXP *old_re, bool *is_bare_re, const U32 rx_flags, const U32 pm_flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_RE_OP_COMPILE          \
-        Perl_assert_aTHX; assert(eng)
+    STMT_START { Perl_assert_aTHX; assert(eng); } STMT_END
 
 PERL_CALLCONV Malloc_t
 Perl_realloc(Malloc_t where, MEM_SIZE nbytes)
@@ -5504,99 +5712,99 @@ PERL_CALLCONV void
 Perl_reentrant_free(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REENTRANT_FREE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_reentrant_init(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REENTRANT_INIT         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void *
 Perl_reentrant_retry(const char *f, ...)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_REENTRANT_RETRY        \
-        assert(f)
+    STMT_START { assert(f); } STMT_END
 
 PERL_CALLCONV void
 Perl_reentrant_size(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REENTRANT_SIZE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV HV *
 Perl_refcounted_he_chain_2hv(pTHX_ const struct refcounted_he *c, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_CHAIN_2HV \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_pv(pTHX_ const struct refcounted_he *chain, const char *key, U32 hash, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PV \
-        Perl_assert_aTHX; assert(key)
+    STMT_START { Perl_assert_aTHX; assert(key); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_pvn(pTHX_ const struct refcounted_he *chain, const char *keypv, STRLEN keylen, U32 hash, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_PVN \
-        Perl_assert_aTHX; assert(keypv)
+    STMT_START { Perl_assert_aTHX; assert(keypv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_refcounted_he_fetch_sv(pTHX_ const struct refcounted_he *chain, SV *key, U32 hash, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FETCH_SV \
-        Perl_assert_aTHX; assert(key)
+    STMT_START { Perl_assert_aTHX; assert(key); } STMT_END
 
 PERL_CALLCONV void
 Perl_refcounted_he_free(pTHX_ struct refcounted_he *he)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_FREE     \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_inc(pTHX_ struct refcounted_he *he)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_INC      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_pv(pTHX_ struct refcounted_he *parent, const char *key, U32 hash, SV *value, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PV   \
-        Perl_assert_aTHX; assert(key)
+    STMT_START { Perl_assert_aTHX; assert(key); } STMT_END
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_pvn(pTHX_ struct refcounted_he *parent, const char *keypv, STRLEN keylen, U32 hash, SV *value, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_PVN  \
-        Perl_assert_aTHX; assert(keypv)
+    STMT_START { Perl_assert_aTHX; assert(keypv); } STMT_END
 
 PERL_CALLCONV struct refcounted_he *
 Perl_refcounted_he_new_sv(pTHX_ struct refcounted_he *parent, SV *key, U32 hash, SV *value, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REFCOUNTED_HE_NEW_SV   \
-        Perl_assert_aTHX; assert(key)
+    STMT_START { Perl_assert_aTHX; assert(key); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff(pTHX_ REGEXP * const rx, SV * const key, SV * const value, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF         \
-        Perl_assert_aTHX; assert(rx)
+    STMT_START { Perl_assert_aTHX; assert(rx); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_all(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ALL     \
-        Perl_assert_aTHX; assert(r)
+    STMT_START { Perl_assert_aTHX; assert(r); } STMT_END
 
 PERL_CALLCONV bool
 Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key, const U32 flags)
@@ -5604,7 +5812,7 @@ Perl_reg_named_buff_exists(pTHX_ REGEXP * const r, SV * const key, const U32 fla
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_EXISTS  \
-        Perl_assert_aTHX; assert(r); assert(key)
+    STMT_START { Perl_assert_aTHX; assert(r); assert(key); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv, const U32 flags)
@@ -5612,49 +5820,49 @@ Perl_reg_named_buff_fetch(pTHX_ REGEXP * const r, SV * const namesv, const U32 f
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FETCH   \
-        Perl_assert_aTHX; assert(r); assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(r); assert(namesv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_firstkey(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_FIRSTKEY \
-        Perl_assert_aTHX; assert(r)
+    STMT_START { Perl_assert_aTHX; assert(r); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_iter(pTHX_ REGEXP * const rx, const SV * const lastkey, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_ITER    \
-        Perl_assert_aTHX; assert(rx)
+    STMT_START { Perl_assert_aTHX; assert(rx); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_nextkey(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_NEXTKEY \
-        Perl_assert_aTHX; assert(r)
+    STMT_START { Perl_assert_aTHX; assert(r); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_named_buff_scalar(pTHX_ REGEXP * const r, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NAMED_BUFF_SCALAR  \
-        Perl_assert_aTHX; assert(r)
+    STMT_START { Perl_assert_aTHX; assert(r); } STMT_END
 
 PERL_CALLCONV void
 Perl_reg_numbered_buff_fetch(pTHX_ REGEXP * const re, const I32 paren, SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH \
-        Perl_assert_aTHX; assert(re)
+    STMT_START { Perl_assert_aTHX; assert(re); } STMT_END
 
 PERL_CALLCONV void
 Perl_reg_numbered_buff_fetch_flags(pTHX_ REGEXP * const re, const I32 paren, SV * const sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_FETCH_FLAGS \
-        Perl_assert_aTHX; assert(re)
+    STMT_START { Perl_assert_aTHX; assert(re); } STMT_END
 
 PERL_CALLCONV I32
 Perl_reg_numbered_buff_length(pTHX_ REGEXP * const r, const SV * const sv, const I32 paren)
@@ -5662,35 +5870,35 @@ Perl_reg_numbered_buff_length(pTHX_ REGEXP * const r, const SV * const sv, const
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_LENGTH \
-        Perl_assert_aTHX; assert(r); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(r); assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_reg_numbered_buff_store(pTHX_ REGEXP * const rx, const I32 paren, SV const * const value)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_NUMBERED_BUFF_STORE \
-        Perl_assert_aTHX; assert(rx)
+    STMT_START { Perl_assert_aTHX; assert(rx); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_reg_qr_package(pTHX_ REGEXP * const rx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REG_QR_PACKAGE         \
-        Perl_assert_aTHX; assert(rx)
+    STMT_START { Perl_assert_aTHX; assert(rx); } STMT_END
 
 PERL_CALLCONV REGEXP *
 Perl_reg_temp_copy(pTHX_ REGEXP *dsv, REGEXP *ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_REG_TEMP_COPY          \
-        Perl_assert_aTHX; assert(ssv)
+    STMT_START { Perl_assert_aTHX; assert(ssv); } STMT_END
 
 PERL_CALLCONV void
 Perl_regdump(pTHX_ const regexp *r)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REGDUMP                \
-        Perl_assert_aTHX; assert(r)
+    STMT_START { Perl_assert_aTHX; assert(r); } STMT_END
 
 PERL_CALLCONV I32
 Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char *strbeg, SSize_t minend, SV *sv, void *data, U32 flags)
@@ -5701,22 +5909,23 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char 
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 #define PERL_ARGS_ASSERT_REGEXEC_FLAGS          \
-        Perl_assert_aTHX; assert(rx); assert(stringarg); assert(strend);  \
-        assert(strbeg); assert(sv); assert(strbeg <= stringarg);  \
-        assert(stringarg <= strend)
+    STMT_START { Perl_assert_aTHX; assert(rx); assert(stringarg);           \
+                 assert(strend); assert(strbeg); assert(sv);                \
+                 assert(strbeg <= stringarg); assert(stringarg <= strend);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_regfree_internal(pTHX_ REGEXP * const rx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REGFREE_INTERNAL       \
-        Perl_assert_aTHX; assert(rx)
+    STMT_START { Perl_assert_aTHX; assert(rx); } STMT_END
 
 PERL_CALLCONV void
 Perl_reginitcolors(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REGINITCOLORS          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_release_RExC_state(pTHX_ void *vstate)
@@ -5724,62 +5933,62 @@ Perl_release_RExC_state(pTHX_ void *vstate)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RELEASE_REXC_STATE     \
-        Perl_assert_aTHX; assert(vstate)
+    STMT_START { Perl_assert_aTHX; assert(vstate); } STMT_END
 
 PERL_CALLCONV void
 Perl_repeatcpy(char *to, const char *from, SSize_t len, IV count)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 #define PERL_ARGS_ASSERT_REPEATCPY              \
-        assert(to); assert(from)
+    STMT_START { assert(to); assert(from); } STMT_END
 
 PERL_CALLCONV void
 Perl_report_evil_fh(pTHX_ const GV *gv)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_REPORT_EVIL_FH         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_report_uninit(pTHX_ const SV *uninit_sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_REPORT_UNINIT          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_report_wrongway_fh(pTHX_ const GV *gv, const char have)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_REPORT_WRONGWAY_FH     \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_require_pv(pTHX_ const char *pv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_REQUIRE_PV             \
-        Perl_assert_aTHX; assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(pv); } STMT_END
 
 PERL_CALLCONV void
 Perl_resume_compcv(pTHX_ struct suspended_compcv *buffer, bool save)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RESUME_COMPCV          \
-        Perl_assert_aTHX; assert(buffer)
+    STMT_START { Perl_assert_aTHX; assert(buffer); } STMT_END
 
 PERL_CALLCONV void
 Perl_resume_compcv_and_save(pTHX_ struct suspended_compcv *buffer)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RESUME_COMPCV_AND_SAVE \
-        Perl_assert_aTHX; assert(buffer)
+    STMT_START { Perl_assert_aTHX; assert(buffer); } STMT_END
 
 PERL_CALLCONV void
 Perl_resume_compcv_final(pTHX_ struct suspended_compcv *buffer)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RESUME_COMPCV_FINAL    \
-        Perl_assert_aTHX; assert(buffer)
+    STMT_START { Perl_assert_aTHX; assert(buffer); } STMT_END
 
 PERL_CALLCONV char *
 Perl_rninstr(const char *big, const char *bigend, const char *little, const char *lend)
@@ -5790,15 +5999,16 @@ Perl_rninstr(const char *big, const char *bigend, const char *little, const char
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_RNINSTR                \
-        assert(big); assert(bigend); assert(little); assert(lend);  \
-        assert(big <= bigend); assert(little <= lend)
+    STMT_START { assert(big); assert(bigend); assert(little); assert(lend);  \
+                 assert(big <= bigend); assert(little <= lend);              \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_rpeep(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RPEEP                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_rpp_free_2_(pTHX_ SV * const sv1, SV * const sv2, const U32 rc1, const U32 rc2)
@@ -5806,26 +6016,26 @@ Perl_rpp_free_2_(pTHX_ SV * const sv1, SV * const sv2, const U32 rc1, const U32 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_RPP_FREE_2_            \
-        Perl_assert_aTHX; assert(sv1); assert(sv2)
+    STMT_START { Perl_assert_aTHX; assert(sv1); assert(sv2); } STMT_END
 
 PERL_CALLCONV void
 Perl_rpp_obliterate_stack_to(pTHX_ I32 ix)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_RPP_OBLITERATE_STACK_TO \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV Sighandler_t
 Perl_rsignal(pTHX_ int i, Sighandler_t t)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_RSIGNAL                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_rsignal_restore(pTHX_ int i, Sigsave_t *t)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RSIGNAL_RESTORE        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_rsignal_save(pTHX_ int i, Sighandler_t t1, Sigsave_t *save)
@@ -5833,32 +6043,32 @@ Perl_rsignal_save(pTHX_ int i, Sighandler_t t1, Sigsave_t *save)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RSIGNAL_SAVE           \
-        Perl_assert_aTHX; assert(save)
+    STMT_START { Perl_assert_aTHX; assert(save); } STMT_END
 
 PERL_CALLCONV Sighandler_t
 Perl_rsignal_state(pTHX_ int i)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_RSIGNAL_STATE          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_runops_debug(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_RUNOPS_DEBUG           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_runops_standard(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_RUNOPS_STANDARD        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV CV *
 Perl_rv2cv_op_cv(pTHX_ OP *cvop, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_RV2CV_OP_CV            \
-        Perl_assert_aTHX; assert(cvop)
+    STMT_START { Perl_assert_aTHX; assert(cvop); } STMT_END
 
 PERL_CALLCONV void
 Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
@@ -5867,7 +6077,7 @@ Perl_rxres_save(pTHX_ void **rsp, REGEXP *rx)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_RXRES_SAVE             \
-        Perl_assert_aTHX; assert(rsp); assert(rx)
+    STMT_START { Perl_assert_aTHX; assert(rsp); assert(rx); } STMT_END
 
 PERL_CALLCONV Malloc_t
 Perl_safesyscalloc(MEM_SIZE elements, MEM_SIZE size)
@@ -5895,28 +6105,30 @@ Perl_save_I16(pTHX_ I16 *intp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I16               \
-        Perl_assert_aTHX; assert(intp)
+    STMT_START { Perl_assert_aTHX; assert(intp); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_I32(pTHX_ I32 *intp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I32               \
-        Perl_assert_aTHX; assert(intp)
+    STMT_START { Perl_assert_aTHX; assert(intp); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_I8(pTHX_ I8 *bytep)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_I8                \
-        Perl_assert_aTHX; assert(bytep)
+    STMT_START { Perl_assert_aTHX; assert(bytep); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_adelete(pTHX_ AV *av, SSize_t key)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ADELETE           \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
@@ -5924,8 +6136,9 @@ Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_AELEM             \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
-        assert(sptr)
+    STMT_START { Perl_assert_aTHX; assert(av);                  \
+                 assert(SvTYPE(av) == SVt_PVAV); assert(sptr);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
@@ -5933,42 +6146,43 @@ Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_AELEM_FLAGS       \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
-        assert(sptr)
+    STMT_START { Perl_assert_aTHX; assert(av);                  \
+                 assert(SvTYPE(av) == SVt_PVAV); assert(sptr);  \
+    } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_save_alloc(pTHX_ SSize_t size, I32 pad)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_ALLOC             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_aptr(pTHX_ AV **aptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_APTR              \
-        Perl_assert_aTHX; assert(aptr)
+    STMT_START { Perl_assert_aTHX; assert(aptr); } STMT_END
 
 PERL_CALLCONV AV *
 Perl_save_ary(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ARY               \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_bool(pTHX_ bool *boolp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_BOOL              \
-        Perl_assert_aTHX; assert(boolp)
+    STMT_START { Perl_assert_aTHX; assert(boolp); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_clearsv(pTHX_ SV **svp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_CLEARSV           \
-        Perl_assert_aTHX; assert(svp)
+    STMT_START { Perl_assert_aTHX; assert(svp); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
@@ -5976,74 +6190,75 @@ Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DELETE            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(key)
+    STMT_START { Perl_assert_aTHX; assert(hv);                 \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(key);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_save_destructor(pTHX_ DESTRUCTORFUNC_NOCONTEXT_t f, void *p)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR        \
-        Perl_assert_aTHX; assert(p)
+    STMT_START { Perl_assert_aTHX; assert(p); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_destructor_x(pTHX_ DESTRUCTORFUNC_t f, void *p)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_DESTRUCTOR_X      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_freeop(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_FREEOP            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_freepv(pTHX_ char *pv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_FREEPV            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_freercpv(pTHX_ char *rcpv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_FREERCPV          \
-        Perl_assert_aTHX; assert(rcpv)
+    STMT_START { Perl_assert_aTHX; assert(rcpv); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_freesv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_FREESV            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_generic_pvref(pTHX_ char **str)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_PVREF     \
-        Perl_assert_aTHX; assert(str)
+    STMT_START { Perl_assert_aTHX; assert(str); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_generic_svref(pTHX_ SV **sptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GENERIC_SVREF     \
-        Perl_assert_aTHX; assert(sptr)
+    STMT_START { Perl_assert_aTHX; assert(sptr); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_gp(pTHX_ GV *gv, I32 empty)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_GP                \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV HV *
 Perl_save_hash(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HASH              \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
@@ -6051,8 +6266,9 @@ Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_HDELETE           \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(keysv)
+    STMT_START { Perl_assert_aTHX; assert(hv);                   \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(keysv);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
@@ -6061,8 +6277,9 @@ Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_HELEM             \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(key); assert(sptr)
+    STMT_START { Perl_assert_aTHX; assert(hv);                               \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(sptr);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
@@ -6071,154 +6288,155 @@ Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_HELEM_FLAGS       \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(key); assert(sptr)
+    STMT_START { Perl_assert_aTHX; assert(hv);                               \
+                 assert(SvTYPE(hv) == SVt_PVHV); assert(key); assert(sptr);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_save_hints(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_HINTS             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_hptr(pTHX_ HV **hptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_HPTR              \
-        Perl_assert_aTHX; assert(hptr)
+    STMT_START { Perl_assert_aTHX; assert(hptr); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_int(pTHX_ int *intp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_INT               \
-        Perl_assert_aTHX; assert(intp)
+    STMT_START { Perl_assert_aTHX; assert(intp); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_item(pTHX_ SV *item)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_ITEM              \
-        Perl_assert_aTHX; assert(item)
+    STMT_START { Perl_assert_aTHX; assert(item); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_iv(pTHX_ IV *ivp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_IV                \
-        Perl_assert_aTHX; assert(ivp)
+    STMT_START { Perl_assert_aTHX; assert(ivp); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_mortalizesv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_MORTALIZESV       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_op(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_OP                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_padsv(pTHX_ PADOFFSET padix)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_PADSV             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_padsv_and_mortalize(pTHX_ PADOFFSET off)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_PADSV_AND_MORTALIZE \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_pptr(pTHX_ char **pptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_PPTR              \
-        Perl_assert_aTHX; assert(pptr)
+    STMT_START { Perl_assert_aTHX; assert(pptr); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_pushi32ptr(pTHX_ const I32 i, void * const ptr, const int type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_PUSHI32PTR        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_pushptr(pTHX_ void * const ptr, const int type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_PUSHPTR           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_pushptrptr(pTHX_ void * const ptr1, void * const ptr2, const int type)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_PUSHPTRPTR        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_save_rcpv(pTHX_ char **prcpv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_RCPV              \
-        Perl_assert_aTHX; assert(prcpv)
+    STMT_START { Perl_assert_aTHX; assert(prcpv); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_re_context(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVE_RE_CONTEXT        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_save_scalar(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SCALAR            \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_set_svflags(pTHX_ SV *sv, U32 mask, U32 val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SET_SVFLAGS       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_shared_pvref(pTHX_ char **str)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SHARED_PVREF      \
-        Perl_assert_aTHX; assert(str)
+    STMT_START { Perl_assert_aTHX; assert(str); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_sptr(pTHX_ SV **sptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SPTR              \
-        Perl_assert_aTHX; assert(sptr)
+    STMT_START { Perl_assert_aTHX; assert(sptr); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_strlen(pTHX_ STRLEN *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_STRLEN            \
-        Perl_assert_aTHX; assert(ptr)
+    STMT_START { Perl_assert_aTHX; assert(ptr); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_save_svref(pTHX_ SV **sptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_SVREF             \
-        Perl_assert_aTHX; assert(sptr)
+    STMT_START { Perl_assert_aTHX; assert(sptr); } STMT_END
 
 PERL_CALLCONV void
 Perl_save_vptr(pTHX_ void *ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SAVE_VPTR              \
-        Perl_assert_aTHX; assert(ptr)
+    STMT_START { Perl_assert_aTHX; assert(ptr); } STMT_END
 
 PERL_CALLCONV char *
 Perl_savesharedpv(pTHX_ const char *pv)
@@ -6226,7 +6444,7 @@ Perl_savesharedpv(pTHX_ const char *pv)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SAVESHAREDPV           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
@@ -6235,39 +6453,39 @@ Perl_savesharedpvn(pTHX_ const char * const pv, const STRLEN len)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SAVESHAREDPVN          \
-        Perl_assert_aTHX; assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(pv); } STMT_END
 
 PERL_CALLCONV void
 Perl_savestack_grow(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVESTACK_GROW         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_savestack_grow_cnt(pTHX_ I32 need)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVESTACK_GROW_CNT     \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_savetmps(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SAVETMPS               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_sawparens(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SAWPARENS              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_scalar(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SCALAR                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_scalarvoid(pTHX_ OP *arg)
@@ -6275,7 +6493,7 @@ Perl_scalarvoid(pTHX_ OP *arg)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SCALARVOID             \
-        Perl_assert_aTHX; assert(arg)
+    STMT_START { Perl_assert_aTHX; assert(arg); } STMT_END
 
 PERL_CALLCONV NV
 Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
@@ -6283,7 +6501,7 @@ Perl_scan_bin(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_BIN               \
-        Perl_assert_aTHX; assert(start); assert(retlen)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(retlen); } STMT_END
 
 PERL_CALLCONV NV
 Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
@@ -6291,7 +6509,7 @@ Perl_scan_hex(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_HEX               \
-        Perl_assert_aTHX; assert(start); assert(retlen)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(retlen); } STMT_END
 
 PERL_CALLCONV char *
 Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp)
@@ -6299,7 +6517,7 @@ Perl_scan_num(pTHX_ const char *start, YYSTYPE *lvalp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_NUM               \
-        Perl_assert_aTHX; assert(start); assert(lvalp)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(lvalp); } STMT_END
 
 PERL_CALLCONV NV
 Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
@@ -6307,7 +6525,7 @@ Perl_scan_oct(pTHX_ const char *start, STRLEN len, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_OCT               \
-        Perl_assert_aTHX; assert(start); assert(retlen)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(retlen); } STMT_END
 
 PERL_CALLCONV char *
 Perl_scan_str(pTHX_ char *start, int keep_quoted, int keep_delims, int re_reparse, char **delimp)
@@ -6315,7 +6533,7 @@ Perl_scan_str(pTHX_ char *start, int keep_quoted, int keep_delims, int re_repars
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SCAN_STR               \
-        Perl_assert_aTHX; assert(start)
+    STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 PERL_CALLCONV const char *
 Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
@@ -6323,7 +6541,7 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SCAN_VERSION           \
-        Perl_assert_aTHX; assert(s); assert(rv)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(rv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
@@ -6332,7 +6550,9 @@ Perl_scan_vstring(pTHX_ const char *s, const char * const e, SV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SCAN_VSTRING           \
-        Perl_assert_aTHX; assert(s); assert(e); assert(sv); assert(s < e)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(e); assert(sv);  \
+                 assert(s < e);                                       \
+    } STMT_END
 
 PERL_CALLCONV char *
 Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STRLEN *slp)
@@ -6341,19 +6561,20 @@ Perl_scan_word(pTHX_ char *s, char *dest, STRLEN destlen, int allow_package, STR
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_SCAN_WORD              \
-        Perl_assert_aTHX; assert(s); assert(dest); assert(slp)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(dest); assert(slp);  \
+    } STMT_END
 
 PERL_CALLCONV U64
 Perl_seed(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SEED                   \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_set_caret_X(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SET_CARET_X            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_set_context(void *t);
@@ -6364,21 +6585,21 @@ Perl_set_numeric_standard(pTHX_ const char *file, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_STANDARD   \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV void
 Perl_set_numeric_underlying(pTHX_ const char *file, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SET_NUMERIC_UNDERLYING \
-        Perl_assert_aTHX; assert(file)
+    STMT_START { Perl_assert_aTHX; assert(file); } STMT_END
 
 PERL_CALLCONV void
 Perl_setdefout(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SETDEFOUT              \
-        Perl_assert_aTHX; assert(gv)
+    STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 PERL_CALLCONV void
 Perl_setfd_cloexec(int fd)
@@ -6390,14 +6611,14 @@ Perl_setfd_cloexec_for_nonsysfd(pTHX_ int fd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SETFD_CLOEXEC_FOR_NONSYSFD \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_setfd_cloexec_or_inhexec_by_sysfdness(pTHX_ int fd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SETFD_CLOEXEC_OR_INHEXEC_BY_SYSFDNESS \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_setfd_inhexec(int fd)
@@ -6409,14 +6630,14 @@ Perl_setfd_inhexec_for_sysfd(pTHX_ int fd)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SETFD_INHEXEC_FOR_SYSFD \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV HEK *
 Perl_share_hek(pTHX_ const char *str, SSize_t len, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SHARE_HEK              \
-        Perl_assert_aTHX; assert(str)
+    STMT_START { Perl_assert_aTHX; assert(str); } STMT_END
 
 PERL_CALLCONV Signal_t
 Perl_sighandler1(int sig)
@@ -6434,21 +6655,21 @@ Perl_skipspace_flags(pTHX_ char *s, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SKIPSPACE_FLAGS        \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV void
 Perl_sortsv(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV                 \
-        Perl_assert_aTHX; assert(cmp)
+    STMT_START { Perl_assert_aTHX; assert(cmp); } STMT_END
 
 PERL_CALLCONV void
 Perl_sortsv_flags(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SORTSV_FLAGS           \
-        Perl_assert_aTHX; assert(cmp)
+    STMT_START { Perl_assert_aTHX; assert(cmp); } STMT_END
 
 PERL_CALLCONV SV **
 Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
@@ -6456,7 +6677,7 @@ Perl_stack_grow(pTHX_ SV **sp, SV **p, SSize_t n)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_STACK_GROW             \
-        Perl_assert_aTHX; assert(sp); assert(p)
+    STMT_START { Perl_assert_aTHX; assert(sp); assert(p); } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_start_glob(pTHX_ SV *tmpglob, IO *io)
@@ -6465,13 +6686,13 @@ Perl_start_glob(pTHX_ SV *tmpglob, IO *io)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_START_GLOB             \
-        Perl_assert_aTHX; assert(tmpglob); assert(io)
+    STMT_START { Perl_assert_aTHX; assert(tmpglob); assert(io); } STMT_END
 
 PERL_CALLCONV I32
 Perl_start_subparse(pTHX_ I32 is_format, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_START_SUBPARSE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV NV
 Perl_str_to_version(pTHX_ SV *sv)
@@ -6479,7 +6700,7 @@ Perl_str_to_version(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_STR_TO_VERSION         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
@@ -6487,7 +6708,8 @@ Perl_strict_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t 
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_STRICT_UTF8_TO_UV      \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
+    STMT_START { assert(s); assert(e); assert(cp_p); assert(s <= e);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_sub_crush_depth(pTHX_ CV *cv)
@@ -6495,8 +6717,9 @@ Perl_sub_crush_depth(pTHX_ CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUB_CRUSH_DEPTH        \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_subsignature_append_fence_op(pTHX_ OP *o)
@@ -6504,7 +6727,7 @@ Perl_subsignature_append_fence_op(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_FENCE_OP \
-        Perl_assert_aTHX; assert(o)
+    STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_subsignature_append_named(pTHX_ const char *paramname, PADOFFSET padix, OPCODE defmode, OP *defexpr)
@@ -6512,56 +6735,56 @@ Perl_subsignature_append_named(pTHX_ const char *paramname, PADOFFSET padix, OPC
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_NAMED \
-        Perl_assert_aTHX; assert(paramname)
+    STMT_START { Perl_assert_aTHX; assert(paramname); } STMT_END
 
 PERL_CALLCONV void
 Perl_subsignature_append_positional(pTHX_ PADOFFSET padix, OPCODE defmode, OP *defexpr)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_POSITIONAL \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_subsignature_append_slurpy(pTHX_ I32 sigil, PADOFFSET padix)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_APPEND_SLURPY \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV OP *
 Perl_subsignature_finish(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_FINISH    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_subsignature_start(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUBSIGNATURE_START     \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_suspend_compcv(pTHX_ struct suspended_compcv *buffer)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SUSPEND_COMPCV         \
-        Perl_assert_aTHX; assert(buffer)
+    STMT_START { Perl_assert_aTHX; assert(buffer); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_2bool(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2BOOL               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_2bool_flags(pTHX_ SV *sv, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2BOOL_FLAGS         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV CV *
 Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref)
@@ -6569,34 +6792,34 @@ Perl_sv_2cv(pTHX_ SV *sv, HV ** const st, GV ** const gvp, const I32 lref)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_2CV                 \
-        Perl_assert_aTHX; assert(st); assert(gvp)
+    STMT_START { Perl_assert_aTHX; assert(st); assert(gvp); } STMT_END
 
 PERL_CALLCONV IO *
 Perl_sv_2io(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IO                 \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV IV
 Perl_sv_2iv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IV                 \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV IV
 Perl_sv_2iv_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2IV_FLAGS           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_2mortal(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_2MORTAL             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_2num_flags(pTHX_ SV * const sv, int flags)
@@ -6604,28 +6827,28 @@ Perl_sv_2num_flags(pTHX_ SV * const sv, int flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_2NUM_FLAGS          \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV NV
 Perl_sv_2nv_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2NV_FLAGS           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pv(pTHX_ SV *sv, STRLEN *lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PV                 \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pv_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PV_FLAGS           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pv_nolen(pTHX_ SV *sv)
@@ -6633,21 +6856,21 @@ Perl_sv_2pv_nolen(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_2PV_NOLEN           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pvbyte(pTHX_ SV *sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVBYTE             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pvbyte_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVBYTE_FLAGS       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
@@ -6655,21 +6878,21 @@ Perl_sv_2pvbyte_nolen(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_2PVBYTE_NOLEN       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pvutf8(pTHX_ SV *sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVUTF8             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pvutf8_flags(pTHX_ SV *sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2PVUTF8_FLAGS       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
@@ -6677,27 +6900,27 @@ Perl_sv_2pvutf8_nolen(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_2PVUTF8_NOLEN       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV UV
 Perl_sv_2uv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2UV                 \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV UV
 Perl_sv_2uv_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_2UV_FLAGS           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_backoff(SV * const sv)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_SV_BACKOFF             \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_bless(pTHX_ SV * const sv, HV * const stash)
@@ -6705,14 +6928,14 @@ Perl_sv_bless(pTHX_ SV * const sv, HV * const stash)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_BLESS               \
-        Perl_assert_aTHX; assert(sv); assert(stash)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(stash); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_can_swipe_pv_buf(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CAN_SWIPE_PV_BUF    \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr, int tlen)
@@ -6723,15 +6946,16 @@ Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_SV_CAT_DECODE          \
-        Perl_assert_aTHX; assert(dsv); assert(encoding); assert(ssv);  \
-        assert(offset); assert(tstr)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(encoding);  \
+                 assert(ssv); assert(offset); assert(tstr);        \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpv(pTHX_ SV * const dsv, const char *sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV               \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
@@ -6739,14 +6963,14 @@ Perl_sv_catpv_flags(pTHX_ SV * const dsv, const char *sstr, const I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPV_FLAGS         \
-        Perl_assert_aTHX; assert(dsv); assert(sstr)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(sstr); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpv_mg(pTHX_ SV * const dsv, const char * const sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATPV_MG            \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpvf(pTHX_ SV * const sv, const char * const pat, ...)
@@ -6755,7 +6979,7 @@ Perl_sv_catpvf(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_CATPVF              \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
@@ -6764,7 +6988,7 @@ Perl_sv_catpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_CATPVF_MG           \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
@@ -6772,7 +6996,7 @@ Perl_sv_catpvn(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPVN              \
-        Perl_assert_aTHX; assert(dsv); assert(sstr)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(sstr); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, const I32 flags)
@@ -6780,7 +7004,7 @@ Perl_sv_catpvn_flags(pTHX_ SV * const dsv, const char *sstr, const STRLEN len, c
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPVN_FLAGS        \
-        Perl_assert_aTHX; assert(dsv); assert(sstr)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(sstr); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
@@ -6788,80 +7012,80 @@ Perl_sv_catpvn_mg(pTHX_ SV * const dsv, const char *sstr, STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_CATPVN_MG           \
-        Perl_assert_aTHX; assert(dsv); assert(sstr)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(sstr); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catsv(pTHX_ SV * const dsv, SV * const sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATSV               \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catsv_flags(pTHX_ SV * const dsv, SV * const sstr, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATSV_FLAGS         \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catsv_mg(pTHX_ SV * const dsv, SV * const sstr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CATSV_MG            \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_chop(pTHX_ SV * const sv, const char * const ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CHOP                \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_sv_clean_all(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_CLEAN_ALL           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_clean_objs(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_CLEAN_OBJS          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_clear(pTHX_ SV * const orig_sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_CLEAR               \
-        Perl_assert_aTHX; assert(orig_sv)
+    STMT_START { Perl_assert_aTHX; assert(orig_sv); } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_cmp(pTHX_ SV * const sv1, SV * const sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_CMP                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_cmp_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_CMP_FLAGS           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_cmp_locale(pTHX_ SV * const sv1, SV * const sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_CMP_LOCALE          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_cmp_locale_flags(pTHX_ SV * const sv1, SV * const sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_CMP_LOCALE_FLAGS    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv)
@@ -6869,7 +7093,7 @@ Perl_sv_copypv(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_COPYPV              \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags)
@@ -6877,7 +7101,7 @@ Perl_sv_copypv_flags(pTHX_ SV * const dsv, SV * const ssv, const I32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_COPYPV_FLAGS        \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv)
@@ -6885,19 +7109,19 @@ Perl_sv_copypv_nomg(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_COPYPV_NOMG         \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_dec(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_DEC                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_dec_nomg(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_DEC_NOMG            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv)
@@ -6905,7 +7129,7 @@ Perl_sv_del_backref(pTHX_ SV * const tsv, SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_DEL_BACKREF         \
-        Perl_assert_aTHX; assert(tsv); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(tsv); assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_derived_from(pTHX_ SV *sv, const char * const name)
@@ -6914,7 +7138,7 @@ Perl_sv_derived_from(pTHX_ SV *sv, const char * const name)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM        \
-        Perl_assert_aTHX; assert(sv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
@@ -6923,8 +7147,9 @@ Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_HV     \
-        Perl_assert_aTHX; assert(sv); assert(hv);  \
-        assert(SvTYPE(hv) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(hv);  \
+                 assert(SvTYPE(hv) == SVt_PVHV);            \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
@@ -6933,7 +7158,7 @@ Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_PV     \
-        Perl_assert_aTHX; assert(sv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
@@ -6942,7 +7167,7 @@ Perl_sv_derived_from_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_PVN    \
-        Perl_assert_aTHX; assert(sv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
@@ -6951,13 +7176,13 @@ Perl_sv_derived_from_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SV     \
-        Perl_assert_aTHX; assert(sv); assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(namesv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_destroyable(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_DESTROYABLE         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_does(pTHX_ SV *sv, const char * const name)
@@ -6966,7 +7191,7 @@ Perl_sv_does(pTHX_ SV *sv, const char * const name)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES                \
-        Perl_assert_aTHX; assert(sv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_does_pv(pTHX_ SV *sv, const char * const name, U32 flags)
@@ -6975,7 +7200,7 @@ Perl_sv_does_pv(pTHX_ SV *sv, const char * const name, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_PV             \
-        Perl_assert_aTHX; assert(sv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_does_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 flags)
@@ -6984,7 +7209,7 @@ Perl_sv_does_pvn(pTHX_ SV *sv, const char * const name, const STRLEN len, U32 fl
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_PVN            \
-        Perl_assert_aTHX; assert(sv); assert(name)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
@@ -6993,71 +7218,71 @@ Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DOES_SV             \
-        Perl_assert_aTHX; assert(sv); assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(namesv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_dump(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_DUMP                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_dump_depth(pTHX_ SV *sv, I32 depth)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_DUMP_DEPTH          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_eq(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_EQ                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_eq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_EQ_FLAGS            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_force_normal(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FORCE_NORMAL        \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_force_normal_flags(pTHX_ SV * const sv, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FORCE_NORMAL_FLAGS  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_free(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_FREE                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_free2(pTHX_ SV * const sv, const U32 refcnt)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_FREE2               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_free_arenas(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_FREE_ARENAS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_get_backrefs(SV * const sv)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_SV_GET_BACKREFS        \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append)
@@ -7065,33 +7290,33 @@ Perl_sv_gets(pTHX_ SV * const sv, PerlIO * const fp, SSize_t append)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_GETS                \
-        Perl_assert_aTHX; assert(sv); assert(fp)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(fp); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_grow(pTHX_ SV * const sv, STRLEN newlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW                \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_grow_fresh(pTHX_ SV * const sv, STRLEN newlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_GROW_FRESH          \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_inc(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_INC                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_inc_nomg(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_INC_NOMG            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char * const little, const STRLEN littlelen)
@@ -7099,7 +7324,8 @@ Perl_sv_insert(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, c
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_SV_INSERT              \
-        Perl_assert_aTHX; assert(bigstr); assert(little)
+    STMT_START { Perl_assert_aTHX; assert(bigstr); assert(little);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN len, const char *little, const STRLEN littlelen, const U32 flags)
@@ -7107,14 +7333,15 @@ Perl_sv_insert_flags(pTHX_ SV * const bigstr, const STRLEN offset, const STRLEN 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_SV_INSERT_FLAGS        \
-        Perl_assert_aTHX; assert(bigstr); assert(little)
+    STMT_START { Perl_assert_aTHX; assert(bigstr); assert(little);  \
+    } STMT_END
 
 PERL_CALLCONV int
 Perl_sv_isa(pTHX_ SV *sv, const char * const name)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_ISA                 \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
@@ -7123,59 +7350,59 @@ Perl_sv_isa_sv(pTHX_ SV *sv, SV *namesv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_ISA_SV              \
-        Perl_assert_aTHX; assert(sv); assert(namesv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(namesv); } STMT_END
 
 PERL_CALLCONV int
 Perl_sv_isobject(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_ISOBJECT            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_langinfo(pTHX_ const nl_item item)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_LANGINFO            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_len(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_LEN                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_len_utf8(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_LEN_UTF8            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_len_utf8_nomg(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_LEN_UTF8_NOMG       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_magic(pTHX_ SV * const sv, SV * const obj, const int how, const char * const name, const I32 namlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGIC               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicext(pTHX_ SV * const sv, SV * const obj, const int how, const MGVTBL * const vtbl, const char * const name, const I32 namlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGICEXT            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicext_mglob(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_MAGICEXT_MGLOB      \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicv2_add(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 flags, SV *auxsv)
@@ -7183,7 +7410,7 @@ Perl_sv_magicv2_add(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 flags,
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_ADD         \
-        Perl_assert_aTHX; assert(sv); assert(funcs)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(funcs); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicv2_find_by_auxsv(pTHX_ const SV *sv, const SV *auxsv)
@@ -7191,7 +7418,7 @@ Perl_sv_magicv2_find_by_auxsv(pTHX_ const SV *sv, const SV *auxsv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_FIND_BY_AUXSV \
-        Perl_assert_aTHX; assert(sv); assert(auxsv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(auxsv); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicv2_find_by_funcs(pTHX_ const SV *sv, const struct MagicFunctions *funcs)
@@ -7199,7 +7426,7 @@ Perl_sv_magicv2_find_by_funcs(pTHX_ const SV *sv, const struct MagicFunctions *f
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_FIND_BY_FUNCS \
-        Perl_assert_aTHX; assert(sv); assert(funcs)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(funcs); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicv2_find_or_add(pTHX_ SV *sv, const struct MagicFunctions *funcs)
@@ -7207,7 +7434,7 @@ Perl_sv_magicv2_find_or_add(pTHX_ SV *sv, const struct MagicFunctions *funcs)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_FIND_OR_ADD \
-        Perl_assert_aTHX; assert(sv); assert(funcs)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(funcs); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicv2_findnext_by_auxsv(pTHX_ const SV *sv, const SV *auxsv, MAGIC *mg)
@@ -7216,7 +7443,8 @@ Perl_sv_magicv2_findnext_by_auxsv(pTHX_ const SV *sv, const SV *auxsv, MAGIC *mg
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_FINDNEXT_BY_AUXSV \
-        Perl_assert_aTHX; assert(sv); assert(auxsv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(auxsv); assert(mg);  \
+    } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicv2_findnext_by_funcs(pTHX_ const SV *sv, const struct MagicFunctions *funcs, MAGIC *mg)
@@ -7225,7 +7453,8 @@ Perl_sv_magicv2_findnext_by_funcs(pTHX_ const SV *sv, const struct MagicFunction
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_FINDNEXT_BY_FUNCS \
-        Perl_assert_aTHX; assert(sv); assert(funcs); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(funcs); assert(mg);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_magicv2_remove(pTHX_ SV *sv, MAGIC *mg)
@@ -7233,7 +7462,7 @@ Perl_sv_magicv2_remove(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_REMOVE      \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_magicv2_remove_by_funcs(pTHX_ SV *sv, const struct MagicFunctions *funcs)
@@ -7241,158 +7470,158 @@ Perl_sv_magicv2_remove_by_funcs(pTHX_ SV *sv, const struct MagicFunctions *funcs
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_MAGICV2_REMOVE_BY_FUNCS \
-        Perl_assert_aTHX; assert(sv); assert(funcs)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(funcs); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_mortalcopy(pTHX_ SV * const oldsv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_MORTALCOPY          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_mortalcopy_flags(pTHX_ SV * const oldsv, U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_MORTALCOPY_FLAGS    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_newmortal(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_NEWMORTAL           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_newref(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NEWREF              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_nosharing(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NOSHARING           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_numcmp(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMCMP              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_numcmp_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMCMP_FLAGS        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numeq(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMEQ               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numeq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMEQ_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numge(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMGE               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numge_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMGE_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numgt(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMGT               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numgt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMGT_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numle(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMLE               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numle_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMLE_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numlt(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMLT               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numlt_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMLT_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numne(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMNE               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_numne_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_NUMNE_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_peek(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_PEEK                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_pos_b2u(pTHX_ SV * const sv, I32 * const offsetp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_B2U             \
-        Perl_assert_aTHX; assert(offsetp)
+    STMT_START { Perl_assert_aTHX; assert(offsetp); } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_pos_b2u_flags(pTHX_ SV * const sv, STRLEN const offset, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_B2U_FLAGS       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_pos_u2b(pTHX_ SV * const sv, I32 * const offsetp, I32 * const lenp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_POS_U2B             \
-        Perl_assert_aTHX; assert(offsetp)
+    STMT_START { Perl_assert_aTHX; assert(offsetp); } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_pos_u2b_flags(pTHX_ SV * const sv, STRLEN uoffset, STRLEN * const lenp, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_POS_U2B_FLAGS       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_pv(pTHX_ SV *sv)
@@ -7400,7 +7629,7 @@ Perl_sv_pv(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_PV                  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_pvbyte(pTHX_ SV *sv)
@@ -7408,28 +7637,28 @@ Perl_sv_pvbyte(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_PVBYTE              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_pvbyten_force(pTHX_ SV * const sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_pvn_force(pTHX_ SV *sv, STRLEN *lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_pvn_force_flags(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVN_FORCE_FLAGS     \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_pvutf8(pTHX_ SV *sv)
@@ -7437,14 +7666,14 @@ Perl_sv_pvutf8(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_PVUTF8              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_pvutf8n_force(pTHX_ SV * const sv, STRLEN * const lp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding)
@@ -7452,14 +7681,14 @@ Perl_sv_recode_to_utf8(pTHX_ SV *sv, SV *encoding)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_RECODE_TO_UTF8      \
-        Perl_assert_aTHX; assert(sv); assert(encoding)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(encoding); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_ref(pTHX_ SV *dst, const SV * const sv, const int ob)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REF                 \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV const char *
 Perl_sv_reftype(pTHX_ const SV * const sv, const int ob)
@@ -7467,7 +7696,7 @@ Perl_sv_reftype(pTHX_ const SV * const sv, const int ob)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REFTYPE             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV U8
 Perl_sv_reftype_id(pTHX_ const SV * const sv)
@@ -7475,14 +7704,14 @@ Perl_sv_reftype_id(pTHX_ const SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REFTYPE_ID          \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_regex_global_pos_clear(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_CLEAR \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_regex_global_pos_get(pTHX_ SV *sv, STRLEN *posp, U32 flags)
@@ -7491,14 +7720,14 @@ Perl_sv_regex_global_pos_get(pTHX_ SV *sv, STRLEN *posp, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_GET \
-        Perl_assert_aTHX; assert(sv); assert(posp)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(posp); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_regex_global_pos_set(pTHX_ SV *sv, STRLEN pos, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_REGEX_GLOBAL_POS_SET \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_replace(pTHX_ SV * const sv, SV * const nsv)
@@ -7506,126 +7735,127 @@ Perl_sv_replace(pTHX_ SV * const sv, SV * const nsv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_REPLACE             \
-        Perl_assert_aTHX; assert(sv); assert(nsv)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(nsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_report_used(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_REPORT_USED         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_reset(pTHX_ const char *s, HV * const stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RESET               \
-        Perl_assert_aTHX; assert(s);  \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV)
+    STMT_START { Perl_assert_aTHX; assert(s);                  \
+                 assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_resetpvn(pTHX_ const char *s, STRLEN len, HV * const stash)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SV_RESETPVN            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_rvunweaken(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVUNWEAKEN          \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_rvweaken(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RVWEAKEN            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_set_bool(pTHX_ SV *sv, const bool bool_val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_BOOL            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_set_false(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_FALSE           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_set_true(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_TRUE            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_set_undef(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SET_UNDEF           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_sethek(pTHX_ SV * const sv, const HEK * const hek)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETHEK              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setiv(pTHX_ SV * const sv, const IV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setiv_mg(pTHX_ SV * const sv, const IV i)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETIV_MG            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setnv(pTHX_ SV * const sv, const NV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setnv_mg(pTHX_ SV * const sv, const NV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETNV_MG            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpv(pTHX_ SV * const sv, const char * const ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV char  *
 Perl_sv_setpv_bufsize(pTHX_ SV * const sv, const STRLEN cur, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_BUFSIZE       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpv_mg(pTHX_ SV * const sv, const char * const ptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPV_MG            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpvf(pTHX_ SV * const sv, const char * const pat, ...)
@@ -7634,7 +7864,7 @@ Perl_sv_setpvf(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETPVF              \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
@@ -7643,21 +7873,21 @@ Perl_sv_setpvf_mg(pTHX_ SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETPVF_MG           \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpvn(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpvn_fresh(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETPVN_FRESH        \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
@@ -7665,28 +7895,28 @@ Perl_sv_setpvn_mg(pTHX_ SV * const sv, const char * const ptr, const STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETPVN_MG           \
-        Perl_assert_aTHX; assert(sv); assert(ptr)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(ptr); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_setref_iv(pTHX_ SV * const rv, const char * const classname, const IV iv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_IV           \
-        Perl_assert_aTHX; assert(rv)
+    STMT_START { Perl_assert_aTHX; assert(rv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_setref_nv(pTHX_ SV * const rv, const char * const classname, const NV nv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_NV           \
-        Perl_assert_aTHX; assert(rv)
+    STMT_START { Perl_assert_aTHX; assert(rv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_setref_pv(pTHX_ SV * const rv, const char * const classname, void * const pv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_PV           \
-        Perl_assert_aTHX; assert(rv)
+    STMT_START { Perl_assert_aTHX; assert(rv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char * const pv, const STRLEN n)
@@ -7694,14 +7924,14 @@ Perl_sv_setref_pvn(pTHX_ SV * const rv, const char * const classname, const char
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SV_SETREF_PVN          \
-        Perl_assert_aTHX; assert(rv); assert(pv)
+    STMT_START { Perl_assert_aTHX; assert(rv); assert(pv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_setref_uv(pTHX_ SV * const rv, const char * const classname, const UV uv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETREF_UV           \
-        Perl_assert_aTHX; assert(rv)
+    STMT_START { Perl_assert_aTHX; assert(rv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref)
@@ -7709,7 +7939,7 @@ Perl_sv_setrv_inc(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC           \
-        Perl_assert_aTHX; assert(sv); assert(ref)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(ref); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref)
@@ -7717,7 +7947,7 @@ Perl_sv_setrv_inc_mg(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_INC_MG        \
-        Perl_assert_aTHX; assert(sv); assert(ref)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(ref); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref)
@@ -7725,7 +7955,7 @@ Perl_sv_setrv_noinc(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC         \
-        Perl_assert_aTHX; assert(sv); assert(ref)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(ref); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref)
@@ -7733,61 +7963,61 @@ Perl_sv_setrv_noinc_mg(pTHX_ SV * const sv, SV * const ref)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_SETRV_NOINC_MG      \
-        Perl_assert_aTHX; assert(sv); assert(ref)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(ref); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setsv(pTHX_ SV *dsv, SV *ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV               \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setsv_flags(pTHX_ SV *dsv, SV *ssv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_FLAGS         \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setsv_mg(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETSV_MG            \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setuv(pTHX_ SV * const sv, const UV num)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setuv_mg(pTHX_ SV * const sv, const UV u)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_SETUV_MG            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_streq(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_STREQ               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_streq_flags(pTHX_ SV *sv1, SV *sv2, const U32 flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_STREQ_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_strftime_ints(pTHX_ SV *fmt, int sec, int min, int hour, int mday, int mon, int year, int isdst)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_INTS       \
-        Perl_assert_aTHX; assert(fmt)
+    STMT_START { Perl_assert_aTHX; assert(fmt); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_strftime_tm(pTHX_ SV *fmt, const struct tm *mytm)
@@ -7795,20 +8025,20 @@ Perl_sv_strftime_tm(pTHX_ SV *fmt, const struct tm *mytm)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_STRFTIME_TM         \
-        Perl_assert_aTHX; assert(fmt); assert(mytm)
+    STMT_START { Perl_assert_aTHX; assert(fmt); assert(mytm); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_string_from_errnum(pTHX_ int errnum, SV *tgtsv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_STRING_FROM_ERRNUM  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_taint(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_TAINT               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_tainted(pTHX_ SV * const sv)
@@ -7816,13 +8046,13 @@ Perl_sv_tainted(pTHX_ SV * const sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_TAINTED             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV I32
 Perl_sv_true(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SV_TRUE                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
@@ -7831,133 +8061,133 @@ Perl_sv_uni_display(pTHX_ SV *dsv, SV *ssv, STRLEN pvlim, UV flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_UNI_DISPLAY         \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); } STMT_END
 
 PERL_CALLCONV int
 Perl_sv_unmagic(pTHX_ SV * const sv, const int type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGIC             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV int
 Perl_sv_unmagicext(pTHX_ SV * const sv, const int type, const MGVTBL *vtbl)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNMAGICEXT          \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_unref(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNREF               \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_unref_flags(pTHX_ SV * const ref, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNREF_FLAGS         \
-        Perl_assert_aTHX; assert(ref)
+    STMT_START { Perl_assert_aTHX; assert(ref); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_untaint(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UNTAINT             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_upgrade(pTHX_ SV * const sv, svtype new_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UPGRADE             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_usepvn(pTHX_ SV *sv, char *ptr, STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_USEPVN              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_usepvn_flags(pTHX_ SV * const sv, char *ptr, const STRLEN len, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_USEPVN_FLAGS        \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_usepvn_mg(pTHX_ SV *sv, char *ptr, STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_USEPVN_MG           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_utf8_decode(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DECODE         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_utf8_downgrade(pTHX_ SV * const sv, const bool fail_ok)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE      \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_utf8_downgrade_flags(pTHX_ SV * const sv, const bool fail_ok, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_FLAGS \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_utf8_downgrade_nomg(pTHX_ SV * const sv, const bool fail_ok)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_DOWNGRADE_NOMG \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_utf8_encode(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_ENCODE         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE        \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_flags(pTHX_ SV * const sv, const I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_flags_grow(pTHX_ SV * const sv, const I32 flags, STRLEN extra)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_FLAGS_GROW \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_sv_utf8_upgrade_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_UTF8_UPGRADE_NOMG   \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -7965,7 +8195,7 @@ Perl_sv_vcatpvf(pTHX_ SV * const sv, const char * const pat, va_list * const arg
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF             \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -7973,7 +8203,7 @@ Perl_sv_vcatpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVF_MG          \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
@@ -7981,7 +8211,7 @@ Perl_sv_vcatpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patle
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN            \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted, const U32 flags)
@@ -7989,7 +8219,7 @@ Perl_sv_vcatpvfn_flags(pTHX_ SV * const sv, const char * const pat, const STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VCATPVFN_FLAGS      \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -7997,7 +8227,7 @@ Perl_sv_vsetpvf(pTHX_ SV * const sv, const char * const pat, va_list * const arg
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF             \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const args)
@@ -8005,7 +8235,7 @@ Perl_sv_vsetpvf_mg(pTHX_ SV * const sv, const char * const pat, va_list * const 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVF_MG          \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patlen, va_list * const args, SV ** const svargs, const Size_t sv_count, bool * const maybe_tainted)
@@ -8013,14 +8243,14 @@ Perl_sv_vsetpvfn(pTHX_ SV * const sv, const char * const pat, const STRLEN patle
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SV_VSETPVFN            \
-        Perl_assert_aTHX; assert(sv); assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV const char *
 Perl_sv_vstring_get(pTHX_ SV * const sv, STRLEN *lenp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_VSTRING_GET         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV const char *
 Perl_svtypename(U8 type)
@@ -8032,20 +8262,20 @@ PERL_CALLCONV void
 Perl_switch_to_global_locale(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SWITCH_TO_GLOBAL_LOCALE \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_sync_locale(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_SYNC_LOCALE            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sys_init(int *argc, char ***argv)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 #define PERL_ARGS_ASSERT_SYS_INIT               \
-        assert(argc); assert(argv)
+    STMT_START { assert(argc); assert(argv); } STMT_END
 
 PERL_CALLCONV void
 Perl_sys_init3(int *argc, char ***argv, char ***env)
@@ -8053,7 +8283,7 @@ Perl_sys_init3(int *argc, char ***argv, char ***env)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_SYS_INIT3              \
-        assert(argc); assert(argv); assert(env)
+    STMT_START { assert(argc); assert(argv); assert(env); } STMT_END
 
 PERL_CALLCONV void
 Perl_sys_term(void);
@@ -8063,14 +8293,14 @@ PERL_CALLCONV void
 Perl_taint_env(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_TAINT_ENV              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_taint_proper(pTHX_ const char *f, const char * const s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_TAINT_PROPER           \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * const mg, const U32 flags, U32 argc, ...)
@@ -8081,14 +8311,15 @@ Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * con
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_TIED_METHOD            \
-        Perl_assert_aTHX; assert(methname); assert(mark); assert(sv);  \
-        assert(mg)
+    STMT_START { Perl_assert_aTHX; assert(methname); assert(mark);  \
+                 assert(sv); assert(mg);                            \
+    } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_tmps_grow_p(pTHX_ SSize_t ix)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_TMPS_GROW_P            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -8096,7 +8327,7 @@ Perl_to_uni_fold(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_FOLD            \
-        Perl_assert_aTHX; assert(p); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(lenp); } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
@@ -8104,7 +8335,7 @@ Perl_to_uni_fold_flags_(pTHX_ UV c, U8 *p, STRLEN *lenp, U8 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_FOLD_FLAGS_     \
-        Perl_assert_aTHX; assert(p); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(lenp); } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -8112,7 +8343,7 @@ Perl_to_uni_lower(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_LOWER           \
-        Perl_assert_aTHX; assert(p); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(lenp); } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -8120,7 +8351,7 @@ Perl_to_uni_title(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_TITLE           \
-        Perl_assert_aTHX; assert(p); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(lenp); } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp)
@@ -8128,7 +8359,7 @@ Perl_to_uni_upper(pTHX_ UV c, U8 *p, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UNI_UPPER           \
-        Perl_assert_aTHX; assert(p); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(lenp); } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, U8 flags)
@@ -8137,7 +8368,9 @@ Perl_to_utf8_fold_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_FOLD_FLAGS_    \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(ustrp);  \
+                 assert(p < e);                                          \
+    } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
@@ -8146,7 +8379,9 @@ Perl_to_utf8_lower_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_LOWER_FLAGS_   \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(ustrp);  \
+                 assert(p < e);                                          \
+    } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
@@ -8155,7 +8390,9 @@ Perl_to_utf8_title_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_TITLE_FLAGS_   \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(ustrp);  \
+                 assert(p < e);                                          \
+    } STMT_END
 
 PERL_CALLCONV UV
 Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *lenp, bool flags)
@@ -8164,19 +8401,21 @@ Perl_to_utf8_upper_flags_(pTHX_ const U8 *p, const U8 *e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_TO_UTF8_UPPER_FLAGS_   \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(p < e)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(ustrp);  \
+                 assert(p < e);                                          \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_try_amagic_bin(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_TRY_AMAGIC_BIN         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV bool
 Perl_try_amagic_un(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_TRY_AMAGIC_UN          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV char *
 Perl_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** const peob)
@@ -8184,7 +8423,7 @@ Perl_uiv_2buf(char * const buf, const IV iv, UV uv, const int is_uv, char ** con
         Perl_attribute_nonnull(5)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UIV_2BUF               \
-        assert(buf); assert(peob)
+    STMT_START { assert(buf); assert(peob); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, const char *strend, U32 flags)
@@ -8194,27 +8433,28 @@ Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_UNPACKSTRING           \
-        Perl_assert_aTHX; assert(pat); assert(patend); assert(s);  \
-        assert(strend); assert(pat <= patend); assert(s <= strend)
+    STMT_START { Perl_assert_aTHX; assert(pat); assert(patend); assert(s);    \
+                 assert(strend); assert(pat <= patend); assert(s <= strend);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_unshare_hek(pTHX_ HEK *hek)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_UNSHARE_HEK            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_unsharepvn(pTHX_ const char *sv, I32 len, U32 hash)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_UNSHAREPVN             \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_upg_version(pTHX_ SV *ver, bool qv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UPG_VERSION            \
-        Perl_assert_aTHX; assert(ver)
+    STMT_START { Perl_assert_aTHX; assert(ver); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_utf16_to_utf8_base(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
@@ -8223,7 +8463,8 @@ Perl_utf16_to_utf8_base(pTHX_ U8 *p, U8 *d, Size_t bytelen, Size_t *newlen, cons
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_UTF16_TO_UTF8_BASE     \
-        Perl_assert_aTHX; assert(p); assert(d); assert(newlen)
+    STMT_START { Perl_assert_aTHX; assert(p); assert(d); assert(newlen);  \
+    } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
@@ -8231,7 +8472,7 @@ Perl_utf8_hop_back(const U8 *s, SSize_t off, const U8 * const start)
         Perl_attribute_nonnull(3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UTF8_HOP_BACK          \
-        assert(s); assert(start); assert(start <= s)
+    STMT_START { assert(s); assert(start); assert(start <= s); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
@@ -8239,7 +8480,7 @@ Perl_utf8_hop_forward(const U8 *s, SSize_t off, const U8 * const end)
         Perl_attribute_nonnull(3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD       \
-        assert(s); assert(end); assert(s <= end)
+    STMT_START { assert(s); assert(end); assert(s <= end); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end)
@@ -8248,8 +8489,9 @@ Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * 
         Perl_attribute_nonnull(4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UTF8_HOP_SAFE          \
-        assert(s); assert(start); assert(end); assert(start <= s);  \
-        assert(s <= end)
+    STMT_START { assert(s); assert(start); assert(end); assert(start <= s);  \
+                 assert(s <= end);                                           \
+    } STMT_END
 
 PERL_CALLCONV STRLEN
 Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
@@ -8258,7 +8500,8 @@ Perl_utf8_length(pTHX_ const U8 *s0, const U8 *e)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UTF8_LENGTH            \
-        Perl_assert_aTHX; assert(s0); assert(e); assert(s0 <= e)
+    STMT_START { Perl_assert_aTHX; assert(s0); assert(e); assert(s0 <= e);  \
+    } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
@@ -8266,7 +8509,7 @@ Perl_utf8_to_bytes(pTHX_ U8 *s, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES          \
-        Perl_assert_aTHX; assert(s); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(lenp); } STMT_END
 
 PERL_CALLCONV bool
 Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to_bytes_arg result_as)
@@ -8275,7 +8518,9 @@ Perl_utf8_to_bytes_(pTHX_ U8 **s_ptr, STRLEN *lenp, void **free_me, Perl_utf8_to
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_UTF8_TO_BYTES_         \
-        Perl_assert_aTHX; assert(s_ptr); assert(lenp); assert(free_me)
+    STMT_START { Perl_assert_aTHX; assert(s_ptr); assert(lenp);  \
+                 assert(free_me);                                \
+    } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, const bool high, const bool low)
@@ -8284,7 +8529,8 @@ Perl_utf8_to_utf16_base(pTHX_ U8 *s, U8 *d, Size_t bytelen, Size_t *newlen, cons
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_UTF8_TO_UTF16_BASE     \
-        Perl_assert_aTHX; assert(s); assert(d); assert(newlen)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(d); assert(newlen);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p)
@@ -8292,7 +8538,8 @@ Perl_utf8_to_uv(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advanc
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_UTF8_TO_UV             \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
+    STMT_START { assert(s); assert(e); assert(cp_p); assert(s <= e);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors)
@@ -8300,7 +8547,8 @@ Perl_utf8_to_uv_errors(const U8 * const s, const U8 * const e, UV *cp_p, Size_t 
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_UTF8_TO_UV_ERRORS      \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
+    STMT_START { assert(s); assert(e); assert(cp_p); assert(s <= e);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags)
@@ -8308,7 +8556,8 @@ Perl_utf8_to_uv_flags(const U8 * const s, const U8 * const e, UV *cp_p, Size_t *
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_UTF8_TO_UV_FLAGS       \
-        assert(s); assert(e); assert(cp_p); assert(s <= e)
+    STMT_START { assert(s); assert(e); assert(cp_p); assert(s <= e);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs)
@@ -8316,19 +8565,20 @@ Perl_utf8_to_uv_msgs_helper_(const U8 * const s0, const U8 * const e, UV *cp_p, 
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_UTF8_TO_UV_MSGS_HELPER_ \
-        assert(s0); assert(e); assert(cp_p); assert(s0 <= e)
+    STMT_START { assert(s0); assert(e); assert(cp_p); assert(s0 <= e);  \
+    } STMT_END
 
 PERL_CALLCONV UV
 Perl_utf8n_to_uvchr(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR         \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV UV
 Perl_utf8n_to_uvchr_error(const U8 *s, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors)
         Perl_attribute_nonnull(1);
 #define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_ERROR   \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV void
 Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
@@ -8336,49 +8586,49 @@ Perl_utilize(pTHX_ int aver, I32 floor, OP *version, OP *idop, OP *arg)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_UTILIZE                \
-        Perl_assert_aTHX; assert(idop)
+    STMT_START { Perl_assert_aTHX; assert(idop); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_uv_to_utf8_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UV_TO_UTF8_MSGS        \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8(pTHX_ U8 *d, UV uv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UVCHR_TO_UTF8          \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS    \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_uvchr_to_utf8_flags_msgs(pTHX_ U8 *d, UV uv, UV flags, HV **msgs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UVCHR_TO_UTF8_FLAGS_MSGS \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_uvoffuni_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_uvoffuni_to_utf8_flags_msgs(pTHX_ U8 *d, UV input_uv, const UV flags, HV **msgs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_UVOFFUNI_TO_UTF8_FLAGS_MSGS \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_CALLCONV bool
 Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
@@ -8386,54 +8636,55 @@ Perl_valid_identifier_pve(pTHX_ const char *s, const char *end, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVE   \
-        Perl_assert_aTHX; assert(s); assert(end); assert(s <= end)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(end); assert(s <= end);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_valid_identifier_pvn(pTHX_ const char *s, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_PVN   \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV bool
 Perl_valid_identifier_sv(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_VALID_IDENTIFIER_SV    \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV UV
 Perl_valid_utf8_to_uvchr(const U8 *s, STRLEN *retlen)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_VALID_UTF8_TO_UVCHR    \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_CALLCONV bool
 Perl_validate_proto(pTHX_ SV *name, SV *proto, bool warn, bool curstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VALIDATE_PROTO         \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_valuemagic_applyto(pTHX_ SV *dsv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VALUEMAGIC_APPLYTO     \
-        Perl_assert_aTHX; assert(dsv)
+    STMT_START { Perl_assert_aTHX; assert(dsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_valuemagic_clear(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_VALUEMAGIC_CLEAR       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_valuemagic_from(pTHX_ SV *ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VALUEMAGIC_FROM        \
-        Perl_assert_aTHX; assert(ssv)
+    STMT_START { Perl_assert_aTHX; assert(ssv); } STMT_END
 
 PERL_CALLCONV int
 Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
@@ -8441,7 +8692,7 @@ Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VCMP                   \
-        Perl_assert_aTHX; assert(lhv); assert(rhv)
+    STMT_START { Perl_assert_aTHX; assert(lhv); assert(rhv); } STMT_END
 
 PERL_CALLCONV_NO_RET void
 Perl_vcroak(pTHX_ const char *pat, va_list *args)
@@ -8452,26 +8703,26 @@ PERL_CALLCONV void
 Perl_vdeb(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VDEB                   \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VFATAL_WARNER          \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV char *
 Perl_vform(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VFORM                  \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_vivify_defelem(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VIVIFY_DEFELEM         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
@@ -8480,20 +8731,20 @@ Perl_vivify_ref(pTHX_ SV *sv, U32 to_what)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_VIVIFY_REF             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_vload_module(pTHX_ U32 flags, SV *name, SV *ver, va_list *args)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VLOAD_MODULE           \
-        Perl_assert_aTHX; assert(name)
+    STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_vmess(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VMESS                  \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
@@ -8501,47 +8752,47 @@ Perl_vnewSVpvf(pTHX_ const char * const pat, va_list * const args)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_VNEWSVPVF              \
-        Perl_assert_aTHX; assert(pat)
+    STMT_START { Perl_assert_aTHX; assert(pat); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_vnormal(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VNORMAL                \
-        Perl_assert_aTHX; assert(vs)
+    STMT_START { Perl_assert_aTHX; assert(vs); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_vnumify(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VNUMIFY                \
-        Perl_assert_aTHX; assert(vs)
+    STMT_START { Perl_assert_aTHX; assert(vs); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_vstringify(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VSTRINGIFY             \
-        Perl_assert_aTHX; assert(vs)
+    STMT_START { Perl_assert_aTHX; assert(vs); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_vverify(pTHX_ SV *vs)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VVERIFY                \
-        Perl_assert_aTHX; assert(vs)
+    STMT_START { Perl_assert_aTHX; assert(vs); } STMT_END
 
 PERL_CALLCONV void
 Perl_vwarn(pTHX_ const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VWARN                  \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_vwarner(pTHX_ U32 err, const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VWARNER                \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV I32
 Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
@@ -8549,35 +8800,35 @@ Perl_wait4pid(pTHX_ Pid_t pid, int *statusp, int flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WAIT4PID               \
-        Perl_assert_aTHX; assert(statusp)
+    STMT_START { Perl_assert_aTHX; assert(statusp); } STMT_END
 
 PERL_CALLCONV void
 Perl_warn(pTHX_ const char *pat, ...)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__format__(__printf__,pTHX_1,pTHX_2);
 #define PERL_ARGS_ASSERT_WARN                   \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_warn_sv(pTHX_ SV *baseex)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WARN_SV                \
-        Perl_assert_aTHX; assert(baseex)
+    STMT_START { Perl_assert_aTHX; assert(baseex); } STMT_END
 
 PERL_CALLCONV void
 Perl_warner(pTHX_ U32 err, const char *pat, ...)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 #define PERL_ARGS_ASSERT_WARNER                 \
-        assert(pat)
+    STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV I32
 Perl_was_lvalue_sub(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_WAS_LVALUE_SUB         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_watch(pTHX_ char **addr)
@@ -8585,35 +8836,35 @@ Perl_watch(pTHX_ char **addr)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WATCH                  \
-        Perl_assert_aTHX; assert(addr)
+    STMT_START { Perl_assert_aTHX; assert(addr); } STMT_END
 
 PERL_CALLCONV I32
 Perl_whichsig(pTHX_ const char *sig)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG               \
-        Perl_assert_aTHX; assert(sig)
+    STMT_START { Perl_assert_aTHX; assert(sig); } STMT_END
 
 PERL_CALLCONV I32
 Perl_whichsig_pv(pTHX_ const char *sig)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PV            \
-        Perl_assert_aTHX; assert(sig)
+    STMT_START { Perl_assert_aTHX; assert(sig); } STMT_END
 
 PERL_CALLCONV I32
 Perl_whichsig_pvn(pTHX_ const char *sig, STRLEN len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_PVN           \
-        Perl_assert_aTHX; assert(sig)
+    STMT_START { Perl_assert_aTHX; assert(sig); } STMT_END
 
 PERL_CALLCONV I32
 Perl_whichsig_sv(pTHX_ SV *sigsv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_WHICHSIG_SV            \
-        Perl_assert_aTHX; assert(sigsv)
+    STMT_START { Perl_assert_aTHX; assert(sigsv); } STMT_END
 
 PERL_CALLCONV void
 Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t *old_plugin_p)
@@ -8621,7 +8872,8 @@ Perl_wrap_infix_plugin(pTHX_ Perl_infix_plugin_t new_plugin, Perl_infix_plugin_t
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_INFIX_PLUGIN      \
-        Perl_assert_aTHX; assert(new_plugin); assert(old_plugin_p)
+    STMT_START { Perl_assert_aTHX; assert(new_plugin); assert(old_plugin_p);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_plugin_t *old_plugin_p)
@@ -8629,7 +8881,8 @@ Perl_wrap_keyword_plugin(pTHX_ Perl_keyword_plugin_t new_plugin, Perl_keyword_pl
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_WRAP_KEYWORD_PLUGIN    \
-        Perl_assert_aTHX; assert(new_plugin); assert(old_plugin_p)
+    STMT_START { Perl_assert_aTHX; assert(new_plugin); assert(old_plugin_p);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t *old_checker_p)
@@ -8637,7 +8890,9 @@ Perl_wrap_op_checker(pTHX_ Optype opcode, Perl_check_t new_checker, Perl_check_t
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_WRAP_OP_CHECKER        \
-        Perl_assert_aTHX; assert(new_checker); assert(old_checker_p)
+    STMT_START { Perl_assert_aTHX; assert(new_checker);  \
+                 assert(old_checker_p);                  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_write_to_stderr(pTHX_ SV *msv)
@@ -8645,20 +8900,20 @@ Perl_write_to_stderr(pTHX_ SV *msv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_WRITE_TO_STDERR        \
-        Perl_assert_aTHX; assert(msv)
+    STMT_START { Perl_assert_aTHX; assert(msv); } STMT_END
 
 PERL_CALLCONV void
 Perl_xs_boot_epilog(pTHX_ const SSize_t ax)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_XS_BOOT_EPILOG         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV Stack_off_t
 Perl_xs_handshake(const U32 key, void *v_my_perl, const char *file, ...)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 #define PERL_ARGS_ASSERT_XS_HANDSHAKE           \
-        assert(v_my_perl); assert(file)
+    STMT_START { assert(v_my_perl); assert(file); } STMT_END
 
 PERL_CALLCONV int
 Perl_yyerror(pTHX_ const char * const s)
@@ -8666,7 +8921,7 @@ Perl_yyerror(pTHX_ const char * const s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR                \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV int
 Perl_yyerror_pv(pTHX_ const char * const s, U32 flags)
@@ -8674,41 +8929,41 @@ Perl_yyerror_pv(pTHX_ const char * const s, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR_PV             \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV int
 Perl_yyerror_pvn(pTHX_ const char * const s, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYERROR_PVN            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_yylex(pTHX)
         Perl_attribute_nonnull_aTHX;
 #define PERL_ARGS_ASSERT_YYLEX                  \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_yyparse(pTHX_ int gramtype)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYPARSE                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_yyquit(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYQUIT                 \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_yyunlex(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_YYUNLEX                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 #if defined(DEBUGGING)
 PERL_CALLCONV int
@@ -8718,33 +8973,37 @@ Perl_get_debug_opts(pTHX_ const char **s, bool givehelp)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GET_DEBUG_OPTS        \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV void
 Perl_hv_assert(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_ASSERT             \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(hv);    \
+                  assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_pad_setsv(pTHX_ PADOFFSET po, SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PAD_SETSV             \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_pad_sv(pTHX_ PADOFFSET po)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PAD_SV                \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_set_padlist(CV *cv, PADLIST *padlist)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_SET_PADLIST           \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { assert(cv);                                                \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 #endif /* defined(DEBUGGING) */
 #if defined(DEBUG_LEAKING_SCALARS_FORK_DUMP)
@@ -8754,16 +9013,16 @@ Perl_dump_sv_child(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DUMP_SV_CHILD         \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
-#endif /* defined(DEBUG_LEAKING_SCALARS_FORK_DUMP) */
+#endif
 #if defined(F_FREESP) && !defined(HAS_CHSIZE) && !defined(HAS_TRUNCATE)
 PERL_CALLCONV I32
 Perl_my_chsize(pTHX_ int fd, Off_t length)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MY_CHSIZE             \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif
 #if !defined(HAS_GETENV_LEN)
@@ -8774,7 +9033,8 @@ Perl_getenv_len(pTHX_ const char *env_elem, unsigned long *len)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GETENV_LEN            \
-        Perl_assert_aTHX; assert(env_elem); assert(len)
+     STMT_START { Perl_assert_aTHX; assert(env_elem); assert(len);  \
+    } STMT_END
 
 #endif /* !defined(HAS_GETENV_LEN) */
 #if !defined(HAS_MKOSTEMP)
@@ -8783,7 +9043,7 @@ Perl_my_mkostemp(char *templte, int flags)
         Perl_attribute_nonnull(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MY_MKOSTEMP           \
-        assert(templte)
+     STMT_START { assert(templte); } STMT_END
 
 #endif
 #if !defined(HAS_MKSTEMP)
@@ -8792,7 +9052,7 @@ Perl_my_mkstemp(char *templte)
         Perl_attribute_nonnull(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MY_MKSTEMP            \
-        assert(templte)
+     STMT_START { assert(templte); } STMT_END
 
 #endif
 #if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
@@ -8803,7 +9063,7 @@ Perl_do_ipcctl(pTHX_ I32 optype, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_IPCCTL             \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV I32
 Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
@@ -8812,7 +9072,7 @@ Perl_do_ipcget(pTHX_ I32 optype, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_IPCGET             \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
@@ -8821,7 +9081,7 @@ Perl_do_msgrcv(pTHX_ SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_MSGRCV             \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV I32
 Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
@@ -8830,7 +9090,7 @@ Perl_do_msgsnd(pTHX_ SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_MSGSND             \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV I32
 Perl_do_semop(pTHX_ SV **mark, SV **sp)
@@ -8839,7 +9099,7 @@ Perl_do_semop(pTHX_ SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_SEMOP              \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV I32
 Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
@@ -8848,7 +9108,7 @@ Perl_do_shmio(pTHX_ I32 optype, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_SHMIO              \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 #endif /* defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM) */
 #if defined(HAS_PIPE)
@@ -8859,7 +9119,7 @@ Perl_PerlProc_pipe_cloexec(pTHX_ int *pipefd)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLPROC_PIPE_CLOEXEC \
-        Perl_assert_aTHX; assert(pipefd)
+     STMT_START { Perl_assert_aTHX; assert(pipefd); } STMT_END
 
 #endif /* defined(HAS_PIPE) */
 #if !defined(HAS_RENAME)
@@ -8870,7 +9130,7 @@ Perl_same_dirent(pTHX_ const char *a, const char *b)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SAME_DIRENT           \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 #endif /* !defined(HAS_RENAME) */
 #if !defined(HAS_SIGNBIT)
@@ -8888,7 +9148,7 @@ Perl_PerlSock_accept_cloexec(pTHX_ int listenfd, struct sockaddr *addr, Sock_siz
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLSOCK_ACCEPT_CLOEXEC \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
@@ -8896,7 +9156,7 @@ Perl_PerlSock_socket_cloexec(pTHX_ int domain, int type, int protocol)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKET_CLOEXEC \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(HAS_SOCKET) */
 #if   defined(HAS_SOCKETPAIR) ||                                     \
@@ -8909,7 +9169,7 @@ Perl_PerlSock_socketpair_cloexec(pTHX_ int domain, int type, int protocol, int *
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PERLSOCK_SOCKETPAIR_CLOEXEC \
-        Perl_assert_aTHX; assert(pairfd)
+     STMT_START { Perl_assert_aTHX; assert(pairfd); } STMT_END
 
 #endif /*   defined(HAS_SOCKETPAIR) ||
           ( defined(AF_INET) && defined(HAS_SOCKET) && defined(PF_INET) &&
@@ -8927,22 +9187,22 @@ PERL_STATIC_INLINE Size_t
 Perl_my_strnlen(const char *str, Size_t maxlen)
         Perl_attribute_nonnull(1);
 #   define PERL_ARGS_ASSERT_MY_STRNLEN          \
-        assert(str)
+     STMT_START { assert(str); } STMT_END
 
 # endif
-#endif /* !defined(HAS_STRNLEN) */
+#endif
 #if defined(HAVE_INTERP_INTERN)
 PERL_CALLCONV void
 Perl_sys_intern_clear(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SYS_INTERN_CLEAR      \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sys_intern_init(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SYS_INTERN_INIT       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # if defined(USE_ITHREADS)
 PERL_CALLCONV void
@@ -8951,9 +9211,9 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SYS_INTERN_DUP      \
-        Perl_assert_aTHX; assert(src); assert(dst)
+       STMT_START { Perl_assert_aTHX; assert(src); assert(dst); } STMT_END
 
-# endif /* defined(USE_ITHREADS) */
+# endif
 #endif /* defined(HAVE_INTERP_INTERN) */
 #if defined(MULTIPLICITY)
 PERL_CALLCONV_NO_RET void
@@ -8967,7 +9227,7 @@ Perl_deb_nocontext(const char *pat, ...)
         Perl_attribute_nonnull(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_DEB_NOCONTEXT         \
-        assert(pat)
+     STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV_NON_VOID_NO_RET(OP *) OP *
 Perl_die_nocontext(const char *pat, ...)
@@ -8980,34 +9240,34 @@ Perl_form_nocontext(const char *pat, ...)
         Perl_attribute_nonnull(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_FORM_NOCONTEXT        \
-        assert(pat)
+     STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_load_module_nocontext(U32 flags, SV *name, SV *ver, ...)
         Perl_attribute_nonnull(2);
 # define PERL_ARGS_ASSERT_LOAD_MODULE_NOCONTEXT \
-        assert(name)
+     STMT_START { assert(name); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_mess_nocontext(const char *pat, ...)
         Perl_attribute_nonnull(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_MESS_NOCONTEXT        \
-        assert(pat)
+     STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void *
 Perl_my_cxt_init(pTHX_ int *indexp, size_t size)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MY_CXT_INIT           \
-        Perl_assert_aTHX; assert(indexp)
+     STMT_START { Perl_assert_aTHX; assert(indexp); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_newSVpvf_nocontext(const char * const pat, ...)
         Perl_attribute_nonnull(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_NEWSVPVF_NOCONTEXT    \
-        assert(pat)
+     STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpvf_mg_nocontext(SV * const sv, const char * const pat, ...)
@@ -9015,7 +9275,7 @@ Perl_sv_catpvf_mg_nocontext(SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_CATPVF_MG_NOCONTEXT \
-        assert(sv); assert(pat)
+     STMT_START { assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_catpvf_nocontext(SV * const sv, const char * const pat, ...)
@@ -9023,7 +9283,7 @@ Perl_sv_catpvf_nocontext(SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_CATPVF_NOCONTEXT   \
-        assert(sv); assert(pat)
+     STMT_START { assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpvf_mg_nocontext(SV * const sv, const char * const pat, ...)
@@ -9031,7 +9291,7 @@ Perl_sv_setpvf_mg_nocontext(SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_SETPVF_MG_NOCONTEXT \
-        assert(sv); assert(pat)
+     STMT_START { assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_setpvf_nocontext(SV * const sv, const char * const pat, ...)
@@ -9039,21 +9299,21 @@ Perl_sv_setpvf_nocontext(SV * const sv, const char * const pat, ...)
         Perl_attribute_nonnull(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_SV_SETPVF_NOCONTEXT   \
-        assert(sv); assert(pat)
+     STMT_START { assert(sv); assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_warn_nocontext(const char *pat, ...)
         Perl_attribute_nonnull(1)
         __attribute__format__(__printf__,1,2);
 # define PERL_ARGS_ASSERT_WARN_NOCONTEXT        \
-        assert(pat)
+     STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
 Perl_warner_nocontext(U32 err, const char *pat, ...)
         Perl_attribute_nonnull(2)
         __attribute__format__(__printf__,2,3);
 # define PERL_ARGS_ASSERT_WARNER_NOCONTEXT      \
-        assert(pat)
+     STMT_START { assert(pat); } STMT_END
 
 #endif /* defined(MULTIPLICITY) */
 #if defined(MYMALLOC)
@@ -9062,14 +9322,14 @@ Perl_dump_mstats(pTHX_ const char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_MSTATS           \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV int
 Perl_get_mstats(pTHX_ perl_mstats_t *buf, int buflen, int level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_MSTATS            \
-        Perl_assert_aTHX; assert(buf)
+     STMT_START { Perl_assert_aTHX; assert(buf); } STMT_END
 
 PERL_CALLCONV MEM_SIZE
 Perl_malloc_good_size(size_t nbytes)
@@ -9083,7 +9343,7 @@ Perl_malloced_size(void *p)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MALLOCED_SIZE         \
-        assert(p)
+     STMT_START { assert(p); } STMT_END
 
 #endif /* defined(MYMALLOC) */
 #if !defined(NO_MATHOMS)
@@ -9097,7 +9357,7 @@ Perl_utf8_to_uvchr(pTHX_ const U8 *s, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR         \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV UV
 Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
@@ -9105,7 +9365,7 @@ Perl_utf8_to_uvuni(pTHX_ const U8 *s, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8_TO_UVUNI         \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV UV
 Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
@@ -9113,7 +9373,7 @@ Perl_utf8n_to_uvuni(pTHX_ const U8 *s, STRLEN curlen, STRLEN *retlen, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVUNI        \
-        Perl_assert_aTHX; assert(s)
+    STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_CALLCONV U8 *
 Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
@@ -9121,7 +9381,7 @@ Perl_uvuni_to_utf8(pTHX_ U8 *d, UV uv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__deprecated__;
 # define PERL_ARGS_ASSERT_UVUNI_TO_UTF8         \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 # if defined(PERL_IN_MATHOMS_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_PERLY_C)   || defined(PERL_IN_TOKE_C)
@@ -9129,7 +9389,7 @@ PERL_CALLCONV OP *
 Perl_ref(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_REF                 \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # endif
 #endif /* !defined(NO_MATHOMS) */
@@ -9139,7 +9399,7 @@ Perl_sv_setsv_cow(pTHX_ SV *dsv, SV *ssv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_SETSV_COW          \
-        Perl_assert_aTHX; assert(ssv)
+     STMT_START { Perl_assert_aTHX; assert(ssv); } STMT_END
 
 #endif
 #if defined(PERL_CORE)
@@ -9149,7 +9409,7 @@ Perl_mg_propagate(pTHX_ SV *ssv, SV *dsv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MG_PROPAGATE          \
-        Perl_assert_aTHX; assert(ssv)
+     STMT_START { Perl_assert_aTHX; assert(ssv); } STMT_END
 
 PERL_CALLCONV void
 Perl_mg_unpropagate(pTHX_ SV *sv)
@@ -9157,7 +9417,7 @@ Perl_mg_unpropagate(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MG_UNPROPAGATE        \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV void
 Perl_opslab_force_free(pTHX_ OPSLAB *slab)
@@ -9165,7 +9425,7 @@ Perl_opslab_force_free(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FORCE_FREE     \
-        Perl_assert_aTHX; assert(slab)
+     STMT_START { Perl_assert_aTHX; assert(slab); } STMT_END
 
 PERL_CALLCONV void
 Perl_opslab_free(pTHX_ OPSLAB *slab)
@@ -9173,7 +9433,7 @@ Perl_opslab_free(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE           \
-        Perl_assert_aTHX; assert(slab)
+     STMT_START { Perl_assert_aTHX; assert(slab); } STMT_END
 
 PERL_CALLCONV void
 Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
@@ -9181,7 +9441,7 @@ Perl_opslab_free_nopad(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OPSLAB_FREE_NOPAD     \
-        Perl_assert_aTHX; assert(slab)
+     STMT_START { Perl_assert_aTHX; assert(slab); } STMT_END
 
 PERL_CALLCONV void
 Perl_parser_free_nexttoke_ops(pTHX_ yy_parser *parser, OPSLAB *slab)
@@ -9190,7 +9450,7 @@ Perl_parser_free_nexttoke_ops(pTHX_ yy_parser *parser, OPSLAB *slab)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PARSER_FREE_NEXTTOKE_OPS \
-        Perl_assert_aTHX; assert(parser); assert(slab)
+     STMT_START { Perl_assert_aTHX; assert(parser); assert(slab); } STMT_END
 
 PERL_CALLCONV bool
 Perl_sv_has_valuemagic(pTHX_ const SV *sv)
@@ -9198,7 +9458,7 @@ Perl_sv_has_valuemagic(pTHX_ const SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_HAS_VALUEMAGIC     \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 # if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV void
@@ -9206,14 +9466,14 @@ Perl_Slab_to_ro(pTHX_ OPSLAB *slab)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RO          \
-        Perl_assert_aTHX; assert(slab)
+       STMT_START { Perl_assert_aTHX; assert(slab); } STMT_END
 
 PERL_CALLCONV void
 Perl_Slab_to_rw(pTHX_ OPSLAB * const slab)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SLAB_TO_RW          \
-        Perl_assert_aTHX; assert(slab)
+       STMT_START { Perl_assert_aTHX; assert(slab); } STMT_END
 
 # endif /* defined(PERL_DEBUG_READONLY_OPS) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -9222,7 +9482,7 @@ S_should_warn_nl(const char *pv)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_SHOULD_WARN_NL      \
-        assert(pv)
+     STMT_START { assert(pv); } STMT_END
 
 # endif
 #endif /* defined(PERL_CORE) */
@@ -9240,7 +9500,9 @@ Perl_isSCRIPT_RUN(pTHX_ const U8 *s, const U8 *send, const bool utf8_target)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISSCRIPT_RUN          \
-        Perl_assert_aTHX; assert(s); assert(send); assert(s <= send)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(send);  \
+                  assert(s <= send);                          \
+    } STMT_END
 
 # if !defined(HAS_MEMRCHR)
 
@@ -9301,14 +9563,14 @@ Perl_finalize_optree(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OPTREE       \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_optimize_optree(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OPTREE       \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 #endif /* defined(PERL_CORE) || defined(PERL_USE_VOLATILE_API) */
 #if defined(PERL_DEBUG_READONLY_COW)
@@ -9318,22 +9580,22 @@ Perl_sv_buf_to_ro(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_BUF_TO_RO          \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
-#endif /* defined(PERL_DEBUG_READONLY_COW) */
+#endif
 #if defined(PERL_DEBUG_READONLY_OPS)
 PERL_CALLCONV PADOFFSET
 Perl_op_refcnt_dec(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_OP_REFCNT_DEC         \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_op_refcnt_inc(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_OP_REFCNT_INC         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(PERL_DEBUG_READONLY_OPS) */
 #if defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION)
@@ -9343,18 +9605,18 @@ Perl_do_exec(pTHX_ const char *cmd)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
-        Perl_assert_aTHX; assert(cmd)
+     STMT_START { Perl_assert_aTHX; assert(cmd); } STMT_END
 
-#else /* if !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
+#else
 PERL_CALLCONV bool
 Perl_do_exec(pTHX_ const char *cmd)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC               \
-        Perl_assert_aTHX; assert(cmd)
+     STMT_START { Perl_assert_aTHX; assert(cmd); } STMT_END
 
-#endif /* !defined(PERL_DEFAULT_DO_EXEC3_IMPLEMENTATION) */
+#endif
 #if defined(PERL_IMPLICIT_SYS)
 PERL_CALLCONV PerlInterpreter *
 perl_alloc_using(const struct IPerlMem **ipM, const struct IPerlMem **ipMS, const struct IPerlMem **ipMP, const struct IPerlEnv **ipE, const struct IPerlStdIO **ipStd, const struct IPerlLIO **ipLIO, const struct IPerlDir **ipD, const struct IPerlSock **ipS, const struct IPerlProc **ipP)
@@ -9368,8 +9630,10 @@ perl_alloc_using(const struct IPerlMem **ipM, const struct IPerlMem **ipMS, cons
         Perl_attribute_nonnull(8)
         Perl_attribute_nonnull(9);
 # define PERL_ARGS_ASSERT_PERL_ALLOC_USING      \
-        assert(ipM); assert(ipMS); assert(ipMP); assert(ipE); assert(ipStd);  \
-        assert(ipLIO); assert(ipD); assert(ipS); assert(ipP)
+     STMT_START { assert(ipM); assert(ipMS); assert(ipMP); assert(ipE);    \
+                  assert(ipStd); assert(ipLIO); assert(ipD); assert(ipS);  \
+                  assert(ipP);                                             \
+    } STMT_END
 
 # if defined(USE_ITHREADS)
 PERL_CALLCONV PerlInterpreter *
@@ -9385,9 +9649,10 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags, const struct IPerlMem **
         Perl_attribute_nonnull(10)
         Perl_attribute_nonnull(11);
 #   define PERL_ARGS_ASSERT_PERL_CLONE_USING    \
-        assert(proto_perl); assert(ipM); assert(ipMS); assert(ipMP);  \
-        assert(ipE); assert(ipStd); assert(ipLIO); assert(ipD); assert(ipS);  \
-        assert(ipP)
+       STMT_START { assert(proto_perl); assert(ipM); assert(ipMS);            \
+                    assert(ipMP); assert(ipE); assert(ipStd); assert(ipLIO);  \
+                    assert(ipD); assert(ipS); assert(ipP);                    \
+    } STMT_END
 
 # endif /* defined(USE_ITHREADS) */
 #else /* if !defined(PERL_IMPLICIT_SYS) */
@@ -9395,7 +9660,7 @@ PERL_CALLCONV I32
 Perl_my_pclose(pTHX_ PerlIO *ptr)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_MY_PCLOSE             \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_my_popen(pTHX_ const char *cmd, const char *mode)
@@ -9403,7 +9668,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_MY_POPEN              \
-        Perl_assert_aTHX; assert(cmd); assert(mode)
+     STMT_START { Perl_assert_aTHX; assert(cmd); assert(mode); } STMT_END
 
 # if defined(USE_ITHREADS)
 
@@ -9413,7 +9678,7 @@ S_PerlEnv_putenv(pTHX_ char *str)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_PERLENV_PUTENV    \
-        Perl_assert_aTHX; assert(str)
+       STMT_START { Perl_assert_aTHX; assert(str); } STMT_END
 
 #   endif
 # endif /* defined(USE_ITHREADS) */
@@ -9424,7 +9689,9 @@ S_get_aux_mg(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GET_AUX_MG            \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+     STMT_START { Perl_assert_aTHX; assert(av);    \
+                  assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 #endif
 #if defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C)
@@ -9434,15 +9701,16 @@ Perl_XS_builtin_indexed(pTHX_ CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_XS_BUILTIN_INDEXED    \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_import_builtin_bundle(pTHX_ U16 ver)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_IMPORT_BUILTIN_BUNDLE \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(PERL_IN_BUILTIN_C) || defined(PERL_IN_OP_C) */
 #if defined(PERL_IN_CLASS_C)
@@ -9451,7 +9719,9 @@ S_class_cleanup_definition(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_CLEANUP_DEFINITION \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(stash);    \
+                  assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 #endif
 #if defined(PERL_IN_CLASS_C) || defined(PERL_IN_GLOBALS_C) || \
@@ -9463,7 +9733,7 @@ Perl_ck_aassign(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_AASSIGN            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_anoncode(pTHX_ OP *o)
@@ -9472,7 +9742,7 @@ Perl_ck_anoncode(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ANONCODE           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_anonhash(pTHX_ OP *o)
@@ -9481,7 +9751,7 @@ Perl_ck_anonhash(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ANONHASH           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_backtick(pTHX_ OP *o)
@@ -9490,7 +9760,7 @@ Perl_ck_backtick(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_BACKTICK           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_bitop(pTHX_ OP *o)
@@ -9499,7 +9769,7 @@ Perl_ck_bitop(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_BITOP              \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_caller(pTHX_ OP *o)
@@ -9508,7 +9778,7 @@ Perl_ck_caller(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CALLER             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_classname(pTHX_ OP *o)
@@ -9517,7 +9787,7 @@ Perl_ck_classname(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CLASSNAME          \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_cmp(pTHX_ OP *o)
@@ -9526,7 +9796,7 @@ Perl_ck_cmp(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CMP                \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_concat(pTHX_ OP *o)
@@ -9535,7 +9805,7 @@ Perl_ck_concat(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_CONCAT             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_defined(pTHX_ OP *o)
@@ -9544,7 +9814,7 @@ Perl_ck_defined(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_DEFINED            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_delete(pTHX_ OP *o)
@@ -9553,7 +9823,7 @@ Perl_ck_delete(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_DELETE             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_each(pTHX_ OP *o)
@@ -9562,7 +9832,7 @@ Perl_ck_each(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EACH               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_eof(pTHX_ OP *o)
@@ -9571,7 +9841,7 @@ Perl_ck_eof(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EOF                \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_eval(pTHX_ OP *o)
@@ -9580,7 +9850,7 @@ Perl_ck_eval(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EVAL               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_exec(pTHX_ OP *o)
@@ -9589,7 +9859,7 @@ Perl_ck_exec(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EXEC               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_exists(pTHX_ OP *o)
@@ -9598,7 +9868,7 @@ Perl_ck_exists(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_EXISTS             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_ftst(pTHX_ OP *o)
@@ -9607,7 +9877,7 @@ Perl_ck_ftst(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_FTST               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_fun(pTHX_ OP *o)
@@ -9616,7 +9886,7 @@ Perl_ck_fun(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_FUN                \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_glob(pTHX_ OP *o)
@@ -9625,7 +9895,7 @@ Perl_ck_glob(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_GLOB               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_grep(pTHX_ OP *o)
@@ -9634,7 +9904,7 @@ Perl_ck_grep(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_GREP               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_helemexistsor(pTHX_ OP *o)
@@ -9643,7 +9913,7 @@ Perl_ck_helemexistsor(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_HELEMEXISTSOR      \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_index(pTHX_ OP *o)
@@ -9652,7 +9922,7 @@ Perl_ck_index(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_INDEX              \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_isa(pTHX_ OP *o)
@@ -9661,7 +9931,7 @@ Perl_ck_isa(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_ISA                \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_join(pTHX_ OP *o)
@@ -9670,7 +9940,7 @@ Perl_ck_join(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_JOIN               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_length(pTHX_ OP *o)
@@ -9679,7 +9949,7 @@ Perl_ck_length(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LENGTH             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_lfun(pTHX_ OP *o)
@@ -9688,7 +9958,7 @@ Perl_ck_lfun(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LFUN               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_listiob(pTHX_ OP *o)
@@ -9697,7 +9967,7 @@ Perl_ck_listiob(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_LISTIOB            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_match(pTHX_ OP *o)
@@ -9706,7 +9976,7 @@ Perl_ck_match(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_MATCH              \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_method(pTHX_ OP *o)
@@ -9715,7 +9985,7 @@ Perl_ck_method(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_METHOD             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_null(pTHX_ OP *o)
@@ -9724,7 +9994,7 @@ Perl_ck_null(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_NULL               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_open(pTHX_ OP *o)
@@ -9733,7 +10003,7 @@ Perl_ck_open(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_OPEN               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_prototype(pTHX_ OP *o)
@@ -9742,7 +10012,7 @@ Perl_ck_prototype(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_PROTOTYPE          \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_readline(pTHX_ OP *o)
@@ -9751,7 +10021,7 @@ Perl_ck_readline(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_READLINE           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_refassign(pTHX_ OP *o)
@@ -9760,7 +10030,7 @@ Perl_ck_refassign(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REFASSIGN          \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_repeat(pTHX_ OP *o)
@@ -9769,7 +10039,7 @@ Perl_ck_repeat(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REPEAT             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_require(pTHX_ OP *o)
@@ -9778,7 +10048,7 @@ Perl_ck_require(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_REQUIRE            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_return(pTHX_ OP *o)
@@ -9787,7 +10057,7 @@ Perl_ck_return(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RETURN             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_rfun(pTHX_ OP *o)
@@ -9796,7 +10066,7 @@ Perl_ck_rfun(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RFUN               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_rvconst(pTHX_ OP *o)
@@ -9805,7 +10075,7 @@ Perl_ck_rvconst(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_RVCONST            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_sassign(pTHX_ OP *o)
@@ -9814,7 +10084,7 @@ Perl_ck_sassign(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SASSIGN            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_scmp(pTHX_ OP *o)
@@ -9823,7 +10093,7 @@ Perl_ck_scmp(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SCMP               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_select(pTHX_ OP *o)
@@ -9832,7 +10102,7 @@ Perl_ck_select(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SELECT             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_shift(pTHX_ OP *o)
@@ -9841,7 +10111,7 @@ Perl_ck_shift(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SHIFT              \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_smartmatch(pTHX_ OP *o)
@@ -9850,7 +10120,7 @@ Perl_ck_smartmatch(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SMARTMATCH         \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_sort(pTHX_ OP *o)
@@ -9859,7 +10129,7 @@ Perl_ck_sort(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SORT               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_spair(pTHX_ OP *o)
@@ -9868,7 +10138,7 @@ Perl_ck_spair(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SPAIR              \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_split(pTHX_ OP *o)
@@ -9877,7 +10147,7 @@ Perl_ck_split(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SPLIT              \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_stringify(pTHX_ OP *o)
@@ -9886,7 +10156,7 @@ Perl_ck_stringify(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_STRINGIFY          \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_subr(pTHX_ OP *o)
@@ -9895,7 +10165,7 @@ Perl_ck_subr(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SUBR               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_substr(pTHX_ OP *o)
@@ -9904,7 +10174,7 @@ Perl_ck_substr(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SUBSTR             \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_svconst(pTHX_ OP *o)
@@ -9913,7 +10183,7 @@ Perl_ck_svconst(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_SVCONST            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_tell(pTHX_ OP *o)
@@ -9922,7 +10192,7 @@ Perl_ck_tell(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TELL               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_trunc(pTHX_ OP *o)
@@ -9931,7 +10201,7 @@ Perl_ck_trunc(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TRUNC              \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_ck_trycatch(pTHX_ OP *o)
@@ -9940,7 +10210,7 @@ Perl_ck_trycatch(pTHX_ OP *o)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CK_TRYCATCH           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 #endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_GLOBALS_C) ||
           defined(PERL_IN_OP_C)    || defined(PERL_IN_PEEP_C) */
@@ -9953,8 +10223,10 @@ Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_ADJUST      \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
-        assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(stash);                           \
+                  assert(SvTYPE(stash) == SVt_PVHV); assert(cv);             \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
@@ -9962,51 +10234,58 @@ Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_FIELD       \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
-        assert(pn)
+     STMT_START { Perl_assert_aTHX; assert(stash);                \
+                  assert(SvTYPE(stash) == SVt_PVHV); assert(pn);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_class_apply_attributes(pTHX_ HV *stash, OP *attrlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_ATTRIBUTES \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(stash);    \
+                  assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_class_apply_field_attributes(pTHX_ PADNAME *pn, OP *attrlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_APPLY_FIELD_ATTRIBUTES \
-        Perl_assert_aTHX; assert(pn)
+     STMT_START { Perl_assert_aTHX; assert(pn); } STMT_END
 
 PERL_CALLCONV void
 Perl_class_declare_padvars(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_DECLARE_PADVARS \
-        Perl_assert_aTHX; assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_class_prepare_initfield_parse(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_INITFIELD_PARSE \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_class_prepare_method_parse(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_METHOD_PARSE \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_class_seal_stash(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SEAL_STASH      \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(stash);    \
+                  assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
@@ -10014,27 +10293,29 @@ Perl_class_set_field_defop(pTHX_ PADNAME *pn, OPCODE defmode, OP *defop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CLASS_SET_FIELD_DEFOP \
-        Perl_assert_aTHX; assert(pn); assert(defop)
+     STMT_START { Perl_assert_aTHX; assert(pn); assert(defop); } STMT_END
 
 PERL_CALLCONV void
 Perl_class_setup_stash(pTHX_ HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_SETUP_STASH     \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(stash);    \
+                  assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV OP *
 Perl_class_wrap_method_body(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_CLASS_WRAP_METHOD_BODY \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_croak_kw_unless_class(pTHX_ const char *kw)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CROAK_KW_UNLESS_CLASS \
-        Perl_assert_aTHX; assert(kw)
+     STMT_START { Perl_assert_aTHX; assert(kw); } STMT_END
 
 #endif /* defined(PERL_IN_CLASS_C) || defined(PERL_IN_OP_C)    ||
           defined(PERL_IN_PAD_C)   || defined(PERL_IN_PERLY_C) ||
@@ -10045,7 +10326,7 @@ S_deb_stack_n(pTHX_ SV **stack_base, SSize_t stack_min, SSize_t stack_max, SSize
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DEB_STACK_N           \
-        Perl_assert_aTHX; assert(stack_base)
+     STMT_START { Perl_assert_aTHX; assert(stack_base); } STMT_END
 
 #endif
 #if defined(PERL_IN_DOIO_C)
@@ -10055,20 +10336,20 @@ S_argvout_final(pTHX_ MAGIC *mg, IO *io, bool is_explicit)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_ARGVOUT_FINAL         \
-        Perl_assert_aTHX; assert(mg); assert(io)
+     STMT_START { Perl_assert_aTHX; assert(mg); assert(io); } STMT_END
 
 static void
 S_exec_failed(pTHX_ const char *cmd, int fd, int do_report)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_EXEC_FAILED           \
-        Perl_assert_aTHX; assert(cmd)
+     STMT_START { Perl_assert_aTHX; assert(cmd); } STMT_END
 
 static bool
 S_is_fork_open(const char *name)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_IS_FORK_OPEN          \
-        assert(name)
+     STMT_START { assert(name); } STMT_END
 
 static bool
 S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname, PerlIO *saveifp, PerlIO *saveofp, int savefd, char savetype, int writing, bool was_fdopen, const char *type, Stat_t *statbufp)
@@ -10078,8 +10359,9 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_OPENN_CLEANUP         \
-        Perl_assert_aTHX; assert(gv); assert(io); assert(mode);  \
-        assert(oname)
+     STMT_START { Perl_assert_aTHX; assert(gv); assert(io); assert(mode);  \
+                  assert(oname);                                           \
+    } STMT_END
 
 static IO *
 S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int *savefd, char *savetype)
@@ -10091,8 +10373,10 @@ S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int 
         Perl_attribute_nonnull(pTHX_5)
         Perl_attribute_nonnull(pTHX_6);
 # define PERL_ARGS_ASSERT_OPENN_SETUP           \
-        Perl_assert_aTHX; assert(gv); assert(mode); assert(saveifp);  \
-        assert(saveofp); assert(savefd); assert(savetype)
+     STMT_START { Perl_assert_aTHX; assert(gv); assert(mode);        \
+                  assert(saveifp); assert(saveofp); assert(savefd);  \
+                  assert(savetype);                                  \
+    } STMT_END
 
 # if !defined(DOSISH)
 static bool
@@ -10100,7 +10384,7 @@ S_ingroup(pTHX_ Gid_t testgid, bool effective)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_INGROUP             \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 # endif
 #endif /* defined(PERL_IN_DOIO_C) */
@@ -10112,7 +10396,7 @@ S_do_trans_complex(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COMPLEX      \
-        Perl_assert_aTHX; assert(sv); assert(tbl)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(tbl); } STMT_END
 
 static Size_t
 S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
@@ -10121,7 +10405,7 @@ S_do_trans_count(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT        \
-        Perl_assert_aTHX; assert(sv); assert(tbl)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(tbl); } STMT_END
 
 static Size_t
 S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
@@ -10130,8 +10414,9 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP \
-        Perl_assert_aTHX; assert(sv); assert(invmap);  \
-        assert(SvTYPE(invmap) == SVt_PVAV)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(invmap);  \
+                  assert(SvTYPE(invmap) == SVt_PVAV);            \
+    } STMT_END
 
 static Size_t
 S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
@@ -10140,8 +10425,9 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_INVMAP       \
-        Perl_assert_aTHX; assert(sv); assert(invmap);  \
-        assert(SvTYPE(invmap) == SVt_PVAV)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(invmap);  \
+                  assert(SvTYPE(invmap) == SVt_PVAV);            \
+    } STMT_END
 
 static Size_t
 S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
@@ -10150,7 +10436,7 @@ S_do_trans_simple(pTHX_ SV * const sv, const OPtrans_map * const tbl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_SIMPLE       \
-        Perl_assert_aTHX; assert(sv); assert(tbl)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(tbl); } STMT_END
 
 #endif /* defined(PERL_IN_DOOP_C) */
 #if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
@@ -10163,7 +10449,7 @@ Perl_invlist_search_(SV * const invlist, const UV cp)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_INVLIST_SEARCH_       \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #endif /* defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        ||
           defined(PERL_IN_PP_C)      || defined(PERL_IN_REGCOMP_ANY) ||
@@ -10180,7 +10466,7 @@ Perl_add_range_to_invlist_(pTHX_ SV *invlist, UV start, UV end)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ADD_RANGE_TO_INVLIST_ \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **i)
@@ -10188,14 +10474,14 @@ Perl_invlist_intersection_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_INVLIST_INTERSECTION_MAYBE_COMPLEMENT_2ND_ \
-        Perl_assert_aTHX; assert(b); assert(i)
+     STMT_START { Perl_assert_aTHX; assert(b); assert(i); } STMT_END
 
 PERL_CALLCONV void
 Perl_invlist_invert_(pTHX_ SV * const invlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INVLIST_INVERT_       \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 PERL_CALLCONV void
 Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const bool complement_b, SV **output)
@@ -10203,14 +10489,14 @@ Perl_invlist_union_maybe_complement_2nd_(pTHX_ SV * const a, SV * const b, const
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_INVLIST_UNION_MAYBE_COMPLEMENT_2ND_ \
-        Perl_assert_aTHX; assert(b); assert(output)
+     STMT_START { Perl_assert_aTHX; assert(b); assert(output); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_new_invlist_(pTHX_ IV initial_size)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_INVLIST_          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0, UV **other_elements_ptr)
@@ -10218,7 +10504,7 @@ Perl_setup_canned_invlist_(pTHX_ const STRLEN size, const UV element0, UV **othe
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SETUP_CANNED_INVLIST_ \
-        Perl_assert_aTHX; assert(other_elements_ptr)
+     STMT_START { Perl_assert_aTHX; assert(other_elements_ptr); } STMT_END
 
 #endif /* defined(PERL_IN_DOOP_C)      || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_UTF8_C) */
@@ -10231,8 +10517,9 @@ Perl_form_alien_digit_msg(pTHX_ const U8 which, const STRLEN valids_len, const c
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FORM_ALIEN_DIGIT_MSG  \
-        Perl_assert_aTHX; assert(first_bad); assert(send);  \
-        assert(first_bad < send)
+     STMT_START { Perl_assert_aTHX; assert(first_bad); assert(send);  \
+                  assert(first_bad < send);                           \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_grok_bslash_c(pTHX_ const char source, U8 *result, const char **message, U32 *packed_warn)
@@ -10241,7 +10528,8 @@ Perl_grok_bslash_c(pTHX_ const char source, U8 *result, const char **message, U3
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GROK_BSLASH_C         \
-        Perl_assert_aTHX; assert(result); assert(message)
+     STMT_START { Perl_assert_aTHX; assert(result); assert(message);  \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv, const char **message, U32 *packed_warn, const bool strict, const bool allow_UV_MAX, const bool utf8)
@@ -10252,8 +10540,9 @@ Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv, const char *
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GROK_BSLASH_O         \
-        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv);  \
-        assert(message); assert(*s < send)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(*s); assert(send);  \
+                  assert(uv); assert(message); assert(*s < send);         \
+    } STMT_END
 
 PERL_CALLCONV bool
 Perl_grok_bslash_x(pTHX_ char **s, const char * const send, UV *uv, const char **message, U32 *packed_warn, const bool strict, const bool allow_UV_MAX, const bool utf8)
@@ -10264,8 +10553,9 @@ Perl_grok_bslash_x(pTHX_ char **s, const char * const send, UV *uv, const char *
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GROK_BSLASH_X         \
-        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv);  \
-        assert(message); assert(*s < send)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(*s); assert(send);  \
+                  assert(uv); assert(message); assert(*s < send);         \
+    } STMT_END
 
 #endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) ||
           defined(PERL_IN_TOKE_C) */
@@ -10276,7 +10566,7 @@ Perl_form_cp_too_large_msg(pTHX_ const U8 which, const char *string, const Size_
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FORM_CP_TOO_LARGE_MSG \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif
 #if defined(PERL_IN_DUMP_C)
@@ -10284,21 +10574,21 @@ static CV *
 S_deb_curcv(pTHX_ I32 ix)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DEB_CURCV             \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_debprof(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DEBPROF               \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static SV *
 S_pm_description(pTHX_ const PMOP *pm)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PM_DESCRIPTION        \
-        Perl_assert_aTHX; assert(pm)
+     STMT_START { Perl_assert_aTHX; assert(pm); } STMT_END
 
 static char *
 S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim, I32 pretty_flags)
@@ -10306,13 +10596,13 @@ S_pv_display_flags(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PV_DISPLAY_FLAGS      \
-        Perl_assert_aTHX; assert(dsv); assert(pv)
+     STMT_START { Perl_assert_aTHX; assert(dsv); assert(pv); } STMT_END
 
 static UV
 S_sequence_num(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SEQUENCE_NUM          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(PERL_IN_DUMP_C) */
 #if defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) || \
@@ -10323,10 +10613,11 @@ Perl_hv_kill_backrefs(pTHX_ HV *hv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HV_KILL_BACKREFS      \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(hv);    \
+                  assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
-#endif /* defined(PERL_IN_DUMP_C)  || defined(PERL_IN_HV_C) ||
-          defined(PERL_IN_SCOPE_C) || defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) || \
     defined(PERL_IN_REGCOMP_ANY)
 PERL_CALLCONV void
@@ -10336,7 +10627,9 @@ Perl_invlist_dump_(pTHX_ PerlIO *file, I32 level, const char * const indent, SV 
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_INVLIST_DUMP_         \
-        Perl_assert_aTHX; assert(file); assert(indent); assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(file); assert(indent);  \
+                  assert(invlist);                                 \
+    } STMT_END
 
 #endif /* defined(PERL_IN_DUMP_C) || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_REGCOMP_ANY) */
@@ -10347,21 +10640,21 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len, const U32 i
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_DEFAULT_STASH    \
-        Perl_assert_aTHX; assert(stash); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(stash); assert(name); } STMT_END
 
 static void
 S_gv_init_svtype(pTHX_ GV *gv, const svtype sv_type)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_INIT_SVTYPE        \
-        Perl_assert_aTHX; assert(gv)
+     STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 static bool
 S_gv_is_in_main(pTHX_ const char *name, STRLEN len, const U32 is_utf8)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_IS_IN_MAIN         \
-        Perl_assert_aTHX; assert(name)
+     STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 static bool
 S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svtype sv_type)
@@ -10370,15 +10663,16 @@ S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svt
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE         \
-        Perl_assert_aTHX; assert(gv); assert(stash);  \
-        assert(SvTYPE(stash) == SVt_PVHV); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(gv); assert(stash);      \
+                  assert(SvTYPE(stash) == SVt_PVHV); assert(name);  \
+    } STMT_END
 
 static void
 S_gv_magicalize_isa(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE_ISA     \
-        Perl_assert_aTHX; assert(gv)
+     STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 static void
 S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
@@ -10386,7 +10680,7 @@ S_maybe_multimagic_gv(pTHX_ GV *gv, const char *name, const svtype sv_type)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_MAYBE_MULTIMAGIC_GV   \
-        Perl_assert_aTHX; assert(gv); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(gv); assert(name); } STMT_END
 
 static bool
 S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len, const char *nambeg, STRLEN full_len, const U32 is_utf8, const I32 add)
@@ -10397,8 +10691,10 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME   \
-        Perl_assert_aTHX; assert(stash); assert(gv); assert(name);  \
-        assert(*name); assert(len); assert(nambeg); assert(nambeg <= *name)
+     STMT_START { Perl_assert_aTHX; assert(stash); assert(gv); assert(name);  \
+                  assert(*name); assert(len); assert(nambeg);                 \
+                  assert(nambeg <= *name);                                    \
+    } STMT_END
 
 static void
 S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len, const U32 flags)
@@ -10406,21 +10702,23 @@ S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_REQUIRE_TIE_MOD       \
-        Perl_assert_aTHX; assert(gv); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(gv); assert(name); } STMT_END
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE GV *
 S_gv_fetchmeth_internal(pTHX_ HV *stash, SV *meth, const char *name, STRLEN len, I32 level, U32 flags)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_GV_FETCHMETH_INTERNAL \
-        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX;                             \
+                  assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE HV *
 S_gv_stashpvn_internal(pTHX_ const char *name, U32 namelen, I32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_GV_STASHPVN_INTERNAL \
-        Perl_assert_aTHX; assert(name)
+     STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_GV_C) */
@@ -10433,13 +10731,13 @@ Perl_sv_add_backref(pTHX_ SV * const tsv, SV * const sv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_ADD_BACKREF        \
-        Perl_assert_aTHX; assert(tsv); assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(tsv); assert(sv); } STMT_END
 
 #endif /* defined(PERL_IN_GV_C)  || defined(PERL_IN_OP_C) ||
           defined(PERL_IN_PAD_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_GV_C) || defined(PERL_IN_UNIVERSAL_C)
 # define PERL_ARGS_ASSERT_GV_STASHSVPVN_CACHED  \
-        Perl_assert_aTHX; assert(namesv || name)
+     STMT_START { Perl_assert_aTHX; assert(namesv || name); } STMT_END
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV HV *
@@ -10454,41 +10752,50 @@ S_clear_placeholders(pTHX_ HV *hv, U32 items)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_PLACEHOLDERS    \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(hv);    \
+                  assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 static void
 S_hsplit(pTHX_ HV *hv, STRLEN const oldsize, STRLEN newsize)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HSPLIT                \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(hv);    \
+                  assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 static struct xpvhv_aux *
 S_hv_auxinit(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_AUXINIT            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(hv);    \
+                  assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 static SV *
 S_hv_delete_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen, int k_flags, I32 d_flags, U32 hash)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_HV_DELETE_COMMON      \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 static SV *
 S_hv_free_ent_ret(pTHX_ HE *entry)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENT_RET       \
-        Perl_assert_aTHX; assert(entry)
+     STMT_START { Perl_assert_aTHX; assert(entry); } STMT_END
 
 static void
 S_hv_free_entries(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_HV_FREE_ENTRIES       \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(hv);    \
+                  assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 static void
 S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
@@ -10496,8 +10803,9 @@ S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 # define PERL_ARGS_ASSERT_HV_MAGIC_CHECK        \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(needs_copy);  \
-        assert(needs_store)
+     STMT_START { assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
+                  assert(needs_copy); assert(needs_store);     \
+    } STMT_END
 
 PERL_STATIC_NO_RET void
 S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
@@ -10506,14 +10814,14 @@ S_hv_notallowed(pTHX_ int flags, const char *key, I32 klen, const char *msg)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_HV_NOTALLOWED         \
-        Perl_assert_aTHX; assert(key); assert(msg)
+     STMT_START { Perl_assert_aTHX; assert(key); assert(msg); } STMT_END
 
 static SV *
 S_refcounted_he_value(pTHX_ const struct refcounted_he *he)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_REFCOUNTED_HE_VALUE   \
-        Perl_assert_aTHX; assert(he)
+     STMT_START { Perl_assert_aTHX; assert(he); } STMT_END
 
 static HEK *
 S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
@@ -10521,7 +10829,7 @@ S_save_hek_flags(const char *str, I32 len, U32 hash, int flags)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVE_HEK_FLAGS        \
-        assert(str)
+     STMT_START { assert(str); } STMT_END
 
 static HEK *
 S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
@@ -10529,13 +10837,13 @@ S_share_hek_flags(pTHX_ const char *str, STRLEN len, U32 hash, int flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SHARE_HEK_FLAGS       \
-        Perl_assert_aTHX; assert(str)
+     STMT_START { Perl_assert_aTHX; assert(str); } STMT_END
 
 static void
 S_unshare_hek_or_pvn(pTHX_ const HEK *hek, const char *str, I32 len, U32 hash)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_UNSHARE_HEK_OR_PVN    \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # if !defined(PURIFY)
 static HE *
@@ -10543,7 +10851,7 @@ S_new_he(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_NEW_HE              \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 # endif
 #endif /* defined(PERL_IN_HV_C) */
@@ -10554,10 +10862,9 @@ Perl_sv_kill_backrefs(pTHX_ SV * const sv, AV * const av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_KILL_BACKREFS      \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
-#endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_MG_C) ||
-          defined(PERL_IN_SV_C) */
+#endif
 #if defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV SV *
 Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
@@ -10566,8 +10873,9 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HFREE_NEXT_ENTRY      \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(indexp)
+     STMT_START { Perl_assert_aTHX; assert(hv);                    \
+                  assert(SvTYPE(hv) == SVt_PVHV); assert(indexp);  \
+    } STMT_END
 
 #endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_LOCALE_C)
@@ -10575,7 +10883,7 @@ static utf8ness_t
 S_get_locale_string_utf8ness_i(pTHX_ const char *string, const locale_utf8ness_t known_utf8, const char *locale, const locale_category_index cat_index)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_GET_LOCALE_STRING_UTF8NESS_I \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_ints_to_tm(pTHX_ struct tm *mytm, const char *locale, int sec, int min, int hour, int mday, int mon, int year, int isdst)
@@ -10583,20 +10891,20 @@ S_ints_to_tm(pTHX_ struct tm *mytm, const char *locale, int sec, int min, int ho
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INTS_TO_TM            \
-        Perl_assert_aTHX; assert(mytm); assert(locale)
+     STMT_START { Perl_assert_aTHX; assert(mytm); assert(locale); } STMT_END
 
 static bool
 S_is_locale_utf8(pTHX_ const char *locale)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_LOCALE_UTF8        \
-        Perl_assert_aTHX; assert(locale)
+     STMT_START { Perl_assert_aTHX; assert(locale); } STMT_END
 
 static HV *
 S_my_localeconv(pTHX_ const int item)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_MY_LOCALECONV         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 which_mask, const lconv_offset_t *strings[2], const lconv_offset_t *integers[2])
@@ -10606,8 +10914,10 @@ S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 wh
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(locale); assert(strings); assert(integers)
+     STMT_START { Perl_assert_aTHX; assert(hv);                    \
+                  assert(SvTYPE(hv) == SVt_PVHV); assert(locale);  \
+                  assert(strings); assert(integers);               \
+    } STMT_END
 
 static bool
 S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm, const utf8ness_t fmt_utf8ness, utf8ness_t *result_utf8ness, const bool called_externally)
@@ -10618,8 +10928,9 @@ S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 # define PERL_ARGS_ASSERT_STRFTIME8             \
-        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale);  \
-        assert(mytm); assert(result_utf8ness)
+     STMT_START { Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale);  \
+                  assert(mytm); assert(result_utf8ness);                      \
+    } STMT_END
 
 static bool
 S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm)
@@ -10630,8 +10941,9 @@ S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm
         Perl_attribute_nonnull(pTHX_4)
         __attribute__format__(__strftime__,pTHX_1,0);
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
-        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale);  \
-        assert(mytm)
+     STMT_START { Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale);  \
+                  assert(mytm);                                               \
+    } STMT_END
 
 static SV *
 S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
@@ -10640,7 +10952,9 @@ S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SV_STRFTIME_COMMON    \
-        Perl_assert_aTHX; assert(fmt); assert(locale); assert(mytm)
+     STMT_START { Perl_assert_aTHX; assert(fmt); assert(locale);  \
+                  assert(mytm);                                   \
+    } STMT_END
 
 # if defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO)
 static const char *
@@ -10649,48 +10963,48 @@ S_emulate_langinfo(pTHX_ const PERL_INTMAX_T item, const char *locale, SV *sv, u
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #   define PERL_ARGS_ASSERT_EMULATE_LANGINFO    \
-        Perl_assert_aTHX; assert(locale); assert(sv)
+       STMT_START { Perl_assert_aTHX; assert(locale); assert(sv); } STMT_END
 
-# endif /* defined(HAS_MISSING_LANGINFO_ITEM_) || !defined(HAS_NL_LANGINFO) */
+# endif
 # if defined(USE_LOCALE)
 static const char *
 S_calculate_LC_ALL_string(pTHX_ const char **category_locales_list, const calc_LC_ALL_format format, const calc_LC_ALL_return returning, const line_t caller_line)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_CALCULATE_LC_ALL_STRING \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 static const char *
 S_external_call_langinfo(pTHX_ const nl_item item, SV *sv, utf8ness_t *utf8ness)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_EXTERNAL_CALL_LANGINFO \
-        Perl_assert_aTHX; assert(sv)
+       STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static locale_category_index
 S_get_category_index_helper(pTHX_ const int category, bool *success, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_GET_CATEGORY_INDEX_HELPER \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 static const char *
 S_native_querylocale_i(pTHX_ const locale_category_index cat_index)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_NATIVE_QUERYLOCALE_I \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_new_LC_ALL(pTHX_ const char *lc_all, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_NEW_LC_ALL          \
-        Perl_assert_aTHX; assert(lc_all)
+       STMT_START { Perl_assert_aTHX; assert(lc_all); } STMT_END
 
 static void
 S_output_check_environment_warning(pTHX_ const char * const language, const char * const lc_all, const char * const lang)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_OUTPUT_CHECK_ENVIRONMENT_WARNING \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 static parse_LC_ALL_string_return
 S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse_LC_ALL_STRING_action, bool always_use_full_array, const bool panic_on_error, const line_t caller_line)
@@ -10698,25 +11012,26 @@ S_parse_LC_ALL_string(pTHX_ const char *string, const char **output, const parse
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_PARSE_LC_ALL_STRING \
-        Perl_assert_aTHX; assert(string); assert(output)
+       STMT_START { Perl_assert_aTHX; assert(string); assert(output);  \
+    } STMT_END
 
 static void
 S_restore_toggled_locale_i(pTHX_ const locale_category_index cat_index, const char *original_locale, const line_t caller_line)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_RESTORE_TOGGLED_LOCALE_I \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 static const char *
 S_save_to_buffer(pTHX_ const char *string, char **buf, Size_t *buf_size)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_SAVE_TO_BUFFER      \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_set_save_buffer_min_size(pTHX_ const Size_t min_len, char **buf, Size_t *buf_size)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_SET_SAVE_BUFFER_MIN_SIZE \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_NO_RET void
 S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, const char *current, const char *failed, const line_t proxy_caller_line, const line_t immediate_caller_line, const char *higher_caller_file, const line_t higher_caller_line)
@@ -10725,14 +11040,16 @@ S_setlocale_failure_panic_via_i(pTHX_ const locale_category_index cat_index, con
         Perl_attribute_nonnull(pTHX_6)
         __attribute__noreturn__;
 #   define PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_VIA_I \
-        Perl_assert_aTHX; assert(failed); assert(higher_caller_file)
+       STMT_START { Perl_assert_aTHX; assert(failed);      \
+                    assert(higher_caller_file);            \
+    } STMT_END
 
 static const char *
 S_toggle_locale_i(pTHX_ const locale_category_index cat_index, const char *new_locale, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOGGLE_LOCALE_I     \
-        Perl_assert_aTHX; assert(new_locale)
+       STMT_START { Perl_assert_aTHX; assert(new_locale); } STMT_END
 
 #   if defined(DEBUGGING)
 static char *
@@ -10740,7 +11057,7 @@ S_my_setlocale_debug_string_i(pTHX_ const locale_category_index cat_index, const
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MY_SETLOCALE_DEBUG_STRING_I \
-        Perl_assert_aTHX
+         STMT_START { Perl_assert_aTHX; } STMT_END
 
 #   endif
 #   if   defined(HAS_LOCALECONV) && \
@@ -10753,8 +11070,10 @@ S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 whic
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #     define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
-        assert(locale); assert(strings); assert(integers)
+         STMT_START { Perl_assert_aTHX; assert(hv);                    \
+                      assert(SvTYPE(hv) == SVt_PVHV); assert(locale);  \
+                      assert(strings); assert(integers);               \
+    } STMT_END
 
 #   endif /*   defined(HAS_LOCALECONV) &&
              ( defined(USE_LOCALE_MONETARY) ||
@@ -10766,16 +11085,17 @@ S_langinfo_sv_i(pTHX_ const nl_item item, locale_category_index cat_index, const
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #     define PERL_ARGS_ASSERT_LANGINFO_SV_I     \
-        Perl_assert_aTHX; assert(locale); assert(sv)
+         STMT_START { Perl_assert_aTHX; assert(locale); assert(sv);  \
+    } STMT_END
 
-#   endif /* defined(HAS_NL_LANGINFO) */
+#   endif
 #   if defined(LC_ALL)
 static void
 S_give_perl_locale_control(pTHX_ const char *lc_all_string, const line_t caller_line)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
-        Perl_assert_aTHX; assert(lc_all_string)
+         STMT_START { Perl_assert_aTHX; assert(lc_all_string); } STMT_END
 
 #   else
 static void
@@ -10783,7 +11103,7 @@ S_give_perl_locale_control(pTHX_ const char **curlocales, const line_t caller_li
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_GIVE_PERL_LOCALE_CONTROL \
-        Perl_assert_aTHX; assert(curlocales)
+         STMT_START { Perl_assert_aTHX; assert(curlocales); } STMT_END
 
 #   endif
 #   if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -10792,7 +11112,7 @@ S_mortalized_pv_copy(pTHX_ const char * const pv)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #     define PERL_ARGS_ASSERT_MORTALIZED_PV_COPY \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 #   endif
 #   if defined(USE_LOCALE_COLLATE)
@@ -10801,7 +11121,7 @@ S_new_collate(pTHX_ const char *newcoll, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_COLLATE       \
-        Perl_assert_aTHX; assert(newcoll)
+         STMT_START { Perl_assert_aTHX; assert(newcoll); } STMT_END
 
 #     if defined(DEBUGGING)
 static void
@@ -10810,23 +11130,25 @@ S_print_collxfrm_input_and_return(pTHX_ const char *s, const char *e, const char
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #       define PERL_ARGS_ASSERT_PRINT_COLLXFRM_INPUT_AND_RETURN \
-        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e)
+           STMT_START { Perl_assert_aTHX; assert(s); assert(e);  \
+                        assert(s <= e);                          \
+    } STMT_END
 
-#     endif /* defined(DEBUGGING) */
+#     endif
 #   endif /* defined(USE_LOCALE_COLLATE) */
 #   if defined(USE_LOCALE_CTYPE)
 static bool
 S_is_codeset_name_UTF8(const char *name)
         Perl_attribute_nonnull(1);
 #     define PERL_ARGS_ASSERT_IS_CODESET_NAME_UTF8 \
-        assert(name)
+         STMT_START { assert(name); } STMT_END
 
 static void
 S_new_ctype(pTHX_ const char *newctype, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_CTYPE         \
-        Perl_assert_aTHX; assert(newctype)
+         STMT_START { Perl_assert_aTHX; assert(newctype); } STMT_END
 
 #   endif /* defined(USE_LOCALE_CTYPE) */
 #   if defined(USE_LOCALE_NUMERIC)
@@ -10835,7 +11157,7 @@ S_new_numeric(pTHX_ const char *newnum, bool force)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_NEW_NUMERIC       \
-        Perl_assert_aTHX; assert(newnum)
+         STMT_START { Perl_assert_aTHX; assert(newnum); } STMT_END
 
 #   endif
 #   if defined(USE_PERL_SWITCH_LOCALE_CONTEXT) || defined(DEBUGGING)
@@ -10843,7 +11165,7 @@ static const char *
 S_get_LC_ALL_display(pTHX)
         Perl_attribute_nonnull_aTHX;
 #     define PERL_ARGS_ASSERT_GET_LC_ALL_DISPLAY \
-        Perl_assert_aTHX
+         STMT_START { Perl_assert_aTHX; } STMT_END
 
 #   endif
 #   if defined(USE_POSIX_2008_LOCALE)
@@ -10852,13 +11174,13 @@ S_bool_setlocale_2008_i(pTHX_ const locale_category_index index, const char *new
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_BOOL_SETLOCALE_2008_I \
-        Perl_assert_aTHX; assert(new_locale)
+         STMT_START { Perl_assert_aTHX; assert(new_locale); } STMT_END
 
 static locale_t
 S_use_curlocale_scratch(pTHX)
         Perl_attribute_nonnull_aTHX;
 #     define PERL_ARGS_ASSERT_USE_CURLOCALE_SCRATCH \
-        Perl_assert_aTHX
+         STMT_START { Perl_assert_aTHX; } STMT_END
 
 #     if defined(HAS_GETLOCALENAME_L)
 static const char *
@@ -10870,7 +11192,7 @@ static const char *
 S_querylocale_2008_i(pTHX_ const locale_category_index index, const line_t line)
         Perl_attribute_nonnull_aTHX;
 #       define PERL_ARGS_ASSERT_QUERYLOCALE_2008_I \
-        Perl_assert_aTHX
+           STMT_START { Perl_assert_aTHX; } STMT_END
 
 #     endif
 #     if !defined(USE_QUERYLOCALE)
@@ -10879,7 +11201,7 @@ S_update_PL_curlocales_i(pTHX_ const locale_category_index index, const char *ne
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #       define PERL_ARGS_ASSERT_UPDATE_PL_CURLOCALES_I \
-        Perl_assert_aTHX; assert(new_locale)
+           STMT_START { Perl_assert_aTHX; assert(new_locale); } STMT_END
 
 #     endif
 #   elif  defined(USE_LOCALE_THREADS) &&                  \
@@ -10891,13 +11213,13 @@ S_less_dicey_bool_setlocale_r(pTHX_ const int cat, const char *locale)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_LESS_DICEY_BOOL_SETLOCALE_R \
-        Perl_assert_aTHX; assert(locale)
+         STMT_START { Perl_assert_aTHX; assert(locale); } STMT_END
 
 static const char *
 S_less_dicey_setlocale_r(pTHX_ const int category, const char *locale)
         Perl_attribute_nonnull_aTHX;
 #     define PERL_ARGS_ASSERT_LESS_DICEY_SETLOCALE_R \
-        Perl_assert_aTHX
+         STMT_START { Perl_assert_aTHX; } STMT_END
 
 #   endif /*  defined(USE_LOCALE_THREADS) &&
              !defined(USE_POSIX_2008_LOCALE) &&
@@ -10916,13 +11238,13 @@ static const char *
 S_win32_setlocale(pTHX_ int category, const char *locale)
         Perl_attribute_nonnull_aTHX;
 #     define PERL_ARGS_ASSERT_WIN32_SETLOCALE   \
-        Perl_assert_aTHX
+         STMT_START { Perl_assert_aTHX; } STMT_END
 
 static const char *
 S_wrap_wsetlocale(pTHX_ const int category, const char *locale)
         Perl_attribute_nonnull_aTHX;
 #     define PERL_ARGS_ASSERT_WRAP_WSETLOCALE   \
-        Perl_assert_aTHX
+         STMT_START { Perl_assert_aTHX; } STMT_END
 
 #   endif /* defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) */
 #   if   defined(WIN32) || defined(WIN32_USE_FAKE_OLD_MINGW_LOCALES) || \
@@ -10931,7 +11253,7 @@ static const char *
 S_find_locale_from_environment(pTHX_ const locale_category_index index)
         Perl_attribute_nonnull_aTHX;
 #     define PERL_ARGS_ASSERT_FIND_LOCALE_FROM_ENVIRONMENT \
-        Perl_assert_aTHX
+         STMT_START { Perl_assert_aTHX; } STMT_END
 
 #   endif
 # endif /* defined(USE_LOCALE) */
@@ -10942,16 +11264,17 @@ S_get_displayable_string(pTHX_ const char * const s, const char * const e, const
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_STRING \
-        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e)
+       STMT_START { Perl_assert_aTHX; assert(s); assert(e); assert(s <= e);  \
+    } STMT_END
 
-# endif /* defined(USE_LOCALE) || defined(DEBUGGING) */
+# endif
 #endif /* defined(PERL_IN_LOCALE_C) */
 #if defined(PERL_IN_MALLOC_C)
 static int
 S_adjust_size_and_find_bucket(size_t *nbytes_p)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_ADJUST_SIZE_AND_FIND_BUCKET \
-        assert(nbytes_p)
+     STMT_START { assert(nbytes_p); } STMT_END
 
 #endif
 #if defined(PERL_IN_MATHOMS_C) || defined(PERL_IN_OP_C) || \
@@ -10964,7 +11287,7 @@ S_fixup_errno_string(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FIXUP_ERRNO_STRING    \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static SV *
 S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV *val)
@@ -10973,7 +11296,8 @@ S_magic_methcall1(pTHX_ SV *sv, const MAGIC *mg, SV *meth, U32 flags, int n, SV 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MAGIC_METHCALL1       \
-        Perl_assert_aTHX; assert(sv); assert(mg); assert(meth)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); assert(meth);  \
+    } STMT_END
 
 static int
 S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
@@ -10982,26 +11306,27 @@ S_magic_methpack(pTHX_ SV *sv, const MAGIC *mg, SV *meth)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MAGIC_METHPACK        \
-        Perl_assert_aTHX; assert(sv); assert(mg); assert(meth)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); assert(meth);  \
+    } STMT_END
 
 static void
 S_restore_magic(pTHX_ void *p)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RESTORE_MAGIC         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_save_magic_flags(pTHX_ SSize_t mgs_ix, SV *sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_MAGIC_FLAGS      \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static void
 S_unwind_handler_stack(pTHX_ void *p)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_UNWIND_HANDLER_STACK  \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(PERL_IN_MG_C) */
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C)
@@ -11011,9 +11336,9 @@ Perl_translate_substr_offsets(STRLEN curlen, IV pos1_iv, bool pos1_is_uv, IV len
         Perl_attribute_nonnull(7)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_TRANSLATE_SUBSTR_OFFSETS \
-        assert(posp); assert(lenp)
+     STMT_START { assert(posp); assert(lenp); } STMT_END
 
-#endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_PP_C) */
+#endif
 #if defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C)
 PERL_CALLCONV void
 Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
@@ -11022,7 +11347,7 @@ Perl_mg_free_struct(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MG_FREE_STRUCT        \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV void
 Perl_mgv2_copy(pTHX_ const MAGIC *smg, MAGIC *dmg)
@@ -11031,7 +11356,7 @@ Perl_mgv2_copy(pTHX_ const MAGIC *smg, MAGIC *dmg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MGV2_COPY             \
-        Perl_assert_aTHX; assert(smg); assert(dmg)
+     STMT_START { Perl_assert_aTHX; assert(smg); assert(dmg); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_sv_magicv2_attach(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 flags)
@@ -11040,7 +11365,7 @@ Perl_sv_magicv2_attach(pTHX_ SV *sv, const struct MagicFunctions *funcs, U32 fla
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_SV_MAGICV2_ATTACH     \
-        Perl_assert_aTHX; assert(sv); assert(funcs)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(funcs); } STMT_END
 
 #endif /* defined(PERL_IN_MG_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_MRO_C)
@@ -11050,8 +11375,10 @@ S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN l
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_MRO_CLEAN_ISAREV      \
-        Perl_assert_aTHX; assert(isa); assert(SvTYPE(isa) == SVt_PVHV);  \
-        assert(name); assert(!exceptions || SvTYPE(exceptions) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(isa);                          \
+                  assert(SvTYPE(isa) == SVt_PVHV); assert(name);          \
+                  assert(!exceptions || SvTYPE(exceptions) == SVt_PVHV);  \
+    } STMT_END
 
 static void
 S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *stash, HV *oldstash, SV *namesv)
@@ -11060,18 +11387,22 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *s
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_MRO_GATHER_AND_RENAME \
-        Perl_assert_aTHX; assert(stashes);  \
-        assert(SvTYPE(stashes) == SVt_PVHV); assert(seen_stashes);  \
-        assert(SvTYPE(seen_stashes) == SVt_PVHV);  \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
-        assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(namesv)
+     STMT_START { Perl_assert_aTHX; assert(stashes);                          \
+                  assert(SvTYPE(stashes) == SVt_PVHV); assert(seen_stashes);  \
+                  assert(SvTYPE(seen_stashes) == SVt_PVHV);                   \
+                  assert(!stash || SvTYPE(stash) == SVt_PVHV);                \
+                  assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV);          \
+                  assert(namesv);                                             \
+    } STMT_END
 
 static AV *
 S_mro_get_linear_isa_dfs(pTHX_ HV *stash, U32 level)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MRO_GET_LINEAR_ISA_DFS \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(stash);    \
+                  assert(SvTYPE(stash) == SVt_PVHV);  \
+    } STMT_END
 
 #endif /* defined(PERL_IN_MRO_C) */
 #if defined(PERL_IN_OP_C)
@@ -11082,15 +11413,17 @@ S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **import_opsp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS_MY        \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
-        assert(target); assert(import_opsp)
+     STMT_START { Perl_assert_aTHX; assert(stash);                    \
+                  assert(SvTYPE(stash) == SVt_PVHV); assert(target);  \
+                  assert(import_opsp);                                \
+    } STMT_END
 
 static I32
 S_assignment_type(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ASSIGNMENT_TYPE       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
@@ -11099,7 +11432,8 @@ S_bad_type_gv(pTHX_ I32 n, GV *gv, const OP *kid, const char *t)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_BAD_TYPE_GV           \
-        Perl_assert_aTHX; assert(gv); assert(kid); assert(t)
+     STMT_START { Perl_assert_aTHX; assert(gv); assert(kid); assert(t);  \
+    } STMT_END
 
 static void
 S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
@@ -11108,14 +11442,15 @@ S_bad_type_pv(pTHX_ I32 n, const char *t, const OP *o, const OP *kid)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_BAD_TYPE_PV           \
-        Perl_assert_aTHX; assert(t); assert(o); assert(kid)
+     STMT_START { Perl_assert_aTHX; assert(t); assert(o); assert(kid);  \
+    } STMT_END
 
 static void
 S_check_alt_hash_fields_hekify(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CHECK_ALT_HASH_FIELDS_HEKIFY \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static CV *
 S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * const cv)
@@ -11124,62 +11459,63 @@ S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * co
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CLEAR_SPECIAL_BLOCKS  \
-        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv);  \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);    \
+    } STMT_END
 
 static void
 S_cop_free(pTHX_ COP *cop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_COP_FREE              \
-        Perl_assert_aTHX; assert(cop)
+     STMT_START { Perl_assert_aTHX; assert(cop); } STMT_END
 
 static OP *
 S_declare_var_attributes(pTHX_ OP *o, OP *attrs, OP **import_opsp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_DECLARE_VAR_ATTRIBUTES \
-        Perl_assert_aTHX; assert(import_opsp)
+     STMT_START { Perl_assert_aTHX; assert(import_opsp); } STMT_END
 
 static OP *
 S_dup_attrlist(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DUP_ATTRLIST          \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static void
 S_find_and_forget_pmops(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FIND_AND_FORGET_PMOPS \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static OP *
 S_fold_constants(pTHX_ OP * const o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FOLD_CONSTANTS        \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static OP *
 S_force_list(pTHX_ OP *arg, bool nullit)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_FORCE_LIST            \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_forget_pmop(pTHX_ PMOP * const o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORGET_PMOP           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static void
 S_gen_constant_list(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_GEN_CONSTANT_LIST     \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_import_attributes_module(pTHX_ HV *stash, SV *target, OP *attrs)
@@ -11187,47 +11523,48 @@ S_import_attributes_module(pTHX_ HV *stash, SV *target, OP *attrs)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_IMPORT_ATTRIBUTES_MODULE \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
-        assert(target)
+     STMT_START { Perl_assert_aTHX; assert(stash);                    \
+                  assert(SvTYPE(stash) == SVt_PVHV); assert(target);  \
+    } STMT_END
 
 static void
 S_inplace_aassign(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INPLACE_AASSIGN       \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static bool
 S_is_dup_mode(const OP *o)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_IS_DUP_MODE           \
-        assert(o)
+     STMT_START { assert(o); } STMT_END
 
 static bool
 S_is_handle_constructor(const OP *o, I32 numargs)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_HANDLE_CONSTRUCTOR \
-        assert(o)
+     STMT_START { assert(o); } STMT_END
 
 static OP *
 S_listkids(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_LISTKIDS              \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static bool
 S_looks_like_bool(pTHX_ const OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_LOOKS_LIKE_BOOL       \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static OP *
 S_modkids(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_MODKIDS               \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
@@ -11236,14 +11573,16 @@ S_move_proto_attr(pTHX_ OP **proto, OP **attrs, const GV *name, bool curstash)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_MOVE_PROTO_ATTR       \
-        Perl_assert_aTHX; assert(proto); assert(attrs); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(proto); assert(attrs);  \
+                  assert(name);                                    \
+    } STMT_END
 
 static OP *
 S_newGIVWHENOP(pTHX_ OP *cond, OP *block, I32 enter_opcode, I32 leave_opcode, PADOFFSET entertarg)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_NEWGIVWHENOP          \
-        Perl_assert_aTHX; assert(block)
+     STMT_START { Perl_assert_aTHX; assert(block); } STMT_END
 
 static OP *
 S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
@@ -11252,7 +11591,8 @@ S_new_logop(pTHX_ I32 type, I32 flags, OP **firstp, OP **otherp)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_LOGOP             \
-        Perl_assert_aTHX; assert(firstp); assert(otherp)
+     STMT_START { Perl_assert_aTHX; assert(firstp); assert(otherp);  \
+    } STMT_END
 
 static OP *
 S_no_fh_allowed(pTHX_ OP *o)
@@ -11260,7 +11600,7 @@ S_no_fh_allowed(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NO_FH_ALLOWED         \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static OP *
 S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
@@ -11269,7 +11609,8 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_PMTRANS               \
-        Perl_assert_aTHX; assert(o); assert(expr); assert(repl)
+     STMT_START { Perl_assert_aTHX; assert(o); assert(expr); assert(repl);  \
+    } STMT_END
 
 static bool
 S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * const gv, CV * const cv)
@@ -11278,20 +11619,21 @@ S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS \
-        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv);  \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);    \
+    } STMT_END
 
 static OP *
 S_ref_array_or_hash(pTHX_ OP *cond)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_REF_ARRAY_OR_HASH     \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static OP *
 S_refkids(pTHX_ OP *o, I32 type)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_REFKIDS               \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static bool
 S_scalar_mod_type(const OP *o, I32 type)
@@ -11303,13 +11645,13 @@ S_scalarboolean(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SCALARBOOLEAN         \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static OP *
 S_scalarkids(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SCALARKIDS            \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static OP *
 S_search_const(pTHX_ OP *o)
@@ -11317,14 +11659,14 @@ S_search_const(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SEARCH_CONST          \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static void
 S_simplify_sort(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SIMPLIFY_SORT         \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static OP *
 S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
@@ -11333,7 +11675,7 @@ S_too_few_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOO_FEW_ARGUMENTS_PV  \
-        Perl_assert_aTHX; assert(o); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(o); assert(name); } STMT_END
 
 static OP *
 S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
@@ -11341,13 +11683,13 @@ S_too_many_arguments_pv(pTHX_ OP *o, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_TOO_MANY_ARGUMENTS_PV \
-        Perl_assert_aTHX; assert(o); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(o); assert(name); } STMT_END
 
 static OP *
 S_voidnonfinal(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_VOIDNONFINAL          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # if defined(DEBUGGING)
 static const char *
@@ -11355,7 +11697,7 @@ S_get_displayable_tr_operand(pTHX_ const U8 *s, STRLEN len, bool is_utf8)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_GET_DISPLAYABLE_TR_OPERAND \
-        Perl_assert_aTHX; assert(s)
+       STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -11363,34 +11705,34 @@ PERL_STATIC_INLINE bool
 S_is_standard_filehandle_name(const char *fhname)
         Perl_attribute_nonnull(1);
 #   define PERL_ARGS_ASSERT_IS_STANDARD_FILEHANDLE_NAME \
-        assert(fhname)
+     STMT_START { assert(fhname); } STMT_END
 
 PERL_STATIC_INLINE OP *
 S_newMETHOP_internal(pTHX_ I32 type, I32 flags, OP *dynamic_meth, SV * const_meth)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_NEWMETHOP_INTERNAL  \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE OP *
 S_op_integerize(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_INTEGERIZE       \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_STATIC_INLINE OP *
 S_op_std_init(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_OP_STD_INIT         \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_STATIC_INLINE U16
 S_opslab_slot_offset(const OPSLAB *slab, const OPSLOT *slot)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 #   define PERL_ARGS_ASSERT_OPSLAB_SLOT_OFFSET  \
-        assert(slab); assert(slot)
+     STMT_START { assert(slab); assert(slot); } STMT_END
 
 PERL_STATIC_INLINE U16
 S_size_to_psize(size_t size);
@@ -11407,7 +11749,7 @@ Perl_check_hash_fields_and_hekify(pTHX_ UNOP *rop, SVOP *key_op, int real)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_CHECK_HASH_FIELDS_AND_HEKIFY \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_no_bareword_allowed(pTHX_ OP *o)
@@ -11415,14 +11757,14 @@ Perl_no_bareword_allowed(pTHX_ OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_NO_BAREWORD_ALLOWED   \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_op_prune_chain_head(OP **op_p)
         Perl_attribute_nonnull(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OP_PRUNE_CHAIN_HEAD   \
-        assert(op_p)
+     STMT_START { assert(op_p); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_op_varname(pTHX_ const OP *o)
@@ -11430,7 +11772,7 @@ Perl_op_varname(pTHX_ const OP *o)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_OP_VARNAME            \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 PERL_CALLCONV void
 Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is_slice)
@@ -11439,7 +11781,7 @@ Perl_warn_elem_scalar_context(pTHX_ const OP *o, SV *name, bool is_hash, bool is
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_WARN_ELEM_SCALAR_CONTEXT \
-        Perl_assert_aTHX; assert(o); assert(name)
+     STMT_START { Perl_assert_aTHX; assert(o); assert(name); } STMT_END
 
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
@@ -11453,7 +11795,7 @@ Perl_report_redefined_cv(pTHX_ const SV *name, const CV *old_cv, SV * const *new
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_REPORT_REDEFINED_CV   \
-        Perl_assert_aTHX; assert(name); assert(old_cv)
+     STMT_START { Perl_assert_aTHX; assert(name); assert(old_cv); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_varname(pTHX_ const GV * const gv, const char gvtype, PADOFFSET targ, const SV * const keyname, SSize_t aindex, int subscript_type)
@@ -11461,7 +11803,7 @@ Perl_varname(pTHX_ const GV * const gv, const char gvtype, PADOFFSET targ, const
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_VARNAME               \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_SV_C) */
 #if defined(PERL_IN_PAD_C)
@@ -11470,15 +11812,16 @@ S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_ALLOC_NAME        \
-        Perl_assert_aTHX; assert(name);  \
-        assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(name);                     \
+                  assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV);  \
+    } STMT_END
 
 static void
 S_pad_check_dup(pTHX_ PADNAME *name, U32 flags, const HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_CHECK_DUP         \
-        Perl_assert_aTHX; assert(name)
+     STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 static PADOFFSET
 S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv, U32 seq, int warn, SV **out_capture, PADNAME **out_name, int *out_flags)
@@ -11488,14 +11831,15 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv,
         Perl_attribute_nonnull(pTHX_8)
         Perl_attribute_nonnull(pTHX_9);
 # define PERL_ARGS_ASSERT_PAD_FINDLEX           \
-        Perl_assert_aTHX; assert(namepv); assert(cv); assert(out_name);  \
-        assert(out_flags)
+     STMT_START { Perl_assert_aTHX; assert(namepv); assert(cv);  \
+                  assert(out_name); assert(out_flags);           \
+    } STMT_END
 
 static void
 S_pad_reset(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PAD_RESET             \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # if defined(DEBUGGING)
 static void
@@ -11504,9 +11848,9 @@ S_cv_dump(pTHX_ const CV *cv, const char *title)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_CV_DUMP             \
-        Perl_assert_aTHX; assert(cv); assert(title)
+       STMT_START { Perl_assert_aTHX; assert(cv); assert(title); } STMT_END
 
-# endif /* defined(DEBUGGING) */
+# endif
 #endif /* defined(PERL_IN_PAD_C) */
 #if defined(PERL_IN_PEEP_C)
 static void
@@ -11514,14 +11858,14 @@ S_finalize_op(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FINALIZE_OP           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static void
 S_optimize_op(pTHX_ OP *o)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_OPTIMIZE_OP           \
-        Perl_assert_aTHX; assert(o)
+     STMT_START { Perl_assert_aTHX; assert(o); } STMT_END
 
 static OP *
 S_traverse_op_tree(pTHX_ OP *top, OP *o)
@@ -11529,7 +11873,7 @@ S_traverse_op_tree(pTHX_ OP *top, OP *o)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_TRAVERSE_OP_TREE      \
-        Perl_assert_aTHX; assert(top); assert(o)
+     STMT_START { Perl_assert_aTHX; assert(top); assert(o); } STMT_END
 
 #endif /* defined(PERL_IN_PEEP_C) */
 #if defined(PERL_IN_PERL_C)
@@ -11539,91 +11883,92 @@ S_find_beginning(pTHX_ SV *linestr_sv, PerlIO *rsfp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_BEGINNING        \
-        Perl_assert_aTHX; assert(linestr_sv); assert(rsfp)
+     STMT_START { Perl_assert_aTHX; assert(linestr_sv); assert(rsfp);  \
+    } STMT_END
 
 static void
 S_forbid_setid(pTHX_ const char flag, const bool suidscript)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_FORBID_SETID          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_incpush(pTHX_ const char * const dir, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH               \
-        Perl_assert_aTHX; assert(dir)
+     STMT_START { Perl_assert_aTHX; assert(dir); } STMT_END
 
 static void
 S_incpush_use_sep(pTHX_ const char *p, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INCPUSH_USE_SEP       \
-        Perl_assert_aTHX; assert(p)
+     STMT_START { Perl_assert_aTHX; assert(p); } STMT_END
 
 static void
 S_init_ids(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_INIT_IDS              \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_init_interp(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_INIT_INTERP           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_init_main_stash(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_INIT_MAIN_STASH       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_init_perllib(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_INIT_PERLLIB          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_init_postdump_symbols(pTHX_ int argc, char **argv, char **env)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INIT_POSTDUMP_SYMBOLS \
-        Perl_assert_aTHX; assert(argv)
+     STMT_START { Perl_assert_aTHX; assert(argv); } STMT_END
 
 static void
 S_init_predump_symbols(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_INIT_PREDUMP_SYMBOLS  \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static SV *
 S_mayberelocate(pTHX_ const char * const dir, STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MAYBERELOCATE         \
-        Perl_assert_aTHX; assert(dir)
+     STMT_START { Perl_assert_aTHX; assert(dir); } STMT_END
 
 PERL_STATIC_NO_RET void
 S_minus_v(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MINUS_V               \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_NO_RET void
 S_my_exit_jump(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MY_EXIT_JUMP          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_nuke_stacks(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_NUKE_STACKS           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static PerlIO *
 S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
@@ -11631,27 +11976,28 @@ S_open_script(pTHX_ const char *scriptname, bool dosearch, bool *suidscript)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_OPEN_SCRIPT           \
-        Perl_assert_aTHX; assert(scriptname); assert(suidscript)
+     STMT_START { Perl_assert_aTHX; assert(scriptname); assert(suidscript);  \
+    } STMT_END
 
 static void *
 S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PARSE_BODY            \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_NO_RET void
 S_run_body(pTHX_ I32 oldscope)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_RUN_BODY              \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_NO_RET void
 S_usage(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_USAGE                 \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # if !defined(PERL_IS_MINIPERL)
 static SV *
@@ -11661,8 +12007,10 @@ S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #   define PERL_ARGS_ASSERT_INCPUSH_IF_EXISTS   \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
-        assert(dir); assert(stem)
+       STMT_START { Perl_assert_aTHX; assert(av);                 \
+                    assert(SvTYPE(av) == SVt_PVAV); assert(dir);  \
+                    assert(stem);                                 \
+    } STMT_END
 
 # endif /* !defined(PERL_IS_MINIPERL) */
 # if !defined(SETUID_SCRIPTS_ARE_SECURE_NOW)
@@ -11671,7 +12019,7 @@ S_validate_suid(pTHX_ PerlIO *rsfp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_VALIDATE_SUID       \
-        Perl_assert_aTHX; assert(rsfp)
+       STMT_START { Perl_assert_aTHX; assert(rsfp); } STMT_END
 
 # endif
 #endif /* defined(PERL_IN_PERL_C) */
@@ -11683,7 +12031,7 @@ Perl_invlistEQ_(pTHX_ SV * const a, SV * const b, const bool complement_b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INVLISTEQ_            \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_new_invlist_C_array_(pTHX_ const UV * const list)
@@ -11691,7 +12039,7 @@ Perl_new_invlist_C_array_(pTHX_ const UV * const list)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_INVLIST_C_ARRAY_  \
-        Perl_assert_aTHX; assert(list)
+     STMT_START { Perl_assert_aTHX; assert(list); } STMT_END
 
 #endif /* defined(PERL_IN_PERL_C) || defined(PERL_IN_REGCOMP_ANY) ||
           defined(PERL_IN_UTF8_C) */
@@ -11702,13 +12050,13 @@ S_do_chomp(pTHX_ SV *retval, SV *sv, bool chomping)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_CHOMP              \
-        Perl_assert_aTHX; assert(retval); assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(retval); assert(sv); } STMT_END
 
 static OP *
 S_do_delete_local(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DO_DELETE_LOCAL       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static SV *
 S_refto(pTHX_ SV *sv)
@@ -11716,7 +12064,7 @@ S_refto(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REFTO                 \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 #endif /* defined(PERL_IN_PP_C) */
 #if defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C)
@@ -11728,7 +12076,7 @@ Perl_softref2xv(pTHX_ SV * const sv, const char * const what, const svtype type)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SOFTREF2XV            \
-        Perl_assert_aTHX; assert(sv); assert(what)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(what); } STMT_END
 
 #endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_PP_HOT_C) */
 #if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
@@ -11743,7 +12091,7 @@ Perl_to_upper_title_latin1_(pTHX_ const U8 c, U8 *p, STRLEN *lenp, const char S_
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_TO_UPPER_TITLE_LATIN1_ \
-        Perl_assert_aTHX; assert(p); assert(lenp)
+     STMT_START { Perl_assert_aTHX; assert(p); assert(lenp); } STMT_END
 
 #endif /* defined(PERL_IN_PP_C) || defined(PERL_IN_UTF8_C) */
 #if defined(PERL_IN_PP_CTL_C)
@@ -11753,37 +12101,39 @@ S_check_type_and_open(pTHX_ SV *name)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_TYPE_AND_OPEN   \
-        Perl_assert_aTHX; assert(name)
+     STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 static void
 S_destroy_matcher(pTHX_ PMOP *matcher)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DESTROY_MATCHER       \
-        Perl_assert_aTHX; assert(matcher)
+     STMT_START { Perl_assert_aTHX; assert(matcher); } STMT_END
 
 static OP *
 S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DO_SMARTMATCH         \
-        Perl_assert_aTHX;  \
-        assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV);  \
-        assert(!seen_other || SvTYPE(seen_other) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX;                                       \
+                  assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV);    \
+                  assert(!seen_other || SvTYPE(seen_other) == SVt_PVHV);  \
+    } STMT_END
 
 static OP *
 S_docatch(pTHX_ Perl_ppaddr_t firstpp)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOCATCH               \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static bool
 S_doeval_compile(pTHX_ U8 gimme, CV *outside, U32 seq, HV *hh)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DOEVAL_COMPILE        \
-        Perl_assert_aTHX;  \
-        assert(!outside || SvTYPE(outside) == SVt_PVCV || SvTYPE(outside) == SVt_PVFM);  \
-        assert(!hh || SvTYPE(hh) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX;                                                                \
+                  assert(!outside || SvTYPE(outside) == SVt_PVCV || SvTYPE(outside) == SVt_PVFM);  \
+                  assert(!hh || SvTYPE(hh) == SVt_PVHV);                                           \
+    } STMT_END
 
 static OP *
 S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstack, OP **oplimit)
@@ -11794,29 +12144,30 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
         Perl_attribute_nonnull(pTHX_6)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOFINDLABEL           \
-        Perl_assert_aTHX; assert(o); assert(label); assert(opstack);  \
-        assert(oplimit)
+     STMT_START { Perl_assert_aTHX; assert(o); assert(label);  \
+                  assert(opstack); assert(oplimit);            \
+    } STMT_END
 
 static MAGIC *
 S_doparseform(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DOPARSEFORM           \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static I32
 S_dopoptoeval(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOEVAL           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static I32
 S_dopoptogivenfor(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOGIVENFOR       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static I32
 S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
@@ -11824,14 +12175,14 @@ S_dopoptolabel(pTHX_ const char *label, STRLEN len, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLABEL          \
-        Perl_assert_aTHX; assert(label)
+     STMT_START { Perl_assert_aTHX; assert(label); } STMT_END
 
 static I32
 S_dopoptoloop(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOLOOP           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static I32
 S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
@@ -11839,14 +12190,14 @@ S_dopoptosub_at(pTHX_ const PERL_CONTEXT *cxstk, I32 startingblock)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOSUB_AT         \
-        Perl_assert_aTHX; assert(cxstk)
+     STMT_START { Perl_assert_aTHX; assert(cxstk); } STMT_END
 
 static I32
 S_dopoptowhen(pTHX_ I32 startingblock)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOPOPTOWHEN           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static PMOP *
 S_make_matcher(pTHX_ REGEXP *re)
@@ -11854,7 +12205,7 @@ S_make_matcher(pTHX_ REGEXP *re)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MAKE_MATCHER          \
-        Perl_assert_aTHX; assert(re)
+     STMT_START { Perl_assert_aTHX; assert(re); } STMT_END
 
 static bool
 S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
@@ -11863,7 +12214,7 @@ S_matcher_matches_sv(pTHX_ PMOP *matcher, SV *sv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MATCHER_MATCHES_SV    \
-        Perl_assert_aTHX; assert(matcher); assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(matcher); assert(sv); } STMT_END
 
 static bool
 S_num_overflow(NV value, I32 fldsize, I32 frcsize)
@@ -11876,14 +12227,14 @@ S_run_user_filter(pTHX_ int idx, SV *buf_sv, int maxlen)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_RUN_USER_FILTER       \
-        Perl_assert_aTHX; assert(buf_sv)
+     STMT_START { Perl_assert_aTHX; assert(buf_sv); } STMT_END
 
 static void
 S_rxres_free(pTHX_ void **rsp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RXRES_FREE            \
-        Perl_assert_aTHX; assert(rsp)
+     STMT_START { Perl_assert_aTHX; assert(rsp); } STMT_END
 
 static void
 S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
@@ -11891,15 +12242,16 @@ S_rxres_restore(pTHX_ void **rsp, REGEXP *rx)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RXRES_RESTORE         \
-        Perl_assert_aTHX; assert(rsp); assert(rx)
+     STMT_START { Perl_assert_aTHX; assert(rsp); assert(rx); } STMT_END
 
 static void
 S_save_lines(pTHX_ AV *array, SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_LINES            \
-        Perl_assert_aTHX; assert(!array || SvTYPE(array) == SVt_PVAV);  \
-        assert(sv)
+     STMT_START { Perl_assert_aTHX;                                         \
+                  assert(!array || SvTYPE(array) == SVt_PVAV); assert(sv);  \
+    } STMT_END
 
 # if !defined(PERL_DISABLE_PMC)
 static PerlIO *
@@ -11908,16 +12260,16 @@ S_doopen_pm(pTHX_ SV *name)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOOPEN_PM           \
-        Perl_assert_aTHX; assert(name)
+       STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
-# endif /* !defined(PERL_DISABLE_PMC) */
+# endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE bool
 S_path_is_searchable(const char *name)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_PATH_IS_SEARCHABLE  \
-        assert(name)
+     STMT_START { assert(name); } STMT_END
 
 # endif
 #endif /* defined(PERL_IN_PP_CTL_C) */
@@ -11927,7 +12279,7 @@ Perl_invoke_exception_hook(pTHX_ SV *ex, bool warn)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_INVOKE_EXCEPTION_HOOK \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif
 #if defined(PERL_IN_PP_HOT_C)
@@ -11937,7 +12289,8 @@ S_do_oddball(pTHX_ SV **oddkey, SV **firstkey)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DO_ODDBALL            \
-        Perl_assert_aTHX; assert(oddkey); assert(firstkey)
+     STMT_START { Perl_assert_aTHX; assert(oddkey); assert(firstkey);  \
+    } STMT_END
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE HV *
@@ -11945,7 +12298,7 @@ S_opmethod_stash(pTHX_ SV *meth)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_OPMETHOD_STASH      \
-        Perl_assert_aTHX; assert(meth)
+     STMT_START { Perl_assert_aTHX; assert(meth); } STMT_END
 
 PERL_STATIC_FORCE_INLINE bool
 S_should_we_output_Debug_r(pTHX_ regexp *prog)
@@ -11954,7 +12307,7 @@ S_should_we_output_Debug_r(pTHX_ regexp *prog)
         __attribute__warn_unused_result__
         __attribute__always_inline__;
 #   define PERL_ARGS_ASSERT_SHOULD_WE_OUTPUT_DEBUG_R \
-        Perl_assert_aTHX; assert(prog)
+     STMT_START { Perl_assert_aTHX; assert(prog); } STMT_END
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_PP_HOT_C) */
@@ -11965,14 +12318,15 @@ S_div128(pTHX_ SV *pnum, bool *done)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DIV128                \
-        Perl_assert_aTHX; assert(pnum); assert(done)
+     STMT_START { Perl_assert_aTHX; assert(pnum); assert(done); } STMT_END
 
 static char
 S_first_symbol(const char *pat, const char *patend)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 # define PERL_ARGS_ASSERT_FIRST_SYMBOL          \
-        assert(pat); assert(patend); assert(pat <= patend)
+     STMT_START { assert(pat); assert(patend); assert(pat <= patend);  \
+    } STMT_END
 
 static const char *
 S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
@@ -11981,7 +12335,8 @@ S_get_num(pTHX_ const char *patptr, SSize_t *lenptr)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_NUM               \
-        Perl_assert_aTHX; assert(patptr); assert(lenptr)
+     STMT_START { Perl_assert_aTHX; assert(patptr); assert(lenptr);  \
+    } STMT_END
 
 static const char *
 S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
@@ -11989,8 +12344,9 @@ S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GROUP_END             \
-        Perl_assert_aTHX; assert(patptr); assert(patend);  \
-        assert(patptr <= patend)
+     STMT_START { Perl_assert_aTHX; assert(patptr); assert(patend);  \
+                  assert(patptr <= patend);                          \
+    } STMT_END
 
 static SV *
 S_is_an_int(pTHX_ const char *s, STRLEN l)
@@ -11998,21 +12354,21 @@ S_is_an_int(pTHX_ const char *s, STRLEN l)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_AN_INT             \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static SSize_t
 S_measure_struct(pTHX_ struct tempsym *symptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MEASURE_STRUCT        \
-        Perl_assert_aTHX; assert(symptr)
+     STMT_START { Perl_assert_aTHX; assert(symptr); } STMT_END
 
 static SV *
 S_mul128(pTHX_ SV *sv, U8 m)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_MUL128                \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static char *
 S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swap)
@@ -12020,21 +12376,22 @@ S_my_bytes_to_utf8(const U8 *start, STRLEN len, char *dest, const bool needs_swa
         Perl_attribute_nonnull(3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MY_BYTES_TO_UTF8      \
-        assert(start); assert(dest)
+     STMT_START { assert(start); assert(dest); } STMT_END
 
 static bool
 S_need_utf8(const char *pat, const char *patend)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 # define PERL_ARGS_ASSERT_NEED_UTF8             \
-        assert(pat); assert(patend); assert(pat <= patend)
+     STMT_START { assert(pat); assert(patend); assert(pat <= patend);  \
+    } STMT_END
 
 static bool
 S_next_symbol(pTHX_ struct tempsym *symptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_NEXT_SYMBOL           \
-        Perl_assert_aTHX; assert(symptr)
+     STMT_START { Perl_assert_aTHX; assert(symptr); } STMT_END
 
 static SV **
 S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
@@ -12044,8 +12401,9 @@ S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PACK_REC              \
-        Perl_assert_aTHX; assert(cat); assert(symptr); assert(beglist);  \
-        assert(endlist)
+     STMT_START { Perl_assert_aTHX; assert(cat); assert(symptr);  \
+                  assert(beglist); assert(endlist);               \
+    } STMT_END
 
 static char *
 S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
@@ -12053,7 +12411,7 @@ S_sv_exp_grow(pTHX_ SV *sv, STRLEN needed)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_EXP_GROW           \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static SSize_t
 S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, const char *strend, const char **new_s)
@@ -12063,8 +12421,10 @@ S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, co
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_UNPACK_REC            \
-        Perl_assert_aTHX; assert(symptr); assert(s); assert(strbeg);  \
-        assert(strend); assert(strbeg <= s); assert(s <= strend)
+     STMT_START { Perl_assert_aTHX; assert(symptr); assert(s);          \
+                  assert(strbeg); assert(strend); assert(strbeg <= s);  \
+                  assert(s <= strend);                                  \
+    } STMT_END
 
 #endif /* defined(PERL_IN_PP_PACK_C) */
 #if defined(PERL_IN_PP_SORT_C)
@@ -12075,7 +12435,7 @@ S_sortcv(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV                \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 static I32
 S_sortcv_stacked(pTHX_ SV * const a, SV * const b)
@@ -12083,7 +12443,7 @@ S_sortcv_stacked(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_STACKED        \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 static I32
 S_sortcv_xsub(pTHX_ SV * const a, SV * const b)
@@ -12091,7 +12451,7 @@ S_sortcv_xsub(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SORTCV_XSUB           \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 PERL_STATIC_INLINE I32
@@ -12100,7 +12460,7 @@ S_amagic_cmp(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP          \
-        Perl_assert_aTHX; assert(str1); assert(str2)
+     STMT_START { Perl_assert_aTHX; assert(str1); assert(str2); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2)
@@ -12108,7 +12468,7 @@ S_amagic_cmp_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_CMP_DESC     \
-        Perl_assert_aTHX; assert(str1); assert(str2)
+     STMT_START { Perl_assert_aTHX; assert(str1); assert(str2); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b)
@@ -12116,7 +12476,7 @@ S_amagic_i_ncmp(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP       \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -12124,7 +12484,7 @@ S_amagic_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_I_NCMP_DESC  \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_amagic_ncmp(pTHX_ SV * const a, SV * const b)
@@ -12132,7 +12492,7 @@ S_amagic_ncmp(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP         \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -12140,7 +12500,7 @@ S_amagic_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_AMAGIC_NCMP_DESC    \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_cmp_desc(pTHX_ SV * const str1, SV * const str2)
@@ -12148,7 +12508,7 @@ S_cmp_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_CMP_DESC            \
-        Perl_assert_aTHX; assert(str1); assert(str2)
+     STMT_START { Perl_assert_aTHX; assert(str1); assert(str2); } STMT_END
 
 PERL_STATIC_FORCE_INLINE void
 S_sortsv_flags_impl(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flags)
@@ -12156,7 +12516,7 @@ S_sortsv_flags_impl(pTHX_ SV **array, size_t num_elts, SVCOMPARE_t cmp, U32 flag
         Perl_attribute_nonnull(pTHX_3)
         __attribute__always_inline__;
 #   define PERL_ARGS_ASSERT_SORTSV_FLAGS_IMPL   \
-        Perl_assert_aTHX; assert(cmp)
+     STMT_START { Perl_assert_aTHX; assert(cmp); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_sv_i_ncmp(pTHX_ SV * const a, SV * const b)
@@ -12164,7 +12524,7 @@ S_sv_i_ncmp(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP           \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -12172,7 +12532,7 @@ S_sv_i_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_I_NCMP_DESC      \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_sv_ncmp(pTHX_ SV *a, SV *b)
@@ -12180,7 +12540,7 @@ S_sv_ncmp(pTHX_ SV *a, SV *b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP             \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b)
@@ -12188,7 +12548,7 @@ S_sv_ncmp_desc(pTHX_ SV * const a, SV * const b)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_NCMP_DESC        \
-        Perl_assert_aTHX; assert(a); assert(b)
+     STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 #   if defined(USE_LOCALE_COLLATE)
 PERL_STATIC_INLINE I32
@@ -12197,7 +12557,7 @@ S_amagic_cmp_locale(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE \
-        Perl_assert_aTHX; assert(str1); assert(str2)
+       STMT_START { Perl_assert_aTHX; assert(str1); assert(str2); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
@@ -12205,7 +12565,7 @@ S_amagic_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_AMAGIC_CMP_LOCALE_DESC \
-        Perl_assert_aTHX; assert(str1); assert(str2)
+       STMT_START { Perl_assert_aTHX; assert(str1); assert(str2); } STMT_END
 
 PERL_STATIC_INLINE I32
 S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
@@ -12213,7 +12573,7 @@ S_cmp_locale_desc(pTHX_ SV * const str1, SV * const str2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #     define PERL_ARGS_ASSERT_CMP_LOCALE_DESC   \
-        Perl_assert_aTHX; assert(str1); assert(str2)
+       STMT_START { Perl_assert_aTHX; assert(str1); assert(str2); } STMT_END
 
 #   endif /* defined(USE_LOCALE_COLLATE) */
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
@@ -12228,21 +12588,23 @@ S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DOFORM                \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(gv)
+     STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+                  assert(gv);                                                \
+    } STMT_END
 
 static SV *
 S_space_join_names_mortal(pTHX_ char * const *array)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SPACE_JOIN_NAMES_MORTAL \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_warn_not_dirhandle(pTHX_ GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_NOT_DIRHANDLE    \
-        Perl_assert_aTHX; assert(gv)
+     STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 # if !defined(HAS_MKDIR) || !defined(HAS_RMDIR)
 static int
@@ -12252,49 +12614,60 @@ S_dooneliner(pTHX_ const char *cmd, const char *filename)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOONELINER          \
-        Perl_assert_aTHX; assert(cmd); assert(filename)
+       STMT_START { Perl_assert_aTHX; assert(cmd); assert(filename);  \
+    } STMT_END
 
 # endif /* !defined(HAS_MKDIR) || !defined(HAS_RMDIR) */
 #endif /* defined(PERL_IN_PP_SYS_C) */
 #if defined(PERL_IN_REGCOMP_ANY)
 # define PERL_ARGS_ASSERT_ADD_ABOVE_LATIN1_FOLDS \
-        Perl_assert_aTHX; assert(pRExC_state); assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(invlist);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_CONSTRUCT_AHOCORASICK_FROM_TRIE \
-        Perl_assert_aTHX; assert(pRExC_state); assert(source)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(source);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_GET_ANYOFHBBM_CONTENTS \
-        Perl_assert_aTHX; assert(n)
+     STMT_START { Perl_assert_aTHX; assert(n); } STMT_END
 
 # define PERL_ARGS_ASSERT_GET_ANYOFM_CONTENTS   \
-        Perl_assert_aTHX; assert(n)
+     STMT_START { Perl_assert_aTHX; assert(n); } STMT_END
 
 # define PERL_ARGS_ASSERT_JOIN_EXACT            \
-        Perl_assert_aTHX; assert(pRExC_state); assert(scan);  \
-        assert(min_subtract); assert(unfolded_multi_char)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(scan);  \
+                  assert(min_subtract); assert(unfolded_multi_char);    \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_MAKE_TRIE             \
-        Perl_assert_aTHX; assert(pRExC_state); assert(startbranch);  \
-        assert(first); assert(last); assert(tail)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(startbranch);  \
+                  assert(first); assert(last); assert(tail);                   \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_POPULATE_ANYOF_BITMAP_FROM_INVLIST \
-        Perl_assert_aTHX; assert(node); assert(invlist_ptr)
+     STMT_START { Perl_assert_aTHX; assert(node); assert(invlist_ptr);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REG_ADD_DATA          \
-        assert(pRExC_state); assert(s)
+     STMT_START { assert(pRExC_state); assert(s); } STMT_END
 
 # define PERL_ARGS_ASSERT_SCAN_COMMIT           \
-        Perl_assert_aTHX; assert(pRExC_state); assert(data); assert(minlenp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(data);  \
+                  assert(minlenp);                                      \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_SET_ANYOF_ARG         \
-        Perl_assert_aTHX; assert(pRExC_state); assert(node)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(node);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_INIT              \
-        Perl_assert_aTHX; assert(pRExC_state); assert(ssc)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(ssc);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_STUDY_CHUNK           \
-        Perl_assert_aTHX; assert(pRExC_state); assert(scanp);  \
-        assert(minlenp); assert(deltap); assert(last)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(scanp);  \
+                  assert(minlenp); assert(deltap); assert(last);         \
+    } STMT_END
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
@@ -12398,33 +12771,39 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharm
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DUMP_TRIE           \
-        Perl_assert_aTHX; assert(trie);  \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
-        assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
+       STMT_START { Perl_assert_aTHX; assert(trie);                           \
+                    assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
+                    assert(revcharmap);                                       \
+                    assert(SvTYPE(revcharmap) == SVt_PVAV);                   \
+    } STMT_END
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST \
-        Perl_assert_aTHX; assert(trie);  \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
-        assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
+       STMT_START { Perl_assert_aTHX; assert(trie);                           \
+                    assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
+                    assert(revcharmap);                                       \
+                    assert(SvTYPE(revcharmap) == SVt_PVAV);                   \
+    } STMT_END
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE \
-        Perl_assert_aTHX; assert(trie);  \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
-        assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
+       STMT_START { Perl_assert_aTHX; assert(trie);                           \
+                    assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
+                    assert(revcharmap);                                       \
+                    assert(SvTYPE(revcharmap) == SVt_PVAV);                   \
+    } STMT_END
 
 # endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_INVLIST_CONTENTS    \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_HIGHEST_RANGE_START \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_IS_ITERATING \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_LOWEST      \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE SV *
@@ -12453,77 +12832,91 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INVLIST_CLONE         \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 #endif
 #if defined(PERL_IN_REGCOMP_C)
 # define PERL_ARGS_ASSERT_ADD_MULTI_MATCH       \
-        Perl_assert_aTHX;  \
-        assert(!multi_char_matches || SvTYPE(multi_char_matches) == SVt_PVAV);  \
-        assert(multi_string)
+     STMT_START { Perl_assert_aTHX;                                                       \
+                  assert(!multi_char_matches || SvTYPE(multi_char_matches) == SVt_PVAV);  \
+                  assert(multi_string);                                                   \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_CHANGE_ENGINE_SIZE    \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_COMPILE_WILDCARD      \
-        Perl_assert_aTHX; assert(subpattern)
+     STMT_START { Perl_assert_aTHX; assert(subpattern); } STMT_END
 
 # define PERL_ARGS_ASSERT_COMPUTE_EXACTISH      \
-        assert(pRExC_state)
+     STMT_START { assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_EDIT_DISTANCE         \
-        assert(src); assert(tgt)
+     STMT_START { assert(src); assert(tgt); } STMT_END
 
 # define PERL_ARGS_ASSERT_EXECUTE_WILDCARD      \
-        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend);  \
-        assert(strbeg); assert(screamer); assert(strbeg <= stringarg);  \
-        assert(stringarg <= strend); assert(*strend == '\0')
+     STMT_START { Perl_assert_aTHX; assert(prog); assert(stringarg);         \
+                  assert(strend); assert(strbeg); assert(screamer);          \
+                  assert(strbeg <= stringarg); assert(stringarg <= strend);  \
+                  assert(*strend == '\0');                                   \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_GET_QUANTIFIER_VALUE  \
-        Perl_assert_aTHX; assert(pRExC_state); assert(start); assert(end);  \
-        assert(start < end)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(start);  \
+                  assert(end); assert(start < end);                      \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_N         \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_HANDLE_NAMED_BACKREF  \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
-        assert(backref_parse_start)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+                  assert(backref_parse_start);                           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_HANDLE_NAMES_WILDCARD \
-        Perl_assert_aTHX; assert(wname); assert(prop_definition);  \
-        assert(strings)
+     STMT_START { Perl_assert_aTHX; assert(wname); assert(prop_definition);  \
+                  assert(strings);                                           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_HANDLE_POSSIBLE_POSIX \
-        Perl_assert_aTHX; assert(pRExC_state); assert(s)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(s);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_HANDLE_REGEX_SETS     \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_HANDLE_USER_DEFINED_PROPERTY \
-        Perl_assert_aTHX; assert(name); assert(contents);  \
-        assert(user_defined_ptr); assert(msg)
+     STMT_START { Perl_assert_aTHX; assert(name); assert(contents);  \
+                  assert(user_defined_ptr); assert(msg);             \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_IS_SSC_WORTH_IT       \
-        assert(pRExC_state); assert(ssc)
+     STMT_START { assert(pRExC_state); assert(ssc); } STMT_END
 
 # define PERL_ARGS_ASSERT_NEXTCHAR              \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_OPTIMIZE_REGCLASS     \
-        Perl_assert_aTHX; assert(pRExC_state); assert(anyof_flags);  \
-        assert(invert); assert(ret); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(anyof_flags);  \
+                  assert(invert); assert(ret); assert(flagp);                  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_OUTPUT_POSIX_WARNINGS \
-        Perl_assert_aTHX; assert(pRExC_state); assert(posix_warnings);  \
-        assert(SvTYPE(posix_warnings) == SVt_PVAV)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state);       \
+                  assert(posix_warnings);                      \
+                  assert(SvTYPE(posix_warnings) == SVt_PVAV);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_PARSE_LPAREN_QUESTION_FLAGS \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_PARSE_UNIPROP_STRING  \
-        Perl_assert_aTHX; assert(name); assert(user_defined_ptr);  \
-        assert(msg)
+     STMT_START { Perl_assert_aTHX; assert(name); assert(user_defined_ptr);  \
+                  assert(msg);                                               \
+    } STMT_END
 
 PERL_STATIC_NO_RET void
 S_re_croak(pTHX_ bool utf8, const char *pat, ...)
@@ -12532,81 +12925,96 @@ S_re_croak(pTHX_ bool utf8, const char *pat, ...)
         __attribute__noreturn__
         __attribute__format__(__printf__,pTHX_2,pTHX_3);
 # define PERL_ARGS_ASSERT_RE_CROAK              \
-        Perl_assert_aTHX; assert(pat)
+     STMT_START { Perl_assert_aTHX; assert(pat); } STMT_END
 
 # define PERL_ARGS_ASSERT_REG                   \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REG1NODE              \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_REG2NODE              \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_REG_LA_NOTHING        \
-        Perl_assert_aTHX; assert(pRExC_state); assert(type)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(type);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REG_LA_OPFAIL         \
-        Perl_assert_aTHX; assert(pRExC_state); assert(type)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(type);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REG_NODE              \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_REG_SCAN_NAME         \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGATOM               \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGBRANCH             \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGCLASS              \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGEX_SET_PRECEDENCE
 
 # define PERL_ARGS_ASSERT_REGINSERT             \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGNODE_GUTS          \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGPIECE              \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGPNODE              \
-        Perl_assert_aTHX; assert(pRExC_state); assert(arg)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(arg);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGTAIL               \
-        Perl_assert_aTHX; assert(pRExC_state)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 # define PERL_ARGS_ASSERT_SET_REGEX_PV          \
-        Perl_assert_aTHX; assert(pRExC_state); assert(Rx)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(Rx);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_SKIP_BRACKETED_WHITE_SPACE \
-        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p);  \
-        assert(*p); assert(stop_p); assert(p_start <= *p);  \
-        assert(*p <= stop_p)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(p_start);  \
+                  assert(p); assert(*p); assert(stop_p);                   \
+                  assert(p_start <= *p); assert(*p <= stop_p);             \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_SKIP_TO_BE_IGNORED_TEXT \
-        Perl_assert_aTHX; assert(pRExC_state); assert(p)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(p);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_FINALIZE          \
-        Perl_assert_aTHX; assert(pRExC_state); assert(ssc)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(ssc);  \
+    } STMT_END
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_REGNODE_GUTS_DEBUG  \
-        Perl_assert_aTHX; assert(pRExC_state)
+       STMT_START { Perl_assert_aTHX; assert(pRExC_state); } STMT_END
 
 #   define PERL_ARGS_ASSERT_REGTAIL_STUDY       \
-        Perl_assert_aTHX; assert(pRExC_state); assert(p); assert(val)
+       STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(p);  \
+                    assert(val);                                       \
+    } STMT_END
 
 #   if defined(ENABLE_REGEX_SETS_DEBUGGING)
 #     define PERL_ARGS_ASSERT_DUMP_REGEX_SETS_STRUCTURES \
-        Perl_assert_aTHX; assert(pRExC_state); assert(stack);  \
-        assert(SvTYPE(stack) == SVt_PVAV); assert(fence_stack);  \
-        assert(SvTYPE(fence_stack) == SVt_PVAV)
+         STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(stack);    \
+                      assert(SvTYPE(stack) == SVt_PVAV); assert(fence_stack);  \
+                      assert(SvTYPE(fence_stack) == SVt_PVAV);                 \
+    } STMT_END
 
 #   endif
 # endif /* defined(DEBUGGING) */
@@ -12829,12 +13237,13 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const I
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_FIND_FIRST_DIFFERING_BYTE_POS \
-        assert(s1); assert(s2)
+     STMT_START { assert(s1); assert(s2); } STMT_END
 
 #   define PERL_ARGS_ASSERT_REG_SKIPCOMMENT     \
-        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p);  \
-        assert(*p); assert(p_end); assert(p_start <= *p);  \
-        assert(*p <= p_end)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(p_start);  \
+                  assert(p); assert(*p); assert(p_end);                    \
+                  assert(p_start <= *p); assert(*p <= p_end);              \
+    } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE Size_t
@@ -12853,10 +13262,12 @@ S_reg_skipcomment(pTHX_ RExC_state_t *pRExC_state, const char *p_start, char **p
 #endif /* defined(PERL_IN_REGCOMP_C) */
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGCOMP_INVLIST_C)
 # define PERL_ARGS_ASSERT_POPULATE_BITMAP_FROM_INVLIST \
-        Perl_assert_aTHX; assert(invlist); assert(bitmap)
+     STMT_START { Perl_assert_aTHX; assert(invlist); assert(bitmap);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_POPULATE_INVLIST_FROM_BITMAP \
-        Perl_assert_aTHX; assert(bitmap); assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(bitmap); assert(invlist);  \
+    } STMT_END
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
@@ -12876,8 +13287,9 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 *bitmap, const Size_t bitmap_le
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_TOKE_C)
 # define PERL_ARGS_ASSERT_IS_GRAPHEME           \
-        Perl_assert_aTHX; assert(strbeg); assert(s); assert(strend);  \
-        assert(strbeg <= s); assert(s < strend)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(s);              \
+                  assert(strend); assert(strbeg <= s); assert(s < strend);  \
+    } STMT_END
 
 #endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
@@ -12887,7 +13299,7 @@ Perl_to_fold_latin1_(const U8 c, U8 *p, STRLEN *lenp, const unsigned int flags)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 # define PERL_ARGS_ASSERT_TO_FOLD_LATIN1_       \
-        assert(p); assert(lenp)
+     STMT_START { assert(p); assert(lenp); } STMT_END
 
 #endif
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C)
@@ -12897,45 +13309,45 @@ Perl_regcurly(const char *s, const char *e, const char *result[5])
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_REGCURLY              \
-        assert(s); assert(e); assert(s < e)
+     STMT_START { assert(s); assert(e); assert(s < e); } STMT_END
 
-#endif /* defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_TOKE_C) */
+#endif
 #if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 # define PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 # define PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_COMMON \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 # define PERL_ARGS_ASSERT_PUT_CHARCLASS_BITMAP_INNARDS_INVLIST \
-        Perl_assert_aTHX; assert(sv); assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(invlist); } STMT_END
 
 # define PERL_ARGS_ASSERT_PUT_CODE_POINT        \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 # define PERL_ARGS_ASSERT_PUT_RANGE             \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGDUMP_EXTFLAGS      \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # define PERL_ARGS_ASSERT_REGDUMP_INTFLAGS      \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING) */
 #if defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD)
 # define PERL_ARGS_ASSERT_APPEND_RANGE_TO_INVLIST_ \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 static void
 S_initialize_invlist_guts(pTHX_ SV *invlist, const Size_t initial_size)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INITIALIZE_INVLIST_GUTS \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 # define PERL_ARGS_ASSERT_INVLIST_REPLACE_LIST_DESTROYS_SRC \
-        Perl_assert_aTHX; assert(dest); assert(src)
+     STMT_START { Perl_assert_aTHX; assert(dest); assert(src); } STMT_END
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static void
@@ -12950,25 +13362,25 @@ S_invlist_replace_list_destroys_src(pTHX_ SV *dest, SV *src)
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_GET_INVLIST_PREVIOUS_INDEX_ADDR \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_ARRAY_INIT_ \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_CLEAR       \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_MAX         \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_PREVIOUS_INDEX \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_SET_PREVIOUS_INDEX \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_TRIM        \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE IV *
@@ -13002,46 +13414,52 @@ S_invlist_trim(SV *invlist)
 #endif /* defined(PERL_IN_REGCOMP_INVLIST_C) && !defined(PERL_EXT_RE_BUILD) */
 #if defined(PERL_IN_REGCOMP_STUDY_C)
 # define PERL_ARGS_ASSERT_GET_ANYOF_CP_LIST_FOR_SSC \
-        Perl_assert_aTHX; assert(pRExC_state); assert(node)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(node);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_MAKE_EXACTF_INVLIST   \
-        Perl_assert_aTHX; assert(pRExC_state); assert(node)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(node);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_RCK_ELIDE_NOTHING     \
-        Perl_assert_aTHX; assert(node)
+     STMT_START { Perl_assert_aTHX; assert(node); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_ADD_RANGE         \
-        Perl_assert_aTHX; assert(ssc)
+     STMT_START { Perl_assert_aTHX; assert(ssc); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_AND               \
-        Perl_assert_aTHX; assert(pRExC_state); assert(ssc); assert(and_with)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(ssc);  \
+                  assert(and_with);                                    \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_ANYTHING          \
-        Perl_assert_aTHX; assert(ssc)
+     STMT_START { Perl_assert_aTHX; assert(ssc); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_CLEAR_LOCALE      \
-        assert(ssc)
+     STMT_START { assert(ssc); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_CP_AND            \
-        Perl_assert_aTHX; assert(ssc)
+     STMT_START { Perl_assert_aTHX; assert(ssc); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_INTERSECTION      \
-        Perl_assert_aTHX; assert(ssc); assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(ssc); assert(invlist); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_IS_ANYTHING       \
-        assert(ssc)
+     STMT_START { assert(ssc); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_IS_CP_POSIXL_INIT \
-        assert(pRExC_state); assert(ssc)
+     STMT_START { assert(pRExC_state); assert(ssc); } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_OR                \
-        Perl_assert_aTHX; assert(pRExC_state); assert(ssc); assert(or_with)
+     STMT_START { Perl_assert_aTHX; assert(pRExC_state); assert(ssc);  \
+                  assert(or_with);                                     \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_SSC_UNION             \
-        Perl_assert_aTHX; assert(ssc); assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(ssc); assert(invlist); } STMT_END
 
 # define PERL_ARGS_ASSERT_UNWIND_SCAN_FRAMES    \
-        Perl_assert_aTHX; assert(p)
+     STMT_START { Perl_assert_aTHX; assert(p); } STMT_END
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 static SV *
@@ -13113,119 +13531,144 @@ S_unwind_scan_frames(pTHX_ void *p)
 #endif /* defined(PERL_IN_REGCOMP_STUDY_C) */
 #if defined(PERL_IN_REGEXEC_C)
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_LB        \
-        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend);  \
-        assert(*curpos < strend)
+     STMT_START { Perl_assert_aTHX; assert(curpos); assert(*curpos);  \
+                  assert(strend); assert(*curpos < strend);           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_SB        \
-        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend);  \
-        assert(*curpos < strend)
+     STMT_START { Perl_assert_aTHX; assert(curpos); assert(*curpos);  \
+                  assert(strend); assert(*curpos < strend);           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_WB_       \
-        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend);  \
-        assert(*curpos < strend)
+     STMT_START { Perl_assert_aTHX; assert(curpos); assert(*curpos);  \
+                  assert(strend); assert(*curpos < strend);           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_GCB        \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos);  \
-        assert(strbeg <= *curpos)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
+                  assert(*curpos); assert(strbeg <= *curpos);        \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_LB_        \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos);  \
-        assert(strbeg <= *curpos)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
+                  assert(*curpos); assert(strbeg <= *curpos);        \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_SB         \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos);  \
-        assert(strbeg <= *curpos)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
+                  assert(*curpos); assert(strbeg <= *curpos);        \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_WB_BUT_OVER_EXTEND_FO \
-        Perl_assert_aTHX; assert(previous); assert(strbeg); assert(curpos);  \
-        assert(*curpos); assert(strbeg <= *curpos)
+     STMT_START { Perl_assert_aTHX; assert(previous); assert(strbeg);          \
+                  assert(curpos); assert(*curpos); assert(strbeg <= *curpos);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_FIND_BYCLASS          \
-        Perl_assert_aTHX; assert(prog); assert(c); assert(s); assert(strend);  \
-        assert(s <= strend)
+     STMT_START { Perl_assert_aTHX; assert(prog); assert(c); assert(s);  \
+                  assert(strend); assert(s <= strend);                   \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_FIND_NEXT_MASKED      \
-        assert(s); assert(send); assert(s <= send)
+     STMT_START { assert(s); assert(send); assert(s <= send); } STMT_END
 
 # define PERL_ARGS_ASSERT_FIND_SPAN_END         \
-        assert(s); assert(send); assert(s <= send)
+     STMT_START { assert(s); assert(send); assert(s <= send); } STMT_END
 
 # define PERL_ARGS_ASSERT_FIND_SPAN_END_MASK    \
-        assert(s); assert(send); assert(s <= send)
+     STMT_START { assert(s); assert(send); assert(s <= send); } STMT_END
 
 # define PERL_ARGS_ASSERT_ISFOO_LC              \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # define PERL_ARGS_ASSERT_ISFOO_UTF8_LC         \
-        Perl_assert_aTHX; assert(character); assert(e);  \
-        assert(character < e)
+     STMT_START { Perl_assert_aTHX; assert(character); assert(e);  \
+                  assert(character < e);                           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_ISGCB                 \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
-        assert(strbeg <= curpos)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
+                  assert(strbeg <= curpos);                          \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_ISLB                  \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend);  \
-        assert(strbeg <= curpos); assert(curpos < strend)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
+                  assert(strend); assert(strbeg <= curpos);          \
+                  assert(curpos < strend);                           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_ISSB                  \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend);  \
-        assert(strbeg <= curpos); assert(curpos < strend)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
+                  assert(strend); assert(strbeg <= curpos);          \
+                  assert(curpos < strend);                           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_ISWB                  \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend);  \
-        assert(strbeg <= curpos); assert(curpos < strend)
+     STMT_START { Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
+                  assert(strend); assert(strbeg <= curpos);          \
+                  assert(curpos < strend);                           \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REG_CHECK_NAMED_BUFF_MATCHED \
-        assert(rex); assert(scan)
+     STMT_START { assert(rex); assert(scan); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGCP_RESTORE         \
-        Perl_assert_aTHX; assert(rex); assert(maxopenparen_p)
+     STMT_START { Perl_assert_aTHX; assert(rex); assert(maxopenparen_p);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGCPPOP              \
-        Perl_assert_aTHX; assert(rex); assert(maxopenparen_p)
+     STMT_START { Perl_assert_aTHX; assert(rex); assert(maxopenparen_p);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGCPPUSH             \
-        Perl_assert_aTHX; assert(rex)
+     STMT_START { Perl_assert_aTHX; assert(rex); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGHOP3               \
-        assert(s); assert(lim)
+     STMT_START { assert(s); assert(lim); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGHOPMAYBE3          \
-        assert(s); assert(lim)
+     STMT_START { assert(s); assert(lim); } STMT_END
 
 # define PERL_ARGS_ASSERT_REGINCLASS            \
-        Perl_assert_aTHX; assert(n); assert(p); assert(p_end);  \
-        assert(p < p_end)
+     STMT_START { Perl_assert_aTHX; assert(n); assert(p); assert(p_end);  \
+                  assert(p < p_end);                                      \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGMATCH              \
-        Perl_assert_aTHX; assert(reginfo); assert(startpos); assert(prog)
+     STMT_START { Perl_assert_aTHX; assert(reginfo); assert(startpos);  \
+                  assert(prog);                                         \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGREPEAT             \
-        Perl_assert_aTHX; assert(prog); assert(startposp); assert(p);  \
-        assert(loceol); assert(reginfo); assert(max)
+     STMT_START { Perl_assert_aTHX; assert(prog); assert(startposp);        \
+                  assert(p); assert(loceol); assert(reginfo); assert(max);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_REGTRY                \
-        Perl_assert_aTHX; assert(reginfo); assert(startposp)
+     STMT_START { Perl_assert_aTHX; assert(reginfo); assert(startposp);  \
+    } STMT_END
 
 # define PERL_ARGS_ASSERT_TO_BYTE_SUBSTR        \
-        Perl_assert_aTHX; assert(prog)
+     STMT_START { Perl_assert_aTHX; assert(prog); } STMT_END
 
 # define PERL_ARGS_ASSERT_TO_UTF8_SUBSTR        \
-        Perl_assert_aTHX; assert(prog)
+     STMT_START { Perl_assert_aTHX; assert(prog); } STMT_END
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DEBUG_START_MATCH   \
-        Perl_assert_aTHX; assert(prog); assert(start); assert(end);  \
-        assert(blurb); assert(start <= end)
+       STMT_START { Perl_assert_aTHX; assert(prog); assert(start);     \
+                    assert(end); assert(blurb); assert(start <= end);  \
+    } STMT_END
 
 #   define PERL_ARGS_ASSERT_DUMP_EXEC_POS       \
-        Perl_assert_aTHX; assert(locinput); assert(scan); assert(loc_regeol);  \
-        assert(loc_bostr); assert(loc_reg_starttry);  \
-        assert(locinput <= loc_regeol)
+       STMT_START { Perl_assert_aTHX; assert(locinput); assert(scan);          \
+                    assert(loc_regeol); assert(loc_bostr);                     \
+                    assert(loc_reg_starttry); assert(locinput <= loc_regeol);  \
+    } STMT_END
 
 #   define PERL_ARGS_ASSERT_RE_EXEC_INDENTF     \
-        Perl_assert_aTHX; assert(fmt)
+       STMT_START { Perl_assert_aTHX; assert(fmt); } STMT_END
 
 # endif /* defined(DEBUGGING) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
@@ -13423,13 +13866,13 @@ Perl_re_exec_indentf(pTHX_ const char *fmt, U32 depth, ...)
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
 #   define PERL_ARGS_ASSERT_CAPTURE_CLEAR       \
-        Perl_assert_aTHX; assert(rex); assert(str)
+     STMT_START { Perl_assert_aTHX; assert(rex); assert(str); } STMT_END
 
 #   define PERL_ARGS_ASSERT_FOLDEQ_LATIN1_S2_FOLDED \
-        Perl_assert_aTHX; assert(s1); assert(s2)
+     STMT_START { Perl_assert_aTHX; assert(s1); assert(s2); } STMT_END
 
 #   define PERL_ARGS_ASSERT_UNWIND_PAREN        \
-        Perl_assert_aTHX; assert(rex)
+     STMT_START { Perl_assert_aTHX; assert(rex); } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE void
@@ -13452,26 +13895,30 @@ S_unwind_paren(pTHX_ regexp *rex, U32 lp, U32 lcp comma_pDEPTH)
 #if defined(PERL_IN_REGEX_ENGINE)
 
 # define PERL_ARGS_ASSERT_REGPROP               \
-        Perl_assert_aTHX; assert(sv); assert(o)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(o); } STMT_END
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DEBUG_PEEP          \
-        Perl_assert_aTHX; assert(str); assert(pRExC_state)
+       STMT_START { Perl_assert_aTHX; assert(str); assert(pRExC_state);  \
+    } STMT_END
 
 #   define PERL_ARGS_ASSERT_DEBUG_SHOW_STUDY_FLAGS \
-        Perl_assert_aTHX; assert(open_str); assert(close_str)
+       STMT_START { Perl_assert_aTHX; assert(open_str); assert(close_str);  \
+    } STMT_END
 
 #   define PERL_ARGS_ASSERT_DEBUG_STUDYDATA     \
-        Perl_assert_aTHX; assert(where)
+       STMT_START { Perl_assert_aTHX; assert(where); } STMT_END
 
 #   define PERL_ARGS_ASSERT_DUMPUNTIL           \
-        Perl_assert_aTHX; assert(r); assert(start); assert(node); assert(sv)
+       STMT_START { Perl_assert_aTHX; assert(r); assert(start); assert(node);  \
+                    assert(sv);                                                \
+    } STMT_END
 
 #   define PERL_ARGS_ASSERT_RE_INDENTF          \
-        Perl_assert_aTHX; assert(fmt)
+       STMT_START { Perl_assert_aTHX; assert(fmt); } STMT_END
 
 #   define PERL_ARGS_ASSERT_RE_PRINTF           \
-        Perl_assert_aTHX; assert(fmt)
+       STMT_START { Perl_assert_aTHX; assert(fmt); } STMT_END
 
 # endif /* defined(DEBUGGING) */
 # if defined(PERL_CORE) || defined(PERL_EXT)
@@ -13522,7 +13969,7 @@ Perl_re_printf(pTHX_ const char *fmt, ...)
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_EXT_RE_BUILD)
 #   define PERL_ARGS_ASSERT_GET_RE_GCLASS_AUX_DATA \
-        Perl_assert_aTHX; assert(node)
+       STMT_START { Perl_assert_aTHX; assert(node); } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT_RE_BUILD)
 PERL_CALLCONV SV *
@@ -13533,7 +13980,7 @@ Perl_get_re_gclass_aux_data(pTHX_ const regexp *prog, const struct regnode *node
 #   endif
 # else /* if !defined(PERL_EXT_RE_BUILD) */
 #   define PERL_ARGS_ASSERT_GET_REGCLASS_AUX_DATA \
-        Perl_assert_aTHX; assert(node)
+       STMT_START { Perl_assert_aTHX; assert(node); } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV SV *
@@ -13549,21 +13996,21 @@ Perl_check_regnode_after(pTHX_ const regnode *p, const STRLEN extra)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_CHECK_REGNODE_AFTER \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE regnode *
 Perl_regnext(pTHX_ const regnode *p)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_REGNEXT             \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE regnode *
 Perl_regnode_after(pTHX_ const regnode *p, bool varies)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_REGNODE_AFTER       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_REGEX_ENGINE) */
@@ -13572,14 +14019,14 @@ static void
 S_save_pushptri32ptr(pTHX_ void * const ptr1, const I32 i, void * const ptr2, const int type)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SAVE_PUSHPTRI32PTR    \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static SV *
 S_save_scalar_at(pTHX_ SV **sptr, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SAVE_SCALAR_AT        \
-        Perl_assert_aTHX; assert(sptr)
+     STMT_START { Perl_assert_aTHX; assert(sptr); } STMT_END
 
 #endif /* defined(PERL_IN_SCOPE_C) */
 #if defined(PERL_IN_SV_C)
@@ -13588,7 +14035,7 @@ S_F0convert(NV nv, char * const endbuf, STRLEN * const len)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 # define PERL_ARGS_ASSERT_F0CONVERT             \
-        assert(endbuf); assert(len)
+     STMT_START { assert(endbuf); assert(len); } STMT_END
 
 static void
 S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv)
@@ -13596,8 +14043,9 @@ S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE    \
-        Perl_assert_aTHX; assert(gv); assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(gv); assert(cv);                  \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 static void
 S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, STRLEN real, SV * const sv)
@@ -13605,7 +14053,7 @@ S_assert_uft8_cache_coherent(pTHX_ const char * const func, STRLEN from_cache, S
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_ASSERT_UFT8_CACHE_COHERENT \
-        Perl_assert_aTHX; assert(func); assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(func); assert(sv); } STMT_END
 
 static void
 S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
@@ -13613,14 +14061,14 @@ S_croak_sv_setsv_flags(pTHX_ SV * const dsv, SV * const ssv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CROAK_SV_SETSV_FLAGS  \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
+     STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); } STMT_END
 
 static bool
 S_curse(pTHX_ SV * const sv, const bool check_refcnt)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CURSE                 \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static STRLEN
 S_expect_number(pTHX_ const char ** const pattern)
@@ -13628,35 +14076,35 @@ S_expect_number(pTHX_ const char ** const pattern)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_EXPECT_NUMBER         \
-        Perl_assert_aTHX; assert(pattern)
+     STMT_START { Perl_assert_aTHX; assert(pattern); } STMT_END
 
 static SSize_t
 S_find_array_subscript(pTHX_ const AV * const av, const SV * const val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_ARRAY_SUBSCRIPT  \
-        Perl_assert_aTHX; assert(val)
+     STMT_START { Perl_assert_aTHX; assert(val); } STMT_END
 
 static SV *
 S_find_hash_subscript(pTHX_ const HV * const hv, const SV * const val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FIND_HASH_SUBSCRIPT   \
-        Perl_assert_aTHX; assert(val)
+     STMT_START { Perl_assert_aTHX; assert(val); } STMT_END
 
 static SV *
 S_find_uninit_var(pTHX_ const OP * const obase, const SV * const uninit_sv, bool match, const char **desc_p)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_FIND_UNINIT_VAR       \
-        Perl_assert_aTHX; assert(desc_p)
+     STMT_START { Perl_assert_aTHX; assert(desc_p); } STMT_END
 
 static bool
 S_glob_2number(pTHX_ GV * const gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_GLOB_2NUMBER          \
-        Perl_assert_aTHX; assert(gv)
+     STMT_START { Perl_assert_aTHX; assert(gv); } STMT_END
 
 static void
 S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype)
@@ -13664,42 +14112,42 @@ S_glob_assign_glob(pTHX_ SV * const dsv, SV * const ssv, const int dtype)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GLOB_ASSIGN_GLOB      \
-        Perl_assert_aTHX; assert(dsv); assert(ssv)
+     STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); } STMT_END
 
 static void
 S_not_a_number(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_A_NUMBER          \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static void
 S_not_incrementable(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_NOT_INCREMENTABLE     \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static PTR_TBL_ENT_t *
 S_ptr_table_find(PTR_TBL_t * const tbl, const void * const sv)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PTR_TABLE_FIND        \
-        assert(tbl)
+     STMT_START { assert(tbl); } STMT_END
 
 static bool
 S_sv_2iuv_common(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_2IUV_COMMON        \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static void
 S_sv_add_arena(pTHX_ char * const ptr, const U32 size, const U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_ADD_ARENA          \
-        Perl_assert_aTHX; assert(ptr)
+     STMT_START { Perl_assert_aTHX; assert(ptr); } STMT_END
 
 static const char *
 S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size)
@@ -13707,14 +14155,14 @@ S_sv_display(pTHX_ SV * const sv, char *tmpbuf, STRLEN tmpbuf_size)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_DISPLAY            \
-        Perl_assert_aTHX; assert(sv); assert(tmpbuf)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(tmpbuf); } STMT_END
 
 static bool
 S_sv_numcmp_common(pTHX_ SV **sv1, SV **sv2, const U32 flags, int method, SV **result)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_SV_NUMCMP_COMMON      \
-        Perl_assert_aTHX; assert(result)
+     STMT_START { Perl_assert_aTHX; assert(result); } STMT_END
 
 static STRLEN
 S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 *end, STRLEN endu)
@@ -13723,8 +14171,9 @@ S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY     \
-        Perl_assert_aTHX; assert(s); assert(target); assert(end);  \
-        assert(s <= target); assert(target <= end)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(target); assert(end);  \
+                  assert(s <= target); assert(target <= end);                \
+    } STMT_END
 
 static STRLEN
 S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const start, const U8 * const send, STRLEN uoffset, STRLEN uoffset0, STRLEN boffset0)
@@ -13734,8 +14183,9 @@ S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const st
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_CACHED     \
-        Perl_assert_aTHX; assert(sv); assert(mgp); assert(start);  \
-        assert(send); assert(start < send)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mgp); assert(start);  \
+                  assert(send); assert(start < send);                        \
+    } STMT_END
 
 static STRLEN
 S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * const uoffset_p, bool * const at_end, bool *canonical_position)
@@ -13745,15 +14195,18 @@ S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * co
         Perl_attribute_nonnull(4)
         Perl_attribute_nonnull(5);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS   \
-        assert(start); assert(send); assert(uoffset_p); assert(at_end);  \
-        assert(canonical_position); assert(start < send)
+     STMT_START { assert(start); assert(send); assert(uoffset_p);  \
+                  assert(at_end); assert(canonical_position);      \
+                  assert(start < send);                            \
+    } STMT_END
 
 static STRLEN
 S_sv_pos_u2b_midway(const U8 * const start, const U8 *send, STRLEN uoffset, const STRLEN uend)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_MIDWAY     \
-        assert(start); assert(send); assert(start < send)
+     STMT_START { assert(start); assert(send); assert(start < send);  \
+    } STMT_END
 
 static void
 S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN ulen)
@@ -13761,7 +14214,7 @@ S_utf8_mg_len_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_LEN_CACHE_UPDATE \
-        Perl_assert_aTHX; assert(sv); assert(mgp)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mgp); } STMT_END
 
 static void
 S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN byte, const STRLEN utf8, const STRLEN blen)
@@ -13769,14 +14222,14 @@ S_utf8_mg_pos_cache_update(pTHX_ SV * const sv, MAGIC ** const mgp, const STRLEN
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_MG_POS_CACHE_UPDATE \
-        Perl_assert_aTHX; assert(sv); assert(mgp)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mgp); } STMT_END
 
 static SSize_t
 S_visit(pTHX_ SVFUNC_t f, const U32 flags, const U32 mask)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_VISIT                 \
-        Perl_assert_aTHX; assert(f)
+     STMT_START { Perl_assert_aTHX; assert(f); } STMT_END
 
 # if defined(DEBUGGING)
 static void
@@ -13784,21 +14237,21 @@ S_del_sv(pTHX_ SV *p)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_DEL_SV              \
-        Perl_assert_aTHX; assert(p)
+       STMT_START { Perl_assert_aTHX; assert(p); } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_mark_arenas(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_SV_MARK_ARENAS      \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_sv_sweep_arenas(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_SV_SWEEP_ARENAS     \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 # endif /* defined(DEBUGGING) */
 # if !defined(NV_PRESERVES_UV)
@@ -13808,7 +14261,7 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv, I32 numtype)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
-        Perl_assert_aTHX; assert(sv)
+         STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 #   else
 static int
@@ -13816,7 +14269,7 @@ S_sv_2iuv_non_preserve(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #     define PERL_ARGS_ASSERT_SV_2IUV_NON_PRESERVE \
-        Perl_assert_aTHX; assert(sv)
+         STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 #   endif
 # endif /* !defined(NV_PRESERVES_UV) */
@@ -13826,7 +14279,7 @@ S_sv_buf_to_rw(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_BUF_TO_RW        \
-        Perl_assert_aTHX; assert(sv)
+       STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 # endif
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -13835,7 +14288,7 @@ S_sv_unglob(pTHX_ SV * const sv, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_SV_UNGLOB           \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 # endif
 # if defined(USE_ITHREADS)
@@ -13846,7 +14299,7 @@ S_sv_dup_common(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_SV_DUP_COMMON       \
-        Perl_assert_aTHX; assert(ssv); assert(param)
+       STMT_START { Perl_assert_aTHX; assert(ssv); assert(param); } STMT_END
 
 static void
 S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param)
@@ -13855,7 +14308,9 @@ S_sv_dup_hvaux(pTHX_ const SV * const ssv, SV *dsv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #   define PERL_ARGS_ASSERT_SV_DUP_HVAUX        \
-        Perl_assert_aTHX; assert(ssv); assert(dsv); assert(param)
+       STMT_START { Perl_assert_aTHX; assert(ssv); assert(dsv);  \
+                    assert(param);                               \
+    } STMT_END
 
 static SV **
 S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_PARAMS * const param)
@@ -13864,15 +14319,18 @@ S_sv_dup_inc_multiple(pTHX_ SV * const *source, SV **dest, SSize_t items, CLONE_
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 #   define PERL_ARGS_ASSERT_SV_DUP_INC_MULTIPLE \
-        Perl_assert_aTHX; assert(source); assert(dest); assert(param)
+       STMT_START { Perl_assert_aTHX; assert(source); assert(dest);  \
+                    assert(param);                                   \
+    } STMT_END
 
 static void
 S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_UNREFERENCED_TO_TMP_STACK \
-        Perl_assert_aTHX; assert(unreferenced);  \
-        assert(SvTYPE(unreferenced) == SVt_PVAV)
+       STMT_START { Perl_assert_aTHX; assert(unreferenced);    \
+                    assert(SvTYPE(unreferenced) == SVt_PVAV);  \
+    } STMT_END
 
 # endif /* defined(USE_ITHREADS) */
 #endif /* defined(PERL_IN_SV_C) */
@@ -13881,13 +14339,13 @@ static int
 S_ao(pTHX_ int toketype)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_AO                    \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_check_unary(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_CHECK_UNARY           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
@@ -13896,7 +14354,8 @@ S_checkcomma(pTHX_ const char *s, const char *name, const char *what)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CHECKCOMMA            \
-        Perl_assert_aTHX; assert(s); assert(name); assert(what)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(name); assert(what);  \
+    } STMT_END
 
 static char *
 S_filter_gets(pTHX_ SV *sv, STRLEN append)
@@ -13904,7 +14363,7 @@ S_filter_gets(pTHX_ SV *sv, STRLEN append)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FILTER_GETS           \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static HV *
 S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
@@ -13912,47 +14371,47 @@ S_find_in_my_stash(pTHX_ const char *pkgname, STRLEN len)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FIND_IN_MY_STASH      \
-        Perl_assert_aTHX; assert(pkgname)
+     STMT_START { Perl_assert_aTHX; assert(pkgname); } STMT_END
 
 static void
 S_force_ident(pTHX_ const char *s, int kind)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_IDENT           \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static void
 S_force_ident_maybe_lex(pTHX_ char pit)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_FORCE_IDENT_MAYBE_LEX \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_force_next(pTHX_ I32 type)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_FORCE_NEXT            \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static char *
 S_force_strict_version(pTHX_ char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_STRICT_VERSION  \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static char *
 S_force_version(pTHX_ char *s, int guessing)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_VERSION         \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static char *
 S_force_word(pTHX_ char *start, int token, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_FORCE_WORD            \
-        Perl_assert_aTHX; assert(start)
+     STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 static SV *
 S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const e)
@@ -13961,7 +14420,8 @@ S_get_and_check_backslash_N_name_wrapper(pTHX_ const char *s, const char * const
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME_WRAPPER \
-        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(e); assert(s <= e);  \
+    } STMT_END
 
 static void
 S_incline(pTHX_ const char *s, const char *end)
@@ -13969,15 +14429,16 @@ S_incline(pTHX_ const char *s, const char *end)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INCLINE               \
-        Perl_assert_aTHX; assert(s); assert(end); assert(s <= end);  \
-        assert(*end == '\0')
+     STMT_START { Perl_assert_aTHX; assert(s); assert(end); assert(s <= end);  \
+                  assert(*end == '\0');                                        \
+    } STMT_END
 
 static int
 S_intuit_method(pTHX_ char *start, SV *ioname, CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_INTUIT_METHOD         \
-        Perl_assert_aTHX; assert(start)
+     STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 static int
 S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t caller_length)
@@ -13985,29 +14446,30 @@ S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INTUIT_MORE           \
-        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e);  \
-        assert(*e == '\0')
+     STMT_START { Perl_assert_aTHX; assert(s); assert(e); assert(s <= e);  \
+                  assert(*e == '\0');                                      \
+    } STMT_END
 
 static bool
 S_is_existing_identifier(pTHX_ char *s, Size_t len, char sigil, bool is_utf8)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_IS_EXISTING_IDENTIFIER \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static I32
 S_lop(pTHX_ enum yytokentype t, I32 f, U8 x, char *s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_LOP                   \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 PERL_STATIC_NO_RET void
 S_missingterm(pTHX_ char *s, STRLEN len)
         Perl_attribute_nonnull_aTHX
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_MISSINGTERM           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static SV *
 S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, SV *sv, SV *pv, const char *type, STRLEN typelen, const char **error_msg)
@@ -14015,7 +14477,7 @@ S_new_constant(pTHX_ const char *s, STRLEN len, const char *key, STRLEN keylen, 
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_NEW_CONSTANT          \
-        Perl_assert_aTHX; assert(key); assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(key); assert(sv); } STMT_END
 
 static char *
 S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * const e, bool is_utf8, HV **failure_details, U32 flags)
@@ -14025,8 +14487,9 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * co
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
-        Perl_assert_aTHX; assert(s); assert(s_end); assert(d); assert(*d);  \
-        assert(e); assert(s <= s_end); assert(*d < e)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(s_end); assert(d);      \
+                  assert(*d); assert(e); assert(s <= s_end); assert(*d < e);  \
+    } STMT_END
 
 static char *
 S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf8, HV **failure_details, U32 flags)
@@ -14034,13 +14497,15 @@ S_parse_ident_no_copy(pTHX_ const char *s, const char * const s_end, bool is_utf
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSE_IDENT_NO_COPY   \
-        Perl_assert_aTHX; assert(s); assert(s_end); assert(s < s_end)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(s_end);  \
+                  assert(s < s_end);                           \
+    } STMT_END
 
 static int
 S_pending_ident(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PENDING_IDENT         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static char *
 S_scan_const(pTHX_ char *start)
@@ -14048,7 +14513,7 @@ S_scan_const(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_CONST            \
-        Perl_assert_aTHX; assert(start)
+     STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 static char *
 S_scan_formline(pTHX_ char *s)
@@ -14056,7 +14521,7 @@ S_scan_formline(pTHX_ char *s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_FORMLINE         \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static char *
 S_scan_heredoc(pTHX_ char *s)
@@ -14064,7 +14529,7 @@ S_scan_heredoc(pTHX_ char *s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_HEREDOC          \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static char *
 S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
@@ -14073,8 +14538,9 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SCAN_IDENT            \
-        Perl_assert_aTHX; assert(s); assert(dest); assert(dest_end);  \
-        assert(dest < dest_end)
+     STMT_START { Perl_assert_aTHX; assert(s); assert(dest);  \
+                  assert(dest_end); assert(dest < dest_end);  \
+    } STMT_END
 
 static char *
 S_scan_inputsymbol(pTHX_ char *start)
@@ -14082,7 +14548,7 @@ S_scan_inputsymbol(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_INPUTSYMBOL      \
-        Perl_assert_aTHX; assert(start)
+     STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 static char *
 S_scan_pat(pTHX_ char *start, I32 type)
@@ -14090,7 +14556,7 @@ S_scan_pat(pTHX_ char *start, I32 type)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_PAT              \
-        Perl_assert_aTHX; assert(start)
+     STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 static char *
 S_scan_subst(pTHX_ char *start)
@@ -14098,7 +14564,7 @@ S_scan_subst(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_SUBST            \
-        Perl_assert_aTHX; assert(start)
+     STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 static char *
 S_scan_trans(pTHX_ char *start)
@@ -14106,28 +14572,28 @@ S_scan_trans(pTHX_ char *start)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SCAN_TRANS            \
-        Perl_assert_aTHX; assert(start)
+     STMT_START { Perl_assert_aTHX; assert(start); } STMT_END
 
 static I32
 S_sublex_done(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_DONE           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static I32
 S_sublex_push(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_PUSH           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static I32
 S_sublex_start(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SUBLEX_START          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static char *
 S_swallow_bom(pTHX_ U8 *s)
@@ -14135,7 +14601,7 @@ S_swallow_bom(pTHX_ U8 *s)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SWALLOW_BOM           \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static char *
 S_tokenize_use(pTHX_ int is_use, char *s)
@@ -14143,41 +14609,41 @@ S_tokenize_use(pTHX_ int is_use, char *s)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_TOKENIZE_USE          \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static SV *
 S_tokeq(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_TOKEQ                 \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 static void
 S_update_debugger_info(pTHX_ SV *orig_sv, const char * const buf, STRLEN len)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_UPDATE_DEBUGGER_INFO  \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static void
 S_warn_expect_operator(pTHX_ const char * const what, char *s, I32 pop_oldbufptr)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_WARN_EXPECT_OPERATOR  \
-        Perl_assert_aTHX; assert(what)
+     STMT_START { Perl_assert_aTHX; assert(what); } STMT_END
 
 static void
 S_yyerror_non_ascii_message(pTHX_ const U8 * const s)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_YYERROR_NON_ASCII_MESSAGE \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static int
 S_yywarn(pTHX_ const char * const s, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_YYWARN                \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 # if defined(DEBUGGING)
 static void
@@ -14187,14 +14653,14 @@ S_printbuf(pTHX_ const char * const fmt, const char * const s)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__format__(__printf__,pTHX_1,0);
 #   define PERL_ARGS_ASSERT_PRINTBUF            \
-        Perl_assert_aTHX; assert(fmt); assert(s)
+       STMT_START { Perl_assert_aTHX; assert(fmt); assert(s); } STMT_END
 
 static int
 S_tokereport(pTHX_ I32 rv, const YYSTYPE *lvalp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_TOKEREPORT          \
-        Perl_assert_aTHX; assert(lvalp)
+       STMT_START { Perl_assert_aTHX; assert(lvalp); } STMT_END
 
 # endif /* defined(DEBUGGING) */
 # if !defined(PERL_NO_UTF16_FILTER)
@@ -14203,14 +14669,14 @@ S_add_utf16_textfilter(pTHX_ U8 * const s, bool reversed)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_ADD_UTF16_TEXTFILTER \
-        Perl_assert_aTHX; assert(s)
+       STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 static I32
 S_utf16_textfilter(pTHX_ int idx, SV *sv, int maxlen)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_UTF16_TEXTFILTER    \
-        Perl_assert_aTHX; assert(sv)
+       STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 # endif /* !defined(PERL_NO_UTF16_FILTER) */
 #endif /* defined(PERL_IN_TOKE_C) */
@@ -14220,15 +14686,17 @@ S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flag
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_ISA_LOOKUP            \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
-        assert(namesv || name)
+     STMT_START { Perl_assert_aTHX; assert(stash);                            \
+                  assert(SvTYPE(stash) == SVt_PVHV); assert(namesv || name);  \
+    } STMT_END
 
 static bool
 S_sv_derived_from_svpvn(pTHX_ SV *sv, SV *namesv, const char *name, const STRLEN len, U32 flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_DERIVED_FROM_SVPVN \
-        Perl_assert_aTHX; assert(sv); assert(namesv || name)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(namesv || name);  \
+    } STMT_END
 
 #endif /* defined(PERL_IN_UNIVERSAL_C) */
 #if defined(PERL_IN_UTF8_C)
@@ -14240,7 +14708,8 @@ S_check_locale_boundary_crossing(pTHX_ const U8 * const p, const UV result, U8 *
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CHECK_LOCALE_BOUNDARY_CROSSING \
-        Perl_assert_aTHX; assert(p); assert(ustrp); assert(lenp)
+     STMT_START { Perl_assert_aTHX; assert(p); assert(ustrp); assert(lenp);  \
+    } STMT_END
 
 static HV *
 S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
@@ -14248,7 +14717,7 @@ S_new_msg_hv(pTHX_ const char * const message, U32 categories, U32 flag)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEW_MSG_HV            \
-        Perl_assert_aTHX; assert(message)
+     STMT_START { Perl_assert_aTHX; assert(message); } STMT_END
 
 static UV
 S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Size_t *remaining_count, SV *invlist, const I32 * const invmap, const U32 * const * const aux_tables, const U8 * const aux_table_lengths, const char * const normal)
@@ -14257,7 +14726,9 @@ S_to_case_cp_list(pTHX_ const UV original, const U32 ** const remaining_list, Si
         Perl_attribute_nonnull(pTHX_5)
         Perl_attribute_nonnull(pTHX_8);
 # define PERL_ARGS_ASSERT_TO_CASE_CP_LIST       \
-        Perl_assert_aTHX; assert(invlist); assert(invmap); assert(normal)
+     STMT_START { Perl_assert_aTHX; assert(invlist); assert(invmap);  \
+                  assert(normal);                                     \
+    } STMT_END
 
 static U8
 S_to_lower_latin1(const U8 c, U8 *p, STRLEN *lenp, const char dummy)
@@ -14273,8 +14744,9 @@ S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, S
         Perl_attribute_nonnull(pTHX_6)
         Perl_attribute_nonnull(pTHX_9);
 # define PERL_ARGS_ASSERT_TO_UTF8_CASE_         \
-        Perl_assert_aTHX; assert(ustrp); assert(lenp); assert(invlist);  \
-        assert(invmap); assert(normal)
+     STMT_START { Perl_assert_aTHX; assert(ustrp); assert(lenp);    \
+                  assert(invlist); assert(invmap); assert(normal);  \
+    } STMT_END
 
 static UV
 S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
@@ -14284,8 +14756,9 @@ S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_FC             \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp);  \
-        assert(p < e)
+     STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(ustrp);  \
+                  assert(lenp); assert(p < e);                            \
+    } STMT_END
 
 static UV
 S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *lenp)
@@ -14295,8 +14768,9 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *le
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_LC             \
-        Perl_assert_aTHX; assert(p0); assert(e); assert(ustrp); assert(lenp);  \
-        assert(p0 < e)
+     STMT_START { Perl_assert_aTHX; assert(p0); assert(e); assert(ustrp);  \
+                  assert(lenp); assert(p0 < e);                            \
+    } STMT_END
 
 static UV
 S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *lenp)
@@ -14306,8 +14780,9 @@ S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_UC             \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp);  \
-        assert(p < e)
+     STMT_START { Perl_assert_aTHX; assert(p); assert(e); assert(ustrp);  \
+                  assert(lenp); assert(p < e);                            \
+    } STMT_END
 
 static char *
 S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, const STRLEN non_cont_byte_pos, const STRLEN expect_len)
@@ -14315,7 +14790,7 @@ S_unexpected_non_continuation_text(pTHX_ const U8 * const s, STRLEN print_len, c
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UNEXPECTED_NON_CONTINUATION_TEXT \
-        Perl_assert_aTHX; assert(s)
+     STMT_START { Perl_assert_aTHX; assert(s); } STMT_END
 
 # if 0
 static void
@@ -14325,7 +14800,9 @@ S_warn_on_first_deprecated_use(pTHX_ U32 category, const char * const name, cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_5);
 #   define PERL_ARGS_ASSERT_WARN_ON_FIRST_DEPRECATED_USE \
-        Perl_assert_aTHX; assert(name); assert(alternative); assert(file)
+       STMT_START { Perl_assert_aTHX; assert(name); assert(alternative);  \
+                    assert(file);                                         \
+    } STMT_END
 
 # endif /* 0 */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -14335,21 +14812,21 @@ S_does_utf8_overflow(const U8 * const s, const U8 *e)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_DOES_UTF8_OVERFLOW  \
-        assert(s); assert(e); assert(s < e)
+     STMT_START { assert(s); assert(e); assert(s < e); } STMT_END
 
 PERL_STATIC_INLINE int
 S_isFF_overlong(const U8 * const s, const STRLEN len)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_ISFF_OVERLONG       \
-        assert(s)
+     STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE SSize_t
 S_is_utf8_overlong(const U8 * const s, const STRLEN len)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_IS_UTF8_OVERLONG    \
-        assert(s)
+     STMT_START { assert(s); } STMT_END
 
 # endif /* !defined(PERL_NO_INLINE_FUNCTIONS) */
 #endif /* defined(PERL_IN_UTF8_C) */
@@ -14358,27 +14835,27 @@ static bool
 S_ckwarn_common(pTHX_ U32 w)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_CKWARN_COMMON         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static SV *
 S_mess_alloc(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_MESS_ALLOC            \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 static SV *
 S_with_queued_errors(pTHX_ SV *ex)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_WITH_QUEUED_ERRORS    \
-        Perl_assert_aTHX; assert(ex)
+     STMT_START { Perl_assert_aTHX; assert(ex); } STMT_END
 
 static void
 S_xs_version_bootcheck(pTHX_ SSize_t items, SSize_t ax, const char *xs_p, STRLEN xs_len)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_XS_VERSION_BOOTCHECK  \
-        Perl_assert_aTHX; assert(xs_p)
+     STMT_START { Perl_assert_aTHX; assert(xs_p); } STMT_END
 
 # if defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL)
 static void
@@ -14387,15 +14864,16 @@ S_mem_log_common(enum mem_log_type mlt, const UV n, const UV typesize, const cha
         Perl_attribute_nonnull(8)
         Perl_attribute_nonnull(10);
 #   define PERL_ARGS_ASSERT_MEM_LOG_COMMON      \
-        assert(type_name); assert(filename); assert(funcname)
+       STMT_START { assert(type_name); assert(filename); assert(funcname);  \
+    } STMT_END
 
-# endif /* defined(PERL_MEM_LOG) && !defined(PERL_MEM_LOG_NOIMPL) */
+# endif
 # if defined(PERL_USES_PL_PIDSTATUS)
 static void
 S_pidgone(pTHX_ Pid_t pid, int status)
         Perl_attribute_nonnull_aTHX;
 #   define PERL_ARGS_ASSERT_PIDGONE             \
-        Perl_assert_aTHX
+       STMT_START { Perl_assert_aTHX; } STMT_END
 
 # endif
 #endif /* defined(PERL_IN_UTIL_C) */
@@ -14406,7 +14884,8 @@ Perl_mem_log_alloc(const UV nconst, UV typesize, const char *type_name, Malloc_t
         Perl_attribute_nonnull(5)
         Perl_attribute_nonnull(7);
 # define PERL_ARGS_ASSERT_MEM_LOG_ALLOC         \
-        assert(type_name); assert(filename); assert(funcname)
+     STMT_START { assert(type_name); assert(filename); assert(funcname);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_mem_log_del_sv(const SV *sv, const char *filename, int linenumber, const char *funcname)
@@ -14414,14 +14893,14 @@ Perl_mem_log_del_sv(const SV *sv, const char *filename, int linenumber, const ch
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(4);
 # define PERL_ARGS_ASSERT_MEM_LOG_DEL_SV        \
-        assert(sv); assert(filename); assert(funcname)
+     STMT_START { assert(sv); assert(filename); assert(funcname); } STMT_END
 
 PERL_CALLCONV Malloc_t
 Perl_mem_log_free(Malloc_t oldalloc, const char *filename, const int linenumber, const char *funcname)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(4);
 # define PERL_ARGS_ASSERT_MEM_LOG_FREE          \
-        assert(filename); assert(funcname)
+     STMT_START { assert(filename); assert(funcname); } STMT_END
 
 PERL_CALLCONV void
 Perl_mem_log_new_sv(const SV *sv, const char *filename, int linenumber, const char *funcname)
@@ -14429,7 +14908,7 @@ Perl_mem_log_new_sv(const SV *sv, const char *filename, int linenumber, const ch
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(4);
 # define PERL_ARGS_ASSERT_MEM_LOG_NEW_SV        \
-        assert(sv); assert(filename); assert(funcname)
+     STMT_START { assert(sv); assert(filename); assert(funcname); } STMT_END
 
 PERL_CALLCONV Malloc_t
 Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Malloc_t oldalloc, Malloc_t newalloc, const char *filename, const int linenumber, const char *funcname)
@@ -14437,7 +14916,8 @@ Perl_mem_log_realloc(const UV n, const UV typesize, const char *type_name, Mallo
         Perl_attribute_nonnull(6)
         Perl_attribute_nonnull(8);
 # define PERL_ARGS_ASSERT_MEM_LOG_REALLOC       \
-        assert(type_name); assert(filename); assert(funcname)
+     STMT_START { assert(type_name); assert(filename); assert(funcname);  \
+    } STMT_END
 
 #endif /* defined(PERL_MEM_LOG) */
 #if !defined(PERL_NO_INLINE_FUNCTIONS)
@@ -14447,80 +14927,83 @@ Perl_AvFILL_(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AVFILL_               \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE I32 *
 Perl_CvDEPTH(const CV * const sv)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_CVDEPTH               \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_STATIC_INLINE GV *
 Perl_CvGV(pTHX_ CV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CVGV                  \
-        Perl_assert_aTHX; assert(sv);  \
-        assert(SvTYPE(sv) == SVt_PVCV || SvTYPE(sv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(sv);                              \
+                 assert(SvTYPE(sv) == SVt_PVCV || SvTYPE(sv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_STATIC_INLINE Stack_off_t
 Perl_POPMARK(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_POPMARK               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE struct regexp *
 Perl_ReANY(const REGEXP * const re)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_REANY                 \
-        assert(re)
+    STMT_START { assert(re); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_SvAMAGIC_off(SV *sv)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_SVAMAGIC_OFF          \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_SvAMAGIC_on(SV *sv)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_SVAMAGIC_ON           \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_SvGETMAGIC(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVGETMAGIC            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE IV
 Perl_SvIV(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV                  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE IV
 Perl_SvIV_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVIV_NOMG             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE NV
 Perl_SvNV(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV                  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE NV
 Perl_SvNV_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVNV_NOMG             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_FORCE_INLINE bool
 Perl_SvPVXtrue(pTHX_ SV *sv)
@@ -14528,7 +15011,7 @@ Perl_SvPVXtrue(pTHX_ SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPVXTRUE             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_FORCE_INLINE char *
 Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const PL_SvPVtype type, Perl_SvPV_helper_non_trivial_t non_trivial, const bool or_null, const U32 return_flags)
@@ -14537,26 +15020,27 @@ Perl_SvPV_helper(pTHX_ SV * const sv, STRLEN * const lp, const U32 flags, const 
         Perl_attribute_nonnull(pTHX_5)
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_SVPV_HELPER           \
-        Perl_assert_aTHX; assert(sv); assert(non_trivial)
+    STMT_START { Perl_assert_aTHX; assert(sv); assert(non_trivial);  \
+    } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC          \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_dec_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC_NN       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE SV *
 Perl_SvREFCNT_dec_ret_NULL(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SVREFCNT_DEC_RET_NULL \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE SV *
 Perl_SvREFCNT_inc(SV *sv);
@@ -14566,7 +15050,7 @@ PERL_STATIC_INLINE SV *
 Perl_SvREFCNT_inc_NN(SV *sv)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_SVREFCNT_INC_NN       \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_SvREFCNT_inc_void(SV *sv);
@@ -14576,53 +15060,53 @@ PERL_STATIC_INLINE bool
 Perl_SvTRUE(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SVTRUE                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_NN             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_common(pTHX_ SV *sv, const bool sv_2bool_is_fallback)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVTRUE_COMMON         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_SvTRUE_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SVTRUE_NOMG           \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_SvUV(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV                  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_SvUV_nomg(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SVUV_NOMG             \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE Stack_off_t
 Perl_TOPMARK(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_TOPMARK               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_append_utf8_from_native_byte(const U8 byte, U8 **dest)
         Perl_attribute_nonnull(2);
 # define PERL_ARGS_ASSERT_APPEND_UTF8_FROM_NATIVE_BYTE \
-        assert(dest)
+    STMT_START { assert(dest); } STMT_END
 
 PERL_STATIC_INLINE Size_t
 Perl_av_count(pTHX_ AV *av)
@@ -14630,7 +15114,9 @@ Perl_av_count(pTHX_ AV *av)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_COUNT              \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE SV **
 Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
@@ -14638,14 +15124,16 @@ Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_FETCH_SIMPLE       \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE AV *
 Perl_av_new_alloc(pTHX_ SSize_t size, bool zeroflag)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_AV_NEW_ALLOC          \
-        Perl_assert_aTHX; assert(size > 0)
+    STMT_START { Perl_assert_aTHX; assert(size > 0); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_av_push_simple(pTHX_ AV *av, SV *val)
@@ -14653,22 +15141,27 @@ Perl_av_push_simple(pTHX_ AV *av, SV *val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_AV_PUSH_SIMPLE        \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
-        assert(val)
+    STMT_START { Perl_assert_aTHX; assert(av);                 \
+                 assert(SvTYPE(av) == SVt_PVAV); assert(val);  \
+    } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_av_remove_offset(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_REMOVE_OFFSET      \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE SV **
 Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_AV_STORE_SIMPLE       \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE unsigned
 Perl_bitcount32(uint32_t v);
@@ -14684,7 +15177,7 @@ Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8         \
-        Perl_assert_aTHX; assert(s); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(lenp); } STMT_END
 
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
@@ -14692,14 +15185,16 @@ Perl_bytes_to_utf8_temp_pv(pTHX_ const U8 *s, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_BYTES_TO_UTF8_TEMP_PV \
-        Perl_assert_aTHX; assert(s); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(lenp); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_clear_defarray_simple(pTHX_ AV *av)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLEAR_DEFARRAY_SIMPLE \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(av);    \
+                 assert(SvTYPE(av) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
@@ -14707,7 +15202,7 @@ Perl_foldEQ(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ                \
-        Perl_assert_aTHX; assert(s1); assert(s2)
+    STMT_START { Perl_assert_aTHX; assert(s1); assert(s2); } STMT_END
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
@@ -14715,7 +15210,7 @@ Perl_foldEQ_latin1(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LATIN1         \
-        Perl_assert_aTHX; assert(s1); assert(s2)
+    STMT_START { Perl_assert_aTHX; assert(s1); assert(s2); } STMT_END
 
 PERL_STATIC_INLINE I32
 Perl_foldEQ_locale(pTHX_ const char *s1, const char *s2, I32 len)
@@ -14723,14 +15218,14 @@ Perl_foldEQ_locale(pTHX_ const char *s1, const char *s2, I32 len)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_FOLDEQ_LOCALE         \
-        Perl_assert_aTHX; assert(s1); assert(s2)
+    STMT_START { Perl_assert_aTHX; assert(s1); assert(s2); } STMT_END
 
 PERL_STATIC_INLINE MGVTBL *
 Perl_get_vtbl(pTHX_ int vtbl_id)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GET_VTBL              \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
@@ -14739,7 +15234,9 @@ Perl_grok_bin(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximat
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_BIN              \
-        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(len_p);  \
+                 assert(flags);                                   \
+    } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
@@ -14748,7 +15245,9 @@ Perl_grok_hex(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximat
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_HEX              \
-        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(len_p);  \
+                 assert(flags);                                   \
+    } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximation)
@@ -14757,14 +15256,18 @@ Perl_grok_oct(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *approximat
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GROK_OCT              \
-        Perl_assert_aTHX; assert(start); assert(len_p); assert(flags)
+    STMT_START { Perl_assert_aTHX; assert(start); assert(len_p);  \
+                 assert(flags);                                   \
+    } STMT_END
 
 PERL_STATIC_INLINE void *
 Perl_hv_common_key_len(pTHX_ HV *hv, const char *key, I32 klen_i32, const int action, SV *val, const U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_HV_COMMON_KEY_LEN     \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(key)
+    STMT_START { Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+                 assert(key);                                              \
+    } STMT_END
 
 PERL_STATIC_INLINE Size_t
 Perl_isC9_STRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
@@ -14772,7 +15275,7 @@ Perl_isC9_STRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISC9_STRICT_UTF8_CHAR \
-        assert(s0); assert(e); assert(s0 <= e)
+    STMT_START { assert(s0); assert(e); assert(s0 <= e); } STMT_END
 
 PERL_STATIC_INLINE Size_t
 Perl_isSTRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
@@ -14780,7 +15283,7 @@ Perl_isSTRICT_UTF8_CHAR(const U8 * const s0, const U8 * const e)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISSTRICT_UTF8_CHAR    \
-        assert(s0); assert(e); assert(s0 <= e)
+    STMT_START { assert(s0); assert(e); assert(s0 <= e); } STMT_END
 
 PERL_STATIC_INLINE Size_t
 Perl_isUTF8_CHAR(const U8 * const s0, const U8 * const e)
@@ -14788,7 +15291,7 @@ Perl_isUTF8_CHAR(const U8 * const s0, const U8 * const e)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISUTF8_CHAR           \
-        assert(s0); assert(e); assert(s0 <= e)
+    STMT_START { assert(s0); assert(e); assert(s0 <= e); } STMT_END
 
 PERL_STATIC_INLINE Size_t
 Perl_isUTF8_CHAR_flags(const U8 * const s0, const U8 * const e, const U32 flags)
@@ -14796,13 +15299,13 @@ Perl_isUTF8_CHAR_flags(const U8 * const s0, const U8 * const e, const U32 flags)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ISUTF8_CHAR_FLAGS     \
-        assert(s0); assert(e); assert(s0 <= e)
+    STMT_START { assert(s0); assert(e); assert(s0 <= e); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_c9strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_IS_C9STRICT_UTF8_STRING_LOCLEN \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_safe_syscall(pTHX_ const char *pv, STRLEN len, const char *what, const char *op_name)
@@ -14812,45 +15315,46 @@ Perl_is_safe_syscall(pTHX_ const char *pv, STRLEN len, const char *what, const c
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_SAFE_SYSCALL       \
-        Perl_assert_aTHX; assert(pv); assert(what); assert(op_name)
+    STMT_START { Perl_assert_aTHX; assert(pv); assert(what); assert(op_name);  \
+    } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_strict_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_IS_STRICT_UTF8_STRING_LOCLEN \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_fixed_width_buf_loclen_flags(const U8 * const s, STRLEN len, const U8 **ep, STRLEN *el, const U32 flags)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_IS_UTF8_FIXED_WIDTH_BUF_LOCLEN_FLAGS \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_invariant_string_loc(const U8 * const s, STRLEN len, const U8 **ep)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_UTF8_INVARIANT_STRING_LOC \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_string_flags(const U8 *s, STRLEN len, const U32 flags)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_UTF8_STRING_FLAGS  \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_string_loclen(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOCLEN \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_string_loclen_flags(const U8 *s, STRLEN len, const U8 **ep, STRLEN *el, const U32 flags)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_IS_UTF8_STRING_LOCLEN_FLAGS \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_is_utf8_valid_partial_char_flags(const U8 * const s0, const U8 * const e, const U32 flags)
@@ -14858,7 +15362,7 @@ Perl_is_utf8_valid_partial_char_flags(const U8 * const s0, const U8 * const e, c
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_IS_UTF8_VALID_PARTIAL_CHAR_FLAGS \
-        assert(s0); assert(e); assert(s0 < e)
+    STMT_START { assert(s0); assert(e); assert(s0 < e); } STMT_END
 
 PERL_STATIC_INLINE unsigned
 Perl_lsbit_pos32(U32 word)
@@ -14870,7 +15374,7 @@ Perl_mortal_getenv(const char *str)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MORTAL_GETENV         \
-        assert(str)
+    STMT_START { assert(str); } STMT_END
 
 PERL_STATIC_INLINE unsigned
 Perl_msbit_pos32(U32 word)
@@ -14882,7 +15386,7 @@ Perl_newPADxVOP(pTHX_ I32 type, I32 flags, PADOFFSET padix)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWPADXVOP            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE SV *
 Perl_newRV_noinc(pTHX_ SV * const tmpRef)
@@ -14890,14 +15394,14 @@ Perl_newRV_noinc(pTHX_ SV * const tmpRef)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWRV_NOINC           \
-        Perl_assert_aTHX; assert(tmpRef)
+    STMT_START { Perl_assert_aTHX; assert(tmpRef); } STMT_END
 
 PERL_STATIC_INLINE SV *
 Perl_newSV_type(pTHX_ const svtype type)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWSV_TYPE            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_FORCE_INLINE SV *
 Perl_newSV_type_mortal(pTHX_ const svtype type)
@@ -14905,14 +15409,14 @@ Perl_newSV_type_mortal(pTHX_ const svtype type)
         __attribute__warn_unused_result__
         __attribute__always_inline__;
 # define PERL_ARGS_ASSERT_NEWSV_TYPE_MORTAL     \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE SV *
 Perl_newSVsv_flags(pTHX_ SV * const old, I32 flags)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWSVSV_FLAGS         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE SV *
 Perl_new_sv(pTHX_ const char *file, int line, const char *func)
@@ -14920,105 +15424,106 @@ Perl_new_sv(pTHX_ const char *file, int line, const char *func)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_NEW_SV                \
-        Perl_assert_aTHX; assert(file); assert(func)
+    STMT_START { Perl_assert_aTHX; assert(file); assert(func); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_pop_stackinfo(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_POP_STACKINFO         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_push_stackinfo(pTHX_ I32 type, UV flags)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PUSH_STACKINFO        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_context(pTHX_ SV **mark, U8 gimme, SSize_t extra)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_CONTEXT           \
-        Perl_assert_aTHX; assert(mark)
+    STMT_START { Perl_assert_aTHX; assert(mark); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_extend(pTHX_ SSize_t n)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_EXTEND            \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_invoke_xs(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_INVOKE_XS         \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+    STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                 assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_rpp_is_lone(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_IS_LONE           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE SV *
 Perl_rpp_pop_1_norc(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_POP_1_NORC        \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_1(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_1         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_1_NN(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_1_NN      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_2(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_2         \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_2_NN(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_POPFREE_2_NN      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_to(pTHX_ SV **sp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO        \
-        Perl_assert_aTHX; assert(sp)
+    STMT_START { Perl_assert_aTHX; assert(sp); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_popfree_to_NN(pTHX_ SV **sp)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_POPFREE_TO_NN     \
-        Perl_assert_aTHX; assert(sp)
+    STMT_START { Perl_assert_aTHX; assert(sp); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1            \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_1_norc(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_1_NORC       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2)
@@ -15026,63 +15531,63 @@ Perl_rpp_push_2(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_PUSH_2            \
-        Perl_assert_aTHX; assert(sv1); assert(sv2)
+    STMT_START { Perl_assert_aTHX; assert(sv1); assert(sv2); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_push_IMM(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_PUSH_IMM          \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_1_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_1_NN    \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_1_IMM_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_1_IMM_NN  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1       \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1_COMMON(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_COMMON \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_1_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_1_NN    \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_2_IMM_NN(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_2_IMM_NN  \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
@@ -15090,7 +15595,7 @@ Perl_rpp_replace_at(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT        \
-        Perl_assert_aTHX; assert(sp); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sp); assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv)
@@ -15098,7 +15603,7 @@ Perl_rpp_replace_at_NN(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NN     \
-        Perl_assert_aTHX; assert(sp); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sp); assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv)
@@ -15106,7 +15611,7 @@ Perl_rpp_replace_at_norc(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC   \
-        Perl_assert_aTHX; assert(sp); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sp); assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_replace_at_norc_NN(pTHX_ SV **sp, SV *sv)
@@ -15114,32 +15619,32 @@ Perl_rpp_replace_at_norc_NN(pTHX_ SV **sp, SV *sv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_REPLACE_AT_NORC_NN \
-        Perl_assert_aTHX; assert(sp); assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sp); assert(sv); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_rpp_stack_is_rc(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_STACK_IS_RC       \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_rpp_try_AMAGIC_1(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_1      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_rpp_try_AMAGIC_2(pTHX_ int method, int flags)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RPP_TRY_AMAGIC_2      \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_1(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_1           \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2)
@@ -15147,14 +15652,14 @@ Perl_rpp_xpush_2(pTHX_ SV *sv1, SV *sv2)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_2           \
-        Perl_assert_aTHX; assert(sv1); assert(sv2)
+    STMT_START { Perl_assert_aTHX; assert(sv1); assert(sv2); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_rpp_xpush_IMM(pTHX_ SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_XPUSH_IMM         \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE char *
 Perl_savepv(pTHX_ const char *pv)
@@ -15162,7 +15667,7 @@ Perl_savepv(pTHX_ const char *pv)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVEPV                \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE char *
 Perl_savepvn(pTHX_ const char *pv, Size_t len)
@@ -15170,7 +15675,7 @@ Perl_savepvn(pTHX_ const char *pv, Size_t len)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVEPVN               \
-        Perl_assert_aTHX
+    STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_STATIC_INLINE char *
 Perl_savesharedsvpv(pTHX_ SV *sv)
@@ -15179,7 +15684,7 @@ Perl_savesharedsvpv(pTHX_ SV *sv)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVESHAREDSVPV        \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE char *
 Perl_savesvpv(pTHX_ SV *sv)
@@ -15188,7 +15693,7 @@ Perl_savesvpv(pTHX_ SV *sv)
         __attribute__malloc__
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SAVESVPV              \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE unsigned
 Perl_single_1bit_pos32(U32 word)
@@ -15196,35 +15701,37 @@ Perl_single_1bit_pos32(U32 word)
 # define PERL_ARGS_ASSERT_SINGLE_1BIT_POS32
 
 # define PERL_ARGS_ASSERT_SV_ONLY_TAINT_GMAGIC  \
-        assert(sv)
+    STMT_START { assert(sv); } STMT_END
 
 PERL_STATIC_INLINE char *
 Perl_sv_pvbyten_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVBYTEN_FORCE_WRAPPER \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE char *
 Perl_sv_pvutf8n_force_wrapper(pTHX_ SV * const sv, STRLEN * const lp, const U32 dummy)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_PVUTF8N_FORCE_WRAPPER \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE char  *
 Perl_sv_setpv_freshbuf(pTHX_ SV * const sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SV_SETPV_FRESHBUF     \
-        Perl_assert_aTHX; assert(sv)
+    STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_switch_argstack(pTHX_ AV *to)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_SWITCH_ARGSTACK       \
-        Perl_assert_aTHX; assert(to); assert(SvTYPE(to) == SVt_PVAV)
+    STMT_START { Perl_assert_aTHX; assert(to);    \
+                 assert(SvTYPE(to) == SVt_PVAV);  \
+    } STMT_END
 
 PERL_STATIC_INLINE IV
 Perl_utf8_distance(pTHX_ const U8 *a, const U8 *b)
@@ -15233,14 +15740,14 @@ Perl_utf8_distance(pTHX_ const U8 *a, const U8 *b)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_DISTANCE         \
-        Perl_assert_aTHX; assert(a); assert(b)
+    STMT_START { Perl_assert_aTHX; assert(a); assert(b); } STMT_END
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop(const U8 *s, SSize_t off)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP              \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_back_overshoot(const U8 *s, SSize_t off, const U8 * const start, SSize_t *remaining)
@@ -15248,7 +15755,7 @@ Perl_utf8_hop_back_overshoot(const U8 *s, SSize_t off, const U8 * const start, S
         Perl_attribute_nonnull(3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_BACK_OVERSHOOT \
-        assert(s); assert(start); assert(start <= s)
+    STMT_START { assert(s); assert(start); assert(start <= s); } STMT_END
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_forward_overshoot(const U8 *s, SSize_t off, const U8 * const end, SSize_t *remaining)
@@ -15256,7 +15763,7 @@ Perl_utf8_hop_forward_overshoot(const U8 *s, SSize_t off, const U8 * const end, 
         Perl_attribute_nonnull(3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_FORWARD_OVERSHOOT \
-        assert(s); assert(end); assert(s <= end)
+    STMT_START { assert(s); assert(end); assert(s <= end); } STMT_END
 
 PERL_STATIC_INLINE U8 *
 Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const U8 * const end, SSize_t *remaining)
@@ -15265,8 +15772,9 @@ Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const 
         Perl_attribute_nonnull(4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_OVERSHOOT    \
-        assert(s); assert(start); assert(end); assert(start <= s);  \
-        assert(s <= end)
+    STMT_START { assert(s); assert(start); assert(end); assert(start <= s);  \
+                 assert(s <= end);                                           \
+    } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void **free_me)
@@ -15275,7 +15783,9 @@ Perl_utf8_to_bytes_new_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp, void **free_me)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_NEW_PV  \
-        Perl_assert_aTHX; assert(s_ptr); assert(lenp); assert(free_me)
+    STMT_START { Perl_assert_aTHX; assert(s_ptr); assert(lenp);  \
+                 assert(free_me);                                \
+    } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
@@ -15283,7 +15793,7 @@ Perl_utf8_to_bytes_overwrite(pTHX_ U8 **s_ptr, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_OVERWRITE \
-        Perl_assert_aTHX; assert(s_ptr); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(s_ptr); assert(lenp); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
@@ -15291,7 +15801,7 @@ Perl_utf8_to_bytes_temp_pv(pTHX_ U8 const **s_ptr, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_BYTES_TEMP_PV \
-        Perl_assert_aTHX; assert(s_ptr); assert(lenp)
+    STMT_START { Perl_assert_aTHX; assert(s_ptr); assert(lenp); } STMT_END
 
 PERL_STATIC_INLINE bool
 Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance_p, U32 flags, U32 *errors, AV **msgs)
@@ -15299,14 +15809,15 @@ Perl_utf8_to_uv_msgs(const U8 * const s0, const U8 *e, UV *cp_p, Size_t *advance
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 # define PERL_ARGS_ASSERT_UTF8_TO_UV_MSGS       \
-        assert(s0); assert(e); assert(cp_p); assert(s0 <= e)
+    STMT_START { assert(s0); assert(e); assert(cp_p); assert(s0 <= e);  \
+    } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_utf8_to_uv_or_die(const U8 * const s, const U8 *e, Size_t *advance_p)
         Perl_attribute_nonnull(1)
         Perl_attribute_nonnull(2);
 # define PERL_ARGS_ASSERT_UTF8_TO_UV_OR_DIE     \
-        assert(s); assert(e); assert(s <= e)
+    STMT_START { assert(s); assert(e); assert(s <= e); } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
@@ -15314,34 +15825,36 @@ Perl_utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_UTF8_TO_UVCHR_BUF     \
-        Perl_assert_aTHX; assert(s); assert(send); assert(s <= send)
+    STMT_START { Perl_assert_aTHX; assert(s); assert(send);  \
+                 assert(s <= send);                          \
+    } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_utf8n_to_uvchr_msgs(const U8 * const s0, STRLEN curlen, STRLEN *retlen, const U32 flags, U32 *errors, AV **msgs)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_UTF8N_TO_UVCHR_MSGS   \
-        assert(s0)
+    STMT_START { assert(s0); } STMT_END
 
 PERL_STATIC_INLINE U8 *
 Perl_uv_to_utf8(pTHX_ U8 *d, UV uv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8            \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_STATIC_INLINE U8 *
 Perl_uv_to_utf8_flags(pTHX_ U8 *d, UV uv, UV flags)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UV_TO_UTF8_FLAGS      \
-        Perl_assert_aTHX; assert(d)
+    STMT_START { Perl_assert_aTHX; assert(d); } STMT_END
 
 PERL_STATIC_INLINE UV
 Perl_valid_utf8_to_uv(const U8 *s, STRLEN *retlen)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_VALID_UTF8_TO_UV      \
-        assert(s)
+    STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE unsigned int
 Perl_variant_byte_number(PERL_UINTMAX_T word)
@@ -15353,77 +15866,77 @@ Perl_cx_popblock(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPBLOCK           \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_popeval(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPEVAL            \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_popformat(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPFORMAT          \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_popgiven(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPGIVEN           \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_poploop(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPLOOP            \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB             \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub_args(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_ARGS        \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_popsub_common(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPSUB_COMMON      \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_popwhen(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_POPWHEN            \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE PERL_CONTEXT *
 Perl_cx_pushblock(pTHX_ U8 type, U8 gimme, SV **sp, I32 saveix)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CX_PUSHBLOCK          \
-        Perl_assert_aTHX; assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(sp); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pusheval(pTHX_ PERL_CONTEXT *cx, OP *retop, SV *namesv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHEVAL           \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
@@ -15431,15 +15944,16 @@ Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHFORMAT         \
-        Perl_assert_aTHX; assert(cx); assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(cx); assert(cv);                  \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pushgiven(pTHX_ PERL_CONTEXT *cx, SV *orig_defsv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHGIVEN          \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave)
@@ -15447,14 +15961,14 @@ Perl_cx_pushloop_for(pTHX_ PERL_CONTEXT *cx, void *itervarp, SV *itersave)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_FOR       \
-        Perl_assert_aTHX; assert(cx); assert(itervarp)
+     STMT_START { Perl_assert_aTHX; assert(cx); assert(itervarp); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pushloop_plain(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHLOOP_PLAIN     \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
@@ -15462,35 +15976,36 @@ Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHSUB            \
-        Perl_assert_aTHX; assert(cx); assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(cx); assert(cv);                  \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pushtry(pTHX_ PERL_CONTEXT *cx, OP *retop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHTRY            \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_pushwhen(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_PUSHWHEN           \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE void
 Perl_cx_topblock(pTHX_ PERL_CONTEXT *cx)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CX_TOPBLOCK           \
-        Perl_assert_aTHX; assert(cx)
+     STMT_START { Perl_assert_aTHX; assert(cx); } STMT_END
 
 PERL_STATIC_INLINE U8
 Perl_gimme_V(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_GIMME_V               \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 # if !defined(HAS_STRLCAT)
 PERL_STATIC_INLINE Size_t
@@ -15507,7 +16022,7 @@ Perl_is_utf8_non_invariant_string(const U8 * const s, STRLEN len)
         Perl_attribute_nonnull(1)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_IS_UTF8_NON_INVARIANT_STRING \
-        assert(s)
+     STMT_START { assert(s); } STMT_END
 
 PERL_STATIC_INLINE STRLEN
 S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp)
@@ -15515,7 +16030,7 @@ S_sv_or_pv_pos_u2b(pTHX_ SV *sv, const char *pv, STRLEN pos, STRLEN *lenp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #   define PERL_ARGS_ASSERT_SV_OR_PV_POS_U2B    \
-        Perl_assert_aTHX; assert(sv); assert(pv)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(pv); } STMT_END
 
 PERL_STATIC_INLINE Size_t
 S_variant_under_utf8_count(const U8 * const s, const U8 * const e)
@@ -15523,14 +16038,14 @@ S_variant_under_utf8_count(const U8 * const s, const U8 * const e)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_VARIANT_UNDER_UTF8_COUNT \
-        assert(s); assert(e); assert(s <= e)
+     STMT_START { assert(s); assert(e); assert(s <= e); } STMT_END
 
 #   if !defined(HAS_MEMRCHR)
 PERL_STATIC_INLINE void *
 S_my_memrchr(const char *s, const char c, const STRLEN len)
         Perl_attribute_nonnull(1);
 #     define PERL_ARGS_ASSERT_MY_MEMRCHR        \
-        assert(s)
+       STMT_START { assert(s); } STMT_END
 
 #   endif
 #   if defined(PERL_IN_DOOP_C)    || defined(PERL_IN_OP_C)        || \
@@ -15592,16 +16107,16 @@ S_get_regex_charset_name(const U32 flags, STRLEN * const lenp)
      defined(PERL_IN_REGEXEC_C) || defined(PERL_IN_TOKE_C)      || \
      defined(PERL_IN_UTF8_C)
 #   define PERL_ARGS_ASSERT_GET_INVLIST_OFFSET_ADDR \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_ARRAY       \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_CONTAINS_CP_ \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_LEN_        \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_IS_INVLIST
 
@@ -15612,39 +16127,38 @@ S_get_regex_charset_name(const U32 flags, STRLEN * const lenp)
 # if defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) || \
      defined(PERL_IN_REGCOMP_ANY)
 #   define PERL_ARGS_ASSERT_ADD_CP_TO_INVLIST   \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_EXTEND      \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_HIGHEST     \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_SET_LEN     \
-        Perl_assert_aTHX; assert(invlist)
+     STMT_START { Perl_assert_aTHX; assert(invlist); } STMT_END
 
-# endif /* defined(PERL_IN_DOOP_C) || defined(PERL_IN_OP_C) ||
-           defined(PERL_IN_REGCOMP_ANY) */
+# endif
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PAD_C)
 PERL_STATIC_INLINE bool
 S_PadnameIN_SCOPE(const PADNAME * const pn, const U32 seq)
         Perl_attribute_nonnull(1);
 #   define PERL_ARGS_ASSERT_PADNAMEIN_SCOPE     \
-        assert(pn)
+     STMT_START { assert(pn); } STMT_END
 
 # endif
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_REGCOMP_ANY)
 #   define PERL_ARGS_ASSERT_GET_INVLIST_ITER_ADDR \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_ITERFINISH  \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_ITERINIT    \
-        assert(invlist)
+     STMT_START { assert(invlist); } STMT_END
 
 #   define PERL_ARGS_ASSERT_INVLIST_ITERNEXT    \
-        assert(invlist); assert(start); assert(end)
+     STMT_START { assert(invlist); assert(start); assert(end); } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE STRLEN *
@@ -15671,13 +16185,13 @@ S_lossless_NV_to_IV(const NV nv, IV *ivp)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 #   define PERL_ARGS_ASSERT_LOSSLESS_NV_TO_IV   \
-        assert(ivp)
+     STMT_START { assert(ivp); } STMT_END
 
 # endif
 # if defined(PERL_IN_PP_C)   || defined(PERL_IN_REGCOMP_ANY) || \
      defined(PERL_IN_TOKE_C) || defined(PERL_IN_UNIVERSAL_C)
 #   define PERL_ARGS_ASSERT_GET_REGEX_CHARSET_NAME \
-        assert(lenp)
+     STMT_START { assert(lenp); } STMT_END
 
 # endif
 # if defined(U64TYPE)
@@ -15703,7 +16217,7 @@ Perl_cop_file_avn(pTHX_ const COP *cop)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_COP_FILE_AVN        \
-        Perl_assert_aTHX; assert(cop)
+     STMT_START { Perl_assert_aTHX; assert(cop); } STMT_END
 
 # endif
 # if !defined(WIN32)
@@ -15720,13 +16234,13 @@ Perl_pp_wrap(pTHX_ Perl_ppaddr_t real_pp_fn, I32 nargs, int nlists)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PP_WRAP               \
-        Perl_assert_aTHX; assert(real_pp_fn)
+     STMT_START { Perl_assert_aTHX; assert(real_pp_fn); } STMT_END
 
 PERL_CALLCONV int
 Perl_runops_wrap(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_RUNOPS_WRAP           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
@@ -15734,8 +16248,9 @@ Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_XS_WRAP               \
-        Perl_assert_aTHX; assert(xsub); assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(xsub); assert(cv);                \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 #endif /* defined(PERL_RC_STACK) */
 #if defined(PERL_USE_3ARG_SIGHANDLER)
@@ -15768,7 +16283,7 @@ Perl_unlnk(pTHX_ const char *f)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_UNLNK                 \
-        Perl_assert_aTHX; assert(f)
+     STMT_START { Perl_assert_aTHX; assert(f); } STMT_END
 
 #endif
 #if defined(USE_C_BACKTRACE)
@@ -15777,20 +16292,20 @@ Perl_dump_c_backtrace(pTHX_ PerlIO *fp, int max_depth, int skip)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DUMP_C_BACKTRACE      \
-        Perl_assert_aTHX; assert(fp)
+     STMT_START { Perl_assert_aTHX; assert(fp); } STMT_END
 
 PERL_CALLCONV Perl_c_backtrace *
 Perl_get_c_backtrace(pTHX_ int max_depth, int skip)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GET_C_BACKTRACE       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SV *
 Perl_get_c_backtrace_dump(pTHX_ int max_depth, int skip)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_GET_C_BACKTRACE_DUMP  \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(USE_C_BACKTRACE) */
 #if defined(USE_DTRACE)
@@ -15799,28 +16314,29 @@ Perl_dtrace_probe_call(pTHX_ CV *cv, bool is_call)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_CALL     \
-        Perl_assert_aTHX; assert(cv);  \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
+     STMT_START { Perl_assert_aTHX; assert(cv);                              \
+                  assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+    } STMT_END
 
 PERL_CALLCONV void
 Perl_dtrace_probe_load(pTHX_ const char *name, bool is_loading)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_LOAD     \
-        Perl_assert_aTHX; assert(name)
+     STMT_START { Perl_assert_aTHX; assert(name); } STMT_END
 
 PERL_CALLCONV void
 Perl_dtrace_probe_op(pTHX_ const OP *op)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_OP       \
-        Perl_assert_aTHX; assert(op)
+     STMT_START { Perl_assert_aTHX; assert(op); } STMT_END
 
 PERL_CALLCONV void
 Perl_dtrace_probe_phase(pTHX_ enum perl_phase phase)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_PHASE    \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(USE_DTRACE) */
 #if defined(USE_ITHREADS)
@@ -15829,7 +16345,9 @@ Perl_alloccopstash(pTHX_ HV *hv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_ALLOCCOPSTASH         \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+     STMT_START { Perl_assert_aTHX; assert(hv);    \
+                  assert(SvTYPE(hv) == SVt_PVHV);  \
+    } STMT_END
 
 PERL_CALLCONV void *
 Perl_any_dup(pTHX_ void *v, const PerlInterpreter *proto_perl)
@@ -15837,13 +16355,13 @@ Perl_any_dup(pTHX_ void *v, const PerlInterpreter *proto_perl)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_ANY_DUP               \
-        Perl_assert_aTHX; assert(proto_perl)
+     STMT_START { Perl_assert_aTHX; assert(proto_perl); } STMT_END
 
 PERL_CALLCONV void
 Perl_clone_params_del(CLONE_PARAMS *param)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_CLONE_PARAMS_DEL      \
-        assert(param)
+     STMT_START { assert(param); } STMT_END
 
 PERL_CALLCONV CLONE_PARAMS *
 Perl_clone_params_new(PerlInterpreter * const from, PerlInterpreter * const to)
@@ -15851,7 +16369,7 @@ Perl_clone_params_new(PerlInterpreter * const from, PerlInterpreter * const to)
         Perl_attribute_nonnull(2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CLONE_PARAMS_NEW      \
-        assert(from); assert(to)
+     STMT_START { assert(from); assert(to); } STMT_END
 
 PERL_CALLCONV PERL_CONTEXT *
 Perl_cx_dup(pTHX_ PERL_CONTEXT *cx, I32 ix, I32 max, CLONE_PARAMS *param)
@@ -15859,7 +16377,7 @@ Perl_cx_dup(pTHX_ PERL_CONTEXT *cx, I32 ix, I32 max, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_CX_DUP                \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV DIR *
 Perl_dirp_dup(pTHX_ DIR * const dp, CLONE_PARAMS * const param)
@@ -15867,14 +16385,14 @@ Perl_dirp_dup(pTHX_ DIR * const dp, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DIRP_DUP              \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_fp_dup(pTHX_ PerlIO * const fp, const char type, CLONE_PARAMS * const param)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_FP_DUP                \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV GP *
 Perl_gp_dup(pTHX_ GP * const gp, CLONE_PARAMS * const param)
@@ -15882,7 +16400,7 @@ Perl_gp_dup(pTHX_ GP * const gp, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GP_DUP                \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV HE *
 Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS *param)
@@ -15890,7 +16408,7 @@ Perl_he_dup(pTHX_ const HE *e, bool shared, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HE_DUP                \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV HEK *
 Perl_hek_dup(pTHX_ HEK *e, CLONE_PARAMS *param)
@@ -15898,7 +16416,7 @@ Perl_hek_dup(pTHX_ HEK *e, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_HEK_DUP               \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV MAGIC *
 Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS * const param)
@@ -15906,7 +16424,7 @@ Perl_mg_dup(pTHX_ MAGIC *mg, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_MG_DUP                \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV struct mro_meta *
 Perl_mro_meta_dup(pTHX_ struct mro_meta *smeta, CLONE_PARAMS *param)
@@ -15915,7 +16433,7 @@ Perl_mro_meta_dup(pTHX_ struct mro_meta *smeta, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MRO_META_DUP          \
-        Perl_assert_aTHX; assert(smeta); assert(param)
+     STMT_START { Perl_assert_aTHX; assert(smeta); assert(param); } STMT_END
 
 PERL_CALLCONV OP *
 Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
@@ -15923,7 +16441,7 @@ Perl_newPADOP(pTHX_ I32 type, I32 flags, SV *sv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_NEWPADOP              \
-        Perl_assert_aTHX; assert(sv)
+     STMT_START { Perl_assert_aTHX; assert(sv); } STMT_END
 
 PERL_CALLCONV PADLIST *
 Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
@@ -15933,7 +16451,8 @@ Perl_padlist_dup(pTHX_ PADLIST *srcpad, CLONE_PARAMS *param)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADLIST_DUP           \
-        Perl_assert_aTHX; assert(srcpad); assert(param)
+     STMT_START { Perl_assert_aTHX; assert(srcpad); assert(param);  \
+    } STMT_END
 
 PERL_CALLCONV PADNAME *
 Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
@@ -15943,7 +16462,7 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADNAME_DUP           \
-        Perl_assert_aTHX; assert(src); assert(param)
+     STMT_START { Perl_assert_aTHX; assert(src); assert(param); } STMT_END
 
 PERL_CALLCONV PADNAMELIST *
 Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
@@ -15952,20 +16471,20 @@ Perl_padnamelist_dup(pTHX_ PADNAMELIST *srcpad, CLONE_PARAMS *param)
         __attribute__warn_unused_result__
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_PADNAMELIST_DUP       \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV yy_parser *
 Perl_parser_dup(pTHX_ const yy_parser * const proto, CLONE_PARAMS * const param)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PARSER_DUP            \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV PerlInterpreter *
 perl_clone(PerlInterpreter *proto_perl, UV flags)
         Perl_attribute_nonnull(1);
 # define PERL_ARGS_ASSERT_PERL_CLONE            \
-        assert(proto_perl)
+     STMT_START { assert(proto_perl); } STMT_END
 
 PERL_CALLCONV void
 Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
@@ -15974,7 +16493,9 @@ Perl_re_dup_guts(pTHX_ const REGEXP *sstr, REGEXP *dstr, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_RE_DUP_GUTS           \
-        Perl_assert_aTHX; assert(sstr); assert(dstr); assert(param)
+     STMT_START { Perl_assert_aTHX; assert(sstr); assert(dstr);  \
+                  assert(param);                                 \
+    } STMT_END
 
 PERL_CALLCONV void *
 Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
@@ -15982,7 +16503,7 @@ Perl_regdupe_internal(pTHX_ REGEXP * const rx, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_REGDUPE_INTERNAL      \
-        Perl_assert_aTHX; assert(rx); assert(param)
+     STMT_START { Perl_assert_aTHX; assert(rx); assert(param); } STMT_END
 
 PERL_CALLCONV void
 Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const param)
@@ -15991,7 +16512,8 @@ Perl_rvpv_dup(pTHX_ SV * const dsv, const SV * const ssv, CLONE_PARAMS * const p
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_RVPV_DUP              \
-        Perl_assert_aTHX; assert(dsv); assert(ssv); assert(param)
+     STMT_START { Perl_assert_aTHX; assert(dsv); assert(ssv); assert(param);  \
+    } STMT_END
 
 PERL_CALLCONV PERL_SI *
 Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS *param)
@@ -15999,7 +16521,7 @@ Perl_si_dup(pTHX_ PERL_SI *si, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SI_DUP                \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV ANY *
 Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS *param)
@@ -16008,7 +16530,8 @@ Perl_ss_dup(pTHX_ PerlInterpreter *proto_perl, CLONE_PARAMS *param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SS_DUP                \
-        Perl_assert_aTHX; assert(proto_perl); assert(param)
+     STMT_START { Perl_assert_aTHX; assert(proto_perl); assert(param);  \
+    } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_dup(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
@@ -16016,7 +16539,7 @@ Perl_sv_dup(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP                \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
@@ -16024,7 +16547,7 @@ Perl_sv_dup_inc(pTHX_ const SV * const ssv, CLONE_PARAMS * const param)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_SV_DUP_INC            \
-        Perl_assert_aTHX; assert(param)
+     STMT_START { Perl_assert_aTHX; assert(param); } STMT_END
 
 # if defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C)
 PERL_CALLCONV void
@@ -16034,7 +16557,7 @@ Perl_op_relocate_sv(pTHX_ SV **svp, PADOFFSET *targp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #   define PERL_ARGS_ASSERT_OP_RELOCATE_SV      \
-        Perl_assert_aTHX; assert(svp); assert(targp)
+       STMT_START { Perl_assert_aTHX; assert(svp); assert(targp); } STMT_END
 
 # endif /* defined(PERL_IN_OP_C) || defined(PERL_IN_PEEP_C) */
 #else /* if !defined(USE_ITHREADS) */
@@ -16044,9 +16567,9 @@ Perl_CopFILEGV_set(pTHX_ COP *c, GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_COPFILEGV_SET         \
-        Perl_assert_aTHX; assert(c); assert(gv)
+     STMT_START { Perl_assert_aTHX; assert(c); assert(gv); } STMT_END
 
-#endif /* !defined(USE_ITHREADS) */
+#endif
 #if defined(USE_LOCALE_COLLATE)
 PERL_CALLCONV int
 Perl_magic_freecollxfrm(pTHX_ SV *sv, MAGIC *mg)
@@ -16055,7 +16578,7 @@ Perl_magic_freecollxfrm(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_FREECOLLXFRM    \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV int
 Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
@@ -16064,14 +16587,14 @@ Perl_magic_setcollxfrm(pTHX_ SV *sv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_MAGIC_SETCOLLXFRM     \
-        Perl_assert_aTHX; assert(sv); assert(mg)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(mg); } STMT_END
 
 PERL_CALLCONV SV *
 Perl_strxfrm(pTHX_ SV *src)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_STRXFRM               \
-        Perl_assert_aTHX; assert(src)
+     STMT_START { Perl_assert_aTHX; assert(src); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp)
@@ -16079,7 +16602,7 @@ Perl_sv_collxfrm(pTHX_ SV * const sv, STRLEN * const nxp)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_COLLXFRM           \
-        Perl_assert_aTHX; assert(sv); assert(nxp)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(nxp); } STMT_END
 
 PERL_CALLCONV char *
 Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
@@ -16087,12 +16610,13 @@ Perl_sv_collxfrm_flags(pTHX_ SV * const sv, STRLEN * const nxp, I32 const flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SV_COLLXFRM_FLAGS     \
-        Perl_assert_aTHX; assert(sv); assert(nxp)
+     STMT_START { Perl_assert_aTHX; assert(sv); assert(nxp); } STMT_END
 
 # if defined(PERL_IN_LOCALE_C) || defined(PERL_IN_MATHOMS_C) || \
      defined(PERL_IN_SV_C)
 #   define PERL_ARGS_ASSERT_MEM_COLLXFRM_       \
-        Perl_assert_aTHX; assert(input_string); assert(xlen)
+       STMT_START { Perl_assert_aTHX; assert(input_string); assert(xlen);  \
+    } STMT_END
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV char *
@@ -16116,153 +16640,153 @@ PERL_CALLCONV void
 Perl_PerlIO_clearerr(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_CLEARERR       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlIO_close(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_CLOSE          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlIO_eof(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_EOF            \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlIO_error(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_ERROR          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlIO_fileno(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_FILENO         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlIO_fill(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_FILL           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlIO_flush(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_FLUSH          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV STDCHAR *
 Perl_PerlIO_get_base(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_GET_BASE       \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_get_bufsiz(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_GET_BUFSIZ     \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_get_cnt(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_GET_CNT        \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV STDCHAR *
 Perl_PerlIO_get_ptr(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_GET_PTR        \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_read(pTHX_ PerlIO *f, void *vbuf, Size_t count)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_READ           \
-        Perl_assert_aTHX; assert(vbuf)
+     STMT_START { Perl_assert_aTHX; assert(vbuf); } STMT_END
 
 PERL_CALLCONV void
 Perl_PerlIO_restore_errno(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_RESTORE_ERRNO  \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_PerlIO_save_errno(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_SAVE_ERRNO     \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV int
 Perl_PerlIO_seek(pTHX_ PerlIO *f, Off_t offset, int whence)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_SEEK           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_PerlIO_set_cnt(pTHX_ PerlIO *f, SSize_t cnt)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_SET_CNT        \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_PerlIO_set_ptrcnt(pTHX_ PerlIO *f, STDCHAR *ptr, SSize_t cnt)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_SET_PTRCNT     \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_PerlIO_setlinebuf(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_SETLINEBUF     \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stderr(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_STDERR         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stdin(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_STDIN          \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV PerlIO *
 Perl_PerlIO_stdout(pTHX)
         Perl_attribute_nonnull_aTHX
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_PERLIO_STDOUT         \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV Off_t
 Perl_PerlIO_tell(pTHX_ PerlIO *f)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_PERLIO_TELL           \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_unread(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_UNREAD         \
-        Perl_assert_aTHX; assert(vbuf)
+     STMT_START { Perl_assert_aTHX; assert(vbuf); } STMT_END
 
 PERL_CALLCONV SSize_t
 Perl_PerlIO_write(pTHX_ PerlIO *f, const void *vbuf, Size_t count)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_PERLIO_WRITE          \
-        Perl_assert_aTHX; assert(vbuf)
+     STMT_START { Perl_assert_aTHX; assert(vbuf); } STMT_END
 
 #endif /* defined(USE_PERLIO) */
 #if defined(USE_PERL_SWITCH_LOCALE_CONTEXT)
@@ -16270,7 +16794,7 @@ PERL_CALLCONV void
 Perl_switch_locale_context(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_SWITCH_LOCALE_CONTEXT \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif
 #if defined(USE_QUADMATH)
@@ -16279,14 +16803,14 @@ Perl_quadmath_format_needed(const char *format)
         Perl_attribute_nonnull(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_QUADMATH_FORMAT_NEEDED \
-        assert(format)
+     STMT_START { assert(format); } STMT_END
 
 PERL_CALLCONV bool
 Perl_quadmath_format_valid(const char *format)
         Perl_attribute_nonnull(1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_QUADMATH_FORMAT_VALID \
-        assert(format)
+     STMT_START { assert(format); } STMT_END
 
 #endif /* defined(USE_QUADMATH) */
 #if defined(USE_THREADS)
@@ -16294,13 +16818,13 @@ PERL_CALLCONV void
 Perl_thread_locale_init(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_INIT    \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV void
 Perl_thread_locale_term(pTHX)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_THREAD_LOCALE_TERM    \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 #endif /* defined(USE_THREADS) */
 #if defined(VMS) || defined(WIN32)
@@ -16310,21 +16834,21 @@ Perl_do_aspawn(pTHX_ SV *really, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_DO_ASPAWN             \
-        Perl_assert_aTHX; assert(mark); assert(sp)
+     STMT_START { Perl_assert_aTHX; assert(mark); assert(sp); } STMT_END
 
 PERL_CALLCONV int
 Perl_do_spawn(pTHX_ char *cmd)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN              \
-        Perl_assert_aTHX; assert(cmd)
+     STMT_START { Perl_assert_aTHX; assert(cmd); } STMT_END
 
 PERL_CALLCONV int
 Perl_do_spawn_nowait(pTHX_ char *cmd)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DO_SPAWN_NOWAIT       \
-        Perl_assert_aTHX; assert(cmd)
+     STMT_START { Perl_assert_aTHX; assert(cmd); } STMT_END
 
 #endif /* defined(VMS) || defined(WIN32) */
 #if defined(WIN32)
@@ -16338,14 +16862,14 @@ Perl_get_win32_message_utf8ness(pTHX_ const char *string)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_GET_WIN32_MESSAGE_UTF8NESS \
-        Perl_assert_aTHX
+     STMT_START { Perl_assert_aTHX; } STMT_END
 
 PERL_CALLCONV_NO_RET void
 win32_croak_not_implemented(const char *fname)
         Perl_attribute_nonnull(1)
         __attribute__noreturn__;
 # define PERL_ARGS_ASSERT_WIN32_CROAK_NOT_IMPLEMENTED \
-        assert(fname)
+     STMT_START { assert(fname); } STMT_END
 
 #else /* if !defined(WIN32) */
 PERL_CALLCONV bool
@@ -16354,7 +16878,7 @@ Perl_do_exec3(pTHX_ const char *incmd, int fd, int do_report)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_DO_EXEC3              \
-        Perl_assert_aTHX; assert(incmd)
+     STMT_START { Perl_assert_aTHX; assert(incmd); } STMT_END
 
 #endif /* !defined(WIN32) */
 

--- a/proto.h
+++ b/proto.h
@@ -196,8 +196,8 @@ Perl_apply_attrs_string(pTHX_ const char *stashpv, CV *cv, const char *attrstr, 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_APPLY_ATTRS_STRING     \
-        Perl_assert_aTHX; assert(stashpv); assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
+        Perl_assert_aTHX; assert(stashpv); assert(cv);  \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
         assert(attrstr)
 
 PERL_CALLCONV OP *
@@ -205,7 +205,7 @@ Perl_apply_builtin_cv_attributes(pTHX_ CV *cv, OP *attrlist)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_APPLY_BUILTIN_CV_ATTRIBUTES \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -286,8 +286,8 @@ Perl_av_extend_guts(pTHX_ AV *av, SSize_t key, SSize_t *maxp, SV ***allocp, SV *
         Perl_attribute_nonnull(pTHX_5)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_AV_EXTEND_GUTS         \
-        Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV); assert(maxp); \
-        assert(allocp); assert(arrayp)
+        Perl_assert_aTHX; assert(!av || SvTYPE(av) == SVt_PVAV);  \
+        assert(maxp); assert(allocp); assert(arrayp)
 
 PERL_CALLCONV SV **
 Perl_av_fetch(pTHX_ AV *av, SSize_t key, I32 lval)
@@ -348,7 +348,7 @@ Perl_av_push(pTHX_ AV *av, SV *val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_AV_PUSH                \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
         assert(val)
 
 PERL_CALLCONV void
@@ -521,7 +521,7 @@ Perl_call_list(pTHX_ I32 oldscope, AV *paramList)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_CALL_LIST              \
-        Perl_assert_aTHX; assert(paramList); \
+        Perl_assert_aTHX; assert(paramList);  \
         assert(SvTYPE(paramList) == SVt_PVAV)
 
 PERL_CALLCONV SSize_t
@@ -602,7 +602,8 @@ Perl_ck_entersub_args_core(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_CORE  \
-        Perl_assert_aTHX; assert(entersubop); assert(namegv); assert(protosv)
+        Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
+        assert(protosv)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_list(pTHX_ OP *entersubop)
@@ -618,7 +619,8 @@ Perl_ck_entersub_args_proto(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO \
-        Perl_assert_aTHX; assert(entersubop); assert(namegv); assert(protosv)
+        Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
+        assert(protosv)
 
 PERL_CALLCONV OP *
 Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protosv)
@@ -627,7 +629,8 @@ Perl_ck_entersub_args_proto_or_list(pTHX_ OP *entersubop, GV *namegv, SV *protos
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CK_ENTERSUB_ARGS_PROTO_OR_LIST \
-        Perl_assert_aTHX; assert(entersubop); assert(namegv); assert(protosv)
+        Perl_assert_aTHX; assert(entersubop); assert(namegv);  \
+        assert(protosv)
 
 PERL_CALLCONV void
 Perl_ck_warner(pTHX_ U32 err, const char *pat, ...)
@@ -861,7 +864,7 @@ Perl_cv_clone(pTHX_ CV *proto)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_CLONE               \
-        Perl_assert_aTHX; assert(proto); \
+        Perl_assert_aTHX; assert(proto);  \
         assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM)
 
 PERL_CALLCONV CV *
@@ -871,9 +874,9 @@ Perl_cv_clone_into(pTHX_ CV *proto, CV *target)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_CLONE_INTO          \
-        Perl_assert_aTHX; assert(proto); \
-        assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM); \
-        assert(target); \
+        Perl_assert_aTHX; assert(proto);  \
+        assert(SvTYPE(proto) == SVt_PVCV || SvTYPE(proto) == SVt_PVFM);  \
+        assert(target);  \
         assert(SvTYPE(target) == SVt_PVCV || SvTYPE(target) == SVt_PVFM)
 
 PERL_CALLCONV SV *
@@ -892,7 +895,7 @@ Perl_cv_forget_slab(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_FORGET_SLAB         \
-        Perl_assert_aTHX; \
+        Perl_assert_aTHX;  \
         assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -902,8 +905,8 @@ Perl_cv_get_call_checker(pTHX_ CV *cv, Perl_call_checker *ckfun_p, SV **ckobj_p)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER    \
-        Perl_assert_aTHX; assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
+        Perl_assert_aTHX; assert(cv);  \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
         assert(ckfun_p); assert(ckobj_p)
 
 PERL_CALLCONV void
@@ -914,8 +917,8 @@ Perl_cv_get_call_checker_flags(pTHX_ CV *cv, U32 gflags, Perl_call_checker *ckfu
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_CV_GET_CALL_CHECKER_FLAGS \
-        Perl_assert_aTHX; assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
+        Perl_assert_aTHX; assert(cv);  \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
         assert(ckfun_p); assert(ckobj_p); assert(ckflags_p)
 
 PERL_CALLCONV SV *
@@ -932,9 +935,9 @@ Perl_cv_set_call_checker(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER    \
-        Perl_assert_aTHX; assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(ckfun); \
-        assert(ckobj)
+        Perl_assert_aTHX; assert(cv);  \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+        assert(ckfun); assert(ckobj)
 
 PERL_CALLCONV void
 Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj, U32 ckflags)
@@ -943,16 +946,16 @@ Perl_cv_set_call_checker_flags(pTHX_ CV *cv, Perl_call_checker ckfun, SV *ckobj,
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_CV_SET_CALL_CHECKER_FLAGS \
-        Perl_assert_aTHX; assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(ckfun); \
-        assert(ckobj)
+        Perl_assert_aTHX; assert(cv);  \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+        assert(ckfun); assert(ckobj)
 
 PERL_CALLCONV void
 Perl_cv_undef(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CV_UNDEF               \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -961,7 +964,7 @@ Perl_cv_undef_flags(pTHX_ CV *cv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_CV_UNDEF_FLAGS         \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV GV *
@@ -969,7 +972,7 @@ Perl_cvgv_from_hek(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_FROM_HEK          \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -977,7 +980,7 @@ Perl_cvgv_set(pTHX_ CV *cv, GV *gv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVGV_SET               \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -985,8 +988,8 @@ Perl_cvstash_set(pTHX_ CV *cv, HV *stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_CVSTASH_SET            \
-        Perl_assert_aTHX; assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); \
+        Perl_assert_aTHX; assert(cv);  \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
         assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
@@ -1080,7 +1083,7 @@ Perl_delimcpy(char *to, const char *to_end, const char *from, const char *from_e
         Perl_attribute_nonnull(4)
         Perl_attribute_nonnull(6);
 #define PERL_ARGS_ASSERT_DELIMCPY               \
-        assert(to); assert(to_end); assert(from); assert(from_end); \
+        assert(to); assert(to_end); assert(from); assert(from_end);  \
         assert(retlen); assert(to <= to_end); assert(from <= from_end)
 
 PERL_CALLCONV char *
@@ -1091,7 +1094,7 @@ Perl_delimcpy_no_escape(char *to, const char *to_end, const char *from, const ch
         Perl_attribute_nonnull(4)
         Perl_attribute_nonnull(6);
 #define PERL_ARGS_ASSERT_DELIMCPY_NO_ESCAPE     \
-        assert(to); assert(to_end); assert(from); assert(from_end); \
+        assert(to); assert(to_end); assert(from); assert(from_end);  \
         assert(retlen); assert(to <= to_end); assert(from <= from_end)
 
 PERL_CALLCONV void
@@ -1176,7 +1179,7 @@ Perl_do_hv_dump(pTHX_ I32 level, PerlIO *file, const char *name, HV *sv)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_DO_HV_DUMP             \
-        Perl_assert_aTHX; assert(file); assert(name); \
+        Perl_assert_aTHX; assert(file); assert(name);  \
         assert(!sv || SvTYPE(sv) == SVt_PVHV)
 
 PERL_CALLCONV void
@@ -1187,7 +1190,8 @@ Perl_do_join(pTHX_ SV *sv, SV *delim, SV **mark, SV **sp)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_DO_JOIN                \
-        Perl_assert_aTHX; assert(sv); assert(delim); assert(mark); assert(sp)
+        Perl_assert_aTHX; assert(sv); assert(delim); assert(mark);  \
+        assert(sp)
 
 PERL_CALLCONV void
 Perl_do_magic_dump(pTHX_ I32 level, PerlIO *file, const MAGIC *mg, I32 nest, I32 maxnest, bool dumpops, STRLEN pvlim)
@@ -1539,7 +1543,7 @@ Perl_fbm_instr(pTHX_ unsigned char *big, unsigned char *bigend, SV *littlestr, U
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_FBM_INSTR              \
-        Perl_assert_aTHX; assert(big); assert(bigend); assert(littlestr); \
+        Perl_assert_aTHX; assert(big); assert(bigend); assert(littlestr);  \
         assert(big <= bigend)
 
 PERL_CALLCONV SV *
@@ -1672,7 +1676,7 @@ Perl_get_and_check_backslash_N_name(pTHX_ const char *s, const char *e, const bo
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GET_AND_CHECK_BACKSLASH_N_NAME \
-        Perl_assert_aTHX; assert(s); assert(e); assert(error_msg); \
+        Perl_assert_aTHX; assert(s); assert(e); assert(error_msg);  \
         assert(s <= e)
 
 PERL_CALLCONV AV *
@@ -1701,7 +1705,7 @@ Perl_get_db_sub(pTHX_ SV **svp, CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GET_DB_SUB             \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV const char *
@@ -1842,7 +1846,7 @@ Perl_grok_infnan(pTHX_ const char **sp, const char *send)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_GROK_INFNAN            \
-        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send); \
+        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send);  \
         assert(*sp <= send)
 
 PERL_CALLCONV int
@@ -1866,7 +1870,7 @@ Perl_grok_numeric_radix(pTHX_ const char **sp, const char *send)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_GROK_NUMERIC_RADIX     \
-        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send); \
+        Perl_assert_aTHX; assert(sp); assert(*sp); assert(send);  \
         assert(*sp <= send)
 
 PERL_CALLCONV UV
@@ -2129,7 +2133,7 @@ Perl_gv_init(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, int multi)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT                \
-        Perl_assert_aTHX; assert(gv); \
+        Perl_assert_aTHX; assert(gv);  \
         assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
@@ -2138,7 +2142,7 @@ Perl_gv_init_pv(pTHX_ GV *gv, HV *stash, const char *name, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PV             \
-        Perl_assert_aTHX; assert(gv); \
+        Perl_assert_aTHX; assert(gv);  \
         assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
@@ -2147,7 +2151,7 @@ Perl_gv_init_pvn(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, U32 flag
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_PVN            \
-        Perl_assert_aTHX; assert(gv); \
+        Perl_assert_aTHX; assert(gv);  \
         assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(name)
 
 PERL_CALLCONV void
@@ -2156,7 +2160,7 @@ Perl_gv_init_sv(pTHX_ GV *gv, HV *stash, SV *namesv, U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_GV_INIT_SV             \
-        Perl_assert_aTHX; assert(gv); \
+        Perl_assert_aTHX; assert(gv);  \
         assert(!stash || SvTYPE(stash) == SVt_PVHV); assert(namesv)
 
 PERL_CALLCONV void
@@ -2279,7 +2283,8 @@ Perl_hv_delete_ent(pTHX_ HV *hv, SV *keysv, I32 flags, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_HV_DELETE_ENT          \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+        assert(keysv)
 
 PERL_CALLCONV void
 Perl_hv_dump(pTHX_ HV *hv)
@@ -2309,7 +2314,7 @@ Perl_hv_ename_add(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_ADD           \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(name)
 
 PERL_CALLCONV void
@@ -2319,7 +2324,7 @@ Perl_hv_ename_delete(pTHX_ HV *hv, const char *name, U32 len, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_HV_ENAME_DELETE        \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(name)
 
 PERL_CALLCONV bool
@@ -2336,7 +2341,8 @@ Perl_hv_exists_ent(pTHX_ HV *hv, SV *keysv, U32 hash)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_EXISTS_ENT          \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+        assert(keysv)
 
 PERL_CALLCONV SV **
 Perl_hv_fetch(pTHX_ HV *hv, const char *key, I32 klen, I32 lval)
@@ -2350,7 +2356,8 @@ Perl_hv_fetch_ent(pTHX_ HV *hv, SV *keysv, I32 lval, U32 hash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_HV_FETCH_ENT           \
-        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV); assert(keysv)
+        Perl_assert_aTHX; assert(!hv || SvTYPE(hv) == SVt_PVHV);  \
+        assert(keysv)
 
 PERL_CALLCONV STRLEN
 Perl_hv_fill(pTHX_ HV * const hv)
@@ -2413,7 +2420,7 @@ Perl_hv_iternextsv(pTHX_ HV *hv, char **key, I32 *retlen)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERNEXTSV          \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(key); assert(retlen)
 
 PERL_CALLCONV SV *
@@ -2423,7 +2430,7 @@ Perl_hv_iterval(pTHX_ HV *hv, HE *entry)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_HV_ITERVAL             \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(entry)
 
 PERL_CALLCONV void
@@ -2615,8 +2622,9 @@ Perl_init_named_cv(pTHX_ CV *cv, OP *nameop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_INIT_NAMED_CV          \
-        Perl_assert_aTHX; assert(cv); \
-        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(nameop)
+        Perl_assert_aTHX; assert(cv);  \
+        assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM);  \
+        assert(nameop)
 
 PERL_CALLCONV void
 Perl_init_stacks(pTHX)
@@ -2996,7 +3004,8 @@ Perl_load_charnames(pTHX_ SV *char_name, const char *context, const STRLEN conte
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_LOAD_CHARNAMES         \
-        Perl_assert_aTHX; assert(char_name); assert(context); assert(error_msg)
+        Perl_assert_aTHX; assert(char_name); assert(context);  \
+        assert(error_msg)
 
 PERL_CALLCONV void
 Perl_load_module(pTHX_ U32 flags, SV *name, SV *ver, ...)
@@ -3365,7 +3374,8 @@ Perl_magic_scalarpack(pTHX_ HV *hv, MAGIC *mg)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_MAGIC_SCALARPACK       \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(mg)
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
+        assert(mg)
 
 PERL_CALLCONV int
 Perl_magic_set(pTHX_ SV *sv, MAGIC *mg)
@@ -3844,7 +3854,7 @@ Perl_mro_package_moved(pTHX_ HV * const stash, HV * const oldstash, const GV * c
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_MRO_PACKAGE_MOVED      \
-        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
         assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(gv)
 
 PERL_CALLCONV void
@@ -3883,7 +3893,7 @@ Perl_multideref_stringify(pTHX_ const OP *o, CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_MULTIDEREF_STRINGIFY   \
-        Perl_assert_aTHX; assert(o); \
+        Perl_assert_aTHX; assert(o);  \
         assert(!cv || SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV NV
@@ -4624,7 +4634,8 @@ Perl_newTRYCATCHOP(pTHX_ I32 flags, OP *tryblock, OP *catchvar, OP *catchblock)
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_NEWTRYCATCHOP          \
-        Perl_assert_aTHX; assert(tryblock); assert(catchvar); assert(catchblock)
+        Perl_assert_aTHX; assert(tryblock); assert(catchvar);  \
+        assert(catchblock)
 
 PERL_CALLCONV OP *
 Perl_newUNOP(pTHX_ I32 type, I32 flags, OP *first)
@@ -4741,7 +4752,7 @@ Perl_ninstr(const char *big, const char *bigend, const char *little, const char 
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_NINSTR                 \
-        assert(big); assert(bigend); assert(little); assert(lend); \
+        assert(big); assert(bigend); assert(little); assert(lend);  \
         assert(big <= bigend); assert(little <= lend)
 
 PERL_CALLCONV void
@@ -4962,8 +4973,8 @@ Perl_packlist(pTHX_ SV *cat, const char *pat, const char *patend, SV **beglist, 
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_PACKLIST               \
-        Perl_assert_aTHX; assert(cat); assert(pat); assert(patend); \
-        assert(beglist); assert(endlist); assert(pat <= patend); \
+        Perl_assert_aTHX; assert(cat); assert(pat); assert(patend);  \
+        assert(beglist); assert(endlist); assert(pat <= patend);  \
         assert(*patend == '\0')
 
 PERL_CALLCONV PADOFFSET
@@ -4971,7 +4982,7 @@ Perl_pad_add_anon(pTHX_ CV *func, I32 optype)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_ANON           \
-        Perl_assert_aTHX; assert(func); \
+        Perl_assert_aTHX; assert(func);  \
         assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
 
 PERL_CALLCONV PADOFFSET
@@ -4979,8 +4990,8 @@ Perl_pad_add_name_pv(pTHX_ const char *name, const U32 flags, HV *typestash, HV 
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PV        \
-        Perl_assert_aTHX; assert(name); \
-        assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(name);  \
+        assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV PADOFFSET
@@ -4988,8 +4999,8 @@ Perl_pad_add_name_pvn(pTHX_ const char *namepv, STRLEN namelen, U32 flags, HV *t
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_PVN       \
-        Perl_assert_aTHX; assert(namepv); \
-        assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(namepv);  \
+        assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV PADOFFSET
@@ -4997,8 +5008,8 @@ Perl_pad_add_name_sv(pTHX_ SV *name, U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_PAD_ADD_NAME_SV        \
-        Perl_assert_aTHX; assert(name); \
-        assert(!typestash || SvTYPE(typestash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(name);  \
+        assert(!typestash || SvTYPE(typestash) == SVt_PVHV);  \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 PERL_CALLCONV void
@@ -5007,7 +5018,7 @@ Perl_pad_add_weakref(pTHX_ CV *func)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_ADD_WEAKREF        \
-        Perl_assert_aTHX; assert(func); \
+        Perl_assert_aTHX; assert(func);  \
         assert(SvTYPE(func) == SVt_PVCV || SvTYPE(func) == SVt_PVFM)
 
 PERL_CALLCONV PADOFFSET
@@ -5052,9 +5063,9 @@ Perl_pad_fixup_inner_anons(pTHX_ PADLIST *padlist, CV *old_cv, CV *new_cv)
         Perl_attribute_nonnull(pTHX_3)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_PAD_FIXUP_INNER_ANONS  \
-        Perl_assert_aTHX; assert(padlist); assert(old_cv); \
-        assert(SvTYPE(old_cv) == SVt_PVCV || SvTYPE(old_cv) == SVt_PVFM); \
-        assert(new_cv); \
+        Perl_assert_aTHX; assert(padlist); assert(old_cv);  \
+        assert(SvTYPE(old_cv) == SVt_PVCV || SvTYPE(old_cv) == SVt_PVFM);  \
+        assert(new_cv);  \
         assert(SvTYPE(new_cv) == SVt_PVCV || SvTYPE(new_cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -5322,8 +5333,8 @@ Perl_pregexec(pTHX_ REGEXP * const prog, char *stringarg, char *strend, char *st
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 #define PERL_ARGS_ASSERT_PREGEXEC               \
-        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend); \
-        assert(strbeg); assert(screamer); assert(strbeg <= stringarg); \
+        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend);  \
+        assert(strbeg); assert(screamer); assert(strbeg <= stringarg);  \
         assert(stringarg <= strend)
 
 PERL_CALLCONV void
@@ -5467,7 +5478,7 @@ Perl_re_intuit_start(pTHX_ REGEXP * const rx, SV *sv, const char * const strbeg,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_RE_INTUIT_START        \
-        Perl_assert_aTHX; assert(rx); assert(strbeg); assert(strpos); \
+        Perl_assert_aTHX; assert(rx); assert(strbeg); assert(strpos);  \
         assert(strend); assert(strbeg <= strpos); assert(strpos <= strend)
 
 PERL_CALLCONV SV *
@@ -5690,8 +5701,8 @@ Perl_regexec_flags(pTHX_ REGEXP * const rx, char *stringarg, char *strend, char 
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 #define PERL_ARGS_ASSERT_REGEXEC_FLAGS          \
-        Perl_assert_aTHX; assert(rx); assert(stringarg); assert(strend); \
-        assert(strbeg); assert(sv); assert(strbeg <= stringarg); \
+        Perl_assert_aTHX; assert(rx); assert(stringarg); assert(strend);  \
+        assert(strbeg); assert(sv); assert(strbeg <= stringarg);  \
         assert(stringarg <= strend)
 
 PERL_CALLCONV void
@@ -5779,7 +5790,7 @@ Perl_rninstr(const char *big, const char *bigend, const char *little, const char
         __attribute__warn_unused_result__
         __attribute__pure__;
 #define PERL_ARGS_ASSERT_RNINSTR                \
-        assert(big); assert(bigend); assert(little); assert(lend); \
+        assert(big); assert(bigend); assert(little); assert(lend);  \
         assert(big <= bigend); assert(little <= lend)
 
 PERL_CALLCONV void
@@ -5913,7 +5924,7 @@ Perl_save_aelem(pTHX_ AV *av, SSize_t idx, SV **sptr)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_AELEM             \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
         assert(sptr)
 
 PERL_CALLCONV void
@@ -5922,7 +5933,7 @@ Perl_save_aelem_flags(pTHX_ AV *av, SSize_t idx, SV **sptr, const U32 flags)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_AELEM_FLAGS       \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
         assert(sptr)
 
 PERL_CALLCONV SSize_t
@@ -5965,7 +5976,7 @@ Perl_save_delete(pTHX_ HV *hv, char *key, I32 klen)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_DELETE            \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(key)
 
 PERL_CALLCONV void
@@ -6040,7 +6051,7 @@ Perl_save_hdelete(pTHX_ HV *hv, SV *keysv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_SAVE_HDELETE           \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(keysv)
 
 PERL_CALLCONV void
@@ -6050,7 +6061,7 @@ Perl_save_helem(pTHX_ HV *hv, SV *key, SV **sptr)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_HELEM             \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(key); assert(sptr)
 
 PERL_CALLCONV void
@@ -6060,7 +6071,7 @@ Perl_save_helem_flags(pTHX_ HV *hv, SV *key, SV **sptr, const U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #define PERL_ARGS_ASSERT_SAVE_HELEM_FLAGS       \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(key); assert(sptr)
 
 PERL_CALLCONV void
@@ -6484,7 +6495,7 @@ Perl_sub_crush_depth(pTHX_ CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_SUB_CRUSH_DEPTH        \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -6712,7 +6723,7 @@ Perl_sv_cat_decode(pTHX_ SV *dsv, SV *encoding, SV *ssv, int *offset, char *tstr
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #define PERL_ARGS_ASSERT_SV_CAT_DECODE          \
-        Perl_assert_aTHX; assert(dsv); assert(encoding); assert(ssv); \
+        Perl_assert_aTHX; assert(dsv); assert(encoding); assert(ssv);  \
         assert(offset); assert(tstr)
 
 PERL_CALLCONV void
@@ -6912,7 +6923,8 @@ Perl_sv_derived_from_hv(pTHX_ SV *sv, HV *hv)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_SV_DERIVED_FROM_HV     \
-        Perl_assert_aTHX; assert(sv); assert(hv); assert(SvTYPE(hv) == SVt_PVHV)
+        Perl_assert_aTHX; assert(sv); assert(hv);  \
+        assert(SvTYPE(hv) == SVt_PVHV)
 
 PERL_CALLCONV bool
 Perl_sv_derived_from_pv(pTHX_ SV *sv, const char * const name, U32 flags)
@@ -7507,7 +7519,8 @@ Perl_sv_reset(pTHX_ const char *s, HV * const stash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_SV_RESET               \
-        Perl_assert_aTHX; assert(s); assert(!stash || SvTYPE(stash) == SVt_PVHV)
+        Perl_assert_aTHX; assert(s);  \
+        assert(!stash || SvTYPE(stash) == SVt_PVHV)
 
 PERL_CALLCONV void
 Perl_sv_resetpvn(pTHX_ const char *s, STRLEN len, HV * const stash)
@@ -8068,7 +8081,8 @@ Perl_tied_method(pTHX_ SV *methname, SV **mark, SV * const sv, const MAGIC * con
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 #define PERL_ARGS_ASSERT_TIED_METHOD            \
-        Perl_assert_aTHX; assert(methname); assert(mark); assert(sv); assert(mg)
+        Perl_assert_aTHX; assert(methname); assert(mark); assert(sv);  \
+        assert(mg)
 
 PERL_CALLCONV SSize_t
 Perl_tmps_grow_p(pTHX_ SSize_t ix)
@@ -8180,8 +8194,8 @@ Perl_unpackstring(pTHX_ const char *pat, const char *patend, const char *s, cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 #define PERL_ARGS_ASSERT_UNPACKSTRING           \
-        Perl_assert_aTHX; assert(pat); assert(patend); assert(s); assert(strend); \
-        assert(pat <= patend); assert(s <= strend)
+        Perl_assert_aTHX; assert(pat); assert(patend); assert(s);  \
+        assert(strend); assert(pat <= patend); assert(s <= strend)
 
 PERL_CALLCONV void
 Perl_unshare_hek(pTHX_ HEK *hek)
@@ -8234,7 +8248,7 @@ Perl_utf8_hop_safe(const U8 *s, SSize_t off, const U8 * const start, const U8 * 
         Perl_attribute_nonnull(4)
         __attribute__warn_unused_result__;
 #define PERL_ARGS_ASSERT_UTF8_HOP_SAFE          \
-        assert(s); assert(start); assert(end); assert(start <= s); \
+        assert(s); assert(start); assert(end); assert(start <= s);  \
         assert(s <= end)
 
 PERL_CALLCONV STRLEN
@@ -9354,7 +9368,7 @@ perl_alloc_using(const struct IPerlMem **ipM, const struct IPerlMem **ipMS, cons
         Perl_attribute_nonnull(8)
         Perl_attribute_nonnull(9);
 # define PERL_ARGS_ASSERT_PERL_ALLOC_USING      \
-        assert(ipM); assert(ipMS); assert(ipMP); assert(ipE); assert(ipStd); \
+        assert(ipM); assert(ipMS); assert(ipMP); assert(ipE); assert(ipStd);  \
         assert(ipLIO); assert(ipD); assert(ipS); assert(ipP)
 
 # if defined(USE_ITHREADS)
@@ -9371,8 +9385,9 @@ perl_clone_using(PerlInterpreter *proto_perl, UV flags, const struct IPerlMem **
         Perl_attribute_nonnull(10)
         Perl_attribute_nonnull(11);
 #   define PERL_ARGS_ASSERT_PERL_CLONE_USING    \
-        assert(proto_perl); assert(ipM); assert(ipMS); assert(ipMP); assert(ipE); \
-        assert(ipStd); assert(ipLIO); assert(ipD); assert(ipS); assert(ipP)
+        assert(proto_perl); assert(ipM); assert(ipMS); assert(ipMP);  \
+        assert(ipE); assert(ipStd); assert(ipLIO); assert(ipD); assert(ipS);  \
+        assert(ipP)
 
 # endif /* defined(USE_ITHREADS) */
 #else /* if !defined(PERL_IMPLICIT_SYS) */
@@ -9419,7 +9434,7 @@ Perl_XS_builtin_indexed(pTHX_ CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_XS_BUILTIN_INDEXED    \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -9938,7 +9953,7 @@ Perl_class_add_ADJUST(pTHX_ HV *stash, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_ADJUST      \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
         assert(cv); assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -9947,7 +9962,7 @@ Perl_class_add_field(pTHX_ HV *stash, PADNAME *pn)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CLASS_ADD_FIELD       \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
         assert(pn)
 
 PERL_CALLCONV void
@@ -9983,7 +9998,7 @@ Perl_class_prepare_method_parse(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CLASS_PREPARE_METHOD_PARSE \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void
@@ -10063,7 +10078,8 @@ S_openn_cleanup(pTHX_ GV *gv, IO *io, PerlIO *fp, char *mode, const char *oname,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_OPENN_CLEANUP         \
-        Perl_assert_aTHX; assert(gv); assert(io); assert(mode); assert(oname)
+        Perl_assert_aTHX; assert(gv); assert(io); assert(mode);  \
+        assert(oname)
 
 static IO *
 S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int *savefd, char *savetype)
@@ -10075,7 +10091,7 @@ S_openn_setup(pTHX_ GV *gv, char *mode, PerlIO **saveifp, PerlIO **saveofp, int 
         Perl_attribute_nonnull(pTHX_5)
         Perl_attribute_nonnull(pTHX_6);
 # define PERL_ARGS_ASSERT_OPENN_SETUP           \
-        Perl_assert_aTHX; assert(gv); assert(mode); assert(saveifp); \
+        Perl_assert_aTHX; assert(gv); assert(mode); assert(saveifp);  \
         assert(saveofp); assert(savefd); assert(savetype)
 
 # if !defined(DOSISH)
@@ -10114,7 +10130,7 @@ S_do_trans_count_invmap(pTHX_ SV * const sv, AV * const invmap)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_COUNT_INVMAP \
-        Perl_assert_aTHX; assert(sv); assert(invmap); \
+        Perl_assert_aTHX; assert(sv); assert(invmap);  \
         assert(SvTYPE(invmap) == SVt_PVAV)
 
 static Size_t
@@ -10124,7 +10140,7 @@ S_do_trans_invmap(pTHX_ SV * const sv, AV * const invmap)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DO_TRANS_INVMAP       \
-        Perl_assert_aTHX; assert(sv); assert(invmap); \
+        Perl_assert_aTHX; assert(sv); assert(invmap);  \
         assert(SvTYPE(invmap) == SVt_PVAV)
 
 static Size_t
@@ -10215,7 +10231,7 @@ Perl_form_alien_digit_msg(pTHX_ const U8 which, const STRLEN valids_len, const c
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_FORM_ALIEN_DIGIT_MSG  \
-        Perl_assert_aTHX; assert(first_bad); assert(send); \
+        Perl_assert_aTHX; assert(first_bad); assert(send);  \
         assert(first_bad < send)
 
 PERL_CALLCONV bool
@@ -10236,7 +10252,7 @@ Perl_grok_bslash_o(pTHX_ char **s, const char * const send, UV *uv, const char *
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GROK_BSLASH_O         \
-        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv); \
+        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv);  \
         assert(message); assert(*s < send)
 
 PERL_CALLCONV bool
@@ -10248,7 +10264,7 @@ Perl_grok_bslash_x(pTHX_ char **s, const char * const send, UV *uv, const char *
         Perl_attribute_nonnull(pTHX_4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_GROK_BSLASH_X         \
-        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv); \
+        Perl_assert_aTHX; assert(s); assert(*s); assert(send); assert(uv);  \
         assert(message); assert(*s < send)
 
 #endif /* defined(PERL_IN_DQUOTE_C) || defined(PERL_IN_REGCOMP_C) ||
@@ -10354,7 +10370,7 @@ S_gv_magicalize(pTHX_ GV *gv, HV *stash, const char *name, STRLEN len, const svt
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_GV_MAGICALIZE         \
-        Perl_assert_aTHX; assert(gv); assert(stash); \
+        Perl_assert_aTHX; assert(gv); assert(stash);  \
         assert(SvTYPE(stash) == SVt_PVHV); assert(name)
 
 static void
@@ -10381,8 +10397,8 @@ S_parse_gv_stash_name(pTHX_ HV **stash, GV **gv, const char **name, STRLEN *len,
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_PARSE_GV_STASH_NAME   \
-        Perl_assert_aTHX; assert(stash); assert(gv); assert(name); assert(*name); \
-        assert(len); assert(nambeg); assert(nambeg <= *name)
+        Perl_assert_aTHX; assert(stash); assert(gv); assert(name);  \
+        assert(*name); assert(len); assert(nambeg); assert(nambeg <= *name)
 
 static void
 S_require_tie_mod(pTHX_ GV *gv, const char varname, const char *name, STRLEN len, const U32 flags)
@@ -10480,7 +10496,7 @@ S_hv_magic_check(HV *hv, bool *needs_copy, bool *needs_store)
         Perl_attribute_nonnull(2)
         Perl_attribute_nonnull(3);
 # define PERL_ARGS_ASSERT_HV_MAGIC_CHECK        \
-        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(needs_copy); \
+        assert(hv); assert(SvTYPE(hv) == SVt_PVHV); assert(needs_copy);  \
         assert(needs_store)
 
 PERL_STATIC_NO_RET void
@@ -10550,7 +10566,7 @@ Perl_hfree_next_entry(pTHX_ HV *hv, STRLEN *indexp)
         Perl_attribute_nonnull(pTHX_2)
         __attribute__visibility__("hidden");
 # define PERL_ARGS_ASSERT_HFREE_NEXT_ENTRY      \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(indexp)
 
 #endif /* defined(PERL_IN_HV_C) || defined(PERL_IN_SV_C) */
@@ -10590,7 +10606,7 @@ S_populate_hash_from_C_localeconv(pTHX_ HV *hv, const char *locale, const U32 wh
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_C_LOCALECONV \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(locale); assert(strings); assert(integers)
 
 static bool
@@ -10602,8 +10618,8 @@ S_strftime8(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_6);
 # define PERL_ARGS_ASSERT_STRFTIME8             \
-        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale); assert(mytm); \
-        assert(result_utf8ness)
+        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale);  \
+        assert(mytm); assert(result_utf8ness)
 
 static bool
 S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm *mytm)
@@ -10614,7 +10630,8 @@ S_strftime_tm(pTHX_ const char *fmt, SV *sv, const char *locale, const struct tm
         Perl_attribute_nonnull(pTHX_4)
         __attribute__format__(__strftime__,pTHX_1,0);
 # define PERL_ARGS_ASSERT_STRFTIME_TM           \
-        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale); assert(mytm)
+        Perl_assert_aTHX; assert(fmt); assert(sv); assert(locale);  \
+        assert(mytm)
 
 static SV *
 S_sv_strftime_common(pTHX_ SV *fmt, const char *locale, const struct tm *mytm)
@@ -10736,7 +10753,7 @@ S_populate_hash_from_localeconv(pTHX_ HV *hv, const char *locale, const U32 whic
         Perl_attribute_nonnull(pTHX_4)
         Perl_attribute_nonnull(pTHX_5);
 #     define PERL_ARGS_ASSERT_POPULATE_HASH_FROM_LOCALECONV \
-        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(hv); assert(SvTYPE(hv) == SVt_PVHV);  \
         assert(locale); assert(strings); assert(integers)
 
 #   endif /*   defined(HAS_LOCALECONV) &&
@@ -11033,7 +11050,7 @@ S_mro_clean_isarev(pTHX_ HV * const isa, const char * const name, const STRLEN l
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_MRO_CLEAN_ISAREV      \
-        Perl_assert_aTHX; assert(isa); assert(SvTYPE(isa) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(isa); assert(SvTYPE(isa) == SVt_PVHV);  \
         assert(name); assert(!exceptions || SvTYPE(exceptions) == SVt_PVHV)
 
 static void
@@ -11043,9 +11060,10 @@ S_mro_gather_and_rename(pTHX_ HV * const stashes, HV * const seen_stashes, HV *s
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_5);
 # define PERL_ARGS_ASSERT_MRO_GATHER_AND_RENAME \
-        Perl_assert_aTHX; assert(stashes); assert(SvTYPE(stashes) == SVt_PVHV); \
-        assert(seen_stashes); assert(SvTYPE(seen_stashes) == SVt_PVHV); \
-        assert(!stash || SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(stashes);  \
+        assert(SvTYPE(stashes) == SVt_PVHV); assert(seen_stashes);  \
+        assert(SvTYPE(seen_stashes) == SVt_PVHV);  \
+        assert(!stash || SvTYPE(stash) == SVt_PVHV);  \
         assert(!oldstash || SvTYPE(oldstash) == SVt_PVHV); assert(namesv)
 
 static AV *
@@ -11064,7 +11082,7 @@ S_apply_attrs_my(pTHX_ HV *stash, OP *target, OP *attrs, OP **import_opsp)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_APPLY_ATTRS_MY        \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
         assert(target); assert(import_opsp)
 
 static I32
@@ -11106,7 +11124,7 @@ S_clear_special_blocks(pTHX_ const char * const fullname, GV * const gv, CV * co
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_CLEAR_SPECIAL_BLOCKS  \
-        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv); \
+        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static void
@@ -11169,7 +11187,7 @@ S_import_attributes_module(pTHX_ HV *stash, SV *target, OP *attrs)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_IMPORT_ATTRIBUTES_MODULE \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
         assert(target)
 
 static void
@@ -11260,7 +11278,7 @@ S_process_special_blocks(pTHX_ I32 floor, const char * const fullname, GV * cons
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PROCESS_SPECIAL_BLOCKS \
-        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv); \
+        Perl_assert_aTHX; assert(fullname); assert(gv); assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static OP *
@@ -11452,7 +11470,7 @@ S_pad_alloc_name(pTHX_ PADNAME *name, U32 flags, HV *typestash, HV *ourstash)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_PAD_ALLOC_NAME        \
-        Perl_assert_aTHX; assert(name); \
+        Perl_assert_aTHX; assert(name);  \
         assert(!ourstash || SvTYPE(ourstash) == SVt_PVHV)
 
 static void
@@ -11470,7 +11488,7 @@ S_pad_findlex(pTHX_ const char *namepv, STRLEN namelen, U32 flags, const CV *cv,
         Perl_attribute_nonnull(pTHX_8)
         Perl_attribute_nonnull(pTHX_9);
 # define PERL_ARGS_ASSERT_PAD_FINDLEX           \
-        Perl_assert_aTHX; assert(namepv); assert(cv); assert(out_name); \
+        Perl_assert_aTHX; assert(namepv); assert(cv); assert(out_name);  \
         assert(out_flags)
 
 static void
@@ -11643,7 +11661,7 @@ S_incpush_if_exists(pTHX_ AV * const av, SV *dir, SV * const stem)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 #   define PERL_ARGS_ASSERT_INCPUSH_IF_EXISTS   \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
         assert(dir); assert(stem)
 
 # endif /* !defined(PERL_IS_MINIPERL) */
@@ -11748,7 +11766,8 @@ static OP *
 S_do_smartmatch(pTHX_ HV *seen_this, HV *seen_other, const bool copied)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DO_SMARTMATCH         \
-        Perl_assert_aTHX; assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV); \
+        Perl_assert_aTHX;  \
+        assert(!seen_this || SvTYPE(seen_this) == SVt_PVHV);  \
         assert(!seen_other || SvTYPE(seen_other) == SVt_PVHV)
 
 static OP *
@@ -11762,8 +11781,8 @@ static bool
 S_doeval_compile(pTHX_ U8 gimme, CV *outside, U32 seq, HV *hh)
         Perl_attribute_nonnull_aTHX;
 # define PERL_ARGS_ASSERT_DOEVAL_COMPILE        \
-        Perl_assert_aTHX; \
-        assert(!outside || SvTYPE(outside) == SVt_PVCV || SvTYPE(outside) == SVt_PVFM); \
+        Perl_assert_aTHX;  \
+        assert(!outside || SvTYPE(outside) == SVt_PVCV || SvTYPE(outside) == SVt_PVFM);  \
         assert(!hh || SvTYPE(hh) == SVt_PVHV)
 
 static OP *
@@ -11775,7 +11794,7 @@ S_dofindlabel(pTHX_ OP *o, const char *label, STRLEN len, U32 flags, OP **opstac
         Perl_attribute_nonnull(pTHX_6)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_DOFINDLABEL           \
-        Perl_assert_aTHX; assert(o); assert(label); assert(opstack); \
+        Perl_assert_aTHX; assert(o); assert(label); assert(opstack);  \
         assert(oplimit)
 
 static MAGIC *
@@ -11879,7 +11898,7 @@ S_save_lines(pTHX_ AV *array, SV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_SAVE_LINES            \
-        Perl_assert_aTHX; assert(!array || SvTYPE(array) == SVt_PVAV); \
+        Perl_assert_aTHX; assert(!array || SvTYPE(array) == SVt_PVAV);  \
         assert(sv)
 
 # if !defined(PERL_DISABLE_PMC)
@@ -11970,7 +11989,7 @@ S_group_end(pTHX_ const char *patptr, const char *patend, char ender)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_GROUP_END             \
-        Perl_assert_aTHX; assert(patptr); assert(patend); \
+        Perl_assert_aTHX; assert(patptr); assert(patend);  \
         assert(patptr <= patend)
 
 static SV *
@@ -12025,7 +12044,7 @@ S_pack_rec(pTHX_ SV *cat, struct tempsym *symptr, SV **beglist, SV **endlist)
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PACK_REC              \
-        Perl_assert_aTHX; assert(cat); assert(symptr); assert(beglist); \
+        Perl_assert_aTHX; assert(cat); assert(symptr); assert(beglist);  \
         assert(endlist)
 
 static char *
@@ -12044,7 +12063,7 @@ S_unpack_rec(pTHX_ struct tempsym *symptr, const char *s, const char *strbeg, co
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_UNPACK_REC            \
-        Perl_assert_aTHX; assert(symptr); assert(s); assert(strbeg); \
+        Perl_assert_aTHX; assert(symptr); assert(s); assert(strbeg);  \
         assert(strend); assert(strbeg <= s); assert(s <= strend)
 
 #endif /* defined(PERL_IN_PP_PACK_C) */
@@ -12209,7 +12228,7 @@ S_doform(pTHX_ CV *cv, GV *gv, OP *retop)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_DOFORM                \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM); assert(gv)
 
 static SV *
@@ -12251,11 +12270,11 @@ S_dooneliner(pTHX_ const char *cmd, const char *filename)
         Perl_assert_aTHX; assert(n)
 
 # define PERL_ARGS_ASSERT_JOIN_EXACT            \
-        Perl_assert_aTHX; assert(pRExC_state); assert(scan); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(scan);  \
         assert(min_subtract); assert(unfolded_multi_char)
 
 # define PERL_ARGS_ASSERT_MAKE_TRIE             \
-        Perl_assert_aTHX; assert(pRExC_state); assert(startbranch); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(startbranch);  \
         assert(first); assert(last); assert(tail)
 
 # define PERL_ARGS_ASSERT_POPULATE_ANYOF_BITMAP_FROM_INVLIST \
@@ -12274,8 +12293,8 @@ S_dooneliner(pTHX_ const char *cmd, const char *filename)
         Perl_assert_aTHX; assert(pRExC_state); assert(ssc)
 
 # define PERL_ARGS_ASSERT_STUDY_CHUNK           \
-        Perl_assert_aTHX; assert(pRExC_state); assert(scanp); assert(minlenp); \
-        assert(deltap); assert(last)
+        Perl_assert_aTHX; assert(pRExC_state); assert(scanp);  \
+        assert(minlenp); assert(deltap); assert(last)
 
 # if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_CALLCONV void
@@ -12379,18 +12398,18 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharm
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DUMP_TRIE           \
-        Perl_assert_aTHX; assert(trie); \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(trie);  \
+        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
         assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST \
-        Perl_assert_aTHX; assert(trie); \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(trie);  \
+        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
         assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE \
-        Perl_assert_aTHX; assert(trie); \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(trie);  \
+        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
         assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
 
 # endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
@@ -12439,8 +12458,8 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
 #endif
 #if defined(PERL_IN_REGCOMP_C)
 # define PERL_ARGS_ASSERT_ADD_MULTI_MATCH       \
-        Perl_assert_aTHX; \
-        assert(!multi_char_matches || SvTYPE(multi_char_matches) == SVt_PVAV); \
+        Perl_assert_aTHX;  \
+        assert(!multi_char_matches || SvTYPE(multi_char_matches) == SVt_PVAV);  \
         assert(multi_string)
 
 # define PERL_ARGS_ASSERT_CHANGE_ENGINE_SIZE    \
@@ -12456,23 +12475,23 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
         assert(src); assert(tgt)
 
 # define PERL_ARGS_ASSERT_EXECUTE_WILDCARD      \
-        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend); \
-        assert(strbeg); assert(screamer); assert(strbeg <= stringarg); \
+        Perl_assert_aTHX; assert(prog); assert(stringarg); assert(strend);  \
+        assert(strbeg); assert(screamer); assert(strbeg <= stringarg);  \
         assert(stringarg <= strend); assert(*strend == '\0')
 
 # define PERL_ARGS_ASSERT_GET_QUANTIFIER_VALUE  \
-        Perl_assert_aTHX; assert(pRExC_state); assert(start); assert(end); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(start); assert(end);  \
         assert(start < end)
 
 # define PERL_ARGS_ASSERT_GROK_BSLASH_N         \
         Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_HANDLE_NAMED_BACKREF  \
-        Perl_assert_aTHX; assert(pRExC_state); assert(flagp); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(flagp);  \
         assert(backref_parse_start)
 
 # define PERL_ARGS_ASSERT_HANDLE_NAMES_WILDCARD \
-        Perl_assert_aTHX; assert(wname); assert(prop_definition); \
+        Perl_assert_aTHX; assert(wname); assert(prop_definition);  \
         assert(strings)
 
 # define PERL_ARGS_ASSERT_HANDLE_POSSIBLE_POSIX \
@@ -12482,7 +12501,7 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
         Perl_assert_aTHX; assert(pRExC_state); assert(flagp)
 
 # define PERL_ARGS_ASSERT_HANDLE_USER_DEFINED_PROPERTY \
-        Perl_assert_aTHX; assert(name); assert(contents); \
+        Perl_assert_aTHX; assert(name); assert(contents);  \
         assert(user_defined_ptr); assert(msg)
 
 # define PERL_ARGS_ASSERT_IS_SSC_WORTH_IT       \
@@ -12492,18 +12511,19 @@ Perl_invlist_clone(pTHX_ SV * const invlist, SV *newlist)
         Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_OPTIMIZE_REGCLASS     \
-        Perl_assert_aTHX; assert(pRExC_state); assert(anyof_flags); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(anyof_flags);  \
         assert(invert); assert(ret); assert(flagp)
 
 # define PERL_ARGS_ASSERT_OUTPUT_POSIX_WARNINGS \
-        Perl_assert_aTHX; assert(pRExC_state); assert(posix_warnings); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(posix_warnings);  \
         assert(SvTYPE(posix_warnings) == SVt_PVAV)
 
 # define PERL_ARGS_ASSERT_PARSE_LPAREN_QUESTION_FLAGS \
         Perl_assert_aTHX; assert(pRExC_state)
 
 # define PERL_ARGS_ASSERT_PARSE_UNIPROP_STRING  \
-        Perl_assert_aTHX; assert(name); assert(user_defined_ptr); assert(msg)
+        Perl_assert_aTHX; assert(name); assert(user_defined_ptr);  \
+        assert(msg)
 
 PERL_STATIC_NO_RET void
 S_re_croak(pTHX_ bool utf8, const char *pat, ...)
@@ -12565,8 +12585,9 @@ S_re_croak(pTHX_ bool utf8, const char *pat, ...)
         Perl_assert_aTHX; assert(pRExC_state); assert(Rx)
 
 # define PERL_ARGS_ASSERT_SKIP_BRACKETED_WHITE_SPACE \
-        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p); \
-        assert(*p); assert(stop_p); assert(p_start <= *p); assert(*p <= stop_p)
+        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p);  \
+        assert(*p); assert(stop_p); assert(p_start <= *p);  \
+        assert(*p <= stop_p)
 
 # define PERL_ARGS_ASSERT_SKIP_TO_BE_IGNORED_TEXT \
         Perl_assert_aTHX; assert(pRExC_state); assert(p)
@@ -12583,8 +12604,8 @@ S_re_croak(pTHX_ bool utf8, const char *pat, ...)
 
 #   if defined(ENABLE_REGEX_SETS_DEBUGGING)
 #     define PERL_ARGS_ASSERT_DUMP_REGEX_SETS_STRUCTURES \
-        Perl_assert_aTHX; assert(pRExC_state); assert(stack); \
-        assert(SvTYPE(stack) == SVt_PVAV); assert(fence_stack); \
+        Perl_assert_aTHX; assert(pRExC_state); assert(stack);  \
+        assert(SvTYPE(stack) == SVt_PVAV); assert(fence_stack);  \
         assert(SvTYPE(fence_stack) == SVt_PVAV)
 
 #   endif
@@ -12811,8 +12832,9 @@ S_dump_regex_sets_structures(pTHX_ RExC_state_t *pRExC_state, AV *stack, const I
         assert(s1); assert(s2)
 
 #   define PERL_ARGS_ASSERT_REG_SKIPCOMMENT     \
-        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p); \
-        assert(*p); assert(p_end); assert(p_start <= *p); assert(*p <= p_end)
+        Perl_assert_aTHX; assert(pRExC_state); assert(p_start); assert(p);  \
+        assert(*p); assert(p_end); assert(p_start <= *p);  \
+        assert(*p <= p_end)
 
 #   if defined(PERL_CORE) || defined(PERL_EXT)
 PERL_STATIC_INLINE Size_t
@@ -12854,7 +12876,7 @@ Perl_populate_invlist_from_bitmap(pTHX_ const U8 *bitmap, const Size_t bitmap_le
 #if defined(PERL_IN_REGCOMP_C) || defined(PERL_IN_REGEXEC_C) || \
     defined(PERL_IN_TOKE_C)
 # define PERL_ARGS_ASSERT_IS_GRAPHEME           \
-        Perl_assert_aTHX; assert(strbeg); assert(s); assert(strend); \
+        Perl_assert_aTHX; assert(strbeg); assert(s); assert(strend);  \
         assert(strbeg <= s); assert(s < strend)
 
 #endif
@@ -13091,35 +13113,35 @@ S_unwind_scan_frames(pTHX_ void *p)
 #endif /* defined(PERL_IN_REGCOMP_STUDY_C) */
 #if defined(PERL_IN_REGEXEC_C)
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_LB        \
-        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend); \
+        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend);  \
         assert(*curpos < strend)
 
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_SB        \
-        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend); \
+        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend);  \
         assert(*curpos < strend)
 
 # define PERL_ARGS_ASSERT_ADVANCE_ONE_WB_       \
-        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend); \
+        Perl_assert_aTHX; assert(curpos); assert(*curpos); assert(strend);  \
         assert(*curpos < strend)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_GCB        \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos);  \
         assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_LB_        \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos);  \
         assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_SB         \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(*curpos);  \
         assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_BACKUP_ONE_WB_BUT_OVER_EXTEND_FO \
-        Perl_assert_aTHX; assert(previous); assert(strbeg); assert(curpos); \
+        Perl_assert_aTHX; assert(previous); assert(strbeg); assert(curpos);  \
         assert(*curpos); assert(strbeg <= *curpos)
 
 # define PERL_ARGS_ASSERT_FIND_BYCLASS          \
-        Perl_assert_aTHX; assert(prog); assert(c); assert(s); assert(strend); \
+        Perl_assert_aTHX; assert(prog); assert(c); assert(s); assert(strend);  \
         assert(s <= strend)
 
 # define PERL_ARGS_ASSERT_FIND_NEXT_MASKED      \
@@ -13135,22 +13157,23 @@ S_unwind_scan_frames(pTHX_ void *p)
         Perl_assert_aTHX
 
 # define PERL_ARGS_ASSERT_ISFOO_UTF8_LC         \
-        Perl_assert_aTHX; assert(character); assert(e); assert(character < e)
+        Perl_assert_aTHX; assert(character); assert(e);  \
+        assert(character < e)
 
 # define PERL_ARGS_ASSERT_ISGCB                 \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos);  \
         assert(strbeg <= curpos)
 
 # define PERL_ARGS_ASSERT_ISLB                  \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend);  \
         assert(strbeg <= curpos); assert(curpos < strend)
 
 # define PERL_ARGS_ASSERT_ISSB                  \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend);  \
         assert(strbeg <= curpos); assert(curpos < strend)
 
 # define PERL_ARGS_ASSERT_ISWB                  \
-        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend); \
+        Perl_assert_aTHX; assert(strbeg); assert(curpos); assert(strend);  \
         assert(strbeg <= curpos); assert(curpos < strend)
 
 # define PERL_ARGS_ASSERT_REG_CHECK_NAMED_BUFF_MATCHED \
@@ -13172,13 +13195,14 @@ S_unwind_scan_frames(pTHX_ void *p)
         assert(s); assert(lim)
 
 # define PERL_ARGS_ASSERT_REGINCLASS            \
-        Perl_assert_aTHX; assert(n); assert(p); assert(p_end); assert(p < p_end)
+        Perl_assert_aTHX; assert(n); assert(p); assert(p_end);  \
+        assert(p < p_end)
 
 # define PERL_ARGS_ASSERT_REGMATCH              \
         Perl_assert_aTHX; assert(reginfo); assert(startpos); assert(prog)
 
 # define PERL_ARGS_ASSERT_REGREPEAT             \
-        Perl_assert_aTHX; assert(prog); assert(startposp); assert(p); \
+        Perl_assert_aTHX; assert(prog); assert(startposp); assert(p);  \
         assert(loceol); assert(reginfo); assert(max)
 
 # define PERL_ARGS_ASSERT_REGTRY                \
@@ -13192,12 +13216,12 @@ S_unwind_scan_frames(pTHX_ void *p)
 
 # if defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DEBUG_START_MATCH   \
-        Perl_assert_aTHX; assert(prog); assert(start); assert(end); \
+        Perl_assert_aTHX; assert(prog); assert(start); assert(end);  \
         assert(blurb); assert(start <= end)
 
 #   define PERL_ARGS_ASSERT_DUMP_EXEC_POS       \
-        Perl_assert_aTHX; assert(locinput); assert(scan); assert(loc_regeol); \
-        assert(loc_bostr); assert(loc_reg_starttry); \
+        Perl_assert_aTHX; assert(locinput); assert(scan); assert(loc_regeol);  \
+        assert(loc_bostr); assert(loc_reg_starttry);  \
         assert(locinput <= loc_regeol)
 
 #   define PERL_ARGS_ASSERT_RE_EXEC_INDENTF     \
@@ -13572,7 +13596,7 @@ S_anonymise_cv_maybe(pTHX_ GV *gv, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_ANONYMISE_CV_MAYBE    \
-        Perl_assert_aTHX; assert(gv); assert(cv); \
+        Perl_assert_aTHX; assert(gv); assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 static void
@@ -13699,7 +13723,7 @@ S_sv_pos_b2u_midway(pTHX_ const U8 * const s, const U8 * const target, const U8 
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SV_POS_B2U_MIDWAY     \
-        Perl_assert_aTHX; assert(s); assert(target); assert(end); \
+        Perl_assert_aTHX; assert(s); assert(target); assert(end);  \
         assert(s <= target); assert(target <= end)
 
 static STRLEN
@@ -13710,8 +13734,8 @@ S_sv_pos_u2b_cached(pTHX_ SV * const sv, MAGIC ** const mgp, const U8 * const st
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_CACHED     \
-        Perl_assert_aTHX; assert(sv); assert(mgp); assert(start); assert(send); \
-        assert(start < send)
+        Perl_assert_aTHX; assert(sv); assert(mgp); assert(start);  \
+        assert(send); assert(start < send)
 
 static STRLEN
 S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * const uoffset_p, bool * const at_end, bool *canonical_position)
@@ -13721,7 +13745,7 @@ S_sv_pos_u2b_forwards(const U8 * const start, const U8 * const send, STRLEN * co
         Perl_attribute_nonnull(4)
         Perl_attribute_nonnull(5);
 # define PERL_ARGS_ASSERT_SV_POS_U2B_FORWARDS   \
-        assert(start); assert(send); assert(uoffset_p); assert(at_end); \
+        assert(start); assert(send); assert(uoffset_p); assert(at_end);  \
         assert(canonical_position); assert(start < send)
 
 static STRLEN
@@ -13847,7 +13871,7 @@ S_unreferenced_to_tmp_stack(pTHX_ AV * const unreferenced)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #   define PERL_ARGS_ASSERT_UNREFERENCED_TO_TMP_STACK \
-        Perl_assert_aTHX; assert(unreferenced); \
+        Perl_assert_aTHX; assert(unreferenced);  \
         assert(SvTYPE(unreferenced) == SVt_PVAV)
 
 # endif /* defined(USE_ITHREADS) */
@@ -13945,7 +13969,7 @@ S_incline(pTHX_ const char *s, const char *end)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INCLINE               \
-        Perl_assert_aTHX; assert(s); assert(end); assert(s <= end); \
+        Perl_assert_aTHX; assert(s); assert(end); assert(s <= end);  \
         assert(*end == '\0')
 
 static int
@@ -13961,7 +13985,7 @@ S_intuit_more(pTHX_ char *s, char *e, U8 caller_context, char *caller_s, Size_t 
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_INTUIT_MORE           \
-        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e); \
+        Perl_assert_aTHX; assert(s); assert(e); assert(s <= e);  \
         assert(*e == '\0')
 
 static bool
@@ -14001,7 +14025,7 @@ S_parse_ident(pTHX_ const char *s, const char * const s_end, char **d, char * co
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_PARSE_IDENT           \
-        Perl_assert_aTHX; assert(s); assert(s_end); assert(d); assert(*d); \
+        Perl_assert_aTHX; assert(s); assert(s_end); assert(d); assert(*d);  \
         assert(e); assert(s <= s_end); assert(*d < e)
 
 static char *
@@ -14049,7 +14073,7 @@ S_scan_ident(pTHX_ char *s, char *dest, char *dest_end, U32 flags)
         Perl_attribute_nonnull(pTHX_2)
         Perl_attribute_nonnull(pTHX_3);
 # define PERL_ARGS_ASSERT_SCAN_IDENT            \
-        Perl_assert_aTHX; assert(s); assert(dest); assert(dest_end); \
+        Perl_assert_aTHX; assert(s); assert(dest); assert(dest_end);  \
         assert(dest < dest_end)
 
 static char *
@@ -14196,7 +14220,7 @@ S_isa_lookup(pTHX_ HV *stash, SV *namesv, const char *name, STRLEN len, U32 flag
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_ISA_LOOKUP            \
-        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV); \
+        Perl_assert_aTHX; assert(stash); assert(SvTYPE(stash) == SVt_PVHV);  \
         assert(namesv || name)
 
 static bool
@@ -14249,7 +14273,7 @@ S_to_utf8_case_(pTHX_ const UV original, const U8 *p, U8 *ustrp, STRLEN *lenp, S
         Perl_attribute_nonnull(pTHX_6)
         Perl_attribute_nonnull(pTHX_9);
 # define PERL_ARGS_ASSERT_TO_UTF8_CASE_         \
-        Perl_assert_aTHX; assert(ustrp); assert(lenp); assert(invlist); \
+        Perl_assert_aTHX; assert(ustrp); assert(lenp); assert(invlist);  \
         assert(invmap); assert(normal)
 
 static UV
@@ -14260,7 +14284,7 @@ S_turkic_fc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_FC             \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp); \
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp);  \
         assert(p < e)
 
 static UV
@@ -14271,7 +14295,7 @@ S_turkic_lc(pTHX_ const U8 * const p0, const U8 * const e, U8 *ustrp, STRLEN *le
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_LC             \
-        Perl_assert_aTHX; assert(p0); assert(e); assert(ustrp); assert(lenp); \
+        Perl_assert_aTHX; assert(p0); assert(e); assert(ustrp); assert(lenp);  \
         assert(p0 < e)
 
 static UV
@@ -14282,7 +14306,7 @@ S_turkic_uc(pTHX_ const U8 * const p, const U8 * const e, U8 *ustrp, STRLEN *len
         Perl_attribute_nonnull(pTHX_3)
         Perl_attribute_nonnull(pTHX_4);
 # define PERL_ARGS_ASSERT_TURKIC_UC             \
-        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp); \
+        Perl_assert_aTHX; assert(p); assert(e); assert(ustrp); assert(lenp);  \
         assert(p < e)
 
 static char *
@@ -14436,7 +14460,7 @@ Perl_CvGV(pTHX_ CV *sv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_CVGV                  \
-        Perl_assert_aTHX; assert(sv); \
+        Perl_assert_aTHX; assert(sv);  \
         assert(SvTYPE(sv) == SVt_PVCV || SvTYPE(sv) == SVt_PVFM)
 
 PERL_STATIC_INLINE Stack_off_t
@@ -14629,7 +14653,7 @@ Perl_av_push_simple(pTHX_ AV *av, SV *val)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_AV_PUSH_SIMPLE        \
-        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV); \
+        Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV);  \
         assert(val)
 
 PERL_STATIC_INLINE void
@@ -14928,7 +14952,7 @@ Perl_rpp_invoke_xs(pTHX_ CV *cv)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_RPP_INVOKE_XS         \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE bool
@@ -15241,7 +15265,7 @@ Perl_utf8_hop_overshoot(const U8 *s, SSize_t off, const U8 * const start, const 
         Perl_attribute_nonnull(4)
         __attribute__warn_unused_result__;
 # define PERL_ARGS_ASSERT_UTF8_HOP_OVERSHOOT    \
-        assert(s); assert(start); assert(end); assert(start <= s); \
+        assert(s); assert(start); assert(end); assert(start <= s);  \
         assert(s <= end)
 
 PERL_STATIC_INLINE bool
@@ -15407,7 +15431,7 @@ Perl_cx_pushformat(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, GV *gv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHFORMAT         \
-        Perl_assert_aTHX; assert(cx); assert(cv); \
+        Perl_assert_aTHX; assert(cx); assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE void
@@ -15438,7 +15462,7 @@ Perl_cx_pushsub(pTHX_ PERL_CONTEXT *cx, CV *cv, OP *retop, bool hasargs)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_CX_PUSHSUB            \
-        Perl_assert_aTHX; assert(cx); assert(cv); \
+        Perl_assert_aTHX; assert(cx); assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_STATIC_INLINE void
@@ -15710,7 +15734,7 @@ Perl_xs_wrap(pTHX_ XSUBADDR_t xsub, CV *cv)
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2);
 # define PERL_ARGS_ASSERT_XS_WRAP               \
-        Perl_assert_aTHX; assert(xsub); assert(cv); \
+        Perl_assert_aTHX; assert(xsub); assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 #endif /* defined(PERL_RC_STACK) */
@@ -15775,7 +15799,7 @@ Perl_dtrace_probe_call(pTHX_ CV *cv, bool is_call)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 # define PERL_ARGS_ASSERT_DTRACE_PROBE_CALL     \
-        Perl_assert_aTHX; assert(cv); \
+        Perl_assert_aTHX; assert(cv);  \
         assert(SvTYPE(cv) == SVt_PVCV || SvTYPE(cv) == SVt_PVFM)
 
 PERL_CALLCONV void

--- a/proto.h
+++ b/proto.h
@@ -8706,10 +8706,11 @@ Perl_vdeb(pTHX_ const char *pat, va_list *args)
     STMT_START { assert(pat); } STMT_END
 
 PERL_CALLCONV void
-Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
+Perl_vfatal_warner(pTHX_ U32 err __attribute__unused__, const char *pat, va_list *args)
         Perl_attribute_nonnull(pTHX_2);
 #define PERL_ARGS_ASSERT_VFATAL_WARNER          \
-    STMT_START { assert(pat); } STMT_END
+    STMT_START { assert(pat); PERL_UNUSED_ARG_FOR_ARGS_ASSERT(err);  \
+    } STMT_END
 
 PERL_CALLCONV char *
 Perl_vform(pTHX_ const char *pat, va_list *args)

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4158,16 +4158,16 @@ sub generate_proto_h {
 
                 my $line = "";
                 while(@asserts) {
-                    my $assert = shift @asserts;
+                    my $component = shift @asserts;
 
-                    if(length($line) + length($assert) > 78) {
+                    if(length($line) + length($component) > 78) {
                         $ret .= $line . "; \\\n";
                         $line = "";
                     }
 
                     $line .= " " x 8 if !length $line;
                     $line .= "; " if $line =~ m/\S/;
-                    $line .= $assert;
+                    $line .= $component;
                 }
 
                 $ret .= $line if length $line;

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4158,21 +4158,21 @@ sub generate_proto_h {
 
                 my $line = "";
                 foreach my $which (\@asserts) {
-                while($which->@*) {
-                    my $component = shift $which->@*;
+                    while($which->@*) {
+                        my $component = shift $which->@*;
 
-                    if(length($line) + length($component) > 78) {
-                        $ret .= $line . "; \\\n";
-                        $line = "";
+                        if(length($line) + length($component) > 78) {
+                            $ret .= $line . "; \\\n";
+                            $line = "";
+                        }
+
+                        $line .= " " x 8 if !length $line;
+                        $line .= "; " if $line =~ m/\S/;
+                        $line .= $component;
                     }
 
-                    $line .= " " x 8 if !length $line;
-                    $line .= "; " if $line =~ m/\S/;
-                    $line .= $component;
-                }
-
-                $ret .= $line if length $line;
-                $ret .= "\n";
+                    $ret .= $line if length $line;
+                    $ret .= "\n";
                 }
             }
         }

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3591,7 +3591,7 @@ sub generate_proto_h {
             or next;
 
         my $level= $_->{level};
-        my $ind= $level ? " " : "";
+        our $ind= $level ? " " : "";
         $ind .= "  " x ($level-1) if $level>1;
         my $inner_ind= $ind ? "  " : " ";
 
@@ -4151,36 +4151,104 @@ sub generate_proto_h {
         # We don't hide the ARGS_ASSERT macro; having that defined does no
         # harm, and otherwise some inline functions that are looking for it
         # would fail to compile.
+        my @args_assert;
         if ($args_assert_line || @asserts) {
-            $ret .= "\n#${ind}define PERL_ARGS_ASSERT_\U$plain_func\E";
-            if (@asserts) {
-                $ret .= " \\\n";
+            $ret .= "\n";
 
-                my $line = "";
-                foreach my $which (\@asserts) {
+            # Do some extra work to make it more human readable
+            push @args_assert,
+                             "#${ind}define PERL_ARGS_ASSERT_\U$plain_func\E";
+
+            # This includes keeping track of the maximum length so that the
+            # continuation characters don't form a ragged right edge
+            my $max_length = length $args_assert[-1];
+
+            # Any subsequent lines are indented this much from the #define
+            my $extra_indent = 4;
+
+            if (@asserts) {
+                local $ind = $ind . " " x $extra_indent;
+
+                # The first line of the expansion is always this
+                my $start = "${ind}STMT_START { ";
+                my $line = $start;
+
+                # Any subsequent expansion lines are indented beyond it.
+                local $ind = " " x length $start;
+
+                my $first_item_on_line = 1;
+                my $is_multi_line = 0;
+
+                # Declaring this to be an array, allows the code below to
+                # "just work" as far as folding
+                my @end = '} STMT_END';
+
+                foreach my $which (\@asserts, \@end) {
+
+                    # Look at each line that goes into the definition
                     while($which->@*) {
                         my $component = shift $which->@*;
 
-                        if (length($line) + length($component)
+                        # It reads better if the STMT_END is on its own line,
+                        # closing up the definition, but not if the whole
+                        # thing fits on a single line.
+                        #
+                        # We also start a new line if the next component won't
+                        # fit in the space allotted.
+                        if (   $is_multi_line && $which == \@end
+                            || (length($line) + length($component))
                                 >  78
                                   - 1   # Trailing semicolon
                                   - 3   # Two blanks and the continuation
                         ) {
-                            $ret .= $line . ";  \\\n";
-                            $line = "";
+                            # Add the full line; the component needs a
+                            # semicolon
+                            push @args_assert, $line . ";";
+
+                            $max_length = length $args_assert[-1] if
+                                        length $args_assert[-1] > $max_length;
+
+                            # The STMT_END is outdented to be directly under
+                            # the STMT_START
+                            local $ind = " " x $extra_indent if $which == \@end;
+
+                            # Setup for the new line, including indentation
+                            $line = $ind;
+                            $is_multi_line = 1;
+                            $first_item_on_line = 1;
                         }
 
-                        $line .= " " x 8 if !length $line;
-                        $line .= "; " if $line =~ m/\S/;
+                        # This component is separated from any predecessor by
+                        # a semicolon
+                        $line .= "; " unless $first_item_on_line;
+                        $first_item_on_line = 0;
                         $line .= $component;
                     }
-
-                    $ret .= $line if length $line;
-                    $ret .= "\n";
                 }
+
+                # Here, all items have been assembled; include the final line
+                push @args_assert, $line if length $line;
+                $max_length = length $args_assert[-1] if
+                                        length $args_assert[-1] > $max_length;
+            }
+
+            # If there is only one line, output it directly
+            if (@args_assert == 1) {
+                $ret .= $args_assert[0] . "\n";
+            }
+            else {
+
+                # Otherwise add the trailing continuation for all but the
+                # final line;
+                for (my $i = 0; $i < @args_assert - 1; $i++) {
+                    $args_assert[$i] .= " " x (  $max_length
+                                            - length $args_assert[$i]);
+                    $args_assert[$i] .= '  \\';
+                }
+
+                $ret .= join("\n", @args_assert) . "\n";
             }
         }
-        $ret .= "\n";
 
         $ret = "#${ind}ifndef PERL_NO_INLINE_FUNCTIONS\n$ret\n#${ind}endif"
             if $static_inline;
@@ -4191,7 +4259,6 @@ sub generate_proto_h {
 
         print $pr $ret;
     }
-
 
     close $pr;
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -3652,6 +3652,7 @@ sub generate_proto_h {
         my $can_ignore = $flags !~ /[RP]/ && !$is_malloc;
         my $extensions_only = ( $flags =~ /[EQ]/ );
         my @asserts;
+        my @unused;
         my @attrs;
         my $func;
         my $args_assert_line;
@@ -3825,6 +3826,7 @@ sub generate_proto_h {
                     my $nz =      ( $arg =~ s/\bNZ\b// );
                     my $nullok =  ( $arg =~ s/\bNULLOK\b// );
                     my $nocheck = ( $arg =~ s/\bNOCHECK\b// );
+                    my $unused = ( $arg =~ s/\bUNUSED\b// );
 
                     # Trim $arg and remove multiple blanks
                     $arg =~ s/^\s+//;
@@ -3902,6 +3904,13 @@ sub generate_proto_h {
                             $type_assert = "!$argname || $type_assert"
                                                                    if $nullok;
                             push @asserts, "assert($type_assert)";
+                        }
+
+                        # Exactly one of these expands to nothing.
+                        if ($unused) {
+                            $arg .= " __attribute__unused__";
+                            push @unused,
+                                 "PERL_UNUSED_ARG_FOR_ARGS_ASSERT($argname)";
                         }
 
                         # If this is a pointer to a character string argument,
@@ -4183,7 +4192,7 @@ sub generate_proto_h {
                 # "just work" as far as folding
                 my @end = '} STMT_END';
 
-                foreach my $which (\@asserts, \@end) {
+                foreach my $which (\@asserts, \@unused, \@end) {
 
                     # Look at each line that goes into the definition
                     while($which->@*) {

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4161,8 +4161,12 @@ sub generate_proto_h {
                     while($which->@*) {
                         my $component = shift $which->@*;
 
-                        if(length($line) + length($component) > 78) {
-                            $ret .= $line . "; \\\n";
+                        if (length($line) + length($component)
+                                >  78
+                                  - 1   # Trailing semicolon
+                                  - 3   # Two blanks and the continuation
+                        ) {
+                            $ret .= $line . ";  \\\n";
                             $line = "";
                         }
 

--- a/regen/embed.pl
+++ b/regen/embed.pl
@@ -4157,8 +4157,9 @@ sub generate_proto_h {
                 $ret .= " \\\n";
 
                 my $line = "";
-                while(@asserts) {
-                    my $component = shift @asserts;
+                foreach my $which (\@asserts) {
+                while($which->@*) {
+                    my $component = shift $which->@*;
 
                     if(length($line) + length($component) > 78) {
                         $ret .= $line . "; \\\n";
@@ -4172,6 +4173,7 @@ sub generate_proto_h {
 
                 $ret .= $line if length $line;
                 $ret .= "\n";
+                }
             }
         }
         $ret .= "\n";

--- a/util.c
+++ b/util.c
@@ -2278,11 +2278,10 @@ Perl_fatal_warner(pTHX_ U32 err, const char *pat, ...)
 }
 
 void
-Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)
+Perl_vfatal_warner(pTHX_ U32 err UNUSED, const char *pat, va_list *args)
 {
     PERL_ARGS_ASSERT_VFATAL_WARNER;
     GET_aTHX_if_NULL;
-    PERL_UNUSED_ARG(err);
 
     SV * const msv = vmess(pat, args);
 


### PR DESCRIPTION
This allows removing many PERL_UNUSED_ARG statements in the code.  (The ones that are conditionally compiled cannot be removed this way.)    

One exemplar statement is removed.  


* I don't think this set of changest requires a perldelta entry.
