### PR TITLE
perlre: (properly) fix undef capture example

### DIFF
--- a/pod/perlre.pod
+++ b/pod/perlre.pod
@@ -1239,8 +1239,8 @@ You can see this in the following code snippet:
 This prints as follows:
 
  Argument       Output
- 'a(x*)b'    matched: undef
- 'a(x)*b'    matched: <>
+ 'a(x)*b'    matched: undef
+ 'a(x*)b'    matched: <>
 
 Both patterns match, but leave the contents of the C<$1> capture group
 in different states.  Back references only match when the capture group


### PR DESCRIPTION
GH #24681

v5.45.1-168-gfe45dc90ce attempted to fix the thjnko in the example, but ended up just swapping the two example lines. The two lines of code should have remained the same: only the code comments at the end of the two lines should have been swapped.

This commit provides the correct fix.

* This set of changes does not require a perldelta entry.
