### PR TITLE
Use parser local variable in perly.y

### DIFF
--- a/perly.act
+++ b/perly.act
@@ -901,7 +901,7 @@ case 2: /* @1: %empty  */
 #line 1059 "perly.y"
                         {
 			  OP *attrlist = (ps[0].val.opval);
-			  if(attrlist && !PL_parser->sig_seen)
+			  if(attrlist && !parser->sig_seen)
 			      attrlist = apply_builtin_cv_attributes(PL_compcv, attrlist);
 			  (yyval.opval) = attrlist;
 			}
@@ -1101,7 +1101,7 @@ case 2: /* @1: %empty  */
 
   case 175: /* $@21: %empty  */
 #line 1242 "perly.y"
-                        { PL_parser->sig_seen = FALSE; }
+                        { parser->sig_seen = FALSE; }
 
     break;
 
@@ -2319,6 +2319,6 @@ case 2: /* @1: %empty  */
     
 
 /* Generated from:
- * 783af8ff7ff42fd7313d85df8bbde58d7480e4964bb41ce7b92a5039a7286074 perly.y
+ * 5d13e7397627b6529dbbe8d2aa9887d2d2940a81fd1bfda72729384d28de76c7 perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.h
+++ b/perly.h
@@ -249,6 +249,6 @@ int yyparse (void);
 
 
 /* Generated from:
- * 783af8ff7ff42fd7313d85df8bbde58d7480e4964bb41ce7b92a5039a7286074 perly.y
+ * 5d13e7397627b6529dbbe8d2aa9887d2d2940a81fd1bfda72729384d28de76c7 perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.tab
+++ b/perly.tab
@@ -1697,6 +1697,6 @@ static const toketypes yy_type_tab[] =
 };
 
 /* Generated from:
- * 783af8ff7ff42fd7313d85df8bbde58d7480e4964bb41ce7b92a5039a7286074 perly.y
+ * 5d13e7397627b6529dbbe8d2aa9887d2d2940a81fd1bfda72729384d28de76c7 perly.y
  * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.y
+++ b/perly.y
@@ -1058,7 +1058,7 @@ subattrlist
 	|	COLONATTR ATTRLIST
 			{
 			  OP *attrlist = $ATTRLIST;
-			  if(attrlist && !PL_parser->sig_seen)
+			  if(attrlist && !parser->sig_seen)
 			      attrlist = apply_builtin_cv_attributes(PL_compcv, attrlist);
 			  $$ = attrlist;
 			}
@@ -1239,7 +1239,7 @@ optsigsubbody
 
 /* Subroutine body with optional signature */
 sigsubbody:	remember optsubsignature PERLY_BRACE_OPEN 
-			{ PL_parser->sig_seen = FALSE; }
+			{ parser->sig_seen = FALSE; }
 		stmtseq PERLY_BRACE_CLOSE
 			{
 			  if (parser->copline > (line_t)$PERLY_BRACE_OPEN)


### PR DESCRIPTION
The semantic actions in `perly.y` are included in a C function that has a local `parser` variable. Two actions still refer to the global `PL_parser` pointer.

Use `parser` consistently in these actions. This keeps the parser actions consistent with the surrounding code and avoids the unnecessary global lookup.

* This set of changes does not require a perldelta entry.
