### PR TITLE
pod/perlre.pod: Correct output order in documentation example

### DIFF
--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1239,8 +1239,8 @@ You can see this in the following code snippet:
 This prints as follows:
 
  Argument       Output
- 'a(x)*b'    matched: <>
  'a(x*)b'    matched: undef
+ 'a(x)*b'    matched: <>
 
 Both patterns match, but leave the contents of the C<$1> capture group
 in different states.  Back references only match when the capture group


### PR DESCRIPTION
Originally reported by @pchang9 in GH #24681.


-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
