### PR TITLE
Synch Win32-0.64 into blead

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3479,6 +3479,7 @@ cpan/version/t/09_list_util.t		Tests for version objects
 cpan/version/t/10_lyon.t		Tests for version objects
 cpan/version/t/11_taint.t		Tests for version objects
 cpan/version/t/coretests.pm		Tests for version objects
+cpan/Win32/CHANGES.md			Win32
 cpan/Win32/longpath.inc			Win32 extension long path support
 cpan/Win32/Makefile.PL			Win32 extension makefile writer
 cpan/Win32/t/CodePage.t			See if Win32 extension works
@@ -3493,8 +3494,9 @@ cpan/Win32/t/GetOSName.t		See if Win32 extension works
 cpan/Win32/t/GetOSVersion.t		See if Win32 extension works
 cpan/Win32/t/GetShortPathName.t		See if Win32 extension works
 cpan/Win32/t/GuidGen.t			See if Win32 extension works
+cpan/Win32/t/HttpGetFile.t		Win32
 cpan/Win32/t/Names.t			See if Win32 extension works
-cpan/Win32/t/Privileges.t
+cpan/Win32/t/Privileges.t		Test file related to Win32
 cpan/Win32/t/Unicode.t			See if Win32 extension works
 cpan/Win32/Win32.pm			Win32 extension Perl module
 cpan/Win32/Win32.xs			Win32 extension external subroutines

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1337,7 +1337,8 @@ our %Modules = (
     },
 
     'Win32' => {
-        'DISTRIBUTION' => 'JDB/Win32-0.59.tar.gz',
+        'DISTRIBUTION' => 'JDB/Win32-0.64.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Wed Aug 12 07:03:16 2026',
         'FILES'        => q[cpan/Win32],
     },
 

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1339,10 +1339,6 @@ our %Modules = (
     'Win32' => {
         'DISTRIBUTION' => 'JDB/Win32-0.59.tar.gz',
         'FILES'        => q[cpan/Win32],
-        'CUSTOMIZED'   => [
-            'Win32.pm',
-            'Win32.xs'
-         ],
     },
 
     'Win32API::File' => {

--- a/cpan/Win32/CHANGES.md
+++ b/cpan/Win32/CHANGES.md
@@ -1,0 +1,341 @@
+# Revision history for the Perl extension Win32
+
+## 0.64 [2026-08-11]
+
+- ship the CPAN tarball with LF line endings again; releases 0.60
+  through 0.63 were packaged with CRLF because the release workflow's
+  Windows runner converted the checkout [#65](https://github.com/perl-libwin32/win32/pull/65)
+
+## 0.63 [2026-08-09]
+
+- fix Win32::GetLastError() returning 0 after list-context Win32::HttpGetFile()
+  calls on Cygwin -DDEBUGGING builds, diagnosed by [@sisyphus](https://github.com/sisyphus);
+  add a CI job testing against a -DDEBUGGING Cygwin perl [#63](https://github.com/perl-libwin32/win32/pull/63)
+- convert Changes to CHANGES.md and bump release-action to @v2
+
+## 0.62 [2026-05-11]
+
+- revert SvUTF8 flagging in wstr_to_sv and my_ansipath under CP_UTF8 ACP;
+  make t/Unicode.t pass under CP_UTF8 ACP [#57](https://github.com/perl-libwin32/win32/pull/57)
+
+## 0.61 [2026-05-10]
+
+- handle CP_UTF8 system codepage in wstr_to_sv and my_ansipath [#53](https://github.com/perl-libwin32/win32/pull/53)
+- fix inverted SKIP condition for non-English locale in t/HttpGetFile.t [#55](https://github.com/perl-libwin32/win32/pull/55)
+- fix t/GetCurrentThreadId.t fork-emulation detection by [@sisyphus](https://github.com/sisyphus) [#45](https://github.com/perl-libwin32/win32/pull/45)
+
+## 0.60 [2026-05-05]
+
+- add LICENSE and modernize README [#51](https://github.com/perl-libwin32/win32/pull/51)
+- update Microsoft doc URLs to learn.microsoft.com
+
+## 0.59_02 [2026-05-04]
+
+- detect newer Windows 10/11, Windows Server 2019/2022/2025, and
+  Server SAC releases by Markus Demml ([@mardem1](https://github.com/mardem1)) [#42](https://github.com/perl-libwin32/win32/pull/42)
+- fix 64-bit registry constant by [@jkahrman](https://github.com/jkahrman) [#37](https://github.com/perl-libwin32/win32/pull/37)
+- follow-up to 64-bit registry fix by Tony Cook ([@tonycoz](https://github.com/tonycoz)) [#39](https://github.com/perl-libwin32/win32/pull/39)
+- fix memory deallocation for WinHttpGetProxyForUrl strings [#49](https://github.com/perl-libwin32/win32/pull/49)
+- include t/HttpGetFile.t in MANIFEST so it ships in the CPAN tarball [#50](https://github.com/perl-libwin32/win32/pull/50)
+- convert tests to Test::More by Graham Knop ([@haarg](https://github.com/haarg)) [#35](https://github.com/perl-libwin32/win32/pull/35)
+- clarify documentation of minor versions by Ferenc Erki ([@ferki](https://github.com/ferki)) [#25](https://github.com/perl-libwin32/win32/pull/25)
+
+## 0.59 [2022-05-05]
+
+- add Win32::GetChipArch and use it in Win32::GetOSName to support arm/arm64
+  architecture by Pierrick Bouvier ([@p-b-o](https://github.com/p-b-o)) [#34](https://github.com/perl-libwin32/win32/pull/34)
+
+## 0.58 [2022-01-17]
+
+- add Win32::HttpGetFile (thanks to Craig Berry for the implementation
+  and Tomasz Konojacki for code review) [#30](https://github.com/perl-libwin32/win32/pull/30)
+- skip failing Unicode.t on Cygwin because cwd() no longer returns an
+  ANSI (short) path there.
+- Fixed test 14,15 of GetFullPathName.t when package is unpacked in a
+  top level folder (thanks to Jianhong Feng) [#20](https://github.com/perl-libwin32/win32/pull/20)
+
+## 0.57 [2021-03-10]
+
+- fix calling convention for PFNRegGetValueA [#28](https://github.com/perl-libwin32/win32/pull/28)
+
+## 0.56 [2021-03-07]
+
+- added t/Privileges.t to MANIFEST
+
+## 0.55 [2021-03-07]
+
+- added Win32::IsSymlinkCreationAllowed(), Win32::IsDeveloperModeEnabled(),
+  and Win32::GetProcessPrivileges() by Tomasz Konojacki ([@xenu](https://github.com/xenu)) [#27](https://github.com/perl-libwin32/win32/pull/27)
+- removed old code for versions before Windows 2000
+  by Tomasz Konojacki ([@xenu](https://github.com/xenu)) [#26](https://github.com/perl-libwin32/win32/pull/26)
+
+## 0.54 [2020-03-27]
+
+- Skip tests that rely upon short names if these are unavailable
+  and additional docs about short filenames. Richard Leach ([@richardleach](https://github.com/richardleach)) [#23](https://github.com/perl-libwin32/win32/pull/23)
+
+## 0.53 [2019-08-05]
+
+- improve Win32::GetOSDisplayName
+- added Win2016/2019 detection and version information by
+  Richard Leach ([@richardleach](https://github.com/richardleach)) [#15](https://github.com/perl-libwin32/win32/pull/15)
+- Include wchar.h to allow building with g++ by Tony Cook [rt#127836]
+
+## 0.52_02 [2018-11-02] by Reini Urban
+
+- added () usage croaks.
+- Fixed a -Warray-bounds buffer overflow in LONGPATH,
+- Fix various -Wunused warnings
+  and two -Wmaybe-uninitialized.
+
+## 0.52_01 [2017-11-30]
+
+- add missing const
+
+## 0.52 [2015-08-19]
+
+- minimal Windows 10 support (thanks to Joel Maslak) [#8](https://github.com/perl-libwin32/win32/pull/8)
+- refactor Windows 10 support to include ProductInfo flags
+- add tests for Windows 8.1, 10, and 2012 R2 server
+- define additional ProductInfo flags (TODO: add support for
+  these codes in _GetOSName)
+
+## 0.51 [2015-01-26]
+
+- Win32-0.50 was released to CPAN from an out-dated Git repo, so
+  didn't actually include the merged pull requests.
+
+## 0.50 [2015-01-26]
+
+- add GetOSName support for Windows 8.1 (thanks to Tony Cook ([@tonycoz](https://github.com/tonycoz))) [#6](https://github.com/perl-libwin32/win32/pull/6)
+- Fix build in C++ mode (thanks to Steve Hay ([@steve-m-hay](https://github.com/steve-m-hay)) and Daniel Dragan) [#7](https://github.com/perl-libwin32/win32/pull/7)
+
+## 0.49 [2014-04-15]
+
+- Make sure Win32.xs uses winsock2.h and not winsock.h. [rt#94730]
+
+## 0.48 [2013-11-20]
+
+- Typo fixes by David Steinbrunner.
+- Fix required perl version 5.6 -> 5.006.
+- Don't call note() in t/GetOSName.t when it has not been
+  imported from Test::More.
+- Convert t/GetOSName.t to Unix line endings like the rest of
+  this repo.
+
+## 0.47 [2013-02-21]
+
+- Make sure %PROCESSOR_ARCHITECTURE% is defined before calling
+  Win32::GetArchName() in t/Names.t.  It may be undefined when
+  the test is running under Cygwin crond.
+- In t/Names.t don't assume that LoginName or NodeName is at
+  least 2 characters long; it may just be 1. [rt#83474]
+
+## 0.46 [2013-02-19]
+
+- add Win2012/Win8 detection (thanks to Michiel Beijen) [rt#82572]
+  [perl#116352]
+
+## 0.45 [2012-08-07]
+
+- add Win32::GetACP(), Win32::GetConsoleCP(),
+  Win32::GetConsoleOutputCP(), Win32::GetOEMCP(), Win32::SetConsoleCP()
+  and Win32::SetConsoleOutputCP(). [rt#78820] (Steve Hay)
+- adjust t/Unicode.t for Cygwin 1.7, where readdir() returns
+  the utf8 encoded filename without setting the SvUTF8 flag [rt#66751]
+  [rt#74332]
+
+## 0.44 [2011-01-12]
+
+- fix memory leak introduced in 0.43
+
+## 0.43 [2011-01-12]
+
+- fix a few potential buffer overrun bugs reported by Alex Davies.
+  [perl#78710]
+
+## 0.42 [2011-01-06]
+
+- remove brittle test for Win32::GetLongPathName($ENV{SYSTEMROOT})
+  which will fail if the case of the environment value doesn't
+  exactly match the case of the directory name on the filesystem.
+
+## 0.41 [2010-12-10]
+
+- Fix Win32::GetChipName() to return the native processor type when
+  running 32-bit Perl on 64-bit Windows (WOW64).  This will also
+  affect the values returned by Win32::GetOSDisplayName() and
+  Win32::GetOSName(). [rt#63797]
+- Fix Win32::GetOSDisplayName() to return the correct values for
+  all products even when a service pack has been installed. (This
+  was only an issue for some "special" editions).
+- The display name for "Windows 7 Business Edition" is actually
+  "Windows 7 Professional".
+- Fix t/GetOSName.t tests to avoid using the values returned by
+  GetSystemMetrics() when the test template didn't specify any
+  value at all.
+
+## 0.40 [2010-12-08]
+
+- Add Win32::GetSystemMetrics function.
+- Add Win32::GetProductInfo() function.
+- Add Win32::GetOSDisplayName() function.
+- Detect "Windows Server 2008 R2" as "Win2008" in Win32::GetOSName()
+  (used to return "Win7" before). [rt#57172]
+- Detect "Windows Home Server" as "WinHomeSvr" in Win32::GetOSName()
+  (used to return "Win2003" before).
+- Add "R2", "Media Center", "Tablet PC", "Starter Edition" etc.
+  tags to the description returned by Win32::GetOSName() in
+  list context.
+- Rewrite the t/GetOSName.t tests
+
+## 0.39 [2009-01-19]
+
+- Add support for Windows 2008 Server and Windows 7 in
+  Win32::GetOSName() and in the documentation for
+  Win32::GetOSVersion().
+- Make Win32::GetOSName() implementation testable.
+- Document that the OSName for Win32s is actually "WinWin32s".
+
+## 0.38 [2008-06-27]
+
+- Fix Cygwin releated problems in t/GetCurrentThreadId.t
+  (Jerry D. Hedden).
+
+## 0.37 [2008-06-26]
+
+- Add Win32::GetCurrentProcessId() function
+
+## 0.36 [2008-04-17]
+
+- Add typecasts for Win64 compilation
+
+## 0.35 [2008-03-31]
+
+Integrate changes from bleadperl:
+- Silence Borland compiler warning (Steve Hay)
+- Fix memory leak in Win32::GetOSVersion (Vincent Pit)
+- Test Win32::GetCurrentThreadId on cygwin (Reini Urban, Steve Hay)
+
+## 0.34 [2007-11-21]
+
+- Document "WinVista" return value for Win32::GetOSName()
+  (Steve Hay).
+
+## 0.33 [2007-11-12]
+
+- Update version to 0.33 for Perl 5.10 release
+- Add $^O test in Makefile.PL for CPAN Testers
+- Use Win32::GetLastError() instead of $^E in t/Names.t for
+  cygwin compatibility (Jerry D. Hedden).
+
+## 0.32 [2007-09-20]
+
+- Additional #define's for older versions of VC++ (Dmitry Karasik).
+- Win32::DomainName() doesn't return anything when the Workstation
+  service isn't running.  Set $^E and adapt t/Names.t accordingly
+  (Steve Hay & Jerry D. Hedden).
+- Fix t/Names.t to allow Win32::GetOSName() to return an empty
+  description as the 2nd return value (e.g. Vista without SP).
+- Fix t/GetFileVersion.t for Perl 5.10
+
+## 0.31 [2007-09-10]
+
+- Apply Cygwin fixes from bleadperl (from Jerry D. Hedden).
+- Make sure Win32::GetLongPathName() always returns drive
+  letters in uppercase (Jerry D. Hedden).
+- Use uppercase environment variable names in t/Unicode.t
+  because the MSWin32 doesn't care, and Cygwin only works
+  with the uppercased version.
+- new t/Names.t test (from Sébastien Aperghis-Tramoni)
+
+## 0.30 [2007-06-25]
+
+- Fixed t/Unicode.t test for Cygwin (with help from Jerry D. Hedden).
+- Fixed and documented Win32::GetShortPathName() to return undef
+  when the pathname doesn't exist (thanks to Steve Hay).
+- Added t/GetShortPathName.t
+
+## 0.29 [2007-05-17]
+
+- Fixed to compile with Borland BCC (thanks to Steve Hay).
+
+## 0.28_01 [2007-05-16]
+
+- Increase version number as 0.28 was already used by an ActivePerl
+  release (for essentially 0.27 plus the Win32::IsAdminUser() change).
+
+- Add MODULE and PROTOTYPES directives to silence warnings from
+  newer versions of xsubpp.
+
+- Use the Cygwin codepath in Win32::GetFullPathName() when
+  PERL_IMPLICIT_SYS is not defined, because the other code
+  relies on the virtualization code in win32/vdir.h.
+
+## 0.27_02 [2007-05-15]
+
+- We need Windows 2000 or later for the Unicode support because
+  WC_NO_BEST_FIT_CHARS is not supported on Windows NT.
+
+- Fix Win32::GetFullPathName() on Windows NT to return an
+  empty file part if the original argument ends with a slash.
+
+## 0.27_01 [2007-04-18]
+
+- Update Win32::IsAdminUser() to use the IsUserAnAdmin() function
+  in shell32.dll when available.  On Windows Vista this will only
+  return true if the process is running with elevated privileges
+  and not just when the owner of the process is a member of the
+  "Administrators" group.
+
+- Win32::ExpandEnvironmentStrings() may return a Unicode string
+  (a string containing characters outside the system codepage)
+
+- new Win32::GetANSIPathName() function returns a pathname in
+  a form containing only characters from the system codepage
+
+- Win32::GetCwd() will return an ANSI version of the directory
+  name if the long name contains characters outside the system
+  codepage.
+
+- Win32::GetFolderPath() will return an ANSI pathname. Call
+  Win32::GetLongPathName() to get the canonical Unicode
+  representation.
+
+- Win32::GetFullPathName() will return an ANSI pathname. Call
+  Win32::GetLongPathName() to get the canonical Unicode
+  representation.
+
+- Win32::GetLongPathName() may return a Unicode path name.
+  Call Win32::GetANSIPathName() to get a representation using
+  only characters from the system codepage.
+
+- Win32::LoginName() may return a Unicode string.
+
+- new Win32::OutputDebugString() function sends a string to
+  the debugger.
+
+- new Win32::GetCurrentThreadId() function returns the thread
+  id (to complement the process id in $$).
+
+- new Win32::CreateDirectory() creates a new directory.  The
+  name of the directory may contain Unicode characters outside
+  the system codepage.
+
+- new Win32::CreateFile() creates a new file.  The name of the
+  file may contain Unicode characters outside the system codepage.
+
+
+## 0.27 [2007-03-07]
+
+- Extracted from the libwin32 distribution to simplify maintenance
+  because Win32 is a dual-life core module since 5.8.4.
+
+- Win32.pm and Win32.xs updated to version in bleadperl.
+  This includes all the Win32::* function from win32/win32.c
+  in core Perl, except for Win32::SetChildShowWindows().
+
+- Install into 'perl' directory instead of 'site' for Perl 5.8.4
+  and later.
+
+- Add some simple tests.

--- a/cpan/Win32/Makefile.PL
+++ b/cpan/Win32/Makefile.PL
@@ -32,7 +32,7 @@ my $test_requires = $ExtUtils::MakeMaker::VERSION >= 6.64
     ? 'TEST_REQUIRES'
     : 'PREREQ_PM';
 
-$param{$test_requires}{'Test'} = 0;
+$param{$test_requires}{'Test::More'} = 0;
 $param{$test_requires}{'File::Temp'} = 0;
 
 WriteMakefile(%param);

--- a/cpan/Win32/Win32.pm
+++ b/cpan/Win32/Win32.pm
@@ -8,7 +8,7 @@ package Win32;
     require DynaLoader;
 
     @ISA = qw|Exporter DynaLoader|;
-    $VERSION = '0.59_01';
+    $VERSION = '0.64';
     $XS_VERSION = $VERSION;
     $VERSION = eval $VERSION;
 
@@ -370,7 +370,7 @@ sub GetOSDisplayName {
 		$desc =~ s/^\s*//;
 		s/(200.)/$name Server $1/;
 	    }
-	    s/^Windows (20(03|08|12|16|19))/Windows Server $1/;
+	    s/^Windows (20(03|08|12|16|19|22|25))/Windows Server $1/;
             s/^Windows SAC/Windows Server/;
 	}
     }
@@ -559,8 +559,13 @@ sub _GetOSName {
         }
 	elsif ($major == 10) {
             if ($producttype == VER_NT_WORKSTATION) {
+                $os = $build < 22000 ? '10' : '11';
+
                 # Build numbers from https://en.wikipedia.org/wiki/Windows_10_version_history
-                $os = '10';
+                # Windows 10. Versions 1507 through 1903 each cover a build
+                # range to label preview/insider builds; from 1909 onward
+                # Microsoft ships releases as enablement packages on the
+                # same kernel build, so each version maps to one build.
                 if (9841 <= $build && $build <= 10240) {
                     $desc = " Version 1507";
                     $desc .= " (Preview Build $build)" if $build < 10240;
@@ -594,11 +599,52 @@ sub _GetOSName {
                     $desc = " Version 1903 (May 2019 Update)";
                     $desc .= " (Preview Build $build)" if $build < 18362;
                 }
+                elsif ($build == 18363) {
+                    $desc = " Version 1909 (November 2019 Update)";
+                }
+                elsif ($build == 19041) {
+                    $desc = " Version 2004 (May 2020 Update)";
+                }
+                elsif ($build == 19042) {
+                    $desc = " Version 20H2 (October 2020 Update)";
+                }
+                elsif ($build == 19043) {
+                    $desc = " Version 21H1 (May 2021 Update)";
+                }
+                elsif ($build == 19044) {
+                    $desc = " Version 21H2 (November 2021 Update)";
+                }
+                elsif ($build == 19045) {
+                    $desc = " Version 22H2 (2022 Update)";
+                }
+                # Build numbers from https://en.wikipedia.org/wiki/Windows_11_version_history
+                # Windows 11
+                elsif ($build == 22000) {
+                    $desc = " Version 21H2 (2021 Update)";
+                }
+                elsif ($build == 22621) {
+                    $desc = " Version 22H2 (2022 Update)";
+                }
+                elsif ($build == 22631) {
+                    $desc = " Version 23H2 (2023 Update)";
+                }
+                elsif ($build == 26100) {
+                    $desc = " Version 24H2 (2024 Update)";
+                }
+                elsif ($build == 26200) {
+                    $desc = " Version 25H2 (2025 Update)";
+                }
+                elsif ($build == 28000) {
+                    $desc = " Version 26H1 (2026 Update)";
+                }
                 else {
                     $desc = " Build $build";
                 }
             }
             else {
+                # Build numbers from  https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions
+                # https://learn.microsoft.com/en-us/windows-server/get-started/servicing-channels-comparison#annual-channel-ac
+                # Long-Term Servicing Channel (LTSC)
                 if ($build == 14393) {
                     $os = "2016";
                     $desc = "Version 1607";
@@ -607,7 +653,16 @@ sub _GetOSName {
                     $os = "2019";
                     $desc = "Version 1809";
                 }
+                elsif ($build == 20348) {
+                    $os = "2022";
+                    $desc = "Version 21H2";
+                }
+                elsif ($build == 26100) {
+                    $os = "2025";
+                    $desc = "Version 24H2";
+                }
                 else {
+                    # (Semi) Annual Channel (AC)
                     $os = "Server";
                     if ($build == 16299) {
                         $desc = "Version 1709";
@@ -617,6 +672,18 @@ sub _GetOSName {
                     }
                     elsif ($build == 18362) {
                         $desc = "Version 1903";
+                    }
+                    elsif ($build == 18363) {
+                        $desc = "Version 1909";
+                    }
+                    elsif ($build == 19041) {
+                        $desc = "Version 2004";
+                    }
+                    elsif ($build == 19042) {
+                        $desc = "Version 20H2";
+                    }
+                    elsif ($build == 25398) {
+                        $desc = "Version 23H2";
                     }
                     else {
                         $desc = "Build $build";
@@ -1128,6 +1195,9 @@ Currently the possible values for the OS name are
     Win10
     Win2016
     Win2019
+    Win2022
+    Win2025
+    Win11
     WinSAC
 
 This routine is just a simple interface into GetOSVersion().  More
@@ -1177,13 +1247,16 @@ Currently known values for ID MAJOR MINOR and BUILD are as follows:
     Windows Server 2008 R2   2      6       1       -
     Windows 8                2      6       2       -
     Windows Server 2012      2      6       2       -
-    Windows 8.1              2      6       2       -
-    Windows Server 2012 R2   2      6       2       -
-    
+    Windows 8.1              2      6       2/3     -
+    Windows Server 2012 R2   2      6       2/3     -
+
     Windows 10               2     10       0       -
     Windows Server 2016      2     10       0   14393
-    Windows Server 2019      2     10       0   17677
-    
+    Windows Server 2019      2     10       0   17763
+    Windows Server 2022      2     10       0   20348
+    Windows Server 2025      2     10       0   26100
+    Windows 11               2     10       0       -
+
 On Windows NT 4 SP6 and later this function returns the following
 additional values: SPMAJOR, SPMINOR, SUITEMASK, PRODUCTTYPE.
 
@@ -1202,6 +1275,15 @@ them.
 The version numbers for Windows 8 and Windows Server 2012 are
 identical; the PRODUCTTYPE field must be used to differentiate between
 them.
+
+The minor version number for Windows 8.1 and Windows Server 2012 R2
+depends on the running Perl version. Perl itself has been manifested
+for Windows 8.1 and Windows 10 starting from 5.24.0 (or more precisely
+from 5.23.3, if one takes development releases into account). Older
+releases of perl return the minor version as 2, while newer releases
+return it as 3. See Microsoft's L<Operating System
+Version|https://learn.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version>
+documentation for more details.
 
 For modern Windows releases, the major and minor version numbers are
 identical. The PRODUCTTYPE field must be used to differentiate between
@@ -1537,7 +1619,7 @@ DllUnregisterServer.
 =head2 Short Path Names
 
 There are many situations in which modern Windows systems will not have
-the L<short path name|https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names>
+the L<short path name|https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names>
 (also called 8.3 or MS-DOS) alias for long file names available.
 
 Short path support can be configured system-wide via the registry,

--- a/cpan/Win32/Win32.xs
+++ b/cpan/Win32/Win32.xs
@@ -1843,8 +1843,9 @@ XS(w32_HttpGetFile)
                 bAborted = TRUE;
                 Perl_warn(aTHX_ "Win32::HttpGetFile: setting proxy options failed");
             }
-            Safefree(ProxyInfo.lpszProxy);
-            Safefree(ProxyInfo.lpszProxyBypass);
+            /* WinHttpGetProxyForUrl allocates these with GlobalAlloc. */
+            if (ProxyInfo.lpszProxy)       GlobalFree(ProxyInfo.lpszProxy);
+            if (ProxyInfo.lpszProxyBypass) GlobalFree(ProxyInfo.lpszProxyBypass);
         }
     }
 
@@ -1976,7 +1977,7 @@ XS(w32_HttpGetFile)
      */
     if (bAborted) {
         if (bHttpError) {
-            SetLastError(dwHttpStatusCode + 1000000000);
+            error = dwHttpStatusCode + 1000000000;
         }
         else {
             DWORD msgFlags = bFileError
@@ -1994,22 +1995,31 @@ XS(w32_HttpGetFile)
                                 NULL)) {
                 wcsncpy(msgbuf, L"unable to format error message", ONE_K_BUFSIZE - 1);
             }
-            SetLastError(error);
         }
     }
 
+    /* Set the last error only after building the return values.
+     * wstr_to_sv() calls WideCharToMultiByte() and allocates SVs, either
+     * of which may clobber it (GH issue #62, seen on Cygwin DEBUGGING builds).
+     */
     if (GIMME_V == G_SCALAR) {
         EXTEND(SP, 1);
         ST(0) = !bAborted ? &PL_sv_yes : &PL_sv_no;
+        if (bAborted)
+            SetLastError(error);
         XSRETURN(1);
     }
     else if (GIMME_V == G_ARRAY) {
         EXTEND(SP, 2);
         ST(0) = !bAborted ? &PL_sv_yes : &PL_sv_no;
         ST(1) = wstr_to_sv(aTHX_ msgbuf);
+        if (bAborted)
+            SetLastError(error);
         XSRETURN(2);
     }
     else {
+        if (bAborted)
+            SetLastError(error);
         XSRETURN_EMPTY;
     }
 }

--- a/cpan/Win32/t/CodePage.t
+++ b/cpan/Win32/t/CodePage.t
@@ -1,8 +1,6 @@
 use strict;
-use Test;
+use Test::More tests => 8;
 use Win32;
-
-plan tests => 8;
 
 my $ansicp = Win32::GetACP();
 ok($ansicp > 0 && $ansicp <= 65001);

--- a/cpan/Win32/t/CreateFile.t
+++ b/cpan/Win32/t/CreateFile.t
@@ -1,12 +1,10 @@
 use strict;
-use Test;
+use Test::More tests => 15;
 use Win32;
 
 my $path = "testing-$$";
 rmdir($path)  if -d $path;
 unlink($path) if -f $path;
-
-plan tests => 15;
 
 ok(!-d $path);
 ok(!-f $path);
@@ -22,7 +20,7 @@ ok(!-d $path);
 
 ok(Win32::CreateFile($path));
 ok(-f $path);
-ok(-s $path, 0);
+is(-s $path, 0);
 
 ok(!Win32::CreateDirectory($path));
 ok(!Win32::CreateFile($path));

--- a/cpan/Win32/t/ExpandEnvironmentStrings.t
+++ b/cpan/Win32/t/ExpandEnvironmentStrings.t
@@ -1,7 +1,5 @@
 use strict;
-use Test;
+use Test::More tests => 1;
 use Win32;
 
-plan tests => 1;
-
-ok(Win32::ExpandEnvironmentStrings("%WINDIR%"), $ENV{WINDIR});
+is(Win32::ExpandEnvironmentStrings("%WINDIR%"), $ENV{WINDIR});

--- a/cpan/Win32/t/GetCurrentThreadId.t
+++ b/cpan/Win32/t/GetCurrentThreadId.t
@@ -1,38 +1,43 @@
 use strict;
 use Config qw(%Config);
-use Test;
+use Test::More;
 use Win32;
 
-my $fork_emulation = $Config{ccflags} =~ /PERL_IMPLICIT_SYS/;
+# Cygwin builds set useithreads=define but use the OS's real fork(),
+# not the Win32 fork emulation — so gate on $^O as well.
+my $fork_emulation = $^O eq 'MSWin32' && ($Config{useithreads} // '') eq 'define';
 
-my $tests = $fork_emulation ? 4 : 2;
-plan tests => $tests;
+plan tests => $fork_emulation ? 4 : 2;
 
 my $pid = $$+0; # make sure we don't copy any magic to $pid
 
 if ($^O eq "cygwin") {
-    skip(!defined &Cygwin::pid_to_winpid,
-	 Cygwin::pid_to_winpid($pid),
-	 Win32::GetCurrentProcessId());
+    SKIP: {
+        skip 'Cygwin::pid_to_winpid is not available', 1
+            if !defined &Cygwin::pid_to_winpid;
+
+        is(Cygwin::pid_to_winpid($pid), Win32::GetCurrentProcessId());
+    }
 }
 else {
-    ok($pid, Win32::GetCurrentProcessId());
+    is($pid, Win32::GetCurrentProcessId());
 }
 
 if ($fork_emulation) {
     # This test relies on the implementation detail that the fork() emulation
     # uses the negative value of the thread id as a pseudo process id.
     if (my $child = fork) {
-	waitpid($child, 0);
-	exit 0;
+        Test::More->builder->no_ending(1);
+        waitpid($child, 0);
+        exit $?;
     }
-    ok(-$$, Win32::GetCurrentThreadId());
+    is(-$$, Win32::GetCurrentThreadId());
 
     # GetCurrentProcessId() should still return the real PID
-    ok($pid, Win32::GetCurrentProcessId());
-    ok($$ != Win32::GetCurrentProcessId());
+    is($pid, Win32::GetCurrentProcessId());
+    isnt($$, Win32::GetCurrentProcessId());
 }
 else {
     # here we just want to see something.
-    ok(Win32::GetCurrentThreadId() > 0);
+    cmp_ok(Win32::GetCurrentThreadId(), '>', 0);
 }

--- a/cpan/Win32/t/GetFileVersion.t
+++ b/cpan/Win32/t/GetFileVersion.t
@@ -1,10 +1,9 @@
 use strict;
-use Test;
+use Test::More;
 use Win32;
 
 unless (defined &Win32::BuildNumber) {
-    print "1..0 # Skip: Only ActivePerl seems to set the perl.exe fileversion\n";
-    exit;
+    plan skip_all => 'Only ActivePerl seems to set the perl.exe fileversion';
 }
 
 plan tests => 2;
@@ -13,6 +12,6 @@ my @version = Win32::GetFileVersion($^X);
 my $version = $version[0] + $version[1] / 1000 + $version[2] / 1000000;
 
 # numify $] because it is a version object in 5.10 which will stringify with trailing 0s
-ok($version, 0+$]);
+is($version, 0+$]);
 
-ok($version[3], int(Win32::BuildNumber()));
+is($version[3], int(Win32::BuildNumber()));

--- a/cpan/Win32/t/GetFolderPath.t
+++ b/cpan/Win32/t/GetFolderPath.t
@@ -1,8 +1,6 @@
 use strict;
-use Test;
+use Test::More tests => 1;
 use Win32;
 
-plan tests => 1;
-
 # "windir" exists back to Win9X; "SystemRoot" only exists on WinNT and later.
-ok(Win32::GetFolderPath(Win32::CSIDL_WINDOWS), $ENV{WINDIR});
+is(Win32::GetFolderPath(Win32::CSIDL_WINDOWS), $ENV{WINDIR});

--- a/cpan/Win32/t/GetFullPathName.t
+++ b/cpan/Win32/t/GetFullPathName.t
@@ -1,34 +1,32 @@
 use strict;
-use Test;
+use Test::More tests => 16;
 use Win32;
-
-plan tests => 16;
 
 my $cwd = Win32::GetCwd;
 my @cwd = split/\\/, $cwd;
 my $file = pop @cwd;
 my $dir = join('\\', @cwd);
 
-ok(scalar Win32::GetFullPathName('.'), $cwd);
-ok((Win32::GetFullPathName('.'))[0], "$dir\\");
-ok((Win32::GetFullPathName('.'))[1], $file);
+is(scalar Win32::GetFullPathName('.'), $cwd);
+is((Win32::GetFullPathName('.'))[0], "$dir\\");
+is((Win32::GetFullPathName('.'))[1], $file);
 
-ok((Win32::GetFullPathName('./'))[0], "$cwd\\");
-ok((Win32::GetFullPathName('.\\'))[0], "$cwd\\");
-ok((Win32::GetFullPathName('./'))[1], "");
+is((Win32::GetFullPathName('./'))[0], "$cwd\\");
+is((Win32::GetFullPathName('.\\'))[0], "$cwd\\");
+is((Win32::GetFullPathName('./'))[1], "");
 
-ok(scalar Win32::GetFullPathName($cwd), $cwd);
-ok((Win32::GetFullPathName($cwd))[0], "$dir\\");
-ok((Win32::GetFullPathName($cwd))[1], $file);
+is(scalar Win32::GetFullPathName($cwd), $cwd);
+is((Win32::GetFullPathName($cwd))[0], "$dir\\");
+is((Win32::GetFullPathName($cwd))[1], $file);
 
-ok(scalar Win32::GetFullPathName(substr($cwd,2)), $cwd);
-ok((Win32::GetFullPathName(substr($cwd,2)))[0], "$dir\\");
-ok((Win32::GetFullPathName(substr($cwd,2)))[1], $file);
+is(scalar Win32::GetFullPathName(substr($cwd,2)), $cwd);
+is((Win32::GetFullPathName(substr($cwd,2)))[0], "$dir\\");
+is((Win32::GetFullPathName(substr($cwd,2)))[1], $file);
 
-ok(scalar Win32::GetFullPathName('/Foo Bar/'), substr($cwd,0,2)."\\Foo Bar\\");
+is(scalar Win32::GetFullPathName('/Foo Bar/'), substr($cwd,0,2)."\\Foo Bar\\");
 
 chdir(my $dird = $dir !~ /^[A-Z]:$/ ? $dir : "$dir\\");
-ok(scalar Win32::GetFullPathName('.'), $dird);
+is(scalar Win32::GetFullPathName('.'), $dird);
 
-ok((Win32::GetFullPathName($file))[0], "$dir\\");
-ok((Win32::GetFullPathName($file))[1], $file);
+is((Win32::GetFullPathName($file))[0], "$dir\\");
+is((Win32::GetFullPathName($file))[1], $file);

--- a/cpan/Win32/t/GetLongPathName.t
+++ b/cpan/Win32/t/GetLongPathName.t
@@ -1,5 +1,5 @@
 use strict;
-use Test;
+use Test::More;
 use Win32;
 
 my @paths = qw(
@@ -43,11 +43,7 @@ my %expect;
 
 plan tests => scalar(@paths);
 
-my $i = 1;
 for (@paths) {
     my $got = Win32::GetLongPathName($_);
-    print "# '$_' => expect '$expect{$_}' => got '$got'\n";
-    print "not " unless $expect{$_} eq $got;
-    print "ok $i\n";
-    ++$i;
+    is $expect{$_}, $got;
 }

--- a/cpan/Win32/t/GetOSName.t
+++ b/cpan/Win32/t/GetOSName.t
@@ -135,14 +135,34 @@ my @win10_tests = (
 ["10 [Version 1903 (May 2019 Update) (Preview Build 18204)]",      "10", 2, 10, 0, 0x00, 0, 0, 18204],
 ["10 [Version 1903 (May 2019 Update)]",                            "10", 2, 10, 0, 0x00, 0, 0, 18362],
 
+["10 [Version 1909 (November 2019 Update)]",                       "10", 2, 10, 0, 0x00, 0, 0, 18363],
+["10 [Version 2004 (May 2020 Update)]",                            "10", 2, 10, 0, 0x00, 0, 0, 19041],
+["10 [Version 20H2 (October 2020 Update)]",                        "10", 2, 10, 0, 0x00, 0, 0, 19042],
+["10 [Version 21H1 (May 2021 Update)]",                            "10", 2, 10, 0, 0x00, 0, 0, 19043],
+["10 [Version 21H2 (November 2021 Update)]",                       "10", 2, 10, 0, 0x00, 0, 0, 19044],
+["10 [Version 22H2 (2022 Update)]",                                "10", 2, 10, 0, 0x00, 0, 0, 19045],
+
+["11 [Version 21H2 (2021 Update)]",                                "11", 2, 10, 0, 0x00, 0, 0, 22000],
+["11 [Version 22H2 (2022 Update)]",                                "11", 2, 10, 0, 0x00, 0, 0, 22621],
+["11 [Version 23H2 (2023 Update)]",                                "11", 2, 10, 0, 0x00, 0, 0, 22631],
+["11 [Version 24H2 (2024 Update)]",                                "11", 2, 10, 0, 0x00, 0, 0, 26100],
+["11 [Version 25H2 (2025 Update)]",                                "11", 2, 10, 0, 0x00, 0, 0, 26200],
+["11 [Version 26H1 (2026 Update)]",                                "11", 2, 10, 0, 0x00, 0, 0, 28000],
+
 ["2016 [Version 1607]",                                    "2016",    2, 10, 0, 0x07, 2, 0, 14393],
 ["2019 [Version 1809]",                                    "2019",    2, 10, 0, 0x07, 2, 0, 17763],
+["2022 [Version 21H2]",                                    "2022",    2, 10, 0, 0x07, 2, 0, 20348],
+["2025 [Version 24H2]",                                    "2025",    2, 10, 0, 0x07, 2, 0, 26100],
 
 ["Server [Version 1709]",                                  "Server",  2, 10, 0, 0x07, 2, 0, 16299],
 ["Server [Version 1803]",                                  "Server",  2, 10, 0, 0x07, 2, 0, 17134],
 # The 1809 version from the semi-annual channel will identify as "Windows Server 2019 Version 1809"
 #["Server [Version 1809]",                                 "Server",  2, 10, 0, 0x07, 2, 0, 17763],
 ["Server [Version 1903]",                                  "Server",  2, 10, 0, 0x07, 2, 0, 18362],
+["Server [Version 1909]",                                  "Server",  2, 10, 0, 0x07, 2, 0, 18363],
+["Server [Version 2004]",                                  "Server",  2, 10, 0, 0x07, 2, 0, 19041],
+["Server [Version 20H2]",                                  "Server",  2, 10, 0, 0x07, 2, 0, 19042],
+["Server [Version 23H2]",                                  "Server",  2, 10, 0, 0x07, 2, 0, 25398],
 ["Server [Build 12345]",                                   "Server",  2, 10, 0, 0x07, 2, 0, 12345],
 
 );
@@ -169,7 +189,7 @@ sub check {
     # and 2003/2008 start with "Windows Server"
     unless ($pretty eq "Win32s") {
 	my $prefix = "Windows";
-	$prefix .= " Server" if $pretty =~ /^20(03|08|12|16|19)/;
+	$prefix .= " Server" if $pretty =~ /^20(03|08|12|16|19|22|25)/;
 	$pretty = "$prefix $pretty";
     }
 
@@ -209,4 +229,3 @@ sub check {
 check($_, Win32::PROCESSOR_ARCHITECTURE_INTEL) for @intel_tests, @dual_tests, @win10_tests;
 check($_, Win32::PROCESSOR_ARCHITECTURE_AMD64) for @amd64_tests, @dual_tests;
 check($_, Win32::PROCESSOR_ARCHITECTURE_IA64)  for @ia64_tests;
-

--- a/cpan/Win32/t/GetOSVersion.t
+++ b/cpan/Win32/t/GetOSVersion.t
@@ -1,11 +1,8 @@
 use strict;
-use Test;
+use Test::More tests => 1;
 use Win32;
-
-plan tests => 1;
 
 my $scalar = Win32::GetOSVersion();
 my @array  = Win32::GetOSVersion();
 
-print "not " unless $scalar == $array[4];
-print "ok 1\n";
+is $scalar, $array[4];

--- a/cpan/Win32/t/GetShortPathName.t
+++ b/cpan/Win32/t/GetShortPathName.t
@@ -1,5 +1,4 @@
 use strict;
-use Test;
 use Win32;
 
 BEGIN {
@@ -8,21 +7,21 @@ BEGIN {
     unlink("8dot3test_canary_GetShortPathName $$");
     if ( length $canary > 12 ) {
         print "1..0 # Skip: The system and/or current volume is not configured to support short names.\n";
-        exit 0;        
+        exit 0;
     }
 }
+
+use Test::More tests => 5;
 
 my $path = "Long Path $$";
 unlink($path);
 END { unlink $path }
 
-plan tests => 5;
-
 Win32::CreateFile($path);
 ok(-f $path);
 
 my $short = Win32::GetShortPathName($path);
-ok($short, qr/^\S{1,8}(\.\S{1,3})?$/);
+like($short, qr/^\S{1,8}(\.\S{1,3})?$/);
 ok(-f $short);
 
 unlink($path);

--- a/cpan/Win32/t/GuidGen.t
+++ b/cpan/Win32/t/GuidGen.t
@@ -1,15 +1,13 @@
 use strict;
-use Test;
+use Test::More tests => 3;
 use Win32;
-
-plan tests => 3;
 
 my $guid1 = Win32::GuidGen();
 my $guid2 = Win32::GuidGen();
 
 # {FB9586CD-273B-43BE-A20C-485A6BD4FCD6}
-ok($guid1, qr/^{\w{8}(-\w{4}){3}-\w{12}}$/);
-ok($guid2, qr/^{\w{8}(-\w{4}){3}-\w{12}}$/);
+like($guid1, qr/^{\w{8}(-\w{4}){3}-\w{12}}$/);
+like($guid2, qr/^{\w{8}(-\w{4}){3}-\w{12}}$/);
 
 # Every GUID is unique
 ok($guid1 ne $guid2);

--- a/cpan/Win32/t/HttpGetFile.t
+++ b/cpan/Win32/t/HttpGetFile.t
@@ -1,0 +1,99 @@
+use strict;
+use warnings;
+use Test::More;
+use Win32;
+use Digest::SHA;
+
+my $tmpfile = "http-download-test-$$.tgz";
+END { 1 while unlink $tmpfile; }
+
+unless (defined &Win32::HttpGetFile) {
+    plan skip_all => 'gcc before 4.8 does not have winhttp library';
+}
+
+# We can only verify specific error messages with a known locale.
+my $english_locale = (Win32::FormatMessage(1) eq "Incorrect function.\r\n");
+
+# We may not always have an internet connection, so don't
+# attempt remote connections unless the user has done
+#   set PERL_WIN32_INTERNET_OK=1
+plan tests => $ENV{PERL_WIN32_INTERNET_OK} ? 20 : 7;
+
+# On Cygwin the test_harness will invoke additional Win32 APIs that
+# will reset the Win32::GetLastError() value, so capture it immediately.
+my $LastError;
+sub HttpGetFile {
+    my $ok = Win32::HttpGetFile(@_);
+    $LastError = Win32::GetLastError();
+    return $ok;
+}
+
+sub HttpGetFileList {
+    my ($ok, $message) = Win32::HttpGetFile(@_);
+    $LastError = Win32::GetLastError();
+    return ($ok, $message);
+}
+
+is(HttpGetFile('nonesuch://example.com', 'NUL:'), "", "'nonesuch://' is not a real protocol");
+is($LastError, '12006', "correct error code for unrecognized protocol");
+is(HttpGetFile('http://!#@!&@$', 'NUL:'), "", "invalid URL");
+is($LastError, '12005', "correct error code for invalid URL");
+
+my ($ok, $message) = HttpGetFileList('nonesuch://example.com', 'NUL:');
+is($ok, "", "'nonesuch://' is not a real protocol");
+SKIP: {
+    skip "Cannot verify error on non-English locale setting", 1
+        unless $english_locale;
+
+    is($message, "The URL does not use a recognized protocol\r\n", "correct bad protocol message");
+}
+is($LastError, '12006', "correct error code for unrecognized protocol with list context return");
+
+if ($ENV{PERL_WIN32_INTERNET_OK}) {
+    # The digest for version 0.57 should obviously stay the same even after new versions are released
+    is(Win32::HttpGetFile('https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-0.57.tar.gz', $tmpfile),
+       '1',
+       "successfully downloaded a tarball");
+
+    my $sha = Digest::SHA->new('sha1');
+    $sha->addfile($tmpfile, 'b');
+    is($sha->hexdigest,
+       '44a6d7d1607d7267b0dbcacbb745cec204f1c1a4',
+       "downloaded tarball has correct digest");
+
+    my ($ok, $message) = HttpGetFileList('https://cpan.metacpan.org/authors/id/Z/ZZ/ZILCH/nonesuch.tar.gz', 'NUL:');
+    is($ok, '', 'Download of nonexistent file from real site should fail with 404');
+    is($LastError - 1e9, '404', 'Correct 404 HTTP status for not found');
+    SKIP: {
+        skip "Cannot verify error on non-English locale setting", 1
+            unless $english_locale;
+        is($message, 'Not Found', 'Should get text of 404 message');
+    }
+    # Since all GitHub downloads use redirects, we can test that they work.
+    1 while unlink $tmpfile;
+    is(Win32::HttpGetFile('https://github.com/perl-libwin32/win32/archive/refs/tags/v0.57.zip', $tmpfile),
+       '1',
+       "successfully downloaded a zipball via redirect");
+
+    $sha = Digest::SHA->new('sha1');
+    $sha->addfile($tmpfile, 'b');
+    is($sha->hexdigest,
+       '9d282e2292e67fb2e25422dfb190474e30a38de3',
+       "downloaded GitHub zip archive has correct digest");
+
+    is(HttpGetFile('https://self-signed.badssl.com/index.html', 'NUL:'),
+       '',
+       'Cannot download from site with self-signed cert without ignoring cert errors');
+    is($LastError, '12175', "correct code for ERROR_WINHTTP_SECURE_FAILURE with self-signed certificate");
+    is(HttpGetFile('https://self-signed.badssl.com/index.html', 'NUL:', 1),
+       '1',
+       'Can download from site with self-signed cert using ignore cert errors parameter');
+
+    is(HttpGetFile('https://expired.badssl.com/index.html', 'NUL:'),
+       '',
+       'Cannot download from site with expired cert without ignoring cert errors');
+    is($LastError, '12175', "correct code for ERROR_WINHTTP_SECURE_FAILURE with expired certificate");
+    is(HttpGetFile('https://expired.badssl.com/index.html', 'NUL:', 1),
+       '1',
+       'Can download from site with expired cert using ignore cert errors parameter');
+}

--- a/cpan/Win32/t/Names.t
+++ b/cpan/Win32/t/Names.t
@@ -1,10 +1,6 @@
 use strict;
-BEGIN {
-    eval "use Test::More";
-    return unless $@;
-    print "1..0 # Skip: Test requires Test::More module\n";
-    exit 0;
-}
+use warnings;
+use Test::More;
 use Win32;
 
 my $tests = 16;

--- a/cpan/Win32/t/Unicode.t
+++ b/cpan/Win32/t/Unicode.t
@@ -1,5 +1,4 @@
 use strict;
-use Test;
 use Config qw(%Config);
 use Cwd qw(cwd);
 use Encode qw();
@@ -27,10 +26,21 @@ BEGIN {
     }
 }
 
+use Test::More tests => 12;
+
 my $home = Win32::GetCwd();
 my $cwd  = cwd(); # may be a Cygwin path
 my $dir  = "Foo \x{394}\x{419} Bar \x{5E7}\x{645} Baz";
 my $file = "$dir\\xyzzy \x{394}\x{419} plugh \x{5E7}\x{645}";
+
+# When CP_ACP == CP_UTF8 ("Use Unicode UTF-8 for worldwide language
+# support"), Win32::* functions and readdir() return UTF-8 bytes
+# without setting the SvUTF8 flag. Encode the test's flag-on literals
+# down to the same shape so all comparisons stay byte-vs-byte.
+if (Win32::GetACP() == 65001) {
+    utf8::encode($dir);
+    utf8::encode($file);
+}
 
 sub cleanup {
     chdir($home);
@@ -42,8 +52,6 @@ sub cleanup {
 
 cleanup();
 END { cleanup() }
-
-plan test => 12;
 
 # Create Unicode directory
 Win32::CreateDirectory($dir);
@@ -60,7 +68,7 @@ while ($_ = readdir($dh)) {
     # On Cygwin 1.7 readdir() returns the utf8 representation of the
     # filename but doesn't turn on the SvUTF8 bit
     Encode::_utf8_on($_) if $^O eq "cygwin" && $Config{osvers} !~ /^1.5/;
-    ok($file, Win32::GetLongPathName("$dir\\$_"));
+    is($file, Win32::GetLongPathName("$dir\\$_"));
 }
 closedir($dh);
 
@@ -68,7 +76,7 @@ closedir($dh);
 my $full = Win32::GetFullPathName($dir);
 my $long = Win32::GetLongPathName($full);
 
-ok($long, Win32::GetLongPathName($home)."\\$dir");
+is($long, Win32::GetLongPathName($home)."\\$dir");
 
 # We can Win32::SetCwd() into the Unicode directory
 ok(Win32::SetCwd($dir));
@@ -80,9 +88,9 @@ my $subdir = cwd();
 # change back to home directory to make sure relative paths
 # in @INC continue to work
 ok(chdir($home));
-ok(Win32::GetCwd(), $home);
+is(Win32::GetCwd(), $home);
 
-ok(Win32::GetLongPathName($w32dir), $long);
+is(Win32::GetLongPathName($w32dir), $long);
 
 # cwd() on Cygwin returns a mapped path that we need to translate
 # back to a Windows path. Invoking `cygpath` on $subdir doesn't work.
@@ -90,9 +98,13 @@ if ($^O eq "cygwin") {
     $subdir = Cygwin::posix_to_win_path($subdir, 1);
 }
 $subdir =~ s,/,\\,g;
-# Cygwin64 no longer returns an ANSI name
-skip($^O eq "cygwin", Win32::GetLongPathName($subdir), $long);
+SKIP: {
+    skip 'Cygwin64 no longer returns an ANSI name', 1
+        if $^O eq "cygwin";
+
+    is(Win32::GetLongPathName($subdir), $long);
+}
 
 # We can chdir() into the Unicode directory if we use the ANSI name
 ok(chdir(Win32::GetANSIPathName($dir)));
-ok(Win32::GetLongPathName(Win32::GetCwd()), $long);
+is(Win32::GetLongPathName(Win32::GetCwd()), $long);

--- a/t/porting/customized.dat
+++ b/t/porting/customized.dat
@@ -10,10 +10,7 @@ MIME::Base64 cpan/MIME-Base64/Base64.xs ad617fe2d01932c35b92defa26d40aba601a95a8
 MIME::Base64 cpan/MIME-Base64/lib/MIME/Base64.pm 18e38d197c7c83f96b24f48bef514e93908e6a82
 MIME::Base64 cpan/MIME-Base64/lib/MIME/QuotedPrint.pm 36cbb455ab57b9bbca7e86f50987c8b1df1a8122
 Pod::Perldoc cpan/Pod-Perldoc/lib/Pod/Perldoc.pm 582be34c077c9ff44d99914724a0cc2140bcd48c
-Win32 cpan/Win32/Win32.pm 07a777ca9c5f642f068f92895a79a096a4a54469
-Win32 cpan/Win32/Win32.xs ff7efeb6b7bfa67e22411b6e3db761c730213a52
 Win32API::File cpan/Win32API-File/File.pm 8fd212857f821cb26648878b96e57f13bf21b99e
 Win32API::File cpan/Win32API-File/File.xs beb870fed4490d2faa547b4a8576b8d64d1d27c5
 autodie cpan/autodie/t/utime.t f94c3000b5b23db59df64895594050d7151f8333
-podlators pod/perlpodstyle.pod 3430e61d84673b62944ceed6d023bfd5aebe3847
 version cpan/version/lib/version.pm 269dffcce5f7410c343237ee8bb04b065182b9f1


### PR DESCRIPTION
Supersedes https://github.com/Perl/perl5/pull/24428 and https://github.com/Perl/perl5/pull/24677

From Changes:

   cpan/Win32 - Update to version 0.64
    
    0.64 [2026-08-11]
    
    - ship the CPAN tarball with LF line endings again; releases 0.60
      through 0.63 were packaged with CRLF because the release workflow's
      Windows runner converted the checkout [#65](https://github.com/perl-libwin32/win32/pull/65)
    
    - 0.63 [2026-08-09]
    
    - fix Win32::GetLastError() returning 0 after list-context Win32::HttpGetFile()
      calls on Cygwin -DDEBUGGING builds, diagnosed by [@sisyphus](https://github.com/sisyphus);
      add a CI job testing against a -DDEBUGGING Cygwin perl [#63](https://github.com/perl-libwin32/win32/pull/63)
    - convert Changes to CHANGES.md and bump release-action to @v2
    
    - 0.62 [2026-05-11]
    
    - revert SvUTF8 flagging in wstr_to_sv and my_ansipath under CP_UTF8 ACP;
      make t/Unicode.t pass under CP_UTF8 ACP [#57](https://github.com/perl-libwin32/win32/pull/57)
    
    - 0.61 [2026-05-10]
    
    - handle CP_UTF8 system codepage in wstr_to_sv and my_ansipath [#53](https://github.com/perl-libwin32/win32/pull/53)
    - fix inverted SKIP condition for non-English locale in t/HttpGetFile.t [#55](https://github.com/perl-libwin32/win32/pull/55)
    - fix t/GetCurrentThreadId.t fork-emulation detection by [@sisyphus](https://github.com/sisyphus) [#45](https://github.com/perl-libwin32/win32/pull/45)
    
    - 0.60 [2026-05-05]
    
    - add LICENSE and modernize README [#51](https://github.com/perl-libwin32/win32/pull/51)
    - update Microsoft doc URLs to learn.microsoft.com
    
    - 0.59_02 [2026-05-04]
    
    - detect newer Windows 10/11, Windows Server 2019/2022/2025, and
      Server SAC releases by Markus Demml ([@mardem1](https://github.com/mardem1)) [#42](https://github.com/perl-libwin32/win32/pull/42)
    - fix 64-bit registry constant by [@jkahrman](https://github.com/jkahrman) [#37](https://github.com/perl-libwin32/win32/pull/37)
    - follow-up to 64-bit registry fix by Tony Cook ([@tonycoz](https://github.com/tonycoz)) [#39](https://github.com/perl-libwin32/win32/pull/39)
    - fix memory deallocation for WinHttpGetProxyForUrl strings [#49](https://github.com/perl-libwin32/win32/pull/49)
    - include t/HttpGetFile.t in MANIFEST so it ships in the CPAN tarball [#50](https://github.com/perl-libwin32/win32/pull/50)
    - convert tests to Test::More by Graham Knop ([@haarg](https://github.com/haarg)) [#35](https://github.com/perl-libwin32/win32/pull/35)
    - clarify documentation of minor versions by Ferenc Erki ([@ferki](https://github.com/ferki)) [#25](https://github.com/perl-libwin32/win32/pull/25)



-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
