### PR TITLE
I18N::LangTags::List: don't keep DATA open

### DIFF
--- a/dist/I18N-LangTags/lib/I18N/LangTags/List.pm
+++ b/dist/I18N-LangTags/lib/I18N/LangTags/List.pm
@@ -28,6 +28,7 @@ our $VERSION = '0.42';
       $Is_Disrec{$1} = 1;
     }
   }
+  close DATA;
   die "No tags read??" unless $count;
 }
 #----------------------------------------------------------------------


### PR DESCRIPTION
We only need it during initialization. After that it just wastes a file descriptor.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
