### PR TITLE
reftype/refaddr: invoke set magic in the non-reference case

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -524,7 +524,7 @@ PP(pp_refaddr)
     if(SvROK(arg))
         sv_setuv_mg(TARG, PTR2UV(SvRV(arg)));
     else
-        sv_setsv(TARG, &PL_sv_undef);
+        sv_setsv_mg(TARG, &PL_sv_undef);
 
     rpp_replace_1_1_NN(TARG);
     return NORMAL;
@@ -540,7 +540,7 @@ PP(pp_reftype)
     if(SvROK(arg))
         sv_setpv_mg(TARG, sv_reftype(SvRV(arg), FALSE));
     else
-        sv_setsv(TARG, &PL_sv_undef);
+        sv_setsv_mg(TARG, &PL_sv_undef);
 
     rpp_replace_1_1_NN(TARG);
     return NORMAL;

--- a/builtin.c
+++ b/builtin.c
@@ -523,8 +523,10 @@ PP(pp_refaddr)
 
     if(SvROK(arg))
         sv_setuv_mg(TARG, PTR2UV(SvRV(arg)));
-    else
-        sv_setsv_mg(TARG, &PL_sv_undef);
+    else {
+        sv_set_undef(TARG);
+        SvSETMAGIC(TARG);
+    }
 
     rpp_replace_1_1_NN(TARG);
     return NORMAL;
@@ -539,8 +541,10 @@ PP(pp_reftype)
 
     if(SvROK(arg))
         sv_setpv_mg(TARG, sv_reftype(SvRV(arg), FALSE));
-    else
-        sv_setsv_mg(TARG, &PL_sv_undef);
+    else {
+        sv_set_undef(TARG);
+        SvSETMAGIC(TARG);
+    }
 
     rpp_replace_1_1_NN(TARG);
     return NORMAL;

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -121,11 +121,21 @@ package FetchStoreCounter {
     is(reftype($obj),        "ARRAY", 'reftype yields basic container type for blessed object');
     is(reftype("not a ref"), undef,   'reftype yields undef for non-reference');
 
+    # GH #24634: refaddr and reftype weren't invoking set magic
+    # on TARG, and TARG could be some lvalue with magic.
+    #
+    # The test here:
+    # - $1 implements read-only-ness in it's magic so if set
+    # magic is called it throws an exception.
+    # - $result is my, so TARGMY optimization should apply
+    # which makes the the assigned to variable the TARG of the OP,
+    # and
+    # - $result is an alias to $1 so $1's magic should be invoked
+    # when it is assigned to, throwing an exception.
+    #
+    # Before the fix the assignments weren't throwing exceptions
     for my $result ($1) {
         my $y = 1; # no constant folding
-        # $result is my, so TARGMY should apply
-        # $1 implements read-only-ness in it's magic
-        # so if set magic is called it throws an exception
         ok(!eval { $result = reftype($y); 1 },
            "magic called for TARGMY reftype");
         ok(!eval { $result = refaddr($y); 1 },

--- a/lib/builtin.t
+++ b/lib/builtin.t
@@ -121,6 +121,17 @@ package FetchStoreCounter {
     is(reftype($obj),        "ARRAY", 'reftype yields basic container type for blessed object');
     is(reftype("not a ref"), undef,   'reftype yields undef for non-reference');
 
+    for my $result ($1) {
+        my $y = 1; # no constant folding
+        # $result is my, so TARGMY should apply
+        # $1 implements read-only-ness in it's magic
+        # so if set magic is called it throws an exception
+        ok(!eval { $result = reftype($y); 1 },
+           "magic called for TARGMY reftype");
+        ok(!eval { $result = refaddr($y); 1 },
+           "magic called for TARGMY refaddr");
+    }
+
     is(blessed($arr), undef, 'blessed yields undef for non-object');
     is(blessed($obj), "Object", 'blessed yields package name for object');
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -457,6 +457,13 @@ folding.  [GH #24661]
 
 =item *
 
+builtin::reftype() and builtin::refaddr() now call set magic for their
+output when their argument isn't a reference.  This would prevent
+propagation of the result if either function was called like
+C<$magical_lexical = reftype($maybe_ref)>.  Fixes #24634
+
+=item *
+
 The regular expression engine's "super-linear cache" wasn't 64-bit clean
 and so could in principle overflow on huge (>256Mb) strings, resulting in
 incorrect matches and potential memory corruption. (The cache engages on


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
Fixes #24634

Also changes to use sv_set_undef() to set the "fail" result.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
