### PR TITLE
hints/darwin.sh: Improve Darwin 6 support

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -280,13 +280,31 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
 1.[0-3].*) # OS X 10.0.x
    lddlflags="-bundle -undefined suppress"
    ;;
-1.*)       # OS X 10.1
+[1-5].*)       # OS X 10.1 - OS X 10.1.x (though [2-4] never existed publicly)
    ldflags="${ldflags} -flat_namespace"
    lddlflags="-bundle -undefined suppress"
    ;;
-[2-6].*)   # OS X 10.1.x - 10.2.x (though [2-4] never existed publicly)
+6.*)   # OS X 10.2.x
    ldflags="${ldflags} -flat_namespace"
-   lddlflags="-bundle -undefined suppress"
+   # ld: -undefined error or -undefined define_a_way must be used when -twolevel_namespace is in effect
+   lddlflags="-bundle -undefined suppress -flat_namespace"
+   # setlocale(3): The current implementation supports only the "C" and "POSIX"
+   # locales for all but the LC_COLLATE, LC_CTYPE, and LC_TIME categories.
+   # perl: warning: Setting locale failed.
+   # perl: warning: Please check that your locale settings:
+   #     LC_ALL = (unset),
+   #     LC_CTYPE = (unset),
+   #     LC_NUMERIC = (unset),
+   #     LC_COLLATE = (unset),
+   #     LC_TIME = (unset),
+   #     LC_MESSAGES = (unset),
+   #     LC_MONETARY = (unset),
+   #     LANG = "en_US"
+   # are supported and installed on your system.
+   # perl: warning: Falling back to the standard locale ("C").
+   d_setlocale="undef"
+   # dyld: ./perl multiple definitions of symbol _Perl_add_above_Latin1_folds
+   static_ext="$static_ext re"
    ;;
 [7-8].*)   # OS X 10.3.x - 10.4.x
    lddlflags="-bundle -undefined dynamic_lookup"


### PR DESCRIPTION
Need to force a flat namespace when building bundles.
Unable to switch to two level namespaces currently due to a different set of linking issues.
Disable `setlocale(3)` support, otherwise `perl` warns about not being able to set the locale, every time it is executed. Need to force a static build of the `re` extension, since a flat namespace is used and there is a symbol clash between `re.bundle` & `perl`.
On newer releases of Darwin, lazy binding is supported and made use of so the problem is not visible there.

With this change, Perl builds out of the box using `./Configure -des -Dcc=cc`
Tested with `GCC 3.3 20030304 (Apple Computer, Inc. build 1435)`

I've separated out version 6 from 5 and prior since I suspect there's more work to do there, for a start prior releases shipped with a C89 compiler.

Fixes issue #21750

* This set of changes does not require a perldelta entry.
