### PR TITLE
splice: add magic to inserted elements for magical non-tied arrays

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -417,6 +417,13 @@ manager will later use a regex to expand these into links.
 
 XXX
 
+=item *
+
+Copy magic to the new elements when splice() inserts elements into a
+non-tied magical array.  In particular, assignment to an element of an
+C<@ISA> array where the element was added by splice() is now correctly
+recognized when performing method lookup.  [GH #24659]
+
 =back
 
 =head1 Known Problems

--- a/pp.c
+++ b/pp.c
@@ -6609,8 +6609,12 @@ PP_wrapped(pp_splice, 0, 1)
         Safefree(tmparyval);
     }
 
-    if (SvMAGICAL(ary))
+    if (UNLIKELY(SvMAGICAL(ary))) {
+        for (i = 0; i < newlen; ++i) {
+            mg_copy(MUTABLE_SV(ary), AvARRAY(ary)[offset+i], NULL, offset+i);
+        }
         mg_set(MUTABLE_SV(ary));
+    }
 
     SP = MARK;
     RETURN;

--- a/t/op/splice.t
+++ b/t/op/splice.t
@@ -98,6 +98,23 @@ $#a++;
 is sprintf("%s", splice @a, 0, 1, undef), "",
   'splice handles nonexistent elems when array len stays the same';
 
+{
+    # GH #24659
+    package BaseA {
+        sub meth { __PACKAGE__ }
+    }
+    package BaseB {
+        sub meth { __PACKAGE__ }
+    }
+    splice(@Derived::ISA, 0, 0, "BaseA");
+    $Derived::ISA[0] = "BaseB";
+    is(Derived->meth, "BaseB", "magic invoked for grown");
+    @Derived::ISA = qw(BaseB BaseB BaseB);
+    splice(@Derived::ISA, 0, 2, "BaseB");
+    $Derived::ISA[0] = "BaseA";
+    is(Derived->meth, "BaseA", "magic invoked for shrunk");
+}
+
 # RT#131000
 {
     local $@;
@@ -112,6 +129,5 @@ is sprintf("%s", splice @a, 0, 1, undef), "",
 fresh_perl_is('my @data = (undef) x 4; splice @data, 1, 1;
     splice @data, 2, 1; $data[3] = undef; splice @data, 3, 1;',
     '', {}, 'GH#18667 - av_extend_guts must zero duplicate SV*s');
-
 
 done_testing;


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
Fixes #24659

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.
