### PR TITLE
t/op/hash-rt85026.t: Rename file to refer to current GH issue

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6457,7 +6457,7 @@ t/op/groups.t				See if $( works
 t/op/gv.t				See if typeglobs work
 t/op/hash.t				See if the complexity attackers are repelled
 t/op/hash-clear-placeholders.t		Tests for corner cases in S_clear_placeholders
-t/op/hash-rt85026.t			See if hash iteration/deletion works
+t/op/hash-iteration-gh11157.t		See if hash iteration/deletion works
 t/op/hashassign.t			See if hash assignments work
 t/op/hashwarn.t				See if warnings for bad hash assignments work
 t/op/heredoc.t				See if heredoc edge and corner cases work

--- a/t/op/hash-iteration-gh11157.t
+++ b/t/op/hash-iteration-gh11157.t
@@ -1,5 +1,8 @@
 #!/usr/bin/perl -w
 
+# Original report: https://rt-archive.perl.org/perl5/Ticket/Display.html?id=85026
+# Now:             https://github.com/perl/perl5/issues/11157
+
 BEGIN {
   chdir 't' if -d 't';
   require './test.pl';
@@ -57,7 +60,7 @@ plan(1);
 # Ok all preparation is done
 note <<"EOF"
 Found keys '$first_key' and '$second_key' on chain $riter
-Will now iterato to key '$first_key' then delete '$first_key' and '$second_key'.
+Will now iterate to key '$first_key' then delete '$first_key' and '$second_key'.
 EOF
 ;
 1 until $first_key eq each %hash;


### PR DESCRIPTION
One-character correction of typo.  Update MANIFEST.

In the course of investigating a smoke-test failure, I spotted a one-character typo in this test file, then figured this was a good time to give the file a name which, in the wake of our 2019 move from RT to GH for issue tracking, makes the file more easy to locate.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
