### PR TITLE
Makefile.SH: Add 'test_regex_tests' as make target

### DIFF
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1697,6 +1697,9 @@ test_reonly test-reonly: test_prep_reonly
 test_porting test-porting: test_prep
 	TEST_ARGS='porting/*.t lib/diagnostics.t' TESTFILE=harness $(RUN_TESTS) choose
 
+test_regex_tests test-regex-tests: test_prep
+	TEST_ARGS='re/*.t ../ext/re/t/*.t' PERL_TEST_HARNESS_ASAP=1 TESTFILE=harness $(RUN_TESTS) choose
+
 !NO!SUBS!
 
 $spitshell>>$Makefile <<!GROK!THIS!


### PR DESCRIPTION
With variant `make-regex-tests`.  This runs `make test_prep`, then runs the harness over all the `re/*.t ../ext/re/t/*.t` tests you expect.

Today I was in a situation where I wanted to run all the customary tests exercising regular expressions.  I vaguely recalled that we had a `make` target called `make test_reonly` and naively called:
```
$ sh ./Configure -des -Dusedevel && make test_reonly
```
But that ended with:
```
...
make[1]: Leaving directory '/home/jkeenan/gitwork/perl2/ext/re'
cd t && (rm -f perl; /usr/bin/ln -s ../perl perl)
TEST_ARGS='re/*.t ../ext/re/t/*.t' PERL_TEST_HARNESS_ASAP=1 TESTFILE=harness  ./runtests choose
Can't locate File/Spec.pm in @INC (you may need to install the File::Spec module) (@INC entries checked: ../lib) at ../lib/TAP/Harness.pm line 7.
BEGIN failed--compilation aborted at ../lib/TAP/Harness.pm line 7.
Compilation failed in require at harness line 60.
BEGIN failed--compilation aborted at harness line 60.
make: *** [makefile:874: test_reonly] Error 2
```
I spent some time peering into `Makefile.SH` and noted that `test_reonly` had a dependency on `test_prep_reonly` but not on `test_prep`.
```
test_reonly test-reonly: test_prep_reonly
    TEST_ARGS='re/*.t ../ext/re/t/*.t' PERL_TEST_HARNESS_ASAP=1 TESTFILE=harness $(RUN_TESTS) choose
```
To make a long story short, I didn't get a DWIM result until I added this target with a patch:
```
$ gitshowf |cat
commit 8c4c47cb730dc3cb0a3790e43b997f99278f627d
Author:     James E Keenan <jamesekeenan@yahoo.com>
AuthorDate: Mon Aug 10 14:21:42 2026 -0400
Commit:     James E Keenan <jamesekeenan@yahoo.com>
CommitDate: Mon Aug 10 14:38:16 2026 -0400

    Makefile.SH: Add 'make_regex_tests'
    
    With variant 'make-regex-tests'.  This runs 'make test_prep', then runs
    the harness over all the 're/*.t ../ext/re/t/*.t' tests you expect.

diff --git a/Makefile.SH b/Makefile.SH
index 6351ef6630..d8b5f788ce 100755
--- a/Makefile.SH
+++ b/Makefile.SH
@@ -1697,6 +1697,9 @@ test_reonly test-reonly: test_prep_reonly
 test_porting test-porting: test_prep
 	TEST_ARGS='porting/*.t lib/diagnostics.t' TESTFILE=harness $(RUN_TESTS) choose
 
+test_regex_tests test-regex-tests: test_prep
+	TEST_ARGS='re/*.t ../ext/re/t/*.t' PERL_TEST_HARNESS_ASAP=1 TESTFILE=harness $(RUN_TESTS) choose
+
 !NO!SUBS!
 
 $spitshell>>$Makefile <<!GROK!THIS!
```
... which ends nicely with this:
```
re/uniprops10.t ............... ok                                      
re/uniprops06.t ............... ok                                      
re/uniprops07.t ............... ok                                      
re/uniprops08.t ............... ok                                      
re/uniprops09.t ............... ok       
All tests successful.
Files=89, Tests=558456, 25 wallclock secs (21.22 usr  0.66 sys + 81.37 cusr 14.89 csys = 118.14 CPU)
Result: PASS
```
Let's add this to `Makefile.SH`.

-------------------------------------------------------------------------------
* This set of changes requires a perldelta entry, and I will submit in a later commit.
