### PR TITLE
hv_macro.h: remove duplicate CAN64BITHASH definition

### DIFF
--- a/hv_macro.h
+++ b/hv_macro.h
@@ -78,8 +78,5 @@
 #define ROTL_UV(x,r) ROTL32(x,r)
 #define ROTR_UV(x,r) ROTR32(x,r)
 #endif
-#if IVSIZE == 8
-#define CAN64BITHASH
-#endif
 
 #endif


### PR DESCRIPTION


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
