### PR TITLE
t/run/todo.t: Limit scope of restrictions on glob test

### DIFF
--- a/t/op/glob.t
+++ b/t/op/glob.t
@@ -6,7 +6,8 @@ BEGIN {
     set_up_inc( qw(. ../lib) );
 }
 
-plan( tests => 18 );
+use Config;
+my $is_debugging_build = $Config{config_args} =~ /\bDDEBUGGING\b(*nla:=none)/;
 
 @oops = @ops = <op/*>;
 
@@ -120,7 +121,6 @@ SKIP: {
 ######## glob() bug Mon, 01 Sep 2003 02:25:41 -0700 <200309010925.h819Pf0X011457@smtp3.ActiveState.com>
 
 SKIP: {
-    use Config;
     skip("glob() works when cross-compiling, but this test doesn't", 1)
         if $Config{usecrosscompile};
 
@@ -150,3 +150,15 @@ SKIP: {
     }
 EOP
 }
+
+SKIP: {
+    skip "Debugging builds on Linux still problematic: GH 16869", 1
+        if ($Config{osname} eq 'linux' and $is_debugging_build);
+    fresh_perl(<<~'HERE', {});
+        my $glob = ("0" x 4094) . "?";
+        glob $glob;
+        HERE
+    is($?, 0, 'No assertion failure; GH 16869');
+}
+
+done_testing();

--- a/t/op/glob.t
+++ b/t/op/glob.t
@@ -152,8 +152,11 @@ EOP
 }
 
 SKIP: {
-    skip "Debugging builds on Linux still problematic: GH 16869", 1
-        if ($Config{osname} eq 'linux' and $is_debugging_build);
+    skip "Debugging builds on Linux and Cygwin still problematic: GH 16869", 1
+        if (
+            ($Config{osname} eq 'linux' or $Config{osname} eq 'cygwin') and
+            $is_debugging_build
+        );
     fresh_perl(<<~'HERE', {});
         my $glob = ("0" x 4094) . "?";
         glob $glob;

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -320,7 +320,12 @@ TODO: {
 }
 
 TODO: {
-    todo_skip "Test needs -DDEBUGGING", 1 unless $is_debugging_build;
+    todo_skip "Test needs -DDEBUGGING on Linux, no miniperl", 1
+        unless (
+            $is_debugging_build and
+            $Config{osname} eq 'linux' and
+            ! is_miniperl()
+        );
     local $::TODO = 'GH 16869';
     fresh_perl(<<~'HERE', {});
         my $glob = ("0" x 4094) . "?";

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -320,10 +320,10 @@ TODO: {
 }
 
 TODO: {
-    todo_skip "Test needs -DDEBUGGING on Linux, no miniperl", 1
+    todo_skip "Test needs -DDEBUGGING on Linux and on Cygwin, no miniperl", 1
         unless (
             $is_debugging_build and
-            $Config{osname} eq 'linux' and
+            ($Config{osname} eq 'linux' or $Config{osname} eq 'cygwin') and
             ! is_miniperl()
         );
     local $::TODO = 'GH 16869';


### PR DESCRIPTION
This pull request implements the approach discussed in https://github.com/Perl/perl5/issues/24709.  It restricts the scope of one `TODO`-ed test in `t/run/todo.t` to those circumstances where, if the test were *not* `TODO`-ed, the test would FAIL, causing `t/run/todo.t` to FAIL as well.

The "GH 16869" test added to `t/run/todo.t` in de313d8e84 (Aug 23 2025) was written in the belief that an assertion failure in glob3 would be encountered on all debugging builds.  Examination of test results suggests that this is only true on Linux and Cygwin.  If so, then we can have this
test run "live" (i.e., without TODO or SKIP conditions) on all non-debugging builds on all platforms and on debugging builds other than on Linux and Cygwin.

To test this hypothesis, we'll restrict the scope of the GH 16869 TODO condition to debugging builds on Linux and Cygwin and run the test without TODO or SKIP conditions from `t/op/glob.t`.  Should the test in `t/op/glob.t` now start to fail, we'll know we have deeper problems which warrant renewed examination in GH #16869.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
