### PR TITLE
`newSVsv()`: Ensure taint propagation on IVs and NVs

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -5087,7 +5087,7 @@ S_newSVsv_flags_NN_PVxx(pTHX_ SV* dsv, SV* ssv, const I32 flags)
     switch(sflags & (SVp_IOK|SVp_NOK|SVf_ROK|SVp_POK|SVf_FAKE|SVppv_STATIC)) {
         case SVp_IOK:  /* [ 50% ]*/
             SvIV_set(dsv, SvIVX(ssv));
-            return dsv;
+            goto check_taint;
         case SVp_POK|SVp_IOK|SVp_NOK:  /* [ 3% ] */
             ASSUME(SvTYPE(dsv) != SVt_PVIV);
             SvNV_set(dsv, SvNVX(ssv));
@@ -5109,7 +5109,7 @@ S_newSVsv_flags_NN_PVxx(pTHX_ SV* dsv, SV* ssv, const I32 flags)
 
             SvIV_set(dsv, SvIVX(ssv));
             SvNV_set(dsv, SvNVX(ssv));
-            return dsv;
+            goto check_taint;
         case SVp_POK|SVp_NOK:  /* [ 3% ]*/
             SvIV_set(dsv, 0); /* Initializing for code that blindly reads IV */
             SvNV_set(dsv, SvNVX(ssv));
@@ -5120,7 +5120,7 @@ S_newSVsv_flags_NN_PVxx(pTHX_ SV* dsv, SV* ssv, const I32 flags)
              * propagate the latter. */
             SvFLAGS(dsv) &= ~SVprv_WEAKREF;
             SvRV_set(dsv, SvREFCNT_inc(SvRV(ssv)));
-            return dsv;
+            goto check_taint;
         default:  /* [ 2% ]*/
             SvIV_set(dsv, 0); /* Initializing for code that blindly reads IV */
             if(!SvOK(ssv))  /* [ ~2% ]*/
@@ -5137,14 +5137,14 @@ S_newSVsv_flags_NN_PVxx(pTHX_ SV* dsv, SV* ssv, const I32 flags)
              * Other cases are also rare but also trickier to handle,
              * so keeps this function smaller to not even try. */
             sv_setsv_flags(dsv,ssv,flags);
-            return dsv;
+            return dsv; /* sv_setsv_flags() has handled taint */
         case SVp_NOK:  /* [ << 1% ]*/
             ASSUME(SvTYPE(dsv) != SVt_PVIV);
             SvIV_set(dsv, 0); /* Initializing for code that blindly reads IV */
             SvNV_set(dsv, SvNVX(ssv));
-            return dsv;
+            goto check_taint;
     }
-    assert(SVp_POK); /* All other cases should have returned */
+    assert(SVp_POK); /* All other cases should jump to check_taint */
 
     S_newSVsv_flags_NN_POK(aTHX_ dsv, ssv, flags);
 
@@ -5167,6 +5167,7 @@ S_newSVsv_flags_NN_PVxx(pTHX_ SV* dsv, SV* ssv, const I32 flags)
             SvRMAGICAL_on(dsv);
         }
     }
+check_taint:
     if (SvTAINTED(ssv)) /* [ <<< 1% ] */
         SvTAINT(dsv);
     return dsv;

--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -14,8 +14,7 @@ BEGIN {
     require './loc_tools.pl';
 }
 
-use strict;
-use warnings;
+use v5.36; # not 5.40 because we don't want to stomp on `is_tainted`
 use Config;
 
 my $NoTaintSupport = exists($Config{taint_support}) && !$Config{taint_support};
@@ -103,11 +102,8 @@ sub taint_these :prototype(@) {
     for (@_) { $_ .= $TAINT }
 }
 
-# How to identify taint when you see it
-sub tainted :prototype($) {
-    local $@;   # Don't pollute caller's value.
-    not eval { no warnings; join("", @_), kill 0; 1 };
-}
+# just import the one from 'builtin' as a different name
+BEGIN { *tainted = \&builtin::is_tainted; }
 
 sub is_tainted {
     my $thing = shift;

--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -24,7 +24,7 @@ if ($NoTaintSupport) {
     exit 0;
 }
 
-plan tests => 1065;
+plan tests => 1071;
 
 $| = 1;
 
@@ -2976,6 +2976,29 @@ is_tainted("$ovtaint", "overload preserves taint");
 	is($r3, $u, 'tainted string with utf8 s/.+//gre');
 	my $r4 = ("$u$TAINT" =~ s/./""/gre);
 	is($r4, '', 'tainted utf8 string with s///gre');
+}
+
+{
+    # GH 24705: newSVsv loses taint on plain IVs and NVs
+    my $strcopy = "$0";
+
+    no warnings 'numeric';
+    my $intcopy = $0 + 0;
+    my $numcopy = $0 + 0.1;
+
+    is_tainted($strcopy, 'tainted stringy copy of $0');
+    is_tainted($intcopy, 'tainted integer copy of $0');
+    is_tainted($numcopy, 'tainted numeric copy of $0');
+
+    my $anonhash = {
+        str => $strcopy,
+        int => $intcopy,
+        num => $numcopy,
+    };
+
+    is_tainted($anonhash->{str}, 'tainted stringy copy of $0 via pp_anonhash');
+    is_tainted($anonhash->{int}, 'tainted integer copy of $0 via pp_anonhash');
+    is_tainted($anonhash->{num}, 'tainted numeric copy of $0 via pp_anonhash');
 }
 
 # This may bomb out with the alarm signal so keep it last


### PR DESCRIPTION
Previously, the `return dsv` meant it skipped the `SvTAINTED(ssv)` check later on, meaning that tainted numbers that don't contain stringy parts would lose that taint annotation.
    
Technically this code also ensures tainted RVs and booleans will propagate correctly, but I could not work out how to generate such a value to test it ;)
    
This came up while testing the related "value magic" which uses similar annotation code, and I found this was missing there too.

Fixes #24705 