### PR TITLE
Fix makedef.pl to use correct compiler flag

### DIFF
--- a/makedef.pl
+++ b/makedef.pl
@@ -1091,7 +1091,7 @@ elsif (PLATFORM eq 'os2') {
 		 ));
 }
 
-if ($define{USE_ITHREADS} && $define{I_PTHREAD}) {
+if ($define{USE_ITHREADS} && $Config{i_pthread}) {
     try_symbols(qw(
 		      perl_tsa_mutex_lock
 		      perl_tsa_mutex_unlock


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
makedef.pl was updated to look for I_PTHREAD and add the perl_tsa_mutex_lock and perl_tsa_mutex_unlock symbols if present, however, I_PTHREAD is not available in the %define hash, so this doesn't actually work.

I updated it to look at $Config{i_pthread} instead, which should either be undef or 'define', so truthy _should_ be the correct check here.

This change impacts AIX using the ibm-clang_r compiler.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
