### PR TITLE
cpan/Module-Metadata - Update to version 1.000040

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -867,8 +867,8 @@ our %Modules = (
     },
 
     'Module::Metadata' => {
-        'DISTRIBUTION' => 'ETHER/Module-Metadata-1.000039.tar.gz',
-        'SYNCINFO'     => 'jkeenan on Sun Apr  5 19:01:14 2026',
+        'DISTRIBUTION' => 'ETHER/Module-Metadata-1.000040.tar.gz',
+        'SYNCINFO'     => 'leonerd on Tue Aug 11 11:07:42 2026',
         'FILES'        => q[cpan/Module-Metadata],
         'EXCLUDED'     => [
             qw(t/00-report-prereqs.t),

--- a/cpan/Module-Metadata/lib/Module/Metadata.pm
+++ b/cpan/Module-Metadata/lib/Module/Metadata.pm
@@ -1,6 +1,6 @@
 # -*- mode: cperl; tab-width: 8; indent-tabs-mode: nil; basic-offset: 2 -*-
 # vim:ts=8:sw=2:et:sta:sts=2:tw=78
-package Module::Metadata; # git description: v1.000038-5-g7f7baae
+package Module::Metadata; # git description: v1.000039-4-gc6c006f
 # ABSTRACT: Gather package and POD information from perl module files
 
 # Adapted from Perl-licensed code originally distributed with
@@ -14,7 +14,7 @@ sub __clean_eval { eval $_[0] }
 use strict;
 use warnings;
 
-our $VERSION = '1.000039';
+our $VERSION = '1.000040';
 
 use Carp qw/croak/;
 use File::Spec;
@@ -861,7 +861,10 @@ Module::Metadata - Gather package and POD information from perl module files
 
 =head1 VERSION
 
-version 1.000039
+version 1.000040
+
+I use a linearly-increasing version numbering scheme. No meaning should be
+presumed or inferred from the version being less than 1.0.
 
 =head1 SYNOPSIS
 
@@ -1101,7 +1104,7 @@ assistance from David Golden (xdg) <dagolden@cpan.org>.
 
 =head1 CONTRIBUTORS
 
-=for stopwords Karen Etheridge David Golden Vincent Pit Matt S Trout Chris Nehren Graham Knop Olivier Mengué Tomas Doran Christian Walde Craig A. Berry Tatsuhiko Miyagawa tokuhirom 'BinGOs' Williams Mitchell Steinbrunner Edward Zborowski Erik Huelsmann Gareth Harper James Raspass Jerry D. Hedden Josh Jore Kent Fredric Leon Timmermans Peter Rabbitson Steve Hay
+=for stopwords Karen Etheridge David Golden Vincent Pit Matt S Trout Chris Nehren Graham Knop Olivier Mengué Tomas Doran Christian Walde Craig A. Berry Tatsuhiko Miyagawa tokuhirom 'BinGOs' Williams Mitchell Steinbrunner Edward Zborowski Erik Huelsmann Gareth Harper James Raspass Jerry D. Hedden Josh Jore Kent Fredric Leon Timmermans Paul "LeoNerd" Evans Peter Rabbitson Steve Hay
 
 =over 4
 
@@ -1196,6 +1199,10 @@ Kent Fredric <kentnl@cpan.org>
 =item *
 
 Leon Timmermans <fawaka@gmail.com>
+
+=item *
+
+Paul "LeoNerd" Evans <leonerd@leonerd.org.uk>
 
 =item *
 

--- a/cpan/Module-Metadata/t/taint.t
+++ b/cpan/Module-Metadata/t/taint.t
@@ -2,9 +2,10 @@
 use strict;
 use warnings;
 
-use Config;
-use Test::More $Config{ccflags} =~ /-DSILENT_NO_TAINT_SUPPORT/
-    ? ( skip_all => 'No taint support' ) : ( tests => 2 );
+use Scalar::Util qw( tainted );
+use Test::More
+    ( tainted $0 ) ? ( tests => 2 ) : ( skip_all => 'No taint support' );
+
 use Module::Metadata;
 use Carp 'croak';
 


### PR DESCRIPTION
1.000040  2026-08-10 21:34:29Z
  - update taint support detection in a test to handle an upcoming change in perl 5.45.2 (Paul Evans)

* This set of changes does not require a perldelta entry.
