### PR TITLE
regex engine - compile tries using utf8 octets 

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6741,6 +6741,9 @@ t/re/subst.t				See if substitution works
 t/re/subst_amp.t			See if $&-related substitution works
 t/re/subst_wamp.t			See if substitution works with $& present
 t/re/substT.t				See if substitution works with -T
+t/re/trie_bench.pl			Shared trie benchmark and regression cases
+t/re/trie_bench.t			Trie benchmark regression tests
+t/re/trie_byte.t			Test byte-oriented trie construction
 t/re/uniprops01.t			Test unicode \p{} regex constructs
 t/re/uniprops02.t			Test unicode \p{} regex constructs
 t/re/uniprops03.t			Test unicode \p{} regex constructs

--- a/MANIFEST
+++ b/MANIFEST
@@ -6749,6 +6749,9 @@ t/re/subst.t				See if substitution works
 t/re/subst_amp.t			See if $&-related substitution works
 t/re/subst_wamp.t			See if substitution works with $& present
 t/re/substT.t				See if substitution works with -T
+t/re/trie_bench.pl			Shared trie benchmark and regression cases
+t/re/trie_bench.t			Trie benchmark regression tests
+t/re/trie_byte.t			Test byte-oriented trie construction
 t/re/uniprops01.t			Test unicode \p{} regex constructs
 t/re/uniprops02.t			Test unicode \p{} regex constructs
 t/re/uniprops03.t			Test unicode \p{} regex constructs

--- a/charclass_invlists.inc
+++ b/charclass_invlists.inc
@@ -492714,5 +492714,5 @@ static const U8 WB_dfa_table[] = {
  * 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * c4f76f4ba54f533e6b3c6197d2733a4f83f7bbf3c01e6d83b8950e291a3fe36a regen/mk_PL_charclass.pl
- * 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+ * 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
  * ex: set ro ft=c: */

--- a/charclass_invlists.inc
+++ b/charclass_invlists.inc
@@ -492714,5 +492714,5 @@ static const U8 WB_dfa_table[] = {
  * 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * 40a2020ba2420e15332d3855a26138f4391b9f49fbb53aafcb9560e1e288dd5a regen/mk_PL_charclass.pl
- * 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+ * 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
  * ex: set ro ft=c: */

--- a/embed.fnc
+++ b/embed.fnc
@@ -5644,6 +5644,7 @@ Ep	|I32	|make_trie	|NN RExC_state_t *pRExC_state		\
 				|NN regnode *last			\
 				|NN regnode *tail			\
 				|U32 word_count 			\
+				|STRLEN octet_count			\
 				|U32 flags				\
 				|U32 depth
 Ep	|void	|populate_anyof_bitmap_from_invlist			\
@@ -5677,20 +5678,14 @@ Ep	|SSize_t|study_chunk	|NN RExC_state_t *pRExC_state		\
 				|bool was_mutate_ok
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 ES	|void	|dump_trie	|NN const struct reg_trie_data_ *trie	\
-				|NULLOK HV *widecharmap 		\
-				|NN AV *revcharmap			\
 				|U32 depth
 ES	|void	|dump_trie_interim_list 				\
 				|NN const struct reg_trie_data_ *trie	\
-				|NULLOK HV *widecharmap 		\
-				|NN AV *revcharmap			\
 				|U32 next_alloc 			\
 				|U32 depth
-ES	|void	|dump_trie_interim_table				\
+ES	|void	|dump_trie_physical					\
 				|NN const struct reg_trie_data_ *trie	\
-				|NULLOK HV *widecharmap 		\
-				|NN AV *revcharmap			\
-				|U32 next_alloc 			\
+				|U32 physical				\
 				|U32 depth
 # endif
 #endif /* defined(PERL_IN_REGCOMP_ANY) */
@@ -5934,7 +5929,7 @@ ERTXp	|bool	|regcurly	|SPTR const char *s			\
 #if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 ES	|U8	|put_charclass_bitmap_innards				\
 				|NN SV *sv				\
-				|NULLOK char *bitmap			\
+				|NULLOK U8 *bitmap			\
 				|NULLOK SV *nonbitmap_invlist		\
 				|NULLOK SV *only_utf8_locale_invlist	\
 				|NULLOK const regnode * const node	\

--- a/embed.fnc
+++ b/embed.fnc
@@ -5672,6 +5672,7 @@ Ep	|I32	|make_trie	|NN RExC_state_t *pRExC_state		\
 				|NN regnode *last			\
 				|NN regnode *tail			\
 				|U32 word_count 			\
+				|STRLEN octet_count			\
 				|U32 flags				\
 				|U32 depth
 Ep	|void	|populate_anyof_bitmap_from_invlist			\
@@ -5705,20 +5706,14 @@ Ep	|SSize_t|study_chunk	|NN RExC_state_t *pRExC_state		\
 				|bool was_mutate_ok
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 ES	|void	|dump_trie	|NN const struct reg_trie_data_ *trie	\
-				|NULLOK HV *widecharmap 		\
-				|NN AV *revcharmap			\
 				|U32 depth
 ES	|void	|dump_trie_interim_list 				\
 				|NN const struct reg_trie_data_ *trie	\
-				|NULLOK HV *widecharmap 		\
-				|NN AV *revcharmap			\
 				|U32 next_alloc 			\
 				|U32 depth
-ES	|void	|dump_trie_interim_table				\
+ES	|void	|dump_trie_physical					\
 				|NN const struct reg_trie_data_ *trie	\
-				|NULLOK HV *widecharmap 		\
-				|NN AV *revcharmap			\
-				|U32 next_alloc 			\
+				|U32 physical				\
 				|U32 depth
 # endif
 #endif /* defined(PERL_IN_REGCOMP_ANY) */
@@ -5962,7 +5957,7 @@ ERTXp	|bool	|regcurly	|SPTR const char *s			\
 #if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 ES	|U8	|put_charclass_bitmap_innards				\
 				|NN SV *sv				\
-				|NULLOK char *bitmap			\
+				|NULLOK U8 *bitmap			\
 				|NULLOK SV *nonbitmap_invlist		\
 				|NULLOK SV *only_utf8_locale_invlist	\
 				|NULLOK const regnode * const node	\

--- a/embed.h
+++ b/embed.h
@@ -2261,7 +2261,7 @@
 #     define invlist_is_iterating               S_invlist_is_iterating
 #     define invlist_lowest                     S_invlist_lowest
 #     define join_exact(a,b,c,d,e,f,g)          Perl_join_exact(aTHX_ a,b,c,d,e,f,g)
-#     define make_trie(a,b,c,d,e,f,g,h)         Perl_make_trie(aTHX_ a,b,c,d,e,f,g,h)
+#     define make_trie(a,b,c,d,e,f,g,h,i)       Perl_make_trie(aTHX_ a,b,c,d,e,f,g,h,i)
 #     define populate_anyof_bitmap_from_invlist(a,b) Perl_populate_anyof_bitmap_from_invlist(aTHX_ a,b)
 #     define reg_add_data                       Perl_reg_add_data
 #     define scan_commit(a,b,c,d)               Perl_scan_commit(aTHX_ a,b,c,d)
@@ -2269,9 +2269,9 @@
 #     define ssc_init(a,b)                      Perl_ssc_init(aTHX_ a,b)
 #     define study_chunk(a,b,c,d,e,f,g,h,i,j,k,l) Perl_study_chunk(aTHX_ a,b,c,d,e,f,g,h,i,j,k,l)
 #     if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
-#       define dump_trie(a,b,c,d)               S_dump_trie(aTHX_ a,b,c,d)
-#       define dump_trie_interim_list(a,b,c,d,e) S_dump_trie_interim_list(aTHX_ a,b,c,d,e)
-#       define dump_trie_interim_table(a,b,c,d,e) S_dump_trie_interim_table(aTHX_ a,b,c,d,e)
+#       define dump_trie(a,b)                   S_dump_trie(aTHX_ a,b)
+#       define dump_trie_interim_list(a,b,c)    S_dump_trie_interim_list(aTHX_ a,b,c)
+#       define dump_trie_physical(a,b,c)        S_dump_trie_physical(aTHX_ a,b,c)
 #     endif
 #   endif /* defined(PERL_IN_REGCOMP_ANY) */
 #   if defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C)

--- a/embed.h
+++ b/embed.h
@@ -2034,7 +2034,7 @@
 #     define invlist_is_iterating               S_invlist_is_iterating
 #     define invlist_lowest                     S_invlist_lowest
 #     define join_exact(a,b,c,d,e,f,g)          Perl_join_exact(aTHX_ a,b,c,d,e,f,g)
-#     define make_trie(a,b,c,d,e,f,g,h)         Perl_make_trie(aTHX_ a,b,c,d,e,f,g,h)
+#     define make_trie(a,b,c,d,e,f,g,h,i)       Perl_make_trie(aTHX_ a,b,c,d,e,f,g,h,i)
 #     define populate_anyof_bitmap_from_invlist(a,b) Perl_populate_anyof_bitmap_from_invlist(aTHX_ a,b)
 #     define reg_add_data                       Perl_reg_add_data
 #     define scan_commit(a,b,c,d)               Perl_scan_commit(aTHX_ a,b,c,d)
@@ -2042,9 +2042,9 @@
 #     define ssc_init(a,b)                      Perl_ssc_init(aTHX_ a,b)
 #     define study_chunk(a,b,c,d,e,f,g,h,i,j,k,l) Perl_study_chunk(aTHX_ a,b,c,d,e,f,g,h,i,j,k,l)
 #     if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
-#       define dump_trie(a,b,c,d)               S_dump_trie(aTHX_ a,b,c,d)
-#       define dump_trie_interim_list(a,b,c,d,e) S_dump_trie_interim_list(aTHX_ a,b,c,d,e)
-#       define dump_trie_interim_table(a,b,c,d,e) S_dump_trie_interim_table(aTHX_ a,b,c,d,e)
+#       define dump_trie(a,b)                   S_dump_trie(aTHX_ a,b)
+#       define dump_trie_interim_list(a,b,c)    S_dump_trie_interim_list(aTHX_ a,b,c)
+#       define dump_trie_physical(a,b,c)        S_dump_trie_physical(aTHX_ a,b,c)
 #     endif
 #   endif /* defined(PERL_IN_REGCOMP_ANY) */
 #   if defined(PERL_IN_REGCOMP_ANY) || defined(PERL_IN_SV_C)

--- a/ext/re/t/regop.t
+++ b/ext/re/t/regop.t
@@ -91,10 +91,8 @@ __END__
 #%MATCHED%
 #Freeing REx: "X(A|[B]Q||C|D)Y"
 Compiling REx "X(A|[B]Q||C|D)Y"
-[A-D]
 TRIE-EXACT
 <BQ>
-matched empty string
 Match successful!
 Found floating substr "Y" at offset 1 (rx_origin now 0)...
 Found anchored substr "X" at offset 0 (rx_origin now 0)...
@@ -104,7 +102,7 @@ minlen 2
 S:1/6   
 W:5
 L:0/2
-C:5/5
+C:5
 %MATCHED%
 ---
 #Compiling REx "[f][o][o][b][a][r]"
@@ -156,7 +154,7 @@ minlen 3
 #     word_info N:(prev,char)= 1:(0,1) 2:(0,1) 3:(0,1) 4:(0,1) 5:(0,1) 6:(0,1)
 # Final program:
 #    1: EXACT <ABC> (3)
-#    3: TRIEC-EXACT<S:4/10 W:6 L:1/1 C:24/7>[A-EGP] (20)
+#    3: TRIE-EXACT<S:4/10 W:6 L:1/1 C:24>[A-EGP] (20)
 #       <P> 
 #       <G> 
 #       <E> 
@@ -170,7 +168,7 @@ minlen 3
 # Guessed: match at offset 0
 # Matching REx "(?:ABCP|ABCG|ABCE|ABCB|ABCA|ABCD)" against "ABCD"
 #    0 <> <ABCD>               |  1:EXACT <ABC>(3)
-#    3 <ABC> <D>               |  3:TRIEC-EXACT<S:4/10 W:6 L:1/1 C:24/7>[A-EGP](20)
+#    3 <ABC> <D>               |  3:TRIE-EXACT<S:4/10 W:6 L:1/1 C:24>[A-EGP](20)
 #    3 <ABC> <D>               |    State:    4 Accepted:    0 Charid:  7 CP:  44 After State:    a
 #    4 <ABCD> <>               |    State:    a Accepted:    1 Charid:  7 CP:   0 After State:    0
 #                                   got 1 possible matches
@@ -181,12 +179,11 @@ minlen 3
 # Freeing REx: "(?:ABCP|ABCG|ABCE|ABCB|ABCA|ABCD)"
 %MATCHED%
 EXACT <ABC>
-TRIEC-EXACT
-[A-EGP]
+TRIE-EXACT
 S:4/10
 W:6
 L:1/1
-C:24/7
+C:24
 minlen 4
 (checking anchored)
 anchored "ABC" at 0

--- a/lib/unicore/uni_keywords.pl
+++ b/lib/unicore/uni_keywords.pl
@@ -1429,5 +1429,5 @@
 # 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
 # 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
 # c4f76f4ba54f533e6b3c6197d2733a4f83f7bbf3c01e6d83b8950e291a3fe36a regen/mk_PL_charclass.pl
-# 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+# 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
 # ex: set ro ft=perl:

--- a/lib/unicore/uni_keywords.pl
+++ b/lib/unicore/uni_keywords.pl
@@ -1429,5 +1429,5 @@
 # 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
 # 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
 # 40a2020ba2420e15332d3855a26138f4391b9f49fbb53aafcb9560e1e288dd5a regen/mk_PL_charclass.pl
-# 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+# 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
 # ex: set ro ft=perl:

--- a/perl.c
+++ b/perl.c
@@ -103,6 +103,22 @@ S_init_tls_and_interp(PerlInterpreter *my_perl)
     }
 }
 
+static void
+S_init_native_octet_utf8(pTHX)
+{
+    U32 i;
+
+    /* The table is process-global, but initializing it here is harmless when
+     * another interpreter is constructed.  It depends only on the character
+     * set selected at compile time. */
+    for (i = 0; i < 256; i++) {
+        U8 * const end = uvoffuni_to_utf8_flags(
+            PL_native_octet_utf8[i].bytes, NATIVE_TO_UNI(i), 0);
+        PL_native_octet_utf8[i].len = (U8)(end -
+                                          PL_native_octet_utf8[i].bytes);
+    }
+}
+
 
 #ifndef PLATFORM_SYS_INIT_
 #  define PLATFORM_SYS_INIT_  NOOP
@@ -247,6 +263,7 @@ perl_construct(pTHXx)
 #endif
 
     init_constants();
+    S_init_native_octet_utf8(aTHX);
 
     SvREADONLY_on(&PL_sv_placeholder);
     SvREFCNT(&PL_sv_placeholder) = SvREFCNT_IMMORTAL;
@@ -2062,6 +2079,9 @@ S_Internals_V(pTHX_ CV *cv)
 #  endif
 #  ifdef PERL_RC_STACK
                              " PERL_RC_STACK"
+#  endif
+#  ifdef PERL_REGEX_OCTET_TRIE
+                             " PERL_REGEX_OCTET_TRIE"
 #  endif
 #  ifdef PERL_RELOCATABLE_INCPUSH
                              " PERL_RELOCATABLE_INCPUSH"

--- a/perl.c
+++ b/perl.c
@@ -103,6 +103,22 @@ S_init_tls_and_interp(PerlInterpreter *my_perl)
     }
 }
 
+static void
+S_init_native_octet_utf8(pTHX)
+{
+    U32 i;
+
+    /* The table is process-global, but initializing it here is harmless when
+     * another interpreter is constructed.  It depends only on the character
+     * set selected at compile time. */
+    for (i = 0; i < 256; i++) {
+        U8 * const end = uv_to_utf8_flags(
+            PL_native_octet_utf8[i].bytes, i, 0);
+        PL_native_octet_utf8[i].len = (U8)(end -
+                                          PL_native_octet_utf8[i].bytes);
+    }
+}
+
 
 #ifndef PLATFORM_SYS_INIT_
 #  define PLATFORM_SYS_INIT_  NOOP
@@ -247,6 +263,7 @@ perl_construct(pTHXx)
 #endif
 
     init_constants();
+    S_init_native_octet_utf8(aTHX);
 
     SvREADONLY_on(&PL_sv_placeholder);
     SvREFCNT(&PL_sv_placeholder) = SvREFCNT_IMMORTAL;
@@ -2067,6 +2084,9 @@ S_Internals_V(pTHX_ CV *cv)
 #  endif
 #  ifdef PERL_RC_STACK
                              " PERL_RC_STACK"
+#  endif
+#  ifdef PERL_REGEX_OCTET_TRIE
+                             " PERL_REGEX_OCTET_TRIE"
 #  endif
 #  ifdef PERL_RELOCATABLE_INCPUSH
                              " PERL_RELOCATABLE_INCPUSH"

--- a/perl.h
+++ b/perl.h
@@ -4744,6 +4744,9 @@ struct Perl_OpDumpContext;
 #include "warnings.h"
 #include "utf8.h"
 
+/* Trie transitions use encoded octets rather than codepoints. */
+#define PERL_REGEX_OCTET_TRIE 1
+
 /* these would be in doio.h if there was such a file */
 #define my_stat()  my_stat_flags(SV_GMAGIC)
 #define my_lstat() my_lstat_flags(SV_GMAGIC)
@@ -8172,7 +8175,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
         STMT_START {                                                        \
             if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
                 Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
-                                       "Wide character (U+%" UVXf ") in %s",\
+                                       "Wide character (U+%" UVXf ") in %s under a non-UTF-8 locale",\
                                        (UV) cp, OP_DESC(PL_op));            \
             }                                                               \
         }  STMT_END
@@ -8184,7 +8187,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                                           (const U8 *) (send),              \
                                           NULL);                            \
                 Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
-                        "Wide character (U+%" UVXf ") in %s",               \
+                        "Wide character (U+%" UVXf ") in %s under a non-UTF-8 locale", \
                         (UV) cp, OP_DESC(PL_op));                           \
             }                                                               \
         }  STMT_END

--- a/perl.h
+++ b/perl.h
@@ -4808,6 +4808,9 @@ struct Perl_OpDumpContext;
 #include "warnings.h"
 #include "utf8.h"
 
+/* Trie transitions use encoded octets rather than codepoints. */
+#define PERL_REGEX_OCTET_TRIE 1
+
 /* these would be in doio.h if there was such a file */
 #define my_stat()  my_stat_flags(SV_GMAGIC)
 #define my_lstat() my_lstat_flags(SV_GMAGIC)
@@ -8236,7 +8239,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
         STMT_START {                                                        \
             if (! IN_UTF8_CTYPE_LOCALE && ckWARN(WARN_LOCALE)) {            \
                 Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
-                                       "Wide character (U+%" UVXf ") in %s",\
+                                       "Wide character (U+%" UVXf ") in %s under a non-UTF-8 locale",\
                                        (UV) cp, OP_DESC(PL_op));            \
             }                                                               \
         }  STMT_END
@@ -8248,7 +8251,7 @@ the plain locale pragma without a parameter (S<C<use locale>>) is in effect.
                                           (const U8 *) (send),              \
                                           NULL);                            \
                 Perl_warner(aTHX_ packWARN(WARN_LOCALE),                    \
-                        "Wide character (U+%" UVXf ") in %s",               \
+                        "Wide character (U+%" UVXf ") in %s under a non-UTF-8 locale", \
                         (UV) cp, OP_DESC(PL_op));                           \
             }                                                               \
         }  STMT_END

--- a/perlvars.h
+++ b/perlvars.h
@@ -380,6 +380,8 @@ PERLVARA(G, hash_state_w, PERL_HASH_STATE_WORDS, PVT__PERL_HASH_WORD_TYPE) /* pe
 PERLVARA(G, hash_chars, PERL_SINGLE_CHAR_HASH_CACHE_ELEMS, unsigned char) /* perl.c and hv.h */
 #endif
 
+PERLVARA(G, native_octet_utf8, 256, native_octet_utf8_t)
+
 /* The path separator can vary depending on whether we're running under DCL or
  * a Unix shell.
  */

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -91,6 +91,14 @@ There may well be none in a stable release.
 
 XXX
 
+=item *
+
+The regular expression trie optimizer has been reworked to compile trie
+transitions as octets.  Large alternations can now avoid work that previously
+grew with both the number of alternatives and the amount of text skipped
+before a match, while preserving the existing matching semantics for native
+and UTF-8 strings.
+
 =back
 
 =head1 Modules and Pragmata
@@ -349,6 +357,19 @@ well.
 =item *
 
 XXX
+
+=item *
+
+The regular expression compiler's TRIE implementation has been changed to use
+the octets of the UTF-8 representation of the pattern in its internal table
+structures. Previous versions used a trie based on code points, which had
+various side effects that required additional complexity, especially because
+of Unicode's potentially very large alphabet. By switching to an octet-based
+representation, a large amount of this complexity could be removed, making
+the new code faster, easier to maintain, and easier to prove correct.
+
+Most users should not notice this change, except perhaps a slight performance
+improvement.
 
 =back
 

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -159,6 +159,14 @@ Specifically, any of the following single subscripts
 
 XXX
 
+=item *
+
+The regular expression trie optimizer has been reworked to compile trie
+transitions as octets.  Large alternations can now avoid work that previously
+grew with both the number of alternatives and the amount of text skipped
+before a match, while preserving the existing matching semantics for native
+and UTF-8 strings.
+
 =back
 
 =head1 Modules and Pragmata
@@ -425,6 +433,19 @@ into two or more adjacent TRIE nodes might now get compiled into a single
 =item *
 
 XXX
+
+=item *
+
+The regular expression compiler's TRIE implementation has been changed to use
+the octets of the UTF-8 representation of the pattern in its internal table
+structures. Previous versions used a trie based on code points, which had
+various side effects that required additional complexity, especially because
+of Unicode's potentially very large alphabet. By switching to an octet-based
+representation, a large amount of this complexity could be removed, making
+the new code faster, easier to maintain, and easier to prove correct.
+
+Most users should not notice this change, except perhaps a slight performance
+improvement.
 
 =back
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -8542,7 +8542,7 @@ indicates that incorrect results are being obtained.  You should examine
 your code to determine how a wide character is getting to an operation
 that doesn't handle them.
 
-=item Wide character (U+%X) in %s
+=item Wide character (U+%X) in %s under a non-UTF-8 locale
 
 (W locale) While in a single-byte locale (I<i.e.>, a non-UTF-8
 one), a multi-byte character was encountered.   Perl considers this

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -8566,7 +8566,7 @@ indicates that incorrect results are being obtained.  You should examine
 your code to determine how a wide character is getting to an operation
 that doesn't handle them.
 
-=item Wide character (U+%X) in %s
+=item Wide character (U+%X) in %s under a non-UTF-8 locale
 
 (W locale) While in a single-byte locale (I<i.e.>, a non-UTF-8
 one), a multi-byte character was encountered.   Perl considers this

--- a/pod/perlreguts.pod
+++ b/pod/perlreguts.pod
@@ -374,19 +374,12 @@ LNBREAK          none       generic newline pattern
 
 # Trie Related
 #
-# Behave the same as A|LIST|OF|WORDS would. The '..C' variants have inline
-# charclass data (ascii only), the 'C' store it in the structure.
+# Behave the same as A|LIST|OF|WORDS would. Trie data is stored in a shared
+# trie structure.
 TRIE             trie 1     Match many EXACT(F[ALU]?)? at once.
                             flags==type
-TRIEC            trie       Same as TRIE, but with embedded charclass
-                 charclass  data
 AHOCORASICK      trie 1     Aho Corasick stclass. flags==type
-AHOCORASICKC     trie       Same as AHOCORASICK, but with embedded
-                 charclass  charclass data
 LTRIE            trie 2     Same as TRIE, but with longjump support
-LTRIEC           trie       Same as TRIEC, but with longjump support
-                 charclass_
-                 trie
 
 # Do nothing types
 NOTHING          no         Match empty string.

--- a/proto.h
+++ b/proto.h
@@ -9209,7 +9209,7 @@ Perl_is_grapheme(pTHX_ const U8 *strbeg, const U8 *s, const U8 *strend, const UV
 # endif
 # if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 static U8
-S_put_charclass_bitmap_innards(pTHX_ SV *sv, char *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display)
+S_put_charclass_bitmap_innards(pTHX_ SV *sv, U8 *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 static SV *
@@ -12251,7 +12251,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan, UV *min_subtract
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 PERL_CALLCONV I32
-Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch, regnode *first, regnode *last, regnode *tail, U32 word_count, U32 flags, U32 depth)
+Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch, regnode *first, regnode *last, regnode *tail, U32 word_count, STRLEN octet_count, U32 flags, U32 depth)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2)
@@ -12301,37 +12301,28 @@ Perl_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp, SSize_t *minl
         __attribute__visibility__("hidden");
 #   if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 static void
-S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 depth)
+S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, U32 depth)
         Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
+        Perl_attribute_nonnull(pTHX_1);
 static void
-S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, U32 next_alloc, U32 depth)
         Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
+        Perl_attribute_nonnull(pTHX_1);
 static void
-S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+S_dump_trie_physical(pTHX_ const struct reg_trie_data_ *trie, U32 physical, U32 depth)
         Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
+        Perl_attribute_nonnull(pTHX_1);
 #   endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DUMP_TRIE           \
-        Perl_assert_aTHX; assert(trie); \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
-        assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
+        Perl_assert_aTHX; assert(trie)
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST \
-        Perl_assert_aTHX; assert(trie); \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
-        assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
+        Perl_assert_aTHX; assert(trie)
 
-#   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE \
-        Perl_assert_aTHX; assert(trie); \
-        assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV); \
-        assert(revcharmap); assert(SvTYPE(revcharmap) == SVt_PVAV)
+#   define PERL_ARGS_ASSERT_DUMP_TRIE_PHYSICAL  \
+        Perl_assert_aTHX; assert(trie)
 
 # endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)

--- a/proto.h
+++ b/proto.h
@@ -9530,7 +9530,7 @@ Perl_is_grapheme(pTHX_ const U8 *strbeg, const U8 *s, const U8 *strend, const UV
 # endif
 # if defined(PERL_IN_REGCOMP_DEBUG_C) && defined(DEBUGGING)
 static U8
-S_put_charclass_bitmap_innards(pTHX_ SV *sv, char *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display)
+S_put_charclass_bitmap_innards(pTHX_ SV *sv, U8 *bitmap, SV *nonbitmap_invlist, SV *only_utf8_locale_invlist, const regnode * const node, const U8 flags, const bool force_as_is_display)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 static SV *
@@ -12704,7 +12704,7 @@ Perl_join_exact(pTHX_ RExC_state_t *pRExC_state, regnode *scan, UV *min_subtract
         Perl_attribute_nonnull(pTHX_4)
         __attribute__visibility__("hidden");
 PERL_CALLCONV I32
-Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch, regnode *first, regnode *last, regnode *tail, U32 word_count, U32 flags, U32 depth)
+Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch, regnode *first, regnode *last, regnode *tail, U32 word_count, STRLEN octet_count, U32 flags, U32 depth)
         Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1)
         Perl_attribute_nonnull(pTHX_2)
@@ -12754,43 +12754,28 @@ Perl_study_chunk(pTHX_ RExC_state_t *pRExC_state, regnode **scanp, SSize_t *minl
         __attribute__visibility__("hidden");
 #   if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 static void
-S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 depth)
+S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, U32 depth)
         Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
+        Perl_attribute_nonnull(pTHX_1);
 static void
-S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie, U32 next_alloc, U32 depth)
         Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
+        Perl_attribute_nonnull(pTHX_1);
 static void
-S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap, AV *revcharmap, U32 next_alloc, U32 depth)
+S_dump_trie_physical(pTHX_ const struct reg_trie_data_ *trie, U32 physical, U32 depth)
         Perl_attribute_nonnull_aTHX
-        Perl_attribute_nonnull(pTHX_1)
-        Perl_attribute_nonnull(pTHX_3);
+        Perl_attribute_nonnull(pTHX_1);
 #   endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
 # endif /* defined(PERL_CORE) || defined(PERL_EXT) */
 # if defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING)
 #   define PERL_ARGS_ASSERT_DUMP_TRIE           \
-       STMT_START { Perl_assert_aTHX; assert(trie);                           \
-                    assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
-                    assert(revcharmap);                                       \
-                    assert(SvTYPE(revcharmap) == SVt_PVAV);                   \
-    } STMT_END
+       STMT_START { Perl_assert_aTHX; assert(trie); } STMT_END
 
 #   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST \
-       STMT_START { Perl_assert_aTHX; assert(trie);                           \
-                    assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
-                    assert(revcharmap);                                       \
-                    assert(SvTYPE(revcharmap) == SVt_PVAV);                   \
-    } STMT_END
+       STMT_START { Perl_assert_aTHX; assert(trie); } STMT_END
 
-#   define PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE \
-       STMT_START { Perl_assert_aTHX; assert(trie);                           \
-                    assert(!widecharmap || SvTYPE(widecharmap) == SVt_PVHV);  \
-                    assert(revcharmap);                                       \
-                    assert(SvTYPE(revcharmap) == SVt_PVAV);                   \
-    } STMT_END
+#   define PERL_ARGS_ASSERT_DUMP_TRIE_PHYSICAL  \
+       STMT_START { Perl_assert_aTHX; assert(trie); } STMT_END
 
 # endif /* defined(PERL_IN_REGCOMP_TRIE_C) && defined(DEBUGGING) */
 # if !defined(PERL_NO_INLINE_FUNCTIONS)

--- a/regcomp.c
+++ b/regcomp.c
@@ -2048,6 +2048,8 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
                 RExC_rxi->regstclass = first;
         }
 #ifdef TRIE_STCLASS
+        /* Aho-Corasick consumes the same processed transition stream as the
+         * ordinary trie executor; it is a trie with failure links. */
         else if (REGNODE_TYPE(OP(first)) == TRIE &&
                 ((reg_trie_data *)RExC_rxi->data->data[ TRIE_DATA_SLOT(first) ])->minlen > 0)
         {
@@ -13757,11 +13759,8 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
                     refcount = --trie->refcount;
                     OP_REFCNT_UNLOCK;
                     if ( !refcount ) {
-                        PerlMemShared_free(trie->charmap);
                         PerlMemShared_free(trie->states);
                         PerlMemShared_free(trie->trans);
-                        if (trie->bitmap)
-                            PerlMemShared_free(trie->bitmap);
                         if (trie->jump)
                             PerlMemShared_free(trie->jump);
                         if (trie->j_before_paren)

--- a/regcomp.c
+++ b/regcomp.c
@@ -2056,6 +2056,8 @@ Perl_re_op_compile(pTHX_ SV ** const patternp, int pat_count,
                 RExC_rxi->regstclass = first;
         }
 #ifdef TRIE_STCLASS
+        /* Aho-Corasick consumes the same processed transition stream as the
+         * ordinary trie executor; it is a trie with failure links. */
         else if (REGNODE_TYPE(OP(first)) == TRIE &&
                 ((reg_trie_data *)RExC_rxi->data->data[ TRIE_DATA_SLOT(first) ])->minlen > 0)
         {
@@ -13979,11 +13981,8 @@ Perl_regfree_internal(pTHX_ REGEXP * const rx)
                     refcount = --trie->refcount;
                     OP_REFCNT_UNLOCK;
                     if ( !refcount ) {
-                        PerlMemShared_free(trie->charmap);
                         PerlMemShared_free(trie->states);
                         PerlMemShared_free(trie->trans);
-                        if (trie->bitmap)
-                            PerlMemShared_free(trie->bitmap);
                         if (trie->jump)
                             PerlMemShared_free(trie->jump);
                         if (trie->j_before_paren)

--- a/regcomp.h
+++ b/regcomp.h
@@ -1235,7 +1235,7 @@ typedef struct reg_trie_trans_list_elem_ reg_trie_trans_le;
   the state has no children (and will be accepting)
 */
 struct reg_trie_state_ {
-  U16 wordnum;
+  U32 wordnum;
   union {
     U32                base;
     reg_trie_trans_le* list;
@@ -1244,7 +1244,7 @@ struct reg_trie_state_ {
 
 /* info per word; indexed by wordnum */
 typedef struct {
-    U16  prev;	/* previous word in acceptance chain; eg in
+    U32  prev;	/* previous word in acceptance chain; eg in
                  * zzz|abc|ab/ after matching the chars abc, the
                  * accepted word is #2, and the previous accepted
                  * word is #3 */

--- a/regcomp.h
+++ b/regcomp.h
@@ -1207,7 +1207,7 @@ struct reg_trie_trans_ {
 
 /* a transition list element for the list based representation */
 struct reg_trie_trans_list_elem_ {
-    U32 forid;
+    U32 octet;
     U32 newstate;
 };
 typedef struct reg_trie_trans_list_elem_ reg_trie_trans_le;
@@ -1290,7 +1290,6 @@ struct reg_trie_data_ {
     U16             after_paren;
 #ifdef DEBUGGING
     STRLEN          charcount;       /* Build only */
-    U8              bitmap[ANYOF_BITMAP_SIZE]; /* all octets, for debugging */
 #endif
 };
 
@@ -1332,14 +1331,6 @@ struct reg_ac_data_ {
     reg_trie_state   *states;
 };
 typedef struct reg_ac_data_ reg_ac_data;
-
-/* ANY_BIT doesn't use the structure, so we can borrow it here.
-   This is simpler than refactoring all of it as wed end up with
-   three different sets... */
-
-#define TRIE_BITMAP(p)		(((reg_trie_data *)(p))->bitmap)
-#define TRIE_BITMAP_SET(p, c) \
-    (BITMAP_BYTE(TRIE_BITMAP(p), c) |= ANYOF_BIT((U8)c))
 
 #define IS_LONG_TRIE(op) (REGNODE_TYPE(op) == TRIE && REGNODE_OFF_BY_ARG(op))
 #define IS_TRIE_AC(op) ((op)==AHOCORASICK)

--- a/regcomp.h
+++ b/regcomp.h
@@ -1224,7 +1224,7 @@ struct reg_trie_trans_ {
 
 /* a transition list element for the list based representation */
 struct reg_trie_trans_list_elem_ {
-    U16 forid;
+    U32 forid;
     U32 newstate;
 };
 typedef struct reg_trie_trans_list_elem_ reg_trie_trans_le;
@@ -1264,7 +1264,7 @@ typedef struct reg_trie_trans_    reg_trie_trans;
 struct reg_trie_data_ {
     U32             refcount;        /* number of times this trie is referenced */
     U32             lasttrans;       /* last valid transition element */
-    U16             *charmap;        /* byte to charid lookup array */
+    U32             *charmap;        /* byte to charid lookup array */
     reg_trie_state  *states;         /* state data */
     reg_trie_trans  *trans;          /* array of transition elements */
     char            *bitmap;         /* stclass bitmap */
@@ -1276,7 +1276,7 @@ struct reg_trie_data_ {
                                         for the given jump. */
 
     reg_trie_wordinfo *wordinfo;     /* array of info per word */
-    U16             uniquecharcount; /* unique chars in trie (width of trans table) */
+    U32             uniquecharcount; /* unique chars in trie (width of trans table) */
     U32             startstate;      /* initial state - used for common prefix optimisation */
     STRLEN          minlen;          /* minimum length of words in trie - build/opt only? */
     STRLEN          maxlen;          /* maximum length of words in trie - build/opt only? */

--- a/regcomp.h
+++ b/regcomp.h
@@ -336,26 +336,17 @@ struct regnode_bbm {
  * regnode has a U32, which is what reganode() allocates as a unit.  Therefore
  * no field can require stricter alignment than U32. */
     
-/* also used by TRIEC */
 struct regnode_charclass {
     union regnode_head head;
     union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];	/* only compile-time */
-};
-
-/* also used by LTRIEC */
-struct regnode_charclass_trie {
-    union regnode_head head;
-    union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];	/* only compile-time */
-    union regnode_arg arg2;
+    U8 bitmap[ANYOF_BITMAP_SIZE];	/* only compile-time */
 };
 
 /* has runtime (locale) \d, \w, ..., [:posix:] classes */
 struct regnode_charclass_posixl {
     union regnode_head head;
     union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];		/* both compile-time ... */
+    U8 bitmap[ANYOF_BITMAP_SIZE];		/* both compile-time ... */
     U32 classflags;	                        /* and run-time */
 };
 
@@ -375,7 +366,7 @@ struct regnode_charclass_posixl {
 struct regnode_ssc {
     union regnode_head head;
     union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];	/* both compile-time ... */
+    U8 bitmap[ANYOF_BITMAP_SIZE];	/* both compile-time ... */
     U32 classflags;	                /* ... and run-time */
 
     /* Auxiliary, only used during construction; NULL afterwards: list of code
@@ -573,12 +564,6 @@ struct regnode_ssc {
 #define ARG2i_LOC(p)    (((struct regnode_2 *)p)->arg2.i32)
 #define ARG2a_LOC(p)    (((struct regnode_2 *)p)->arg2.hi_lo.u16a)
 #define ARG2b_LOC(p)    (((struct regnode_2 *)p)->arg2.hi_lo.u16b)
-/* For regnodes that store a trailing U32 after an inline charclass bitmap,
- * such as regnode_charclass_trie and regnode_charclass_posixl. */
-#define ARG2u_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.u32)
-#define ARG2i_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.i32)
-#define ARG2a_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.hi_lo.u16a)
-#define ARG2b_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.hi_lo.u16b)
 #define ARG3u_LOC(p)    (((struct regnode_3 *)p)->arg3.u32)
 #define ARG3i_LOC(p)    (((struct regnode_3 *)p)->arg3.i32)
 #define ARG3a_LOC(p)    (((struct regnode_3 *)p)->arg3.hi_lo.u16a)
@@ -1171,8 +1156,6 @@ END_EXTERN_C
  *       multicharacter strings resulting from casefolding the single-character
  *       entries in the character class
  *   t - trie struct
- *   u - trie struct's widecharmap (a HV, so can't share, must dup)
- *       also used for revcharmap and words under DEBUGGING
  *   T - aho-trie struct
  *   S - sv for named capture lookup
  * 20010712 mjd@plover.com
@@ -1229,17 +1212,26 @@ struct reg_trie_trans_list_elem_ {
 };
 typedef struct reg_trie_trans_list_elem_ reg_trie_trans_le;
 
-/* a state for compressed nodes. base is an offset
-  into an array of reg_trie_trans array. If wordnum is
-  nonzero the state is accepting. if base is zero then
-  the state has no children (and will be accepting)
-*/
+/* A state for compressed nodes. base is an offset into an array of
+ * reg_trie_trans. If wordnum is nonzero the state is accepting. If base is
+ * zero then the state has no children (and will be accepting).
+ *
+ * min_octet and max_octet describe the range of octets with transitions from
+ * this state. They are retained after the construction lists are discarded so
+ * the delayed Aho-Corasick construction can avoid scanning the whole octet
+ * alphabet. They are also useful when debugging the trie. Because trie
+ * construction and Aho construction are currently separate, these fields
+ * remain in the state structures for now; the call pattern could be changed
+ * in the future so this information is kept only until Aho construction.
+ */
 struct reg_trie_state_ {
-  U32 wordnum;
-  union {
-    U32                base;
-    reg_trie_trans_le* list;
-  } trans;
+    U32 wordnum;
+    U8 min_octet;
+    U8 max_octet;
+    union {
+        U32                base;
+        reg_trie_trans_le* list;
+    } trans;
 };
 
 /* info per word; indexed by wordnum */
@@ -1261,46 +1253,73 @@ typedef struct reg_trie_trans_    reg_trie_trans;
    should be dealt with in pregfree.
    refcount is first in both this and reg_ac_data_ to allow a space
    optimisation in Perl_regdupe.  */
+enum trie_flags {
+    TRIE_CP_INVARIANT = 1, /* codepoints invariant in UTF-8 */
+    TRIE_CP_AWKWARD = 2,   /* non-invariant codepoints <= 255 */
+    TRIE_CP_HIGH = 4,      /* codepoints > 255; absent from non-UTF-8 strings */
+    TRIE_CP_WIDE = TRIE_CP_AWKWARD | TRIE_CP_HIGH,
+    TRIE_FOLD_NATIVE = 8,
+    TRIE_FOLD_UNICODE = 16,
+    TRIE_FOLD_MASK = TRIE_FOLD_NATIVE | TRIE_FOLD_UNICODE
+};
+
 struct reg_trie_data_ {
     U32             refcount;        /* number of times this trie is referenced */
     U32             lasttrans;       /* last valid transition element */
-    U32             *charmap;        /* byte to charid lookup array */
     reg_trie_state  *states;         /* state data */
     reg_trie_trans  *trans;          /* array of transition elements */
-    char            *bitmap;         /* stclass bitmap */
     TRIE_JUMP_TYPE  *jump;           /* optional 1 indexed array of offsets before tail
                                         for the node following a given word. */
+    SSize_t         jump_correction; /* distance from original trie base */
     U16             *j_before_paren; /* optional 1 indexed array of parno reset data
                                         for the given jump. */
     U16             *j_after_paren;  /* optional 1 indexed array of parno reset data
                                         for the given jump. */
 
     reg_trie_wordinfo *wordinfo;     /* array of info per word */
-    U32             uniquecharcount; /* unique chars in trie (width of trans table) */
     U32             startstate;      /* initial state - used for common prefix optimisation */
     STRLEN          minlen;          /* minimum length of words in trie - build/opt only? */
     STRLEN          maxlen;          /* maximum length of words in trie - build/opt only? */
-    U32             prefixlen;       /* #chars in common prefix */
+    U32             prefixlen_octets; /* octets in common prefix */
+    U32             prefixlen_chars; /* source codepoints in common prefix */
     U32             statecount;      /* Build only - number of states in the states array 
                                         (including the unused zero state) */
     U32             wordcount;       /* Build only */
+    U8              prop_flags;      /* TRIE_CP_* and TRIE_FOLD_* bit mask */
     U16             before_paren;
     U16             after_paren;
 #ifdef DEBUGGING
     STRLEN          charcount;       /* Build only */
+    U8              bitmap[ANYOF_BITMAP_SIZE]; /* all octets, for debugging */
 #endif
 };
+
+/* A jump is stored relative to the original location of the trie.  The
+ * correction is normally zero; prefix extraction can use it to rebase the
+ * target without rewriting the jump table. */
+#define TRIE_JUMP_TARGET(node, jump, correction, word) \
+    ((node) + (jump)[word] - (correction))
+#define TRIE_JUMP_FIRST_UNABSORBED_BRANCH(node, jump, correction) \
+    ((node) + (jump)[0] - (correction))
+#define TRIE_JUMP_ROOM(trie) \
+    ((SSize_t)(trie)->jump[1] - (trie)->jump_correction)
+
+#define TRIE_CONTAINS_WIDE(trie) \
+    ((trie)->prop_flags & TRIE_CP_WIDE)
+#define TRIE_IS_FOLDED(trie) \
+    ((trie)->prop_flags & TRIE_FOLD_MASK)
+#define TRIE_RAW_INPUT_MODE(trie, utf8_target) \
+    ((utf8_target && !TRIE_IS_FOLDED(trie)) || \
+     (!utf8_target && !((trie)->prop_flags & (TRIE_CP_WIDE | TRIE_FOLD_MASK))))
 /* There is one (3 under DEBUGGING) pointers that logically belong in this
    structure, but are held outside as they need duplication on thread cloning,
    whereas the rest of the structure can be read only:
-    HV              *widecharmap;    code points > 255 to charid
 #ifdef DEBUGGING
     AV              *words;          Array of words contained in trie, for dumping
-    AV              *revcharmap;     Map of each charid back to its character representation
 #endif
 */
 
-#define TRIE_WORDS_OFFSET 2
+#define TRIE_WORDS_OFFSET 1
 
 typedef struct reg_trie_data_ reg_trie_data;
 
@@ -1319,25 +1338,18 @@ typedef struct reg_ac_data_ reg_ac_data;
    three different sets... */
 
 #define TRIE_BITMAP(p)		(((reg_trie_data *)(p))->bitmap)
-#define TRIE_BITMAP_BYTE(p, c)	BITMAP_BYTE(TRIE_BITMAP(p), c)
-#define TRIE_BITMAP_SET(p, c)	(TRIE_BITMAP_BYTE(p, c) |=  ANYOF_BIT((U8)c))
-#define TRIE_BITMAP_CLEAR(p,c)	(TRIE_BITMAP_BYTE(p, c) &= ~ANYOF_BIT((U8)c))
-#define TRIE_BITMAP_TEST(p, c)	(TRIE_BITMAP_BYTE(p, c) &   ANYOF_BIT((U8)c))
+#define TRIE_BITMAP_SET(p, c) \
+    (BITMAP_BYTE(TRIE_BITMAP(p), c) |= ANYOF_BIT((U8)c))
 
 #define IS_LONG_TRIE(op) (REGNODE_TYPE(op) == TRIE && REGNODE_OFF_BY_ARG(op))
-#define IS_ANYOF_TRIE(op) ((op)==TRIEC || (op)==LTRIEC || (op)==AHOCORASICKC)
-#define IS_TRIE_AC(op) ((op)==AHOCORASICK || (op)==AHOCORASICKC)
+#define IS_TRIE_AC(op) ((op)==AHOCORASICK)
 
-#define TRIE_DATA_SLOT(p) ((OP(p) == LTRIEC) ? ARG2u_AFTERCC(p)              \
-                          : REGNODE_OFF_BY_ARG(OP(p)) ? ARG2u(p) : ARG1u(p))
+#define TRIE_DATA_SLOT(p) (REGNODE_OFF_BY_ARG(OP(p)) ? ARG2u(p) : ARG1u(p))
 #define SHORT_TRIE_DATA_SLOT_set(p, val) STMT_START {                      \
     ARG1u_SET((p), (val));                                                 \
 } STMT_END
 #define LONG_TRIE_DATA_SLOT_set(p, val) STMT_START {                       \
-    if (OP(p) == LTRIEC)                                                   \
-        ARG2u_AFTERCC_SET((p), (val));                                     \
-    else                                                                   \
-        ARG2u_SET((p), (val));                                             \
+    ARG2u_SET((p), (val));                                                 \
 } STMT_END
 #define TRIE_DATA_SLOT_set(p, val) STMT_START {                            \
     if (REGNODE_OFF_BY_ARG(OP(p)))                                         \
@@ -1353,10 +1365,13 @@ typedef struct reg_ac_data_ reg_ac_data;
         NEXT_OFF_set((p), (val));                                          \
 } STMT_END
 
-/* these defines assume uniquecharcount is the correct variable, and state may be evaluated twice */
-#define TRIE_NODENUM(state) (((state)-1)/(trie->uniquecharcount)+1)
-#define SAFE_TRIE_NODENUM(state) ((state) ? (((state)-1)/(trie->uniquecharcount)+1) : (state))
-#define TRIE_NODEIDX(state) ((state) ? (((state)-1)*(trie->uniquecharcount)+1) : (state))
+#define TRIE_ALPHABET_SIZE 256
+
+/* These defines assume a 256-octet trie alphabet, and state may be evaluated
+ * twice. */
+#define TRIE_NODENUM(state) (((state)-1)/(TRIE_ALPHABET_SIZE)+1)
+#define SAFE_TRIE_NODENUM(state) ((state) ? (((state)-1)/(TRIE_ALPHABET_SIZE)+1) : (state))
+#define TRIE_NODEIDX(state) ((state) ? (((state)-1)*(TRIE_ALPHABET_SIZE)+1) : (state))
 
 #ifdef DEBUGGING
 #define TRIE_CHARCOUNT(trie) ((trie)->charcount)
@@ -1364,7 +1379,7 @@ typedef struct reg_ac_data_ reg_ac_data;
 #define TRIE_CHARCOUNT(trie) (trie_charcount)
 #endif
 
-#define RE_TRIE_MAXBUF_INIT 65536
+#define RE_TRIE_MAXBUF_INIT 655360
 #define RE_TRIE_MAXBUF_NAME "\022E_TRIE_MAXBUF"
 #define RE_TRIE_PREFER_LONG_NAME "\022E_TRIE_PREFER_LONG"
 #define RE_DEBUG_FLAGS "\022E_DEBUG_FLAGS"

--- a/regcomp.h
+++ b/regcomp.h
@@ -336,26 +336,17 @@ struct regnode_bbm {
  * regnode has a U32, which is what reganode() allocates as a unit.  Therefore
  * no field can require stricter alignment than U32. */
     
-/* also used by TRIEC */
 struct regnode_charclass {
     union regnode_head head;
     union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];	/* only compile-time */
-};
-
-/* also used by LTRIEC */
-struct regnode_charclass_trie {
-    union regnode_head head;
-    union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];	/* only compile-time */
-    union regnode_arg arg2;
+    U8 bitmap[ANYOF_BITMAP_SIZE];	/* only compile-time */
 };
 
 /* has runtime (locale) \d, \w, ..., [:posix:] classes */
 struct regnode_charclass_posixl {
     union regnode_head head;
     union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];		/* both compile-time ... */
+    U8 bitmap[ANYOF_BITMAP_SIZE];		/* both compile-time ... */
     U32 classflags;	                        /* and run-time */
 };
 
@@ -375,7 +366,7 @@ struct regnode_charclass_posixl {
 struct regnode_ssc {
     union regnode_head head;
     union regnode_arg arg1;
-    char bitmap[ANYOF_BITMAP_SIZE];	/* both compile-time ... */
+    U8 bitmap[ANYOF_BITMAP_SIZE];	/* both compile-time ... */
     U32 classflags;	                /* ... and run-time */
 
     /* Auxiliary, only used during construction; NULL afterwards: list of code
@@ -573,12 +564,6 @@ struct regnode_ssc {
 #define ARG2i_LOC(p)    (((struct regnode_2 *)p)->arg2.i32)
 #define ARG2a_LOC(p)    (((struct regnode_2 *)p)->arg2.hi_lo.u16a)
 #define ARG2b_LOC(p)    (((struct regnode_2 *)p)->arg2.hi_lo.u16b)
-/* For regnodes that store a trailing U32 after an inline charclass bitmap,
- * such as regnode_charclass_trie and regnode_charclass_posixl. */
-#define ARG2u_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.u32)
-#define ARG2i_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.i32)
-#define ARG2a_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.hi_lo.u16a)
-#define ARG2b_AFTERCC_LOC(p) (((struct regnode_charclass_trie *)p)->arg2.hi_lo.u16b)
 #define ARG3u_LOC(p)    (((struct regnode_3 *)p)->arg3.u32)
 #define ARG3i_LOC(p)    (((struct regnode_3 *)p)->arg3.i32)
 #define ARG3a_LOC(p)    (((struct regnode_3 *)p)->arg3.hi_lo.u16a)
@@ -1171,8 +1156,6 @@ END_EXTERN_C
  *       multicharacter strings resulting from casefolding the single-character
  *       entries in the character class
  *   t - trie struct
- *   u - trie struct's widecharmap (a HV, so can't share, must dup)
- *       also used for revcharmap and words under DEBUGGING
  *   T - aho-trie struct
  *   S - sv for named capture lookup
  * 20010712 mjd@plover.com
@@ -1224,22 +1207,31 @@ struct reg_trie_trans_ {
 
 /* a transition list element for the list based representation */
 struct reg_trie_trans_list_elem_ {
-    U32 forid;
+    U32 octet;
     U32 newstate;
 };
 typedef struct reg_trie_trans_list_elem_ reg_trie_trans_le;
 
-/* a state for compressed nodes. base is an offset
-  into an array of reg_trie_trans array. If wordnum is
-  nonzero the state is accepting. if base is zero then
-  the state has no children (and will be accepting)
-*/
+/* A state for compressed nodes. base is an offset into an array of
+ * reg_trie_trans. If wordnum is nonzero the state is accepting. If base is
+ * zero then the state has no children (and will be accepting).
+ *
+ * min_octet and max_octet describe the range of octets with transitions from
+ * this state. They are retained after the construction lists are discarded so
+ * the delayed Aho-Corasick construction can avoid scanning the whole octet
+ * alphabet. They are also useful when debugging the trie. Because trie
+ * construction and Aho construction are currently separate, these fields
+ * remain in the state structures for now; the call pattern could be changed
+ * in the future so this information is kept only until Aho construction.
+ */
 struct reg_trie_state_ {
-  U32 wordnum;
-  union {
-    U32                base;
-    reg_trie_trans_le* list;
-  } trans;
+    U32 wordnum;
+    U8 min_octet;
+    U8 max_octet;
+    union {
+        U32                base;
+        reg_trie_trans_le* list;
+    } trans;
 };
 
 /* info per word; indexed by wordnum */
@@ -1261,46 +1253,72 @@ typedef struct reg_trie_trans_    reg_trie_trans;
    should be dealt with in pregfree.
    refcount is first in both this and reg_ac_data_ to allow a space
    optimisation in Perl_regdupe.  */
+enum trie_flags {
+    TRIE_CP_INVARIANT = 1, /* codepoints invariant in UTF-8 */
+    TRIE_CP_AWKWARD = 2,   /* non-invariant codepoints <= 255 */
+    TRIE_CP_HIGH = 4,      /* codepoints > 255; absent from non-UTF-8 strings */
+    TRIE_CP_WIDE = TRIE_CP_AWKWARD | TRIE_CP_HIGH,
+    TRIE_FOLD_NATIVE = 8,
+    TRIE_FOLD_UNICODE = 16,
+    TRIE_FOLD_MASK = TRIE_FOLD_NATIVE | TRIE_FOLD_UNICODE
+};
+
 struct reg_trie_data_ {
     U32             refcount;        /* number of times this trie is referenced */
     U32             lasttrans;       /* last valid transition element */
-    U32             *charmap;        /* byte to charid lookup array */
     reg_trie_state  *states;         /* state data */
     reg_trie_trans  *trans;          /* array of transition elements */
-    char            *bitmap;         /* stclass bitmap */
     TRIE_JUMP_TYPE  *jump;           /* optional 1 indexed array of offsets before tail
                                         for the node following a given word. */
+    SSize_t         jump_correction; /* distance from original trie base */
     U16             *j_before_paren; /* optional 1 indexed array of parno reset data
                                         for the given jump. */
     U16             *j_after_paren;  /* optional 1 indexed array of parno reset data
                                         for the given jump. */
 
     reg_trie_wordinfo *wordinfo;     /* array of info per word */
-    U32             uniquecharcount; /* unique chars in trie (width of trans table) */
     U32             startstate;      /* initial state - used for common prefix optimisation */
     STRLEN          minlen;          /* minimum length of words in trie - build/opt only? */
     STRLEN          maxlen;          /* maximum length of words in trie - build/opt only? */
-    U32             prefixlen;       /* #chars in common prefix */
+    U32             prefixlen_octets; /* octets in common prefix */
+    U32             prefixlen_chars; /* source codepoints in common prefix */
     U32             statecount;      /* Build only - number of states in the states array 
                                         (including the unused zero state) */
     U32             wordcount;       /* Build only */
+    U8              prop_flags;      /* TRIE_CP_* and TRIE_FOLD_* bit mask */
     U16             before_paren;
     U16             after_paren;
 #ifdef DEBUGGING
     STRLEN          charcount;       /* Build only */
 #endif
 };
+
+/* A jump is stored relative to the original location of the trie.  The
+ * correction is normally zero; prefix extraction can use it to rebase the
+ * target without rewriting the jump table. */
+#define TRIE_JUMP_TARGET(node, jump, correction, word) \
+    ((node) + (jump)[word] - (correction))
+#define TRIE_JUMP_FIRST_UNABSORBED_BRANCH(node, jump, correction) \
+    ((node) + (jump)[0] - (correction))
+#define TRIE_JUMP_ROOM(trie) \
+    ((SSize_t)(trie)->jump[1] - (trie)->jump_correction)
+
+#define TRIE_CONTAINS_WIDE(trie) \
+    ((trie)->prop_flags & TRIE_CP_WIDE)
+#define TRIE_IS_FOLDED(trie) \
+    ((trie)->prop_flags & TRIE_FOLD_MASK)
+#define TRIE_RAW_INPUT_MODE(trie, utf8_target) \
+    ((utf8_target && !TRIE_IS_FOLDED(trie)) || \
+     (!utf8_target && !((trie)->prop_flags & (TRIE_CP_WIDE | TRIE_FOLD_MASK))))
 /* There is one (3 under DEBUGGING) pointers that logically belong in this
    structure, but are held outside as they need duplication on thread cloning,
    whereas the rest of the structure can be read only:
-    HV              *widecharmap;    code points > 255 to charid
 #ifdef DEBUGGING
     AV              *words;          Array of words contained in trie, for dumping
-    AV              *revcharmap;     Map of each charid back to its character representation
 #endif
 */
 
-#define TRIE_WORDS_OFFSET 2
+#define TRIE_WORDS_OFFSET 1
 
 typedef struct reg_trie_data_ reg_trie_data;
 
@@ -1314,30 +1332,15 @@ struct reg_ac_data_ {
 };
 typedef struct reg_ac_data_ reg_ac_data;
 
-/* ANY_BIT doesn't use the structure, so we can borrow it here.
-   This is simpler than refactoring all of it as wed end up with
-   three different sets... */
-
-#define TRIE_BITMAP(p)		(((reg_trie_data *)(p))->bitmap)
-#define TRIE_BITMAP_BYTE(p, c)	BITMAP_BYTE(TRIE_BITMAP(p), c)
-#define TRIE_BITMAP_SET(p, c)	(TRIE_BITMAP_BYTE(p, c) |=  ANYOF_BIT((U8)c))
-#define TRIE_BITMAP_CLEAR(p,c)	(TRIE_BITMAP_BYTE(p, c) &= ~ANYOF_BIT((U8)c))
-#define TRIE_BITMAP_TEST(p, c)	(TRIE_BITMAP_BYTE(p, c) &   ANYOF_BIT((U8)c))
-
 #define IS_LONG_TRIE(op) (REGNODE_TYPE(op) == TRIE && REGNODE_OFF_BY_ARG(op))
-#define IS_ANYOF_TRIE(op) ((op)==TRIEC || (op)==LTRIEC || (op)==AHOCORASICKC)
-#define IS_TRIE_AC(op) ((op)==AHOCORASICK || (op)==AHOCORASICKC)
+#define IS_TRIE_AC(op) ((op)==AHOCORASICK)
 
-#define TRIE_DATA_SLOT(p) ((OP(p) == LTRIEC) ? ARG2u_AFTERCC(p)              \
-                          : REGNODE_OFF_BY_ARG(OP(p)) ? ARG2u(p) : ARG1u(p))
+#define TRIE_DATA_SLOT(p) (REGNODE_OFF_BY_ARG(OP(p)) ? ARG2u(p) : ARG1u(p))
 #define SHORT_TRIE_DATA_SLOT_set(p, val) STMT_START {                      \
     ARG1u_SET((p), (val));                                                 \
 } STMT_END
 #define LONG_TRIE_DATA_SLOT_set(p, val) STMT_START {                       \
-    if (OP(p) == LTRIEC)                                                   \
-        ARG2u_AFTERCC_SET((p), (val));                                     \
-    else                                                                   \
-        ARG2u_SET((p), (val));                                             \
+    ARG2u_SET((p), (val));                                                 \
 } STMT_END
 #define TRIE_DATA_SLOT_set(p, val) STMT_START {                            \
     if (REGNODE_OFF_BY_ARG(OP(p)))                                         \
@@ -1353,10 +1356,13 @@ typedef struct reg_ac_data_ reg_ac_data;
         NEXT_OFF_set((p), (val));                                          \
 } STMT_END
 
-/* these defines assume uniquecharcount is the correct variable, and state may be evaluated twice */
-#define TRIE_NODENUM(state) (((state)-1)/(trie->uniquecharcount)+1)
-#define SAFE_TRIE_NODENUM(state) ((state) ? (((state)-1)/(trie->uniquecharcount)+1) : (state))
-#define TRIE_NODEIDX(state) ((state) ? (((state)-1)*(trie->uniquecharcount)+1) : (state))
+#define TRIE_ALPHABET_SIZE 256
+
+/* These defines assume a 256-octet trie alphabet, and state may be evaluated
+ * twice. */
+#define TRIE_NODENUM(state) (((state)-1)/(TRIE_ALPHABET_SIZE)+1)
+#define SAFE_TRIE_NODENUM(state) ((state) ? (((state)-1)/(TRIE_ALPHABET_SIZE)+1) : (state))
+#define TRIE_NODEIDX(state) ((state) ? (((state)-1)*(TRIE_ALPHABET_SIZE)+1) : (state))
 
 #ifdef DEBUGGING
 #define TRIE_CHARCOUNT(trie) ((trie)->charcount)
@@ -1364,7 +1370,7 @@ typedef struct reg_ac_data_ reg_ac_data;
 #define TRIE_CHARCOUNT(trie) (trie_charcount)
 #endif
 
-#define RE_TRIE_MAXBUF_INIT 65536
+#define RE_TRIE_MAXBUF_INIT 655360
 #define RE_TRIE_MAXBUF_NAME "\022E_TRIE_MAXBUF"
 #define RE_TRIE_PREFER_LONG_NAME "\022E_TRIE_PREFER_LONG"
 #define RE_DEBUG_FLAGS "\022E_DEBUG_FLAGS"

--- a/regcomp.sym
+++ b/regcomp.sym
@@ -974,16 +974,6 @@ return {
               "struct" => "regnode_1",
             },
             {
-              "NAME" => "TRIEC",
-              "TYPE" => "TRIE",
-              "attr" => {
-                  "arg_spec" => "trie",
-                },
-              "desc" => "Same as TRIE, but with embedded charclass data",
-              "line" => __LINE__,
-              "struct" => "regnode_charclass",
-            },
-            {
               "NAME" => "AHOCORASICK",
               "TYPE" => "TRIE",
               "attr" => {
@@ -995,16 +985,6 @@ return {
               "struct" => "regnode_1",
             },
             {
-              "NAME" => "AHOCORASICKC",
-              "TYPE" => "TRIE",
-              "attr" => {
-                  "arg_spec" => "trie",
-                },
-              "desc" => "Same as AHOCORASICK, but with embedded charclass data",
-              "line" => __LINE__,
-              "struct" => "regnode_charclass",
-            },
-            {
               "NAME" => "LTRIE",
               "TYPE" => "TRIE",
               "attr" => {
@@ -1014,23 +994,12 @@ return {
               "line" => __LINE__,
               "struct" => "regnode_2",
             },
-            {
-              "NAME" => "LTRIEC",
-              "TYPE" => "TRIE",
-              "attr" => {
-                  "arg_spec" => "trie",
-                },
-              "desc" => "Same as TRIEC, but with longjump support",
-              "line" => __LINE__,
-              "struct" => "regnode_charclass_trie",
-            },
           ],
         "pod" => [
             ["Trie Related"],
             [
-              "Behave the same as A|LIST|OF|WORDS would. The '..C' variants",
-              "have inline charclass data (ascii only), the 'C' store it in the",
-              "structure.",
+              "Behave the same as A|LIST|OF|WORDS would. Trie data is stored",
+              "in a shared trie structure.",
             ],
           ],
       },

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -260,11 +260,18 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
                 if (trie->jump) {
                     TRIE_JUMP_TYPE dist = trie->jump[word_idx+1];
                     re_printf("(%" UVuf ")\n",
-                               (UV)((dist ? this_trie + dist : next) - start));
+                               (UV)((dist
+                                     ? TRIE_JUMP_TARGET(this_trie, trie->jump,
+                                                       trie->jump_correction,
+                                                       word_idx+1)
+                                     : next) - start));
                     if (dist) {
                         if (!nextbranch)
-                            nextbranch = this_trie + trie->jump[0];
-                        DUMPUNTIL(this_trie + dist, nextbranch);
+                            nextbranch = TRIE_JUMP_FIRST_UNABSORBED_BRANCH(
+                                this_trie, trie->jump, trie->jump_correction);
+                        DUMPUNTIL(TRIE_JUMP_TARGET(this_trie, trie->jump,
+                                                   trie->jump_correction,
+                                                   word_idx+1), nextbranch);
                     }
                     if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
                         nextbranch = regnext((regnode *)nextbranch);
@@ -568,10 +575,9 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
     }
     else if (k == EXACT) {
         sv_catpvs(sv, " ");
-        /* Using is_utf8_string() (via PERL_PV_UNI_DETECT)
-         * is a crude hack but it may be the best for now since
-         * we have no flag "this EXACTish node was UTF-8"
-         * --jhi */
+        /* This is only diagnostic formatting.  Trie construction uses the
+         * node type and the pattern flags to classify its source; it must not
+         * infer the encoding from the contents of the string. */
         pv_pretty(sv, STRING(o), STR_LEN(o), PL_dump_re_max_len,
                   PL_colors[0], PL_colors[1],
                   PERL_PV_ESCAPE_UNI_DETECT |
@@ -594,31 +600,28 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         DEBUG_TRIE_COMPILE_r({
           if (trie->jump)
             sv_catpvs(sv, "(JUMP)");
-          sv_catpvf(sv,
-            "<S:%" UVuf "/%" IVdf " W:%" UVuf " L:%" UVuf "/%" UVuf " C:%" UVuf "/%" UVuf ">",
-            (UV)trie->startstate,
-            (IV)trie->statecount-1, /* -1 because of the unused 0 element */
-            (UV)trie->wordcount,
-            (UV)trie->minlen,
-            (UV)trie->maxlen,
-            (UV)TRIE_CHARCOUNT(trie),
-            (UV)trie->uniquecharcount
-          );
+          if (!TRIE_RAW_INPUT_MODE(trie, FALSE)) {
+            sv_catpvf(sv,
+                "<S:%" UVuf "/%" IVdf " W:%" UVuf " L:%" UVuf "/%" UVuf " C:%" UVuf ">",
+                (UV)trie->startstate,
+                (IV)trie->statecount-1,
+                (UV)trie->wordcount,
+                (UV)trie->minlen,
+                (UV)trie->maxlen,
+                (UV)TRIE_CHARCOUNT(trie));
+          }
+          else {
+            sv_catpvf(sv,
+                "<S:%" UVuf "/%" IVdf " W:%" UVuf " L:%" UVuf "/%" UVuf " C:%" UVuf "/%" UVuf ">",
+                (UV)trie->startstate,
+                (IV)trie->statecount-1,
+                (UV)trie->wordcount,
+                (UV)trie->minlen,
+                (UV)trie->maxlen,
+                (UV)TRIE_CHARCOUNT(trie),
+                (UV)TRIE_ALPHABET_SIZE);
+          }
         });
-        if ( IS_ANYOF_TRIE(op) || trie->bitmap ) {
-            sv_catpvs(sv, "[");
-            (void) put_charclass_bitmap_innards(sv,
-                                                ((IS_ANYOF_TRIE(op))
-                                                 ? ANYOF_BITMAP(o)
-                                                 : TRIE_BITMAP(trie)),
-                                                NULL,
-                                                NULL,
-                                                NULL,
-                                                0,
-                                                false
-                                               );
-            sv_catpvs(sv, "]");
-        }
         if (trie->before_paren || trie->after_paren)
             sv_catpvf(sv, " (buf:%" IVdf "/%" IVdf ")",
                     (IV)trie->before_paren,(IV)trie->after_paren);
@@ -746,7 +749,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         sv_catpvf(sv, "[%d]", FLAGS(o));
     else if (k == ANYOF || k == ANYOFH || k == ANYOFR) {
         U8 flags;
-        char * bitmap;
+        U8 * bitmap;
         U8 do_sep = 0;    /* Do we need to separate various components of the
                              output? */
         /* Set if there is still an unresolved user-defined property */
@@ -1411,7 +1414,7 @@ S_put_charclass_bitmap_innards_common(pTHX_
 
 static U8
 S_put_charclass_bitmap_innards(pTHX_ SV *sv,
-                                     char *bitmap,
+                                     U8 *bitmap,
                                      SV *nonbitmap_invlist,
                                      SV *only_utf8_locale_invlist,
                                      const regnode * const node,

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -575,10 +575,9 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
     }
     else if (k == EXACT) {
         sv_catpvs(sv, " ");
-        /* Using is_utf8_string() (via PERL_PV_UNI_DETECT)
-         * is a crude hack but it may be the best for now since
-         * we have no flag "this EXACTish node was UTF-8"
-         * --jhi */
+        /* This is only diagnostic formatting.  Trie construction uses the
+         * node type and the pattern flags to classify its source; it must not
+         * infer the encoding from the contents of the string. */
         pv_pretty(sv, STRING(o), STR_LEN(o), PL_dump_re_max_len,
                   PL_colors[0], PL_colors[1],
                   PERL_PV_ESCAPE_UNI_DETECT |

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -260,11 +260,18 @@ Perl_dumpuntil(pTHX_ const regexp *r, const regnode *start, const regnode *node,
                 if (trie->jump) {
                     TRIE_JUMP_TYPE dist = trie->jump[word_idx+1];
                     re_printf("(%" UVuf ")\n",
-                               (UV)((dist ? this_trie + dist : next) - start));
+                               (UV)((dist
+                                     ? TRIE_JUMP_TARGET(this_trie, trie->jump,
+                                                       trie->jump_correction,
+                                                       word_idx+1)
+                                     : next) - start));
                     if (dist) {
                         if (!nextbranch)
-                            nextbranch = this_trie + trie->jump[0];
-                        DUMPUNTIL(this_trie + dist, nextbranch);
+                            nextbranch = TRIE_JUMP_FIRST_UNABSORBED_BRANCH(
+                                this_trie, trie->jump, trie->jump_correction);
+                        DUMPUNTIL(TRIE_JUMP_TARGET(this_trie, trie->jump,
+                                                   trie->jump_correction,
+                                                   word_idx+1), nextbranch);
                     }
                     if (nextbranch && REGNODE_TYPE(OP(nextbranch))==BRANCH)
                         nextbranch = regnext((regnode *)nextbranch);
@@ -594,31 +601,31 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         DEBUG_TRIE_COMPILE_r({
           if (trie->jump)
             sv_catpvs(sv, "(JUMP)");
-          sv_catpvf(sv,
-            "<S:%" UVuf "/%" IVdf " W:%" UVuf " L:%" UVuf "/%" UVuf " C:%" UVuf "/%" UVuf ">",
-            (UV)trie->startstate,
-            (IV)trie->statecount-1, /* -1 because of the unused 0 element */
-            (UV)trie->wordcount,
-            (UV)trie->minlen,
-            (UV)trie->maxlen,
-            (UV)TRIE_CHARCOUNT(trie),
-            (UV)trie->uniquecharcount
-          );
+          if (!TRIE_RAW_INPUT_MODE(trie, FALSE)) {
+            sv_catpvf(sv,
+                "<S:%" UVuf "/%" IVdf " W:%" UVuf " L:%" UVuf "/%" UVuf " C:%" UVuf ">",
+                (UV)trie->startstate,
+                (IV)trie->statecount-1,
+                (UV)trie->wordcount,
+                (UV)trie->minlen,
+                (UV)trie->maxlen,
+                (UV)TRIE_CHARCOUNT(trie));
+          }
+          else {
+            sv_catpvf(sv,
+                "<S:%" UVuf "/%" IVdf " W:%" UVuf " L:%" UVuf "/%" UVuf " C:%" UVuf "/%" UVuf ">",
+                (UV)trie->startstate,
+                (IV)trie->statecount-1,
+                (UV)trie->wordcount,
+                (UV)trie->minlen,
+                (UV)trie->maxlen,
+                (UV)TRIE_CHARCOUNT(trie),
+                (UV)TRIE_ALPHABET_SIZE);
+          }
         });
-        if ( IS_ANYOF_TRIE(op) || trie->bitmap ) {
-            sv_catpvs(sv, "[");
-            (void) put_charclass_bitmap_innards(sv,
-                                                ((IS_ANYOF_TRIE(op))
-                                                 ? ANYOF_BITMAP(o)
-                                                 : TRIE_BITMAP(trie)),
-                                                NULL,
-                                                NULL,
-                                                NULL,
-                                                0,
-                                                false
-                                               );
-            sv_catpvs(sv, "]");
-        }
+        /* The trie start bitmap is temporarily not displayed.  Prefix
+         * extraction is still being made authoritative, and displaying the
+         * pre-extraction mask here is misleading. */
         if (trie->before_paren || trie->after_paren)
             sv_catpvf(sv, " (buf:%" IVdf "/%" IVdf ")",
                     (IV)trie->before_paren,(IV)trie->after_paren);
@@ -746,7 +753,7 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
         sv_catpvf(sv, "[%d]", FLAGS(o));
     else if (k == ANYOF || k == ANYOFH || k == ANYOFR) {
         U8 flags;
-        char * bitmap;
+        U8 * bitmap;
         U8 do_sep = 0;    /* Do we need to separate various components of the
                              output? */
         /* Set if there is still an unresolved user-defined property */
@@ -1411,7 +1418,7 @@ S_put_charclass_bitmap_innards_common(pTHX_
 
 static U8
 S_put_charclass_bitmap_innards(pTHX_ SV *sv,
-                                     char *bitmap,
+                                     U8 *bitmap,
                                      SV *nonbitmap_invlist,
                                      SV *only_utf8_locale_invlist,
                                      const regnode * const node,

--- a/regcomp_debug.c
+++ b/regcomp_debug.c
@@ -623,9 +623,6 @@ Perl_regprop(pTHX_ const regexp *prog, SV *sv, const regnode *o, const regmatch_
                 (UV)TRIE_ALPHABET_SIZE);
           }
         });
-        /* The trie start bitmap is temporarily not displayed.  Prefix
-         * extraction is still being made authoritative, and displaying the
-         * pre-extraction mask here is misleading. */
         if (trie->before_paren || trie->after_paren)
             sv_catpvf(sv, " (buf:%" IVdf "/%" IVdf ")",
                     (IV)trie->before_paren,(IV)trie->after_paren);

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1829,6 +1829,8 @@ Perl_study_chunk(pTHX_
                         regnode *prev = (regnode *)NULL;
                         regnode *tail = scan;
                         U8 trietype = 0;
+                        /* count is the number of source words; octet_count
+                         * is the total size of their trieable strings. */
                         U32 count = 0;
                         STRLEN octet_count = 0;
 
@@ -1922,13 +1924,13 @@ Perl_study_chunk(pTHX_
                               || EXACTFU_REQ8 == (X)                       \
                               || EXACTFUP == (X) )                          \
                            ? EXACTFU                                        \
-                             : ( EXACTFAA == (X) )                            \
-                               ? EXACTFAA                                     \
-                               : ( EXACTL == (X) )                            \
-                                 ? EXACTL                                     \
-                                 : ( EXACTFLU8 == (X) )                       \
-                                   ? EXACTFLU8                                \
-                                   : 0 )
+                             : ( EXACTFAA == (X) )                          \
+                               ? EXACTFAA                                   \
+                             : ( EXACTL == (X) )                            \
+                               ? EXACTL                                     \
+                             : ( EXACTFLU8 == (X) )                         \
+                               ? EXACTFLU8                                  \
+                             : 0 )
 
                         /* dont use tail as the end marker for this traverse */
                         for ( cur = startbranch ; cur != scan ; cur = regnext( cur ) ) {

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -3509,8 +3509,10 @@ Perl_study_chunk(pTHX_
 
                     if (trie->jump[word]) {
                         if (!nextbranch)
-                            nextbranch = trie_node + trie->jump[0];
-                        scan = trie_node + trie->jump[word];
+                            nextbranch = TRIE_JUMP_FIRST_UNABSORBED_BRANCH(
+                                trie_node, trie->jump, trie->jump_correction);
+                        scan = TRIE_JUMP_TARGET(trie_node, trie->jump,
+                                                trie->jump_correction, word);
                         /* We go from the jump point to the branch that follows
                            it. Note this means we need the vestigal unused
                            branches even though they arent otherwise used. */

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1829,9 +1829,9 @@ Perl_study_chunk(pTHX_
                         regnode *prev = (regnode *)NULL;
                         regnode *tail = scan;
                         U8 trietype = 0;
-                        /* count is the number of source words; octet_count
+                        /* word_count is the number of source words; octet_count
                          * is the total size of their trieable strings. */
-                        U32 count = 0;
+                        U32 word_count = 0;
                         STRLEN octet_count = 0;
 
                         /* var tail is used because there may be a TAIL
@@ -1985,7 +1985,7 @@ Perl_study_chunk(pTHX_
 #ifdef NOJUMPTRIE
                                   && noper_next >= tail
 #endif
-                                  && count < U16_MAX)
+                                  && word_count < U16_MAX)
                             {
                                 /* Handle mergable triable node Either we are
                                  * the first node in a new trieable sequence,
@@ -2017,7 +2017,7 @@ Perl_study_chunk(pTHX_
                                     prev = cur;
                                 }
                                 if (first) {
-                                    count++;
+                                    word_count++;
                                     octet_count += noper_octets;
                                 }
                             } /* end handle mergable triable node */
@@ -2038,7 +2038,7 @@ Perl_study_chunk(pTHX_
                                     if ( trietype && trietype != NOTHING )
                                         make_trie( pRExC_state,
                                                 startbranch, first, cur, tail,
-                                                count, octet_count,
+                                                word_count, octet_count,
                                                 trietype, depth+1 );
                                     prev = NULL; /* note: we clear/update
                                                     first, trietype etc below,
@@ -2051,7 +2051,7 @@ Perl_study_chunk(pTHX_
                                 ){
                                     /* noper is triable, so we can start a new
                                      * trie sequence */
-                                    count = 1;
+                                    word_count = 1;
                                     octet_count = noper_octets;
                                     first = cur;
                                     trietype = noper_trietype;
@@ -2059,7 +2059,7 @@ Perl_study_chunk(pTHX_
                                     /* if we already saw a first but the
                                      * current node is not triable then we have
                                      * to reset the first information. */
-                                    count = 0;
+                                    word_count = 0;
                                     first = NULL;
                                     trietype = 0;
                                 }
@@ -2081,7 +2081,7 @@ Perl_study_chunk(pTHX_
                                  * a trie, so we have to construct it here
                                  * outside of the loop */
                                 made = make_trie( pRExC_state, startbranch,
-                                                 first, scan, tail, count,
+                                                 first, scan, tail, word_count,
                                                  octet_count, trietype,
                                                  depth+1 );
 #ifdef TRIE_STUDY_OPT

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1830,6 +1830,7 @@ Perl_study_chunk(pTHX_
                         regnode *tail = scan;
                         U8 trietype = 0;
                         U32 count = 0;
+                        STRLEN octet_count = 0;
 
                         /* var tail is used because there may be a TAIL
                            regop in the way. Ie, the exacts will point to the
@@ -1921,24 +1922,25 @@ Perl_study_chunk(pTHX_
                               || EXACTFU_REQ8 == (X)                       \
                               || EXACTFUP == (X) )                          \
                            ? EXACTFU                                        \
-                           : ( EXACTFAA == (X) )                            \
-                             ? EXACTFAA                                     \
-                             : ( EXACTL == (X) )                            \
-                               ? EXACTL                                     \
-                               : ( EXACTFLU8 == (X) )                       \
-                                 ? EXACTFLU8                                \
-                                 : 0 )
+                             : ( EXACTFAA == (X) )                            \
+                               ? EXACTFAA                                     \
+                               : ( EXACTL == (X) )                            \
+                                 ? EXACTL                                     \
+                                 : ( EXACTFLU8 == (X) )                       \
+                                   ? EXACTFLU8                                \
+                                   : 0 )
 
                         /* dont use tail as the end marker for this traverse */
                         for ( cur = startbranch ; cur != scan ; cur = regnext( cur ) ) {
                             regnode * const noper = REGNODE_AFTER( cur );
                             U8 noper_type = OP( noper );
                             U8 noper_trietype = TRIE_TYPE( noper_type );
-#if defined(DEBUGGING) || defined(NOJUMPTRIE)
                             regnode * const noper_next = regnext( noper );
                             U8 noper_next_type = (noper_next && noper_next < tail) ? OP(noper_next) : 0;
                             U8 noper_next_trietype = (noper_next && noper_next < tail) ? TRIE_TYPE( noper_next_type ) :0;
-#endif
+                            STRLEN noper_octets = noper_trietype == NOTHING
+                                ? noper_next_trietype ? STR_LEN(noper_next) : 0
+                                : noper_trietype ? STR_LEN(noper) : 0;
 
                             DEBUG_TRIE_COMPILE_r({
                                 regprop(RExC_rx, RExC_mysv, cur, NULL, pRExC_state);
@@ -1970,6 +1972,14 @@ Perl_study_chunk(pTHX_
                                         || ( trietype == NOTHING )
                                         || ( trietype == noper_trietype )
                                   )
+                                  /* Do not replace a common first node when
+                                   * its branches continue with a different
+                                   * trie type.  The octet-trie construction
+                                   * cannot preserve those suffix branches as
+                                   * a partial trie. */
+                                  && ( !noper_next_trietype
+                                       || noper_next_trietype == noper_trietype
+                                       || noper_trietype == NOTHING )
 #ifdef NOJUMPTRIE
                                   && noper_next >= tail
 #endif
@@ -2004,8 +2014,10 @@ Perl_study_chunk(pTHX_
                                         trietype = noper_trietype;
                                     prev = cur;
                                 }
-                                if (first)
+                                if (first) {
                                     count++;
+                                    octet_count += noper_octets;
+                                }
                             } /* end handle mergable triable node */
                             else {
                                 /* handle unmergable node -
@@ -2024,7 +2036,8 @@ Perl_study_chunk(pTHX_
                                     if ( trietype && trietype != NOTHING )
                                         make_trie( pRExC_state,
                                                 startbranch, first, cur, tail,
-                                                count, trietype, depth+1 );
+                                                count, octet_count,
+                                                trietype, depth+1 );
                                     prev = NULL; /* note: we clear/update
                                                     first, trietype etc below,
                                                     so we dont do it here */
@@ -2037,6 +2050,7 @@ Perl_study_chunk(pTHX_
                                     /* noper is triable, so we can start a new
                                      * trie sequence */
                                     count = 1;
+                                    octet_count = noper_octets;
                                     first = cur;
                                     trietype = noper_trietype;
                                 } else if (first) {
@@ -2066,10 +2080,10 @@ Perl_study_chunk(pTHX_
                                  * outside of the loop */
                                 made = make_trie( pRExC_state, startbranch,
                                                  first, scan, tail, count,
-                                                 trietype, depth+1 );
+                                                 octet_count, trietype,
+                                                 depth+1 );
 #ifdef TRIE_STUDY_OPT
-                                if ( ((made == MADE_EXACT_TRIE &&
-                                     startbranch == first)
+                                if ( ((made == MADE_EXACT_TRIE)
                                      || ( first_non_open == first )) &&
                                      depth == 0 ) {
                                     flags |= SCF_TRIE_RESTUDY;
@@ -3580,6 +3594,14 @@ Perl_study_chunk(pTHX_
 
             min += trie->minlen;
             delta += (trie->maxlen - trie->minlen);
+            /* The trie consumes encoded octets, while the start class built
+             * during the pre-trie branch study describes source characters.
+             * Do not retain that class as a shared filter for a UTF-8 octet
+             * trie; it can reject valid two-byte UTF-8 starts before TRIE is
+             * reached. */
+            if (!TRIE_RAW_INPUT_MODE(trie, FALSE)
+                    && data && data->start_class)
+                ssc_init_zero(pRExC_state, data->start_class);
             flags &= ~SCF_DO_STCLASS; /* xxx */
             if (flags & SCF_DO_SUBSTR) {
                 /* Cannot expect anything... */

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1829,7 +1829,10 @@ Perl_study_chunk(pTHX_
                         regnode *prev = (regnode *)NULL;
                         regnode *tail = scan;
                         U8 trietype = 0;
-                        U32 count = 0;
+                        /* word_count is the number of source words; octet_count
+                         * is the total size of their trieable strings. */
+                        U32 word_count = 0;
+                        STRLEN octet_count = 0;
 
                         /* var tail is used because there may be a TAIL
                            regop in the way. Ie, the exacts will point to the
@@ -1921,24 +1924,25 @@ Perl_study_chunk(pTHX_
                               || EXACTFU_REQ8 == (X)                       \
                               || EXACTFUP == (X) )                          \
                            ? EXACTFU                                        \
-                           : ( EXACTFAA == (X) )                            \
-                             ? EXACTFAA                                     \
+                             : ( EXACTFAA == (X) )                          \
+                               ? EXACTFAA                                   \
                              : ( EXACTL == (X) )                            \
                                ? EXACTL                                     \
-                               : ( EXACTFLU8 == (X) )                       \
-                                 ? EXACTFLU8                                \
-                                 : 0 )
+                             : ( EXACTFLU8 == (X) )                         \
+                               ? EXACTFLU8                                  \
+                             : 0 )
 
                         /* dont use tail as the end marker for this traverse */
                         for ( cur = startbranch ; cur != scan ; cur = regnext( cur ) ) {
                             regnode * const noper = REGNODE_AFTER( cur );
                             U8 noper_type = OP( noper );
                             U8 noper_trietype = TRIE_TYPE( noper_type );
-#if defined(DEBUGGING) || defined(NOJUMPTRIE)
                             regnode * const noper_next = regnext( noper );
                             U8 noper_next_type = (noper_next && noper_next < tail) ? OP(noper_next) : 0;
                             U8 noper_next_trietype = (noper_next && noper_next < tail) ? TRIE_TYPE( noper_next_type ) :0;
-#endif
+                            STRLEN noper_octets = noper_trietype == NOTHING
+                                ? noper_next_trietype ? STR_LEN(noper_next) : 0
+                                : noper_trietype ? STR_LEN(noper) : 0;
 
                             DEBUG_TRIE_COMPILE_r({
                                 regprop(RExC_rx, RExC_mysv, cur, NULL, pRExC_state);
@@ -1970,10 +1974,18 @@ Perl_study_chunk(pTHX_
                                         || ( trietype == NOTHING )
                                         || ( trietype == noper_trietype )
                                   )
+                                  /* Do not replace a common first node when
+                                   * its branches continue with a different
+                                   * trie type.  The octet-trie construction
+                                   * cannot preserve those suffix branches as
+                                   * a partial trie. */
+                                  && ( !noper_next_trietype
+                                       || noper_next_trietype == noper_trietype
+                                       || noper_trietype == NOTHING )
 #ifdef NOJUMPTRIE
                                   && noper_next >= tail
 #endif
-                                  && count < U16_MAX)
+                                  && word_count < U16_MAX)
                             {
                                 /* Handle mergable triable node Either we are
                                  * the first node in a new trieable sequence,
@@ -2004,8 +2016,10 @@ Perl_study_chunk(pTHX_
                                         trietype = noper_trietype;
                                     prev = cur;
                                 }
-                                if (first)
-                                    count++;
+                                if (first) {
+                                    word_count++;
+                                    octet_count += noper_octets;
+                                }
                             } /* end handle mergable triable node */
                             else {
                                 /* handle unmergable node -
@@ -2024,7 +2038,8 @@ Perl_study_chunk(pTHX_
                                     if ( trietype && trietype != NOTHING )
                                         make_trie( pRExC_state,
                                                 startbranch, first, cur, tail,
-                                                count, trietype, depth+1 );
+                                                word_count, octet_count,
+                                                trietype, depth+1 );
                                     prev = NULL; /* note: we clear/update
                                                     first, trietype etc below,
                                                     so we dont do it here */
@@ -2036,14 +2051,15 @@ Perl_study_chunk(pTHX_
                                 ){
                                     /* noper is triable, so we can start a new
                                      * trie sequence */
-                                    count = 1;
+                                    word_count = 1;
+                                    octet_count = noper_octets;
                                     first = cur;
                                     trietype = noper_trietype;
                                 } else if (first) {
                                     /* if we already saw a first but the
                                      * current node is not triable then we have
                                      * to reset the first information. */
-                                    count = 0;
+                                    word_count = 0;
                                     first = NULL;
                                     trietype = 0;
                                 }
@@ -2065,11 +2081,11 @@ Perl_study_chunk(pTHX_
                                  * a trie, so we have to construct it here
                                  * outside of the loop */
                                 made = make_trie( pRExC_state, startbranch,
-                                                 first, scan, tail, count,
-                                                 trietype, depth+1 );
+                                                 first, scan, tail, word_count,
+                                                 octet_count, trietype,
+                                                 depth+1 );
 #ifdef TRIE_STUDY_OPT
-                                if ( ((made == MADE_EXACT_TRIE &&
-                                     startbranch == first)
+                                if ( ((made == MADE_EXACT_TRIE)
                                      || ( first_non_open == first )) &&
                                      depth == 0 ) {
                                     flags |= SCF_TRIE_RESTUDY;
@@ -3501,8 +3517,10 @@ Perl_study_chunk(pTHX_
 
                     if (trie->jump[word]) {
                         if (!nextbranch)
-                            nextbranch = trie_node + trie->jump[0];
-                        scan = trie_node + trie->jump[word];
+                            nextbranch = TRIE_JUMP_FIRST_UNABSORBED_BRANCH(
+                                trie_node, trie->jump, trie->jump_correction);
+                        scan = TRIE_JUMP_TARGET(trie_node, trie->jump,
+                                                trie->jump_correction, word);
                         /* We go from the jump point to the branch that follows
                            it. Note this means we need the vestigal unused
                            branches even though they arent otherwise used. */
@@ -3588,6 +3606,14 @@ Perl_study_chunk(pTHX_
 
             min += trie->minlen;
             delta += (trie->maxlen - trie->minlen);
+            /* The trie consumes encoded octets, while the start class built
+             * during the pre-trie branch study describes source characters.
+             * Do not retain that class as a shared filter for a UTF-8 octet
+             * trie; it can reject valid two-byte UTF-8 starts before TRIE is
+             * reached. */
+            if (!TRIE_RAW_INPUT_MODE(trie, FALSE)
+                    && data && data->start_class)
+                ssc_init_zero(pRExC_state, data->start_class);
             flags &= ~SCF_DO_STCLASS; /* xxx */
             if (flags & SCF_DO_SUBSTR) {
                 /* Cannot expect anything... */

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -1940,6 +1940,9 @@ Perl_study_chunk(pTHX_
                             regnode * const noper_next = regnext( noper );
                             U8 noper_next_type = (noper_next && noper_next < tail) ? OP(noper_next) : 0;
                             U8 noper_next_trietype = (noper_next && noper_next < tail) ? TRIE_TYPE( noper_next_type ) :0;
+                            const bool noper_next_is_trie =
+                                noper_next && noper_next < tail
+                                && REGNODE_TYPE(noper_next_type) == TRIE;
                             STRLEN noper_octets = noper_trietype == NOTHING
                                 ? noper_next_trietype ? STR_LEN(noper_next) : 0
                                 : noper_trietype ? STR_LEN(noper) : 0;
@@ -1978,7 +1981,11 @@ Perl_study_chunk(pTHX_
                                    * its branches continue with a different
                                    * trie type.  The octet-trie construction
                                    * cannot preserve those suffix branches as
-                                   * a partial trie. */
+                                   * a partial trie.  An EXACT prefix split
+                                   * from an existing trie is likewise not an
+                                   * independent branch word and must remain
+                                   * attached to that trie. */
+                                  && !noper_next_is_trie
                                   && ( !noper_next_trietype
                                        || noper_next_trietype == noper_trietype
                                        || noper_trietype == NOTHING )
@@ -2044,7 +2051,10 @@ Perl_study_chunk(pTHX_
                                                     first, trietype etc below,
                                                     so we dont do it here */
                                 }
+                                /* The same extracted-prefix restriction
+                                 * applies when starting a fresh sequence. */
                                 if ( noper_trietype
+                                     && !noper_next_is_trie
 #ifdef NOJUMPTRIE
                                      && noper_next >= tail
 #endif

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -318,7 +318,7 @@ S_dump_trie_physical(pTHX_ const struct reg_trie_data_ *trie,
   last       : Thing following the last branch.
                May be the same as tail.
   tail       : item following the branch sequence
-  count      : words in the sequence
+  word_count : words in the sequence
   flags      : currently the OP() type we will be building one of /EXACT(|F|FA|FU|FU_SS|L|FLU8)/
   depth      : indent depth
 

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -18,12 +18,26 @@
 #include "unicode_constants.h"
 #include "regcomp_internal.h"
 
-#define TRIE_LIST_ITEM(state,idx) (trie->states[state].trans.list)[ idx ]
-#define TRIE_LIST_CUR(state)  ( TRIE_LIST_ITEM( state, 0 ).forid )
-#define TRIE_LIST_LEN(state) ( TRIE_LIST_ITEM( state, 0 ).newstate )
-#define TRIE_LIST_USED(idx)  ( trie->states[state].trans.list         \
-                               ? (TRIE_LIST_CUR( idx ) - 1)            \
-                               : 0 )
+/* During construction each state's transitions are kept in a sorted list.
+ * Element zero is a header, not a transition.  The header's forid field is
+ * the next insertion position, so transitions occupy elements 1 through
+ * forid - 1; its newstate field is the allocated capacity. */
+#define TRIE_LIST_HEAD(state)      (trie->states[state].trans.list[0])
+#define TRIE_LIST_ITEM(state, idx) (trie->states[state].trans.list[idx])
+#define TRIE_LIST_CUR(state)       (TRIE_LIST_HEAD(state).forid)
+#define TRIE_LIST_LEN(state)       (TRIE_LIST_HEAD(state).newstate)
+#define TRIE_LIST_USED(state)      (trie->states[state].trans.list       \
+                                    ? TRIE_LIST_CUR(state) - 1           \
+                                    : 0)
+
+#ifdef DEBUGGING
+#  define TRIE_MARK_OCTET(octet)                                            \
+    STMT_START {                                                           \
+        TRIE_BITMAP_SET(trie, octet);                                       \
+    } STMT_END
+#else
+#  define TRIE_MARK_OCTET(octet) NOOP
+#endif
 
 #ifndef RE_PREFER_LONG_TRIE
 #  define RE_PREFER_LONG_TRIE 0
@@ -31,15 +45,11 @@
 
 
 static U8
-S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
-                 const bool want_charclass)
+S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next)
 {
     assert(needed_next <= U32_MAX);
 
     if (RE_PREFER_LONG_TRIE || needed_next > U16_MAX) {
-        if (want_charclass && trie_room >= sizeof(tregnode_LTRIEC)) {
-            return LTRIEC;
-        }
         if (trie_room >= sizeof(tregnode_LTRIE)) {
             return LTRIE;
         }
@@ -48,14 +58,8 @@ S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
         }
     }
     else {
-        if (want_charclass && trie_room >= sizeof(tregnode_TRIEC)) {
-            return TRIEC;
-        }
         if (trie_room >= sizeof(tregnode_TRIE)) {
             return TRIE;
-        }
-        if (want_charclass && trie_room >= sizeof(tregnode_LTRIEC)) {
-            return LTRIEC;
         }
         if (trie_room >= sizeof(tregnode_LTRIE)) {
             return LTRIE;
@@ -67,10 +71,27 @@ S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
 
 
 #ifdef DEBUGGING
+
+#define TRIE_DEBUG_OCTET_USED(trie, octet) \
+    BITMAP_TEST((trie)->bitmap, octet)
+
+static void
+S_dump_trie_char(pTHX_ const reg_trie_data *trie, U32 octet,
+                 const int colwidth)
+{
+    octet = (U8)octet;
+
+    PERL_UNUSED_VAR(trie);
+    if (isPRINT_A(octet) && octet != ' ' && octet != '\\')
+        re_printf("%*c", colwidth, (int)octet);
+    else {
+        re_printf("%*.*X", colwidth, 2, (unsigned)octet);
+    }
+}
+
 /*
-   dump_trie(trie,widecharmap,revcharmap)
-   dump_trie_interim_list(trie,widecharmap,revcharmap,next_alloc)
-   dump_trie_interim_table(trie,widecharmap,revcharmap,next_alloc)
+   dump_trie(trie)
+   dump_trie_interim_list(trie,next_alloc)
 
    These routines dump out a trie in a somewhat readable format.
    The _interim_ variants are used for debugging the interim
@@ -88,41 +109,34 @@ S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
 */
 
 static void
-S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
-            AV *revcharmap, U32 depth)
+S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, U32 depth)
 {
     PERL_ARGS_ASSERT_DUMP_TRIE;
 
     U32 state;
-    SV *sv = sv_newmortal();
-    int colwidth = widecharmap ? 6 : 4;
+    const int colwidth = 4;
     U32 word;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     re_indentf("Char : %-6s%-6s%-4s ",
         depth+1, "Match","Base","Ofs" );
 
-    for( state = 0 ; state < trie->uniquecharcount ; state++ ) {
-        SV ** const tmp = av_fetch_simple( revcharmap, state, 0);
-        if ( tmp ) {
-            re_printf("%*s",
-                colwidth,
-                pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), colwidth,
-                            PL_colors[0], PL_colors[1],
-                            (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0) |
-                            PERL_PV_ESCAPE_FIRSTCHAR
-                )
-            );
-        }
+    for( state = 0 ; state < TRIE_ALPHABET_SIZE ; state++ ) {
+        if (!TRIE_DEBUG_OCTET_USED(trie, state))
+            continue;
+        S_dump_trie_char(aTHX_ trie, state, colwidth);
     }
     re_printf("\n");
     re_indentf("State|-----------------------", depth+1);
 
-    for( state = 0 ; state < trie->uniquecharcount ; state++ )
-        re_printf("%.*s", colwidth, "--------");
+    for( state = 0 ; state < TRIE_ALPHABET_SIZE ; state++ )
+        if (TRIE_DEBUG_OCTET_USED(trie, state))
+            re_printf("%.*s", colwidth, "--------");
     re_printf("\n");
 
-    for( state = 1 ; state < trie->statecount ; state++ ) {
+    /* Prefix extraction leaves the old prefix states in the table, but the
+     * executable trie begins at startstate.  Dump only the executable part. */
+    for( state = trie->startstate ; state < trie->statecount ; state++ ) {
         const U32 base = trie->states[ state ].trans.base;
 
         re_indentf("#%4" UVXf "|", depth+1, (UV)state);
@@ -138,23 +152,25 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
         if ( base ) {
             U32 ofs = 0;
 
-            while( ( base + ofs  < trie->uniquecharcount ) ||
-                   ( base + ofs - trie->uniquecharcount < trie->lasttrans
-                     && trie->trans[ base + ofs - trie->uniquecharcount ].check
+            while( ( base + ofs  < TRIE_ALPHABET_SIZE ) ||
+                   ( base + ofs - TRIE_ALPHABET_SIZE < trie->lasttrans
+                     && trie->trans[ base + ofs - TRIE_ALPHABET_SIZE ].check
                                                                     != state))
                     ofs++;
 
             re_printf("+%2" UVXf "[ ", (UV)ofs);
 
-            for ( ofs = 0 ; ofs < trie->uniquecharcount ; ofs++ ) {
-                if ( ( base + ofs >= trie->uniquecharcount )
-                        && ( base + ofs - trie->uniquecharcount
+            for ( ofs = 0 ; ofs < TRIE_ALPHABET_SIZE ; ofs++ ) {
+                if (!TRIE_DEBUG_OCTET_USED(trie, ofs))
+                    continue;
+                if ( ( base + ofs >= TRIE_ALPHABET_SIZE )
+                        && ( base + ofs - TRIE_ALPHABET_SIZE
                                                         < trie->lasttrans )
                         && trie->trans[ base + ofs
-                                    - trie->uniquecharcount ].check == state )
+                                    - TRIE_ALPHABET_SIZE ].check == state )
                 {
                    re_printf("%*" UVXf, colwidth,
-                    (UV)trie->trans[ base + ofs - trie->uniquecharcount ].next
+                    (UV)trie->trans[ base + ofs - TRIE_ALPHABET_SIZE ].next
                    );
                 } else {
                     re_printf("%*s", colwidth,"   ." );
@@ -177,20 +193,17 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
 }
 /*
   Dumps a fully constructed but uncompressed trie in list form.
-  List tries normally only are used for construction when the number of
-  possible chars (trie->uniquecharcount) is very high.
+  List tries are used for construction with the fixed 256-octet alphabet.
   Used for debugging make_trie().
 */
 static void
 S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
-                         HV *widecharmap, AV *revcharmap, U32 next_alloc,
-                         U32 depth)
+                         U32 next_alloc, U32 depth)
 {
     PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST;
 
     U32 state;
-    SV *sv = sv_newmortal();
-    int colwidth = widecharmap ? 6 : 4;
+    const int colwidth = 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     /* print out the table precompression.  */
@@ -200,7 +213,7 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
             depth+1, "------:-----+-----------------\n" );
 
     for( state = 1; state < next_alloc; state++ ) {
-        U32 charid;
+        U32 idx;
 
         re_indentf(" %4" UVXf " :",
             depth+1, (UV)state  );
@@ -211,101 +224,72 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
                 trie->states[ state ].wordnum
             );
         }
-        for( charid = 1 ; charid <= TRIE_LIST_USED( state ) ; charid++ ) {
-            SV ** const tmp = av_fetch_simple( revcharmap,
-                                        TRIE_LIST_ITEM(state, charid).forid, 0);
-            if ( tmp ) {
-                re_printf("%*s:%3X=%4" UVXf " | ",
-                    colwidth,
-                    pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp),
-                              colwidth,
-                              PL_colors[0], PL_colors[1],
-                              (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0)
-                              | PERL_PV_ESCAPE_FIRSTCHAR
-                    ) ,
-                    TRIE_LIST_ITEM(state, charid).forid,
-                    (UV)TRIE_LIST_ITEM(state, charid).newstate
-                );
-                if (!(charid % 10))
-                    re_printf("\n%*s| ",
-                        (int)((depth * 2) + 14), "");
+        for( idx = 1 ; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
+            const U32 forid = TRIE_LIST_ITEM(state, idx).forid;
+            if (forid <= U8_MAX && isPRINT_A((U8)forid)
+                    && forid != ' ' && forid != '\\' && forid != '\'') {
+                re_printf(" '%c'", (int)forid);
+            } else {
+                re_printf("%*.*X", colwidth, 2, (unsigned)forid);
             }
+            re_printf("=%4" UVXf " | ",
+                      (UV)TRIE_LIST_ITEM(state, idx).newstate);
+            if (!(idx % 10))
+                re_printf("\n%*s| ",
+                    (int)((depth * 2) + 14), "");
         }
         re_printf("\n");
     }
 }
 
-/*
-  Dumps a fully constructed but uncompressed trie in table form.
-  This is the normal DFA style state transition table, with a few
-  twists to facilitate compression later.
-  Used for debugging make_trie().
-*/
 static void
-S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
-                          HV *widecharmap, AV *revcharmap, U32 next_alloc,
-                          U32 depth)
+S_dump_trie_physical_char(pTHX_ U32 octet)
 {
-    PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE;
+    octet = (U8)octet;
 
-    U32 state;
-    U32 charid;
-    SV *sv = sv_newmortal();
-    int colwidth = widecharmap ? 6 : 4;
-    DECLARE_AND_GET_RE_DEBUG_FLAGS;
+    if (isPRINT_A(octet) && octet != ' ' && octet != '\\' && octet != '\'')
+        re_printf(" '%c'", (int)octet);
+    else
+        re_printf("  %02X", (unsigned)octet);
+}
 
-    /*
-       print out the table precompression so that we can do a visual check
-       that they are identical.
-     */
+static void
+S_dump_trie_physical(pTHX_ const struct reg_trie_data_ *trie,
+                     U32 physical, U32 depth)
+{
+    U32 slot;
+    PERL_ARGS_ASSERT_DUMP_TRIE_PHYSICAL;
 
-    re_indentf("Char : ", depth+1 );
-
-    for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
-        SV ** const tmp = av_fetch_simple( revcharmap, charid, 0);
-        if ( tmp ) {
-            STRLEN n;
-            const char *s = SvPV_const(*tmp, n);
-            re_printf("%*s",
-                colwidth,
-                pv_pretty(sv, s, n, colwidth,
-                            PL_colors[0], PL_colors[1],
-                            (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0) |
-                            PERL_PV_ESCAPE_FIRSTCHAR
-                )
-            );
-        }
-    }
-
-    re_printf("\n");
-    re_indentf("State+-", depth+1 );
-
-    for( charid = 0; charid < trie->uniquecharcount; charid++ ) {
-        re_printf("%.*s", colwidth,"--------");
-    }
-
-    re_printf("\n" );
-
-    for( state = 1; state < next_alloc; state += trie->uniquecharcount ) {
-
-        re_indentf("%4" UVXf " : ",
-            depth+1,
-            (UV)TRIE_NODENUM( state ) );
-
-        for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
-            UV v = (UV)SAFE_TRIE_NODENUM( trie->trans[ state + charid ].next );
-            if (v)
-                re_printf("%*" UVXf, colwidth, v );
+    re_indentf("Physical transitions:\n", depth+1);
+    re_indentf("Physical| State | Word  | Base  | Ofs | Char | Next\n", depth+1);
+    re_indentf("--------+-------+-------+-------+-----+------+-----\n", depth+1);
+    for (slot = 0; slot < physical; slot++) {
+        const reg_trie_trans * const trans = trie->trans + slot;
+        if (!trans->next)
+            continue;
+        {
+            const U32 state = trans->check;
+            const U32 octet = slot + TRIE_ALPHABET_SIZE
+                                     - trie->states[state].trans.base;
+            re_indentf("%8" UVXf "| #%4" UVXf " |",
+                       depth+1,
+                       (UV)slot,
+                       (UV)state);
+            if (trie->states[state].wordnum)
+                re_printf(" W%4" UVuf " |", (UV)trie->states[state].wordnum);
             else
-                re_printf("%*s", colwidth, "." );
-        }
-        if ( ! trie->states[ TRIE_NODENUM( state ) ].wordnum ) {
-            re_printf(" (%4" UVXf ")\n",
-                                            (UV)trie->trans[ state ].check );
-        } else {
-            re_printf(" (%4" UVXf ") W%4X\n",
-                                            (UV)trie->trans[ state ].check,
-            trie->states[ TRIE_NODENUM( state ) ].wordnum );
+                re_printf("       |");
+            re_printf(" @%4" UVXf " | +%02" UVXf " |",
+                      (UV)trie->states[state].trans.base,
+                      (UV)octet);
+            re_printf(" ");
+            S_dump_trie_physical_char(aTHX_ octet);
+            re_printf(" | %4" UVXf, (UV)trans->next);
+            if (!trie->states[trans->next].trans.base
+                    && trie->states[trans->next].wordnum)
+                re_printf(" (W%" UVuf ")",
+                          (UV)trie->states[trans->next].wordnum);
+            re_printf("\n");
         }
     }
 }
@@ -313,7 +297,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
 #endif
 
 
-/* make_trie(startbranch,first,last,tail,word_count,flags,depth)
+/* make_trie(startbranch,first,last,tail,word_count,octet_count,flags,depth)
   startbranch: the first branch in the whole branch sequence
   first      : start branch of sequence of branch-exact nodes.
                May be the same as startbranch
@@ -430,204 +414,175 @@ is the recommended Unicode-aware way of saying
     *(d++) = uv;
 */
 
-#define TRIE_STORE_REVCHAR(val)                                            \
-    STMT_START {                                                           \
-        if (UTF) {                                                         \
-            SV *zlopp = newSV(UTF8_MAXBYTES);                              \
-            unsigned char *flrbbbbb = (unsigned char *) SvPVX(zlopp);      \
-            unsigned char *const kapow = uv_to_utf8(flrbbbbb, val);     \
-            *kapow = '\0';                                                 \
-            SvCUR_set(zlopp, kapow - flrbbbbb);                            \
-            SvPOK_on(zlopp);                                               \
-            SvUTF8_on(zlopp);                                              \
-            av_push_simple(revcharmap, zlopp);                                     \
-        } else {                                                           \
-            char ooooff = (char)val;                                           \
-            av_push_simple(revcharmap, newSVpvn(&ooooff, 1));                      \
-        }                                                                  \
-        } STMT_END
+/* These node types contain UTF-8 source octets even when the pattern itself
+ * is not marked UTF-8.  Ordinary non-UTF-8 nodes contain native octets; they
+ * must not be identified as UTF-8 merely because their octets happen to form
+ * a valid UTF-8 sequence. */
+#define TRIE_SOURCE_UTF8(noper)                                             \
+    (UTF || OP(noper) == EXACT_REQ8 || OP(noper) == EXACTFU_REQ8            \
+        || OP(noper) == EXACTL || OP(noper) == EXACTFLU8)
 
-/* This gets the next character from the input, folding it if not already
- * folded. */
-#define TRIE_READ_CHAR STMT_START {                                           \
-    wordlen++;                                                                \
-    if ( UTF ) {                                                              \
-        /* if it is UTF then it is either already folded, or does not need    \
-         * folding */                                                         \
-        uvc = valid_utf8_to_uv( (const U8*) uc, &len);                     \
-    }                                                                         \
-    else if (folder == PL_fold_latin1) {                                      \
-        /* This folder implies Unicode rules, which in the range expressible  \
-         *  by not UTF is the lower case, with the two exceptions, one of     \
-         *  which should have been taken care of before calling this */       \
-        assert(*uc != LATIN_SMALL_LETTER_SHARP_S);                            \
-        uvc = toLOWER_L1(*uc);                                                \
-        if (UNLIKELY(uvc == MICRO_SIGN)) uvc = GREEK_SMALL_LETTER_MU;         \
-        len = 1;                                                              \
-    } else {                                                                  \
-        /* raw data, will be folded later if needed */                        \
-        uvc = (U32)*uc;                                                       \
-        len = 1;                                                              \
-    }                                                                         \
-} STMT_END
-
-
-
-#define TRIE_LIST_PUSH(state,fid,ns) STMT_START {               \
-    if ( TRIE_LIST_CUR( state ) >=TRIE_LIST_LEN( state ) ) {    \
-        U32 ging = TRIE_LIST_LEN( state ) * 2;                  \
-        Renew( trie->states[ state ].trans.list, ging, reg_trie_trans_le ); \
-        TRIE_LIST_LEN( state ) = ging;                          \
-    }                                                           \
-    TRIE_LIST_ITEM( state, TRIE_LIST_CUR( state ) ).forid = fid;     \
-    TRIE_LIST_ITEM( state, TRIE_LIST_CUR( state ) ).newstate = ns;   \
-    TRIE_LIST_CUR( state )++;                                   \
-} STMT_END
-
-#define TRIE_LIST_NEW(state) STMT_START {                       \
-    Newx( trie->states[ state ].trans.list,                     \
-        4, reg_trie_trans_le );                                 \
-     TRIE_LIST_CUR( state ) = 1;                                \
-     TRIE_LIST_LEN( state ) = 4;                                \
-} STMT_END
-
-#define TRIE_HANDLE_WORD(state) STMT_START {                    \
-    U32 dupe = trie->states[ state ].wordnum;                    \
-    regnode * const noper_next = regnext( noper );              \
-                                                                \
-    DEBUG_r({                                                   \
-        /* store the word for dumping */                        \
-        SV* tmp;                                                \
-        if (OP(noper) != NOTHING)                               \
-            tmp = newSVpvn_utf8(STRING(noper), STR_LEN(noper), UTF);    \
-        else                                                    \
-            tmp = newSVpvn_utf8( "", 0, UTF );                  \
-        av_push_simple( trie_words, tmp );                      \
-    });                                                         \
-                                                                \
-    curword++;                                                  \
-    assert(curword <= word_count);                              \
-    trie->wordinfo[curword].prev   = 0;                         \
-    trie->wordinfo[curword].len    = wordlen;                   \
-    trie->wordinfo[curword].accept = state;                     \
-                                                                \
-    if ( noper_next < tail ) {                                  \
-        if (!trie->jump) {                                      \
-            trie->jump = (TRIE_JUMP_TYPE *) PerlMemShared_calloc( word_count + 1, sizeof(TRIE_JUMP_TYPE) ); \
-            trie->j_before_paren = (U16 *) PerlMemShared_calloc( word_count + 1, sizeof(U16) ); \
-            trie->j_after_paren = (U16 *) PerlMemShared_calloc( word_count + 1, sizeof(U16) );  \
-        }                                                       \
-        assert(noper_next > convert);                           \
-        assert(curword <= word_count);                          \
-        assert(!trie->jump[curword]);                           \
-        assert((noper_next - convert) >= 0);                    \
-        assert((noper_next - convert) <= TRIE_JUMP_TYPE_MAX);   \
-        trie->jump[curword] = noper_next - convert;             \
-        U16 set_before_paren;                                   \
-        U16 set_after_paren;                                    \
-        if (OP(cur) == BRANCH) {                                \
-            set_before_paren = ARG1a(cur);                      \
-            set_after_paren = ARG1b(cur);                       \
-        } else {                                                \
-            set_before_paren = ARG2a(cur);                      \
-            set_after_paren = ARG2b(cur);                       \
-        }                                                       \
-        trie->j_before_paren[curword] = set_before_paren;       \
-        trie->j_after_paren[curword] = set_after_paren;         \
-        if (!jumper)                                            \
-            jumper = noper_next;                                \
-        if (!nextbranch)                                        \
-            nextbranch = regnext(cur);                          \
-    }                                                           \
-                                                                \
-    if ( dupe ) {                                               \
-        /* It's a dupe. Pre-insert into the wordinfo[].prev   */\
-        /* chain, so that when the bits of chain are later    */\
-        /* linked together, the dups appear in the chain      */\
-        trie->wordinfo[curword].prev = trie->wordinfo[dupe].prev; \
-        trie->wordinfo[dupe].prev = curword;                    \
-    } else {                                                    \
-        /* we haven't inserted this word yet.                */ \
-        trie->states[ state ].wordnum = curword;                \
-    }                                                           \
-} STMT_END
-
-
-#define TRIE_TRANS_STATE(state,base,ucharcount,charid,special)          \
-     ( ( base + charid >=  ucharcount                                   \
-         && base + charid < ubound                                      \
-         && state == trie->trans[ base - ucharcount + charid ].check    \
-         && trie->trans[ base - ucharcount + charid ].next )            \
-           ? trie->trans[ base - ucharcount + charid ].next             \
-           : ( state == 1 ? special : 0 )                                 \
-      )
-
-/* Helper function for make_trie(): set a trie bit for both the character
- * and its folded variant, and for the first byte of a variant codepoint,
- * if any */
-
-static void
-S_trie_bitmap_set_folded(pTHX_ RExC_state_t *pRExC_state,
-    reg_trie_data *trie, U8 ch, const U8 * folder)
+PERL_STATIC_INLINE void
+S_trie_list_push(reg_trie_data *trie, const U32 state, const U32 fid,
+                 const U32 newstate, const U32 position)
 {
-    TRIE_BITMAP_SET(trie, ch);
-    /* store the folded codepoint */
-    if ( folder )
-        TRIE_BITMAP_SET(trie, folder[ch]);
+    /* Element zero is the list header, not a transition.  Its forid field
+     * stores the next insertion position (one past the last transition),
+     * while newstate stores the allocated capacity.  Transition records
+     * occupy elements 1 through forid - 1 and remain sorted by forid. */
+    reg_trie_trans_le *list = trie->states[state].trans.list;
+    const U32 used = list[0].forid;
 
-    if ( !UTF ) {
-        /* store first byte of utf8 representation of */
-        /* variant codepoints */
-        if (! UVCHR_IS_INVARIANT(ch)) {
-            U8 hi = UTF8_TWO_BYTE_HI(ch);
-            /* Note that hi will be either 0xc2 or 0xc3 (apart from EBCDIC
-             * systems), and TRIE_BITMAP_SET() will do >>3 to get the byte
-             * offset within the bit table, which is constant, and
-             * Coverity complained about this (CID 488118). */
-            TRIE_BITMAP_SET(trie, hi);
-        }
+    if (used >= list[0].newstate) {
+        const U32 new_len = list[0].newstate * 2;
+        Renew(list, new_len, reg_trie_trans_le);
+        trie->states[state].trans.list = list;
+        list[0].newstate = new_len;
     }
+
+    /* An insertion at the end is the common fast path. */
+    if (position < used)
+        Move(&list[position], &list[position + 1], used - position,
+             reg_trie_trans_le);
+    list[position].forid = fid;
+    list[position].newstate = newstate;
+    list[0].forid++;
+}
+
+PERL_STATIC_INLINE void
+S_trie_list_new(reg_trie_data *trie, const U32 state)
+{
+    /* These lists exist only while the trie is being constructed.  They use
+     * the ordinary allocator and are released after the lists are packed
+     * into trie->trans; the persistent trie arrays use the shared allocator. */
+    /* Allocate initial storage for this state's transition list.  The
+     * length is measured in transitions, not octets: it is the number of
+     * transition records we can add before the list must be resized.  Most
+     * states in a trie have only one transition, and only a few states have
+     * several; when there is a branching state it is very often the first
+     * state.  Give that state more room up front, while keeping later sparse
+     * states cheap to create. */
+    const U32 initial_len = (state == 1) ? 16 : 4;
+    Newx(trie->states[state].trans.list, initial_len, reg_trie_trans_le);
+    trie->states[state].trans.list[0].forid = 1;
+    trie->states[state].trans.list[0].newstate = initial_len;
+}
+
+PERL_STATIC_INLINE void
+S_trie_list_transition(reg_trie_data *trie, U32 *state, const U32 octet,
+                       U32 *next_alloc, U32 *state_capacity,
+                       U32 **prev_states, STRLEN *transition_count)
+{
+    U32 check;
+    U32 newstate = 0;
+    reg_trie_trans_le *list;
+    const U32 current_state = *state;
+
+    TRIE_MARK_OCTET(octet);
+    if (!trie->states[current_state].trans.list)
+        S_trie_list_new(trie, current_state);
+    list = trie->states[current_state].trans.list;
+
+    for (check = 1; check <= list[0].forid - 1; check++) {
+        if (list[check].forid == octet) {
+            newstate = list[check].newstate;
+            break;
+        }
+        if (list[check].forid > octet)
+            break;
+    }
+    if (!newstate) {
+        if (*next_alloc >= *state_capacity) {
+            const U32 old_capacity = *state_capacity;
+            *state_capacity *= 2;
+            trie->states = (reg_trie_state *)
+                PerlMemShared_realloc(trie->states,
+                                      *state_capacity * sizeof(reg_trie_state));
+            Renew(*prev_states, *state_capacity, U32);
+            Zero(trie->states + old_capacity,
+                 *state_capacity - old_capacity, reg_trie_state);
+            Zero(*prev_states + old_capacity,
+                 *state_capacity - old_capacity, U32);
+        }
+        newstate = (*next_alloc)++;
+        (*prev_states)[newstate] = current_state;
+        if (!TRIE_LIST_USED(current_state)) {
+            trie->states[current_state].min_octet = (U8)octet;
+            trie->states[current_state].max_octet = (U8)octet;
+        }
+        else {
+            if (octet < trie->states[current_state].min_octet)
+                trie->states[current_state].min_octet = (U8)octet;
+            if (octet > trie->states[current_state].max_octet)
+                trie->states[current_state].max_octet = (U8)octet;
+        }
+        S_trie_list_push(trie, current_state, octet, newstate, check);
+        (*transition_count)++;
+    }
+    *state = newstate;
+}
+
+PERL_STATIC_INLINE U32
+S_trie_trans_state(const reg_trie_data *trie, const U32 state,
+                   const U32 base, const U32 ucharcount, const U32 octet,
+                   const U32 special, const U32 ubound)
+{
+    const U32 index = base - ucharcount + octet;
+
+    /* The packed table stores a transition at base - alphabet_size + octet.
+     * The check field confirms that the physical slot belongs to this state.
+     * During Aho-Corasick construction, special is the fallback transition
+     * used when the lookup is performed from the root state. */
+    return base + octet >= ucharcount
+        && base + octet < ubound
+        && state == trie->trans[index].check
+        && trie->trans[index].next
+        ? trie->trans[index].next
+        : state == 1 ? special : 0;
 }
 
 
 I32
 Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                   regnode *first, regnode *last, regnode *tail,
-                  U32 word_count, U32 flags, U32 depth)
+                  U32 word_count, STRLEN octet_count, U32 flags, U32 depth)
 {
     PERL_ARGS_ASSERT_MAKE_TRIE;
 
-    /* first pass, loop through and scan words */
+    /* Scan the source words and construct the trie in one pass. */
     reg_trie_data *trie;
-    HV *widecharmap = NULL;
-    AV *revcharmap = newAV();
     regnode *cur;
     STRLEN len = 0;
     UV uvc = 0;
     U32 curword = 0;
     U32 next_alloc = 0;
+    U32 state_capacity = 0;
     regnode *jumper = NULL;
     regnode *nextbranch = NULL;
     regnode *lastbranch = NULL;
     regnode *convert = NULL;
-    U32 *prev_states; /* temp array mapping each state to previous one */
-    /* we just use folder as a flag in utf8 */
+    /* Temporary predecessor links.  Once the list representation has been
+     * compressed, these links are used to reconstruct the wordinfo[].prev
+     * chains for words which end at the same or an earlier state. */
+    U32 *prev_states;
+    /* A non-NULL folder identifies a folded trie and also means that its
+     * transitions must use the processed UTF-8 representation. */
     const U8 * folder = NULL;
+    /* Every trie transition is an octet.  In raw mode, native source octets
+     * are used directly.  In processed mode, source codepoints are encoded
+     * as UTF-8 octets before entering the trie.  Invariant codepoints have
+     * the same representation in both modes; awkward and high codepoints
+     * require processed mode. */
+    bool trie_needs_codepoint_processing;
 
-    /* in the below reg_add_data call we are storing either 'tu' or 'tuaa'
-     * which stands for one trie structure, one hash, optionally followed
-     * by two arrays */
+    /* Store the trie and, in debugging builds, its word list. */
 #ifdef DEBUGGING
-    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("tuaa"));
+    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("ta"));
     AV *trie_words = NULL;
-    /* along with revcharmap, this only used during construction but both are
-     * useful during debugging so we store them in the struct when debugging.
-     */
 #else
-    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("tu"));
+    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("t"));
     STRLEN trie_charcount = 0;
 #endif
-    SV *re_trie_maxbuff;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
 #ifndef DEBUGGING
@@ -638,20 +593,34 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         case EXACTFAA:
         case EXACTFUP:
         case EXACTFU:
-        case EXACTFLU8: folder = PL_fold_latin1; break;
+        case EXACTFLU8:
+            folder = PL_fold_latin1;
+            break;
         case EXACTF:  folder = PL_fold; break;
         default: croak("panic! In trie construction, unknown node type %u %s", (unsigned) flags, REGNODE_NAME(flags) );
     }
 
-    /* create the trie struct, all zeroed */
+    /* Trie data is immutable after compilation and is shared by cloned
+     * regexes through refcounting.  Allocate the trie and its persistent
+     * storage from the shared allocator, and use PerlMemShared_realloc() and
+     * PerlMemShared_free() for it; pregfree() releases it only when the last
+     * regex reference disappears. */
     trie = (reg_trie_data *) PerlMemShared_calloc( 1, sizeof(reg_trie_data) );
     trie->refcount = 1;
     trie->startstate = 1;
     trie->wordcount = word_count;
+    trie->prop_flags = folder == NULL
+        ? 0
+        : folder == PL_fold
+            ? TRIE_FOLD_NATIVE
+            : TRIE_FOLD_UNICODE;
     RExC_rxi->data->data[ data_slot ] = (void*)trie;
-    trie->charmap = (U32 *) PerlMemShared_calloc( 256, sizeof(U32) );
-    if (flags == EXACT || flags == EXACT_REQ8 || flags == EXACTL)
-        trie->bitmap = (char *) PerlMemShared_calloc( ANYOF_BITMAP_SIZE, 1 );
+#ifdef DEBUGGING
+    /* The compiler can return early if no replacement node fits.  Install
+     * the optional word-list slot before that can happen, so regex cleanup
+     * never sees an uninitialised data pointer. */
+    RExC_rxi->data->data[ data_slot + TRIE_WORDS_OFFSET ] = NULL;
+#endif
     trie->wordinfo = (reg_trie_wordinfo *) PerlMemShared_calloc(
                        trie->wordcount+1, sizeof(reg_trie_wordinfo));
 
@@ -659,11 +628,6 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         trie_words = newAV();
     });
 
-    re_trie_maxbuff = get_sv(RE_TRIE_MAXBUF_NAME, GV_ADD);
-    assert(re_trie_maxbuff);
-    if (!SvIOK(re_trie_maxbuff)) {
-        sv_setiv(re_trie_maxbuff, RE_TRIE_MAXBUF_INIT);
-    }
     DEBUG_TRIE_COMPILE_r({
         re_indentf(
           "make_trie start == %d, first == %d, last == %d, tail == %d depth = %d\n",
@@ -680,255 +644,39 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         /* branch sub-chain */
         convert = REGNODE_AFTER( first );
     }
+    /* Jump offsets are recorded relative to this location.  Prefix
+     * extraction may move the trie, in which case jump_correction rebases
+     * them. */
+    regnode * const jump_base = convert;
 
-    /*  -- First loop and Setup --
-
-       We first traverse the branches and scan each word to determine if it
-       contains widechars, and how many unique chars there are, this is
-       important as we have to build a table with at least as many columns as we
-       have unique chars.
-
-       We use an array of integers to represent the character codes 0..255
-       (trie->charmap) and we use a an HV* to store Unicode characters. We use
-       the native representation of the character value as the key and IV's for
-       the coded index.
-
-       *TODO* If we keep track of how many times each character is used we can
-       remap the columns so that the table compression later on is more
-       efficient in terms of memory by ensuring the most common value is in the
-       middle and the least common are on the outside.  IMO this would be better
-       than a most to least common mapping as theres a decent chance the most
-       common letter will share a node with the least common, meaning the node
-       will not be compressible. With a middle is most common approach the worst
-       case is when we have the least common nodes twice.
-
-     */
-
-    for ( cur = first ; cur < last ; cur = regnext( cur ) ) {
-        regnode *noper = REGNODE_AFTER( cur );
-        const U8 *uc;
-        const U8 *e;
-        int foldlen = 0;
-        U32 wordlen      = 0;         /* required init */
-        STRLEN minchars = 0;
-        STRLEN maxchars = 0;
-        bool set_bit = trie->bitmap ? 1 : 0; /*store the first char in the
-                                               bitmap?*/
-
-        /* wordlen is needed for the TRIE_READ_CHAR() macro, but we don't use its
-           value in this scope, we only modify it.  clang 17 warns about this.
-           The later definitions of wordlen in this function do have their values
-           used.
-        */
-        PERL_UNUSED_VAR(wordlen);
-
-        lastbranch = cur;
-
-        if (OP(noper) == NOTHING) {
-            /* skip past a NOTHING at the start of an alternation
-             * eg, /(?:)a|(?:b)/ should be the same as /a|b/
-             *
-             * If the next node is not something we are supposed to process
-             * we will just ignore it due to the condition guarding the
-             * next block.
-             */
-
-            regnode *noper_next= regnext(noper);
-            if (noper_next < tail)
-                noper = noper_next;
-        }
-
-        if (    noper < tail
-            && (    OP(noper) == flags
-                || (flags == EXACT && OP(noper) == EXACT_REQ8)
-                || (flags == EXACTFU && (   OP(noper) == EXACTFU_REQ8
-                                         || OP(noper) == EXACTFUP))))
-        {
-            uc = (U8*)STRING(noper);
-            e = uc + STR_LEN(noper);
-        } else {
-            trie->minlen= 0;
-            continue;
-        }
-
-
-        if ( set_bit ) { /* bitmap only alloced when !(UTF && Folding) */
-            TRIE_BITMAP_SET(trie,*uc); /* store the raw first byte
-                                          regardless of encoding */
-            if (OP( noper ) == EXACTFUP) {
-                /* false positives are ok, so just set this */
-                TRIE_BITMAP_SET(trie, LATIN_SMALL_LETTER_SHARP_S);
-            }
-        }
-
-        for ( ; uc < e ; uc += len ) {  /* Look at each char in the current
-                                           branch */
-            TRIE_CHARCOUNT(trie)++;
-            TRIE_READ_CHAR;
-
-            /* TRIE_READ_CHAR returns the current character, or its fold if /i
-             * is in effect.  Under /i, this character can match itself, or
-             * anything that folds to it.  If not under /i, it can match just
-             * itself.  Most folds are 1-1, for example k, K, and KELVIN SIGN
-             * all fold to k, and all are single characters.   But some folds
-             * expand to more than one character, so for example LATIN SMALL
-             * LIGATURE FFI folds to the three character sequence 'ffi'.  If
-             * the string beginning at 'uc' is 'ffi', it could be matched by
-             * three characters, or just by the one ligature character. (It
-             * could also be matched by two characters: LATIN SMALL LIGATURE FF
-             * followed by 'i', or by 'f' followed by LATIN SMALL LIGATURE FI).
-             * (Of course 'I' and/or 'F' instead of 'i' and 'f' can also
-             * match.)  The trie needs to know the minimum and maximum number
-             * of characters that could match so that it can use size alone to
-             * quickly reject many match attempts.  The max is simple: it is
-             * the number of folded characters in this branch (since a fold is
-             * never shorter than what folds to it. */
-
-            maxchars++;
-
-            /* And the min is equal to the max if not under /i (indicated by
-             * 'folder' being NULL), or there are no multi-character folds.  If
-             * there is a multi-character fold, the min is incremented just
-             * once, for the character that folds to the sequence.  Each
-             * character in the sequence needs to be added to the list below of
-             * characters in the trie, but we count only the first towards the
-             * min number of characters needed.  This is done through the
-             * variable 'foldlen', which is returned by the macros that look
-             * for these sequences as the number of bytes the sequence
-             * occupies.  Each time through the loop, we decrement 'foldlen' by
-             * how many bytes the current char occupies.  Only when it reaches
-             * 0 do we increment 'minchars' or look for another multi-character
-             * sequence. */
-            if (folder == NULL) {
-                minchars++;
-            }
-            else if (foldlen > 0) {
-                foldlen -= (UTF) ? UTF8SKIP(uc) : 1;
-            }
-            else {
-                minchars++;
-
-                /* See if *uc is the beginning of a multi-character fold.  If
-                 * so, we decrement the length remaining to look at, to account
-                 * for the current character this iteration.  (We can use 'uc'
-                 * instead of the fold returned by TRIE_READ_CHAR because the
-                 * macro is smart enough to account for any unfolded
-                 * characters. */
-                if (UTF) {
-                    if ((foldlen = is_MULTI_CHAR_FOLD_utf8_safe(uc, e))) {
-                        foldlen -= UTF8SKIP(uc);
-                    }
-                }
-                else if ((foldlen = is_MULTI_CHAR_FOLD_latin1_safe(uc, e))) {
-                    foldlen--;
-                }
-            }
-
-            /* The current character (and any potential folds) should be added
-             * to the possible matching characters for this position in this
-             * branch */
-            if ( uvc < 256 ) {
-                if ( folder ) {
-                    U8 folded = folder[ (U8) uvc ];
-                    if ( !trie->charmap[ folded ] ) {
-                        trie->charmap[ folded ]=( ++trie->uniquecharcount );
-                        TRIE_STORE_REVCHAR( folded );
-                    }
-                }
-                if ( !trie->charmap[ uvc ] ) {
-                    trie->charmap[ uvc ]=( ++trie->uniquecharcount );
-                    TRIE_STORE_REVCHAR( uvc );
-                }
-                if ( set_bit ) {
-                    /* store the codepoint in the bitmap, and its folded
-                     * equivalent. */
-                    S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, uvc, folder);
-                    set_bit = 0; /* We've done our bit :-) */
-                }
-            } else {
-
-                /* XXX We could come up with the list of code points that fold
-                 * to this using PL_utf8_foldclosures, except not for
-                 * multi-char folds, as there may be multiple combinations
-                 * there that could work, which needs to wait until runtime to
-                 * resolve (The comment about LIGATURE FFI above is such an
-                 * example */
-
-                SV** svpp;
-                if ( !widecharmap )
-                    widecharmap = newHV();
-
-                svpp = hv_fetch( widecharmap, (char*)&uvc, sizeof( UV ), 1 );
-
-                if ( !svpp )
-                    croak("error creating/fetching widecharmap entry for 0x%" UVXf, uvc );
-
-                if ( !SvTRUE( *svpp ) ) {
-                    sv_setiv( *svpp, ++trie->uniquecharcount );
-                    TRIE_STORE_REVCHAR(uvc);
-                }
-            }
-        } /* end loop through characters in this branch of the trie */
-
-        /* We take the min and max for this branch and combine to find the min
-         * and max for all branches processed so far */
-        if( cur == first ) {
-            trie->minlen = minchars;
-            trie->maxlen = maxchars;
-        } else if (minchars < trie->minlen) {
-            trie->minlen = minchars;
-        } else if (maxchars > trie->maxlen) {
-            trie->maxlen = maxchars;
-        }
-    } /* end first pass */
-    trie->before_paren = OP(first) == BRANCH
-                 ? ARG1a(first)
-                 : ARG2a(first); /* BRANCHJ */
-
-    trie->after_paren = OP(lastbranch) == BRANCH
-                 ? ARG1b(lastbranch)
-                 : ARG2b(lastbranch); /* BRANCHJ */
-    DEBUG_TRIE_COMPILE_r(
-        re_indentf(
-                "TRIE(%s): W:%d C:%d Uq:%d Min:%d Max:%d\n",
-                depth+1,
-                ( widecharmap ? "UTF8" : "NATIVE" ), (int)word_count,
-                (int)TRIE_CHARCOUNT(trie), trie->uniquecharcount,
-                (int)trie->minlen, (int)trie->maxlen )
-    );
+    /* State zero is reserved as the sentinel; state one is the root, and
+     * next_alloc always names the next state to allocate. */
+    /* The list compiler performs source analysis and transition-list
+     * construction in one pass.  The larger of the word and octet counts is
+     * a useful initial estimate: common prefixes reduce the number of states,
+     * while UTF-8 expansion and folding can increase it.  State storage
+     * therefore grows on demand when the estimate is low. */
+    state_capacity = MAX(word_count, octet_count) + 2;
+    if (state_capacity < 16)
+        state_capacity = 16;
+    trie_needs_codepoint_processing = folder != NULL;
 
     /*
-        We now know what we are dealing with in terms of unique chars and
-        string sizes so we can calculate how much memory a naive
-        representation using a flat table  will take. If it's over a reasonable
-        limit (as specified by ${^RE_TRIE_MAXBUF}) we use a more memory
-        conservative but potentially much slower representation using an array
-        of lists.
-
-        At the end we convert both representations into the same compressed
-        form that will be used in regexec.c for matching with. The latter
-        is a form that cannot be used to construct with but has memory
-        properties similar to the list form and access properties similar
-        to the table form making it both suitable for fast searches and
-        small enough that its feasable to store for the duration of a program.
-
-        See the comment in the code where the compressed table is produced
-        inplace from the flat tabe representation for an explanation of how
-        the compression works.
+        We construct every trie using an array of transition lists.  Once
+        construction is complete, the list representation is converted into
+        the compressed transition form used by regexec.c.
 
     */
 
 
-    Newx(prev_states, TRIE_CHARCOUNT(trie) + 2, U32);
+    Newx(prev_states, state_capacity, U32);
     prev_states[1] = 0;
 
-    if ( (IV)( ( TRIE_CHARCOUNT(trie) + 1 ) * trie->uniquecharcount + 1)
-                                                    > SvIV(re_trie_maxbuff) )
     {
         /*
-            Second Pass -- Array Of Lists Representation
+            Array Of Lists Representation
 
-            Each state will be represented by a list of charid:state records
+            Each state will be represented by a list of octet:state records
             (reg_trie_trans_le) the first such element holds the CUR and LEN
             points of the allocated array. (See defines above).
 
@@ -937,23 +685,29 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             (but cant be modified once converted).
         */
 
-        STRLEN transcount = 1;
+        /* TRIE_CHARCOUNT counts source characters for diagnostics.  This
+         * count is different from transition_count, which counts distinct
+         * list transitions and provides the initial packed-table estimate. */
+        STRLEN transition_count = 1;
 
         DEBUG_TRIE_COMPILE_MORE_r( re_indentf("Compiling trie using list compiler\n",
             depth+1));
 
         trie->states = (reg_trie_state *)
-            PerlMemShared_calloc( TRIE_CHARCOUNT(trie) + 2,
+            PerlMemShared_calloc( state_capacity,
                                   sizeof(reg_trie_state) );
-        TRIE_LIST_NEW(1);
+        S_trie_list_new(trie, 1);
         next_alloc = 2;
 
         for ( cur = first ; cur < last ; cur = regnext( cur ) ) {
 
             regnode *noper   = REGNODE_AFTER( cur );
             U32 state        = 1;         /* required init */
-            U32 charid       = 0;         /* sanity init */
             U32 wordlen      = 0;         /* required init */
+            int foldlen      = 0;
+            STRLEN minchars  = 0;
+            STRLEN maxchars  = 0;
+            lastbranch = cur;
 
             if (OP(noper) == NOTHING) {
                 regnode *noper_next= regnext(noper);
@@ -968,71 +722,250 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 && (    OP(noper) == flags
                     || (flags == EXACT && OP(noper) == EXACT_REQ8)
                     || (flags == EXACTFU && (   OP(noper) == EXACTFU_REQ8
-                                             || OP(noper) == EXACTFUP))))
+                                              || OP(noper) == EXACTFUP))))
             {
                 const U8 *uc= (U8*)STRING(noper);
                 const U8 *e= uc + STR_LEN(noper);
 
+                bool is_utf8 = TRIE_SOURCE_UTF8(noper);
+
                 for ( ; uc < e ; uc += len ) {
+                    if (is_utf8 && folder == NULL) {
+                        const U8 *bp;
+                        const U8 * const ep = uc + UTF8SKIP(uc);
 
-                    TRIE_READ_CHAR;
+                        /* An un-folded UTF-8 source word is already in the
+                         * representation used by the trie.  Avoid decoding
+                         * and re-encoding it; UTF8SKIP is sufficient here
+                         * because compiled pattern strings are well formed. */
+                        len = (STRLEN)(ep - uc);
+                        wordlen++;
+                        minchars++;
+                        maxchars++;
+                        TRIE_CHARCOUNT(trie)++;
 
-                    if ( uvc < 256 ) {
-                        charid = trie->charmap[ uvc ];
-                    } else {
-                        SV** const svpp = hv_fetch( widecharmap,
-                                                    (char*)&uvc,
-                                                    sizeof( UV ),
-                                                    0);
-                        if ( !svpp ) {
-                            charid = 0;
-                        } else {
-                            charid = (U32)SvIV( *svpp );
+                        if (len == 1) {
+                            trie->prop_flags |= TRIE_CP_INVARIANT;
                         }
+                        else if (UTF8_IS_ABOVE_LATIN1(*uc)) {
+                            trie->prop_flags |= TRIE_CP_HIGH;
+                            trie_needs_codepoint_processing = true;
+                        }
+                        else {
+                            trie->prop_flags |= TRIE_CP_AWKWARD;
+                            trie_needs_codepoint_processing = true;
+                        }
+
+                        for (bp = uc; bp < ep; bp++)
+                            S_trie_list_transition(trie, &state, *bp,
+                                                    &next_alloc, &state_capacity,
+                                                    &prev_states, &transition_count);
+                        continue;
                     }
-                    /* charid is now 0 if we dont know the char read, or
-                     * nonzero if we do */
-                    if ( charid ) {
 
-                        U32 check;
-                        U32 newstate = 0;
+                    wordlen++;
+                    if (is_utf8) {
+                        /* If it is UTF then it is either already folded, or
+                         * does not need folding. */
+                        uvc = valid_utf8_to_uv((const U8 *)uc, &len);
+                    }
+                    else if (folder == PL_fold_latin1) {
+                        /* This folder implies Unicode rules, which in the
+                         * range expressible by not UTF is the lower case,
+                         * with the two exceptions, one of which should have
+                         * been taken care of before calling this. */
+                        assert(*uc != LATIN_SMALL_LETTER_SHARP_S);
+                        uvc = toLOWER_L1(*uc);
+                        if (UNLIKELY(uvc == MICRO_SIGN))
+                            uvc = GREEK_SMALL_LETTER_MU;
+                        len = 1;
+                    }
+                    else {
+                        /* Raw data, will be folded later if needed. */
+                        uvc = (U32)*uc;
+                        len = 1;
+                    }
+                    TRIE_CHARCOUNT(trie)++;
 
-                        charid--;
-                        if ( !trie->states[ state ].trans.list ) {
-                            TRIE_LIST_NEW( state );
+                    if (UVCHR_IS_INVARIANT(uvc))
+                        trie->prop_flags |= TRIE_CP_INVARIANT;
+                    else if (NATIVE_TO_UNI(uvc) < 256) {
+                        trie->prop_flags |= TRIE_CP_AWKWARD;
+                        trie_needs_codepoint_processing = true;
+                    }
+                    else {
+                        trie->prop_flags |= TRIE_CP_HIGH;
+                        trie_needs_codepoint_processing = true;
+                    }
+
+                    /* The trie contains every character in the folded
+                     * representation, so maxchars counts each character
+                     * visited here.  A multi-character fold can make the
+                     * actual match longer than the source word. */
+                    maxchars++;
+                    if (folder == NULL) {
+                        minchars++;
+                    }
+                    else if (foldlen > 0) {
+                        /* The remaining characters of a multi-character
+                         * fold are represented in the trie, but they do not
+                         * consume additional source characters. */
+                        foldlen -= (UTF) ? UTF8SKIP(uc) : 1;
+                    }
+                    else {
+                        minchars++;
+                        /* Count the first character of a fold normally, then
+                         * suppress the additional folded characters from the
+                         * minimum.  foldlen is measured in source octets. */
+                        if (UTF) {
+                            if ((foldlen = is_MULTI_CHAR_FOLD_utf8_safe(uc, e)))
+                                foldlen -= UTF8SKIP(uc);
                         }
-                        for ( check = 1;
-                              check <= TRIE_LIST_USED( state );
-                              check++ )
-                        {
-                            if ( TRIE_LIST_ITEM( state, check ).forid
-                                                                    == charid )
-                            {
-                                newstate = TRIE_LIST_ITEM( state, check ).newstate;
-                                break;
-                            }
+                        else if ((foldlen = is_MULTI_CHAR_FOLD_latin1_safe(uc, e)))
+                            foldlen--;
+                    }
+
+                    if ( trie_needs_codepoint_processing ) {
+                        const U8 *bp;
+                        const U8 *ep;
+                        U8 encoded[UTF8_MAXBYTES + 1];
+
+                        if (!is_utf8 && FITS_IN_8_BITS(uvc)) {
+                            const native_octet_utf8_t * const octet =
+                                &PL_native_octet_utf8[(U8)uvc];
+                            bp = octet->bytes;
+                            ep = bp + octet->len;
                         }
-                        if ( ! newstate ) {
-                            newstate = next_alloc++;
-                            prev_states[newstate] = state;
-                            TRIE_LIST_PUSH( state, charid, newstate );
-                            transcount++;
+                        else {
+                            UV unicode_uv = uvc;
+                            /* The trie is always encoded as UTF-8.  Convert a
+                             * native source codepoint only for this encoding
+                             * step; keep uvc in its source representation for
+                             * the rest of the pass. */
+                            if (!is_utf8)
+                                unicode_uv = NATIVE_TO_UNI(uvc);
+                            ep = uvoffuni_to_utf8_flags(encoded, unicode_uv, 0);
+                            bp = encoded;
                         }
-                        state = newstate;
+
+                        for ( ; bp < ep; bp++)
+                            S_trie_list_transition(trie, &state, *bp,
+                                                    &next_alloc, &state_capacity,
+                                                    &prev_states, &transition_count);
                     } else {
-                        croak("panic! In trie construction, no char mapping for %" IVdf, uvc );
+                        S_trie_list_transition(trie, &state, uvc,
+                                                &next_alloc, &state_capacity,
+                                                &prev_states, &transition_count);
                     }
                 }
             } else {
                 /* If we end up here it is because we skipped past a NOTHING, but did not end up
                  * on a trieable type. So we need to reset noper back to point at the first regop
-                 * in the branch before we call TRIE_HANDLE_WORD()
+                 * in the branch before we record the word
                 */
                 noper = REGNODE_AFTER(cur);
             }
-            TRIE_HANDLE_WORD(state);
+            if (cur == first) {
+                trie->minlen = minchars;
+                trie->maxlen = maxchars;
+            }
+            else if (minchars < trie->minlen) {
+                trie->minlen = minchars;
+            }
+            else if (maxchars > trie->maxlen) {
+                trie->maxlen = maxchars;
+            }
+            {
+                U32 dupe = trie->states[state].wordnum;
+                regnode * const noper_next = regnext(noper);
 
-        } /* end second pass */
+                DEBUG_r({
+                    /* Store the word for dumping. */
+                    SV *tmp;
+                    if (OP(noper) != NOTHING)
+                        tmp = newSVpvn_utf8(STRING(noper), STR_LEN(noper), UTF);
+                    else
+                        tmp = newSVpvn_utf8("", 0, UTF);
+                    av_push_simple(trie_words, tmp);
+                });
+
+                curword++;
+                assert(curword <= word_count);
+                trie->wordinfo[curword].prev = 0;
+                trie->wordinfo[curword].len = wordlen;
+                trie->wordinfo[curword].accept = state;
+
+                /* If this branch continues past its exact node, preserve the
+                 * continuation and the capture-state values associated with
+                 * the branch.  Replacing the branch chain with one trie node
+                 * would otherwise discard that control-flow information. */
+                if (noper_next < tail) {
+                    if (!trie->jump) {
+                        trie->jump = (TRIE_JUMP_TYPE *)
+                            PerlMemShared_calloc(word_count + 1,
+                                                 sizeof(TRIE_JUMP_TYPE));
+                        trie->j_before_paren = (U16 *)
+                            PerlMemShared_calloc(word_count + 1, sizeof(U16));
+                        trie->j_after_paren = (U16 *)
+                            PerlMemShared_calloc(word_count + 1, sizeof(U16));
+                    }
+                    assert(noper_next > convert);
+                    assert(curword <= word_count);
+                    assert(!trie->jump[curword]);
+                    assert((noper_next - convert) >= 0);
+                    assert((noper_next - convert) <= TRIE_JUMP_TYPE_MAX);
+                    trie->jump[curword] = noper_next - convert;
+                    U16 set_before_paren;
+                    U16 set_after_paren;
+                    if (OP(cur) == BRANCH) {
+                        set_before_paren = ARG1a(cur);
+                        set_after_paren = ARG1b(cur);
+                    }
+                    else {
+                        set_before_paren = ARG2a(cur);
+                        set_after_paren = ARG2b(cur);
+                    }
+                    trie->j_before_paren[curword] = set_before_paren;
+                    trie->j_after_paren[curword] = set_after_paren;
+                    if (!jumper)
+                        jumper = noper_next;
+                    if (!nextbranch)
+                        nextbranch = regnext(cur);
+                }
+
+                if (dupe) {
+                    /* It's a duplicate.  Pre-insert it into the
+                     * wordinfo[].prev chain so duplicate words appear in
+                     * the chain when it is linked below. */
+                    trie->wordinfo[curword].prev = trie->wordinfo[dupe].prev;
+                    trie->wordinfo[dupe].prev = curword;
+                }
+                else {
+                    trie->states[state].wordnum = curword;
+                }
+            }
+
+        } /* end list construction */
+
+        /* The list pass has also completed the source analysis. */
+#ifdef DEBUGGING
+        Zero(trie->bitmap, sizeof(trie->bitmap), U8);
+#endif
+        trie->before_paren = OP(first) == BRANCH
+                     ? ARG1a(first)
+                     : ARG2a(first); /* BRANCHJ */
+
+        trie->after_paren = OP(lastbranch) == BRANCH
+                     ? ARG1b(lastbranch)
+                     : ARG2b(lastbranch); /* BRANCHJ */
+        DEBUG_TRIE_COMPILE_r(
+            re_indentf(
+                    "TRIE(%s): W:%d C:%d Uq:%d Min:%d Max:%d\n",
+                    depth+1,
+                    ( trie_needs_codepoint_processing ? "PROCESSED" : "RAW" ), (int)word_count,
+                    (int)TRIE_CHARCOUNT(trie), TRIE_ALPHABET_SIZE,
+                    (int)trie->minlen, (int)trie->maxlen )
+        );
 
         /* next alloc is the NEXT state to be allocated */
         trie->statecount = next_alloc;
@@ -1042,17 +975,29 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                    * sizeof(reg_trie_state) );
 
         /* and now dump it out before we compress it */
-        DEBUG_TRIE_COMPILE_MORE_r(dump_trie_interim_list(trie, widecharmap,
-                                                         revcharmap, next_alloc,
+        DEBUG_TRIE_COMPILE_MORE_r(dump_trie_interim_list(trie, next_alloc,
                                                          depth+1)
         );
 
+        /* The list compiler has counted each distinct transition.  The flat
+         * table has an unused slot zero, so this is the ideal number of
+         * occupied entries.  The table itself may need more physical slots
+         * because a state's character-ID range can contain holes. */
+#ifdef DEBUGGING
+        const STRLEN ideal_transition_count = transition_count - 1;
+#endif
+        STRLEN transition_capacity = transition_count;
         trie->trans = (reg_trie_trans *)
-            PerlMemShared_calloc( transcount, sizeof(reg_trie_trans) );
+            PerlMemShared_calloc( transition_capacity,
+                                  sizeof(reg_trie_trans) );
         {
             U32 state;
-            U32 tp = 0;
-            U32 zp = 0;
+            /* table_highwater is one past the packed portion of trie->trans;
+             * next_hole is the first unused slot within that portion.  A
+             * non-zero next field marks an occupied slot, so holes can be
+             * reused without a separate occupancy map. */
+            U32 table_highwater = 0;
+            U32 next_hole = 0;
 
 
             for( state = 1; state < next_alloc; state ++ ) {
@@ -1060,63 +1005,135 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
                 /*
                 DEBUG_TRIE_COMPILE_MORE_r(
-                    re_printf("tp: %d zp: %d ",tp,zp)
+                    re_printf("table_highwater: %d next_hole: %d ",
+                              table_highwater, next_hole)
                 );
                 */
 
                 if (trie->states[state].trans.list) {
-                    U32 minid = TRIE_LIST_ITEM( state, 1).forid;
-                    U32 maxid = minid;
+                    const U32 used = TRIE_LIST_USED( state );
+                    const U32 minid = TRIE_LIST_ITEM( state, 1).forid;
+                    const U32 maxid = TRIE_LIST_ITEM( state, used).forid;
+                    const U32 frame_span = maxid - minid;
+                    const U32 frame_width = frame_span + 1;
+                    bool placed = false;
                     U32 idx;
 
-                    for( idx = 2 ; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
-                        const U32 forid = TRIE_LIST_ITEM( state, idx).forid;
-                        if ( forid < minid ) {
-                            minid = forid;
-                        } else if ( forid > maxid ) {
-                            maxid = forid;
+                    /* A state's transitions form a frame from minid through
+                     * maxid.  Sparse frames may fit into holes left by earlier
+                     * frames.  Try the first available position.  The
+                     * frame may extend beyond table_highwater, provided it
+                     * fits in the allocation and its occupied slots do not
+                     * clash. */
+                    while (next_hole < table_highwater
+                            && trie->trans[next_hole].next)
+                        next_hole++;
+                    /* Only sparse frames benefit from hole searching.  Small
+                     * frames are cheap to try, while larger frames are tried
+                     * only when their span is much wider than their payload. */
+                    if (used > 1 && (used <= 4 || used * 8 < frame_span)
+                            && next_hole < table_highwater
+                            && next_hole + frame_width >= next_hole) {
+                        const U32 candidate_end = next_hole + frame_width;
+                        if (transition_capacity < candidate_end) {
+                            const U32 old_capacity = transition_capacity;
+                            const U32 needed = candidate_end;
+
+                            while (transition_capacity < needed)
+                                transition_capacity *= 2;
+                            trie->trans = (reg_trie_trans *)
+                                PerlMemShared_realloc(
+                                    trie->trans,
+                                    transition_capacity
+                                      * sizeof(reg_trie_trans) );
+                            Zero( trie->trans + old_capacity,
+                                  transition_capacity - old_capacity,
+                                  reg_trie_trans );
+                        }
+                        for (idx = 1; idx <= used; idx++) {
+                            const U32 tid = next_hole
+                                           + TRIE_LIST_ITEM( state, idx ).forid
+                                           - minid;
+                            if (trie->trans[ tid ].next)
+                                break;
+                        }
+                        if (idx > used) {
+                            base = TRIE_ALPHABET_SIZE + next_hole - minid;
+                            for (idx = 1; idx <= used; idx++) {
+                                const U32 tid = base
+                                               - TRIE_ALPHABET_SIZE
+                                               + TRIE_LIST_ITEM( state, idx ).forid;
+                                trie->trans[ tid ].next = TRIE_LIST_ITEM( state,
+                                                                    idx ).newstate;
+                                trie->trans[ tid ].check = state;
+                            }
+                            if (candidate_end > table_highwater)
+                                table_highwater = candidate_end;
+                            while (next_hole < table_highwater
+                                    && trie->trans[next_hole].next)
+                                next_hole++;
+                            placed = true;
                         }
                     }
-                    if ( transcount < tp + maxid - minid + 1) {
-                        transcount *= 2;
+
+                    /* Grow the physical table when the frame cannot fit at
+                     * the current high-water mark. */
+                    if (!placed
+                            && transition_capacity < table_highwater + frame_width) {
+                        const U32 old_capacity = transition_capacity;
+                        const U32 needed = table_highwater + frame_width;
+
+                        while (transition_capacity < needed)
+                            transition_capacity *= 2;
                         trie->trans = (reg_trie_trans *)
                             PerlMemShared_realloc( trie->trans,
-                                                     transcount
+                                                     transition_capacity
                                                      * sizeof(reg_trie_trans) );
-                        Zero( trie->trans + (transcount / 2),
-                              transcount / 2,
+                        Zero( trie->trans + old_capacity,
+                              transition_capacity - old_capacity,
                               reg_trie_trans );
                     }
-                    base = trie->uniquecharcount + tp - minid;
-                    if ( maxid == minid ) {
+                    if (!placed) {
+                        base = TRIE_ALPHABET_SIZE + table_highwater - minid;
+                    }
+                    /* A one-transition frame can occupy one existing hole;
+                     * it does not need its full frame width to be reserved. */
+                    if ( !placed && maxid == minid ) {
                         U32 set = 0;
-                        for ( ; zp < tp ; zp++ ) {
-                            if ( ! trie->trans[ zp ].next ) {
-                                base = trie->uniquecharcount + zp - minid;
-                                trie->trans[ zp ].next = TRIE_LIST_ITEM( state,
+                        for ( ; next_hole < table_highwater ; next_hole++ ) {
+                            if ( ! trie->trans[ next_hole ].next ) {
+                                base = TRIE_ALPHABET_SIZE + next_hole - minid;
+                                trie->trans[ next_hole ].next = TRIE_LIST_ITEM( state,
                                                                    1).newstate;
-                                trie->trans[ zp ].check = state;
+                                trie->trans[ next_hole ].check = state;
                                 set = 1;
                                 break;
                             }
                         }
                         if ( !set ) {
-                            trie->trans[ tp ].next = TRIE_LIST_ITEM( state,
+                            trie->trans[ table_highwater ].next = TRIE_LIST_ITEM( state,
                                                                    1).newstate;
-                            trie->trans[ tp ].check = state;
-                            tp++;
-                            zp = tp;
+                            trie->trans[ table_highwater ].check = state;
+                            table_highwater++;
+                            next_hole = table_highwater;
+                        } else {
+                            while (next_hole < table_highwater
+                                    && trie->trans[next_hole].next)
+                                next_hole++;
                         }
-                    } else {
+                    } else if (!placed) {
                         for ( idx = 1; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
                             const U32 tid = base
-                                           - trie->uniquecharcount
+                                           - TRIE_ALPHABET_SIZE
                                            + TRIE_LIST_ITEM( state, idx ).forid;
                             trie->trans[ tid ].next = TRIE_LIST_ITEM( state,
                                                                 idx ).newstate;
                             trie->trans[ tid ].check = state;
                         }
-                        tp += ( maxid - minid + 1 );
+                        table_highwater += frame_width;
+                        while (next_hole < table_highwater
+                                && trie->trans[next_hole].next)
+                            next_hole++;
                     }
                     Safefree(trie->states[ state ].trans.list);
                 }
@@ -1127,259 +1144,23 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 */
                 trie->states[ state ].trans.base = base;
             }
-            trie->lasttrans = tp + 1;
-        }
-    } else {
-        /*
-           Second Pass -- Flat Table Representation.
-
-           we dont use the 0 slot of either trans[] or states[] so we add 1 to
-           each.  We know that we will need Charcount+1 trans at most to store
-           the data (one row per char at worst case) So we preallocate both
-           structures assuming worst case.
-
-           We then construct the trie using only the .next slots of the entry
-           structs.
-
-           We use the .check field of the first entry of the node temporarily
-           to make compression both faster and easier by keeping track of how
-           many non zero fields are in the node.
-
-           Since trans are numbered from 1 any 0 pointer in the table is a FAIL
-           transition.
-
-           There are two terms at use here: state as a TRIE_NODEIDX() which is
-           a number representing the first entry of the node, and state as a
-           TRIE_NODENUM() which is the trans number. state 1 is TRIE_NODEIDX(1)
-           and TRIE_NODENUM(1), state 2 is TRIE_NODEIDX(2) and TRIE_NODENUM(3)
-           if there are 2 entrys per node. eg:
-
-             A B       A B
-          1. 2 4    1. 3 7
-          2. 0 3    3. 0 5
-          3. 0 0    5. 0 0
-          4. 0 0    7. 0 0
-
-           The table is internally in the right hand, idx form. However as we
-           also have to deal with the states array which is indexed by nodenum
-           we have to use TRIE_NODENUM() to convert.
-
-        */
-        DEBUG_TRIE_COMPILE_MORE_r( re_indentf("Compiling trie using table compiler\n",
-            depth+1));
-
-        trie->trans = (reg_trie_trans *)
-            PerlMemShared_calloc( ( TRIE_CHARCOUNT(trie) + 1 )
-                                  * trie->uniquecharcount + 1,
-                                  sizeof(reg_trie_trans) );
-        trie->states = (reg_trie_state *)
-            PerlMemShared_calloc( TRIE_CHARCOUNT(trie) + 2,
-                                  sizeof(reg_trie_state) );
-        next_alloc = trie->uniquecharcount + 1;
-
-
-        for ( cur = first ; cur < last ; cur = regnext( cur ) ) {
-
-            regnode *noper   = REGNODE_AFTER( cur );
-
-            U32 state        = 1;         /* required init */
-
-            U32 charid       = 0;         /* sanity init */
-            U32 accept_state = 0;         /* sanity init */
-
-            U32 wordlen      = 0;         /* required init */
-
-            if (OP(noper) == NOTHING) {
-                regnode *noper_next= regnext(noper);
-                if (noper_next < tail)
-                    noper = noper_next;
-                /* we will undo this assignment if noper does not
-                 * point at a trieable type in the else clause of
-                 * the following statement. */
-            }
-
-            if (    noper < tail
-                && (    OP(noper) == flags
-                    || (flags == EXACT && OP(noper) == EXACT_REQ8)
-                    || (flags == EXACTFU && (   OP(noper) == EXACTFU_REQ8
-                                             || OP(noper) == EXACTFUP))))
-            {
-                const U8 *uc= (U8*)STRING(noper);
-                const U8 *e= uc + STR_LEN(noper);
-
-                for ( ; uc < e ; uc += len ) {
-
-                    TRIE_READ_CHAR;
-
-                    if ( uvc < 256 ) {
-                        charid = trie->charmap[ uvc ];
-                    } else {
-                        SV* const * const svpp = hv_fetch( widecharmap,
-                                                           (char*)&uvc,
-                                                           sizeof( UV ),
-                                                           0);
-                        charid = svpp ? (U32)SvIV(*svpp) : 0;
-                    }
-                    if ( charid ) {
-                        charid--;
-                        if ( !trie->trans[ state + charid ].next ) {
-                            trie->trans[ state + charid ].next = next_alloc;
-                            trie->trans[ state ].check++;
-                            prev_states[TRIE_NODENUM(next_alloc)]
-                                    = TRIE_NODENUM(state);
-                            next_alloc += trie->uniquecharcount;
-                        }
-                        state = trie->trans[ state + charid ].next;
-                    } else {
-                        croak("panic! In trie construction, no char mapping for %" IVdf, uvc );
-                    }
-                    /* charid is now 0 if we dont know the char read, or
-                     * nonzero if we do */
-                }
-            } else {
-                /* If we end up here it is because we skipped past a NOTHING, but did not end up
-                 * on a trieable type. So we need to reset noper back to point at the first regop
-                 * in the branch before we call TRIE_HANDLE_WORD().
-                */
-                noper = REGNODE_AFTER(cur);
-            }
-            accept_state = TRIE_NODENUM( state );
-            TRIE_HANDLE_WORD(accept_state);
-
-        } /* end second pass */
-
-        /* and now dump it out before we compress it */
-        DEBUG_TRIE_COMPILE_MORE_r(dump_trie_interim_table(trie, widecharmap,
-                                                          revcharmap,
-                                                          next_alloc, depth+1));
-
-        {
-        /*
-           * Inplace compress the table.*
-
-           For sparse data sets the table constructed by the trie algorithm will
-           be mostly 0/FAIL transitions or to put it another way mostly empty.
-           (Note that leaf nodes will not contain any transitions.)
-
-           This algorithm compresses the tables by eliminating most such
-           transitions, at the cost of a modest bit of extra work during lookup:
-
-           - Each states[] entry contains a .base field which indicates the
-           index in the state[] array wheres its transition data is stored.
-
-           - If .base is 0 there are no valid transitions from that node.
-
-           - If .base is nonzero then charid is added to it to find an entry in
-           the trans array.
-
-           -If trans[states[state].base+charid].check!=state then the
-           transition is taken to be a 0/Fail transition. Thus if there are fail
-           transitions at the front of the node then the .base offset will point
-           somewhere inside the previous nodes data (or maybe even into a node
-           even earlier), but the .check field determines if the transition is
-           valid.
-
-           XXX - wrong maybe?
-           The following process inplace converts the table to the compressed
-           table: We first do not compress the root node 1,and mark all its
-           .check pointers as 1 and set its .base pointer as 1 as well. This
-           allows us to do a DFA construction from the compressed table later,
-           and ensures that any .base pointers we calculate later are greater
-           than 0.
-
-           - We set 'pos' to indicate the first entry of the second node.
-
-           - We then iterate over the columns of the node, finding the first and
-           last used entry at l and m. We then copy l..m into pos..(pos+m-l),
-           and set the .check pointers accordingly, and advance pos
-           appropriately and repreat for the next node. Note that when we copy
-           the next pointers we have to convert them from the original
-           NODEIDX form to NODENUM form as the former is not valid post
-           compression.
-
-           - If a node has no transitions used we mark its base as 0 and do not
-           advance the pos pointer.
-
-           - If a node only has one transition we use a second pointer into the
-           structure to fill in allocated fail transitions from other states.
-           This pointer is independent of the main pointer and scans forward
-           looking for null transitions that are allocated to a state. When it
-           finds one it writes the single transition into the "hole".  If the
-           pointer doesnt find one the single transition is appended as normal.
-
-           - Once compressed we can Renew/realloc the structures to release the
-           excess space.
-
-           See "Table-Compression Methods" in sec 3.9 of the Red Dragon,
-           specifically Fig 3.47 and the associated pseudocode.
-
-           demq
-        */
-        const U32 laststate = TRIE_NODENUM( next_alloc );
-        U32 state, charid;
-        U32 pos = 0, zp = 0;
-        trie->statecount = laststate;
-
-        for ( state = 1 ; state < laststate ; state++ ) {
-            U8 flag = 0;
-            const U32 stateidx = TRIE_NODEIDX( state );
-            const U32 o_used = trie->trans[ stateidx ].check;
-            U32 used = trie->trans[ stateidx ].check;
-            trie->trans[ stateidx ].check = 0;
-
-            for ( charid = 0;
-                  used && charid < trie->uniquecharcount;
-                  charid++ )
-            {
-                if ( flag || trie->trans[ stateidx + charid ].next ) {
-                    if ( trie->trans[ stateidx + charid ].next ) {
-                        if (o_used == 1) {
-                            for ( ; zp < pos ; zp++ ) {
-                                if ( ! trie->trans[ zp ].next ) {
-                                    break;
-                                }
-                            }
-                            trie->states[ state ].trans.base
-                                                    = zp
-                                                      + trie->uniquecharcount
-                                                      - charid ;
-                            trie->trans[ zp ].next
-                                = SAFE_TRIE_NODENUM( trie->trans[ stateidx
-                                                             + charid ].next );
-                            trie->trans[ zp ].check = state;
-                            if ( ++zp > pos ) pos = zp;
-                            break;
-                        }
-                        used--;
-                    }
-                    if ( !flag ) {
-                        flag = 1;
-                        trie->states[ state ].trans.base
-                                       = pos + trie->uniquecharcount - charid ;
-                    }
-                    trie->trans[ pos ].next
-                        = SAFE_TRIE_NODENUM(
-                                       trie->trans[ stateidx + charid ].next );
-                    trie->trans[ pos ].check = state;
-                    pos++;
-                }
-            }
-        }
-        trie->lasttrans = pos + 1;
-        trie->states = (reg_trie_state *)
-            PerlMemShared_realloc( trie->states, laststate
-                                   * sizeof(reg_trie_state) );
-        DEBUG_TRIE_COMPILE_MORE_r(
-            re_indentf("Alloc: %d Orig: %" IVdf " elements, Final:%" IVdf ". Savings of %%%5.2f\n",
-                depth+1,
-                (int)( ( TRIE_CHARCOUNT(trie) + 1 ) * trie->uniquecharcount
-                       + 1 ),
-                (IV)next_alloc,
-                (IV)pos,
-                ( ( next_alloc - pos ) * 100 ) / (double)next_alloc );
+            /* Slot zero is reserved by the packed-table representation; keep
+             * it in the recorded range even when table_highwater is zero. */
+            trie->lasttrans = table_highwater + 1;
+            assert(next_hole <= table_highwater);
+            assert(table_highwater <= transition_capacity);
+            DEBUG_TRIE_COMPILE_MORE_r(
+                re_indentf("Compressed table: physical=%" UVuf
+                           " ideal=%" UVuf " overhead=%" UVuf "\n",
+                    depth+1,
+                    (UV)table_highwater,
+                    (UV)ideal_transition_count,
+                    (UV)(table_highwater - ideal_transition_count))
             );
-
-        } /* end table compress */
+            DEBUG_TRIE_COMPILE_MORE_r(
+                dump_trie_physical(trie, table_highwater, depth+1)
+            );
+        }
     }
     DEBUG_TRIE_COMPILE_MORE_r(
             re_indentf("Statecount:%" UVxf " Lasttrans:%" UVxf "\n",
@@ -1396,10 +1177,20 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         U8 nodetype =(U8) flags;
         U8 trie_op = TRIE;
         char *str = NULL;
+        U8 original_len = 0;
+        U8 original_string[256];
+        U32 original_next = 0;
+        const U32 original_minlen = trie->minlen;
+        const U32 original_maxlen = trie->maxlen;
 
 #ifdef DEBUGGING
         regnode *optimize = NULL;
 #endif /* DEBUGGING */
+        if (trie->jump) {
+            original_len = STR_LEN(convert);
+            Copy(STRING(convert), original_string, original_len, U8);
+            original_next = TRIE_NEXT(convert);
+        }
         /* make sure we have enough room to inject the TRIE op */
         assert((!trie->jump) || !trie->jump[1] ||
                 (trie->jump[1] >= (sizeof(tregnode_TRIE)/sizeof(struct regnode))));
@@ -1419,62 +1210,183 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         }
         /* But first we check to see if there is a common prefix we can
            split out as an EXACT and put in front of the TRIE node.  */
-        trie->startstate= 1;
-        if ( trie->bitmap && !widecharmap && !trie->jump  ) {
+        trie->startstate = 1;
+        DEBUG_TRIE_COMPILE_MORE_r({
+            re_printf("Trie prefix probe: mode=%u ranges=%#x\n",
+                      (unsigned)(trie->prop_flags & TRIE_FOLD_MASK),
+                      (unsigned)(trie->prop_flags & (TRIE_CP_INVARIANT
+                                                     | TRIE_CP_AWKWARD
+                                                     | TRIE_CP_HIGH)));
+            if (trie_needs_codepoint_processing) {
+                U32 debug_state = 1;
+                U32 debug_octets = 0;
+                U32 debug_complete_octets = 0;
+                U32 debug_chars = 0;
+                U32 debug_need = 0;
+                U8 debug_prefix[256];
+
+                re_printf("Octet trie prefix probe:\n");
+                while (debug_state < trie->statecount - 1
+                       && debug_octets < sizeof(debug_prefix)) {
+                    U32 ofs;
+                    U32 count = trie->states[debug_state].wordnum ? 1 : 0;
+                    U32 transition = 0;
+                    const U32 min_octet =
+                        trie->states[debug_state].min_octet;
+                    const U32 max_octet =
+                        trie->states[debug_state].max_octet;
+
+                    for (ofs = min_octet; ofs <= max_octet; ofs++) {
+                        const U32 index = trie->states[debug_state].trans.base
+                                        + ofs - TRIE_ALPHABET_SIZE;
+                        if (trie->states[debug_state].trans.base + ofs
+                                >= TRIE_ALPHABET_SIZE
+                            && index < trie->lasttrans
+                            && trie->trans[index].check == debug_state) {
+                            count++;
+                            transition = ofs;
+                        }
+                    }
+                    if (count != 1)
+                        break;
+
+                    debug_prefix[debug_octets++] = (U8)transition;
+                    if (!debug_need) {
+                        if (transition < 0x80)
+                            debug_need = 0;
+                        else if (transition < 0xe0)
+                            debug_need = 1;
+                        else if (transition < 0xf0)
+                            debug_need = 2;
+                        else
+                            debug_need = 3;
+                    }
+                    else
+                        debug_need--;
+                    if (!debug_need) {
+                        debug_complete_octets = debug_octets;
+                        debug_chars++;
+                    }
+                    debug_state++;
+                }
+                re_printf("  states=%u octets=%u complete_octets=%u chars=%u "
+                          "tail_octets=%u\n", (unsigned)debug_state,
+                          (unsigned)debug_octets, (unsigned)debug_complete_octets,
+                          (unsigned)debug_chars, (unsigned)debug_need);
+                re_printf("  raw prefix:");
+                for (debug_octets = 0; debug_octets < debug_complete_octets;
+                     debug_octets++)
+                    re_printf(" %02x", (unsigned)debug_prefix[debug_octets]);
+                re_printf("\n");
+            }
+        });
+        /* Extract a common prefix only when it is safe to remove complete
+         * characters from the trie.  Raw invariant tries consume one octet
+         * per character.  Processed tries must stop at UTF-8 codepoint
+         * boundaries; native processed tries also reject an awkward encoded
+         * transition (TRIE-PREFIX-XX) rather than treating its first octet as
+         * a complete character. */
+        if ( (!trie_needs_codepoint_processing || UTF) ) {
             /* we want to find the first state that has more than
              * one transition, if that state is not the first state
              * then we have a common prefix which we can remove.
              */
             U32 state;
+            U32 complete_state = 1;
+            /* prefixlen_octets and prefixlen_chars have different units in
+             * the processed path.  complete_state is the first trie state
+             * left after the complete prefix has been extracted. */
+            U32 complete_octets = 0;
+            U32 complete_chars = 0;
+            U8 utf8_prefix[256];
+
+            if (trie_needs_codepoint_processing) {
+                U32 octets = 0;
+                U32 chars = 0;
+                U32 need = 0;
+
+                state = 1;
+                /* The final state has no outgoing transition and is not a
+                 * prefix state, so stop before statecount - 1. */
+                while (state < trie->statecount - 1
+                       && octets < sizeof(utf8_prefix)) {
+                    U32 ofs;
+                    U32 count = trie->states[state].wordnum ? 1 : 0;
+                    U32 next_state = 0;
+                    const U32 base = trie->states[state].trans.base;
+                    const U32 min_octet = trie->states[state].min_octet;
+                    const U32 max_octet = trie->states[state].max_octet;
+
+                    for (ofs = min_octet; ofs <= max_octet; ofs++) {
+                        if (base + ofs >= TRIE_ALPHABET_SIZE
+                            && base + ofs - TRIE_ALPHABET_SIZE < trie->lasttrans
+                            && trie->trans[base + ofs - TRIE_ALPHABET_SIZE].check == state) {
+                            if (++count > 1)
+                                break;
+                            next_state = trie->trans[base + ofs
+                                                   - TRIE_ALPHABET_SIZE].next;
+                            utf8_prefix[octets] = (U8)ofs;
+                        }
+                    }
+                    if (count != 1)
+                        break;
+
+                    if (!need) {
+                        /* The trie contains only valid UTF-8 sequences, so
+                         * UTF8SKIP() gives the number of octets remaining in
+                         * this codepoint. */
+                        need = UTF8SKIP(&utf8_prefix[octets]) - 1;
+                    }
+                    else if (!UTF8_IS_CONTINUATION(utf8_prefix[octets]))
+                        break;
+                    else
+                        need--;
+
+                    octets++;
+                    state = next_state;
+                    if (!need) {
+                        complete_state = state;
+                        complete_octets = octets;
+                        complete_chars = ++chars;
+                    }
+                }
+                state = complete_state;
+                if (complete_octets) {
+                    OP(convert) = nodetype;
+                    str = STRING(convert);
+                    setSTR_LEN(convert, 0);
+                    /* The replacement EXACT node stores its string length in
+                     * an octet, so the extracted prefix must fit in 255. */
+                    assert(STR_LEN(convert) + complete_octets < 256);
+                    Copy(utf8_prefix, str, complete_octets, U8);
+                    str += complete_octets;
+                    setSTR_LEN(convert, (U8)complete_octets);
+                }
+            }
+            else {
+            /* The final state has no outgoing transition and is not a prefix
+             * state, so stop before statecount - 1. */
             for ( state = 1 ; state < trie->statecount-1 ; state++ ) {
                 U32 ofs = 0;
                 I32 first_ofs = -1; /* keeps track of the ofs of the first
                                        transition, -1 means none */
                 U32 count = 0;
                 const U32 base = trie->states[ state ].trans.base;
+                const U32 min_octet = trie->states[state].min_octet;
+                const U32 max_octet = trie->states[state].max_octet;
 
                 /* does this state terminate an alternation? */
                 if ( trie->states[state].wordnum )
                         count = 1;
 
-                for ( ofs = 0 ; ofs < trie->uniquecharcount ; ofs++ ) {
-                    if ( ( base + ofs >= trie->uniquecharcount ) &&
-                         ( base + ofs - trie->uniquecharcount < trie->lasttrans ) &&
-                         trie->trans[ base + ofs - trie->uniquecharcount ].check == state )
+                for ( ofs = min_octet ; ofs <= max_octet ; ofs++ ) {
+                    if ( ( base + ofs >= TRIE_ALPHABET_SIZE ) &&
+                         ( base + ofs - TRIE_ALPHABET_SIZE < trie->lasttrans ) &&
+                         trie->trans[ base + ofs - TRIE_ALPHABET_SIZE ].check == state )
                     {
                         if ( ++count > 1 ) {
-                            /* we have more than one transition */
-                            SV **tmp;
-                            U8 *ch;
-                            /* if this is the first state there is no common prefix
-                             * to extract, so we can exit */
-                            if ( state == 1 ) break;
-                            tmp = av_fetch_simple( revcharmap, ofs, 0);
-                            ch = (U8*)SvPV_nolen_const( *tmp );
-
-                            /* if we are on count 2 then we need to initialize the
-                             * bitmap, and store the previous char if there was one
-                             * in it*/
-                            if ( count == 2 ) {
-                                /* clear the bitmap */
-                                Zero(trie->bitmap, ANYOF_BITMAP_SIZE, char);
-                                DEBUG_OPTIMISE_r(
-                                    re_indentf("New Start State = %" UVuf " Class: [",
-                                        depth+1,
-                                        (UV)state));
-                                if (first_ofs >= 0) {
-                                    SV ** const tmp = av_fetch_simple( revcharmap, first_ofs, 0);
-                                    const U8 * const ch = (U8*)SvPV_nolen_const( *tmp );
-
-                                    S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, *ch, folder);
-                                    DEBUG_OPTIMISE_r(
-                                        re_printf("%s", (char*)ch)
-                                    );
-                                }
-                            }
-                            /* store the current firstchar in the bitmap */
-                            S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, *ch, folder);
-                            DEBUG_OPTIMISE_r(re_printf("%s", ch));
+                            /* more than one transition here, so we can exit the loop */
+                            break;
                         }
                         first_ofs = ofs;
                     }
@@ -1483,17 +1395,19 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     /* This state has only one transition, its transition is part
                      * of a common prefix - we need to concatenate the char it
                      * represents to what we have so far. */
-                    SV **tmp = av_fetch_simple( revcharmap, first_ofs, 0);
                     STRLEN len;
-                    char *ch = SvPV( *tmp, len );
+                    char *ch;
+                    U8 octet;
+                    octet = (U8)first_ofs;
+                    ch = (char *)&octet;
+                    len = 1;
                     DEBUG_OPTIMISE_r({
                         SV *sv = sv_newmortal();
                         re_indentf("Prefix State: %" UVuf " Ofs: %" UVuf " Char: '%s'\n",
                             depth+1,
                             (UV)state, (UV)first_ofs,
-                            pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), 6,
+                            pv_pretty(sv, ch, len, 6,
                                 PL_colors[0], PL_colors[1],
-                                (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0) |
                                 PERL_PV_ESCAPE_FIRSTCHAR
                             )
                         );
@@ -1503,6 +1417,8 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         str = STRING(convert);
                         setSTR_LEN(convert, 0);
                     }
+                    /* The replacement EXACT node stores its string length in
+                     * an octet, so the extracted prefix must fit in 255. */
                     assert( ( STR_LEN(convert) + len ) < 256 );
                     setSTR_LEN(convert, (U8)(STR_LEN(convert) + len));
                     while (len--)
@@ -1515,58 +1431,92 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     break;
                 }
             }
-            trie->prefixlen = (state-1);
+            trie->prefixlen_octets = (state-1);
+            trie->prefixlen_chars = (state-1);
+            }
+            if (trie_needs_codepoint_processing) {
+                trie->prefixlen_octets = complete_octets;
+                trie->prefixlen_chars = complete_chars;
+            }
             if (str) {
+                /* A non-NULL str means that at least one common prefix
+                 * character was copied out of the trie and into convert. */
                 regnode *n = REGNODE_AFTER(convert);
-                TRIE_NEXT_set(convert, n - convert);
-                trie->startstate = state;
-                trie->minlen -= (state - 1);
-                trie->maxlen -= (state - 1);
+                if (trie->jump && trie->jump[1]
+                    && (SSize_t)trie->jump[1] - (n - jump_base)
+                         < (SSize_t)(sizeof(tregnode_TRIE)
+                                     / sizeof(struct regnode))) {
+                    /* The extracted prefix left too little room for a
+                     * jump-capable trie.  Restore the source node and leave
+                     * the trie at its original location. */
+                    Copy(original_string, STRING(convert), original_len, U8);
+                    setSTR_LEN(convert, original_len);
+                    TRIE_NEXT_set(convert, original_next);
+                    trie->startstate = 1;
+                    trie->minlen = original_minlen;
+                    trie->maxlen = original_maxlen;
+                    trie->prefixlen_octets = 0;
+                    trie->prefixlen_chars = 0;
+                    trie->jump_correction = 0;
+                    str = NULL;
+                }
+                if (str) {
+                    TRIE_NEXT_set(convert, n - convert);
+                    trie->startstate = state;
+                    /* The extracted prefix is now matched by convert, so remove
+                     * its character count from the length bounds that describe
+                     * the remaining trie.  In the processed path state - 1 counts
+                     * octet states, so use prefixlen_chars rather than state - 1. */
+                    trie->minlen -= trie->prefixlen_chars;
+                    trie->maxlen -= trie->prefixlen_chars;
 #ifdef DEBUGGING
-               /* At least the UNICOS C compiler choked on this
-                * being argument to DEBUG_r(), so let's just have
-                * it right here. */
-               if (
+                    /* At least the UNICOS C compiler choked on this
+                     * being argument to DEBUG_r(), so let's just have
+                     * it right here. */
+                    if (
 #ifdef PERL_EXT_RE_BUILD
-                   1
+                        1
 #else
-                   DEBUG_r_TEST
+                        DEBUG_r_TEST
 #endif
-                   ) {
-                   U32 word = trie->wordcount;
-                   while (word--) {
-                       SV ** const tmp = av_fetch_simple( trie_words, word, 0 );
-                       if (tmp) {
-                           if ( STR_LEN(convert) <= SvCUR(*tmp) )
-                               sv_chop(*tmp, SvPV_nolen(*tmp) + STR_LEN(convert));
-                           else
-                               sv_chop(*tmp, SvPV_nolen(*tmp) + SvCUR(*tmp));
-                       }
-                   }
-               }
+                    ) {
+                        U32 word = trie->wordcount;
+                        while (word--) {
+                            SV ** const tmp = av_fetch_simple( trie_words, word, 0 );
+                            if (tmp) {
+                                if ( STR_LEN(convert) <= SvCUR(*tmp) )
+                                    sv_chop(*tmp, SvPV_nolen(*tmp) + STR_LEN(convert));
+                                else
+                                    sv_chop(*tmp, SvPV_nolen(*tmp) + SvCUR(*tmp));
+                            }
+                        }
+                    }
 #endif
-                if (trie->maxlen) {
-                    convert = n;
-                } else {
-                    TRIE_NEXT_set(convert, tail - convert);
-                    DEBUG_r(optimize= n);
+                    if (trie->maxlen || (trie->jump && str)) {
+                        if (trie->jump)
+                            trie->jump_correction = n - jump_base;
+                        convert = n;
+                    } else {
+                        trie->jump_correction = 0;
+                        TRIE_NEXT_set(convert, tail - convert);
+                        DEBUG_r(optimize= n);
+                    }
                 }
             }
         }
         if (!jumper)
             jumper = last;
-        if ( trie->maxlen ) {
+        if ( trie->maxlen || (trie->jump && str) ) {
             const U32 needed_next = tail - convert;
-            const Size_t trie_room = (
-                (trie->jump && trie->jump[1])
-                    ? trie->jump[1] * sizeof(struct regnode)
-                    : (Size_t)((char *)jumper - (char *)convert)
-            );
-            const bool want_charclass = !trie->states[trie->startstate].wordnum
-                                        && trie->bitmap;
-
-            trie_op = S_select_trie_op(aTHX_ trie_room, needed_next,
-                                       want_charclass);
+            /* The replacement trie must fit in the program space being
+             * overwritten.  Jump tries reserve their first jump distance;
+             * otherwise jumper marks the end of the replaceable region. */
+            const SSize_t jump_room = trie->jump ? TRIE_JUMP_ROOM(trie) : 0;
+            const Size_t trie_room = trie->jump && trie->jump[1]
+                ? (Size_t)jump_room * sizeof(struct regnode)
+                : (Size_t)((char *)jumper - (char *)convert);
+            assert(!trie->jump || !trie->jump[1] || jump_room >= 0);
+            trie_op = S_select_trie_op(aTHX_ trie_room, needed_next);
 
             if (!trie_op) {
                 DEBUG_TRIE_COMPILE_r(
@@ -1591,13 +1541,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 assert(trie->jump[0] == 0);
                 assert(nextbranch <= tail);
 
-                trie->jump[0] = nextbranch - convert;
-            }
-
-            if (OP(convert) == TRIEC || OP(convert) == LTRIEC) {
-                Copy(trie->bitmap, ANYOF_BITMAP(convert), ANYOF_BITMAP_SIZE, char);
-                PerlMemShared_free(trie->bitmap);
-                trie->bitmap= NULL;
+                trie->jump[0] = nextbranch - jump_base;
             }
 
             /* store the type in the flags */
@@ -1623,9 +1567,10 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         });
     } /* end node insert */
 
-    /*  Finish populating the prev field of the wordinfo array.  Walk back
-     *  from each accept state until we find another accept state, and if
-     *  so, point the first word's .prev field at the second word. If the
+    /*  Finish populating the prev field of the wordinfo array.  Starting at
+     *  each word's accept state, walk back through predecessor states until
+     *  we find the next earlier accepting state, and point the first word's
+     *  .prev field at that word. If the
      *  second already has a .prev field set, stop now. This will be the
      *  case either if we've already processed that word's accept state,
      *  or that state had multiple words, and the overspill words were
@@ -1656,14 +1601,9 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
 
     /* and now dump out the compressed format */
-    DEBUG_TRIE_COMPILE_r(dump_trie(trie, widecharmap, revcharmap, depth+1));
-
-    RExC_rxi->data->data[ data_slot + 1 ] = (void*)widecharmap;
+    DEBUG_TRIE_COMPILE_r(dump_trie(trie, depth+1));
 #ifdef DEBUGGING
     RExC_rxi->data->data[ data_slot + TRIE_WORDS_OFFSET ] = (void*)trie_words;
-    RExC_rxi->data->data[ data_slot + 3 ] = (void*)revcharmap;
-#else
-    SvREFCNT_dec_NN(revcharmap);
 #endif
     return trie->jump
            ? MADE_JUMP_TRIE
@@ -1703,12 +1643,12 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
     const U32 trie_offset = TRIE_DATA_SLOT(source);
     reg_trie_data *trie = (reg_trie_data *)RExC_rxi->data->data[trie_offset];
     U32 *q;
-    const U32 ucharcount = trie->uniquecharcount;
+    const U32 ucharcount = TRIE_ALPHABET_SIZE;
     const U32 numstates = trie->statecount;
     const U32 ubound = trie->lasttrans + ucharcount;
     U32 q_read = 0;
     U32 q_write = 0;
-    U32 charid;
+    U32 octet;
     U32 base = trie->states[ 1 ].trans.base;
     U32 *fail;
     reg_ac_data *aho;
@@ -1720,14 +1660,7 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
 #ifndef DEBUGGING
     PERL_UNUSED_ARG(depth);
 #endif
-    if (IS_ANYOF_TRIE(OP(source))) {
-        tregnode_AHOCORASICKC *op = (tregnode_AHOCORASICKC *)
-            PerlMemShared_calloc(1, sizeof(tregnode_AHOCORASICKC));
-        OP(op) = AHOCORASICKC;
-        FLAGS(op) = FLAGS(source);
-        Copy(ANYOF_BITMAP(source), ANYOF_BITMAP(op), ANYOF_BITMAP_SIZE, char);
-        stclass = (regnode *)op;
-    } else {
+    {
         tregnode_AHOCORASICK *op = (tregnode_AHOCORASICK *)
             PerlMemShared_calloc(1, sizeof(tregnode_AHOCORASICK));
         OP(op) = AHOCORASICK;
@@ -1735,7 +1668,7 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
         stclass = (regnode *)op;
     }
 
-    assert(OP(stclass)==AHOCORASICK || OP(stclass)==AHOCORASICKC);
+    assert(OP(stclass)==AHOCORASICK);
     /* AHOCORASICK nodes are short TRIE's, some compilers arn't smart
      * enough to know that the normal TRIE_DATA_SLOT_set() macro wont
      * ever access undefined memory because of the opcode guards. So we
@@ -1747,6 +1680,9 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
     aho->trie = trie_offset;
     aho->states = (reg_trie_state *)PerlMemShared_malloc( numstates * sizeof(reg_trie_state) );
     Copy( trie->states, aho->states, numstates, reg_trie_state );
+    /* The breadth-first work queue can contain each state at most once, so
+     * numstates entries suffice.  q_read and q_write address it as a
+     * circular queue while q_write advances monotonically. */
     Newx( q, numstates, U32);
     aho->fail = (U32 *) PerlMemShared_calloc( numstates, sizeof(U32) );
     aho->refcount = 1;
@@ -1755,35 +1691,50 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
        a valid final fail state */
     fail[ 0 ] = fail[ 1 ] = 1;
 
-    for ( charid = 0; charid < ucharcount ; charid++ ) {
-        const U32 newstate = TRIE_TRANS_STATE( 1, base, ucharcount, charid, 0 );
-        if ( newstate ) {
-            q[ q_write ] = newstate;
-            /* set to point at the root */
-            fail[ q[ q_write++ ] ]=1;
+    /* Root transitions have no failure link to follow.  Seed the breadth-
+     * first traversal with them and make their failure state the root.
+     * Later lookups use special = 1 so a failed transition falls back to the
+     * root transition. */
+    if (base) {
+        for ( octet = trie->states[1].min_octet;
+              octet <= trie->states[1].max_octet; octet++ ) {
+            const U32 newstate = S_trie_trans_state(trie, 1, base, ucharcount,
+                                                    octet, 0, ubound);
+            if ( newstate ) {
+                q[ q_write ] = newstate;
+                /* set to point at the root */
+                fail[ q[ q_write++ ] ]=1;
+            }
         }
     }
     while ( q_read < q_write) {
         const U32 cur = q[ q_read++ % numstates ];
         base = trie->states[ cur ].trans.base;
 
-        for ( charid = 0 ; charid < ucharcount ; charid++ ) {
-            const U32 ch_state = TRIE_TRANS_STATE( cur, base, ucharcount, charid, 1 );
-            if (ch_state) {
-                U32 fail_state = cur;
-                U32 fail_base;
-                do {
-                    fail_state = fail[ fail_state ];
-                    fail_base = aho->states[ fail_state ].trans.base;
-                } while ( !TRIE_TRANS_STATE( fail_state, fail_base, ucharcount, charid, 1 ) );
+        if (base) {
+            for ( octet = aho->states[cur].min_octet;
+                  octet <= aho->states[cur].max_octet; octet++ ) {
+                const U32 ch_state = S_trie_trans_state(trie, cur, base,
+                                                        ucharcount, octet, 1,
+                                                        ubound);
+                if (ch_state) {
+                    U32 fail_state = cur;
+                    U32 fail_base;
+                    do {
+                        fail_state = fail[ fail_state ];
+                        fail_base = aho->states[ fail_state ].trans.base;
+                    } while ( !S_trie_trans_state(trie, fail_state, fail_base,
+                                                  ucharcount, octet, 1, ubound) );
 
-                fail_state = TRIE_TRANS_STATE( fail_state, fail_base, ucharcount, charid, 1 );
-                fail[ ch_state ] = fail_state;
-                if ( !aho->states[ ch_state ].wordnum && aho->states[ fail_state ].wordnum )
-                {
-                        aho->states[ ch_state ].wordnum =  aho->states[ fail_state ].wordnum;
+                    fail_state = S_trie_trans_state(trie, fail_state, fail_base,
+                                                ucharcount, octet, 1, ubound);
+                    fail[ ch_state ] = fail_state;
+                    if ( !aho->states[ ch_state ].wordnum && aho->states[ fail_state ].wordnum )
+                    {
+                            aho->states[ ch_state ].wordnum =  aho->states[ fail_state ].wordnum;
+                    }
+                    q[ q_write++ % numstates] = ch_state;
                 }
-                q[ q_write++ % numstates] = ch_state;
             }
         }
     }

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -484,7 +484,7 @@ S_trie_list_new(reg_trie_data *trie, const U32 state)
 }
 
 PERL_STATIC_INLINE void
-S_trie_list_transition(reg_trie_data *trie, U32 *state, const U32 octet,
+S_trie_list_transition(pTHX_ reg_trie_data *trie, U32 *state, const U32 octet,
                        U32 *next_alloc, U32 *state_capacity,
                        U32 **prev_states, STRLEN *transition_count)
 {
@@ -771,7 +771,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         }
 
                         for (bp = uc; bp < ep; bp++)
-                            S_trie_list_transition(trie, &state, *bp,
+                            S_trie_list_transition(aTHX_ trie, &state, *bp,
                                                     &next_alloc, &state_capacity,
                                                     &prev_states, &transition_count);
                         continue;
@@ -868,11 +868,11 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         }
 
                         for ( ; bp < ep; bp++)
-                            S_trie_list_transition(trie, &state, *bp,
+                            S_trie_list_transition(aTHX_ trie, &state, *bp,
                                                     &next_alloc, &state_capacity,
                                                     &prev_states, &transition_count);
                     } else {
-                        S_trie_list_transition(trie, &state, uvc,
+                        S_trie_list_transition(aTHX_ trie, &state, uvc,
                                                 &next_alloc, &state_capacity,
                                                 &prev_states, &transition_count);
                     }

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -19,25 +19,17 @@
 #include "regcomp_internal.h"
 
 /* During construction each state's transitions are kept in a sorted list.
- * Element zero is a header, not a transition.  The header's forid field is
+ * Element zero is a header, not a transition.  The header's octet field is
  * the next insertion position, so transitions occupy elements 1 through
- * forid - 1; its newstate field is the allocated capacity. */
+ * octet - 1; its newstate field is the allocated capacity. */
 #define TRIE_LIST_HEAD(state)      (trie->states[state].trans.list[0])
-#define TRIE_LIST_ITEM(state, idx) (trie->states[state].trans.list[idx])
-#define TRIE_LIST_CUR(state)       (TRIE_LIST_HEAD(state).forid)
+#define TRIE_LIST_ITEM(state, transition_index) \
+    (trie->states[state].trans.list[transition_index])
+#define TRIE_LIST_CUR(state)       (TRIE_LIST_HEAD(state).octet)
 #define TRIE_LIST_LEN(state)       (TRIE_LIST_HEAD(state).newstate)
 #define TRIE_LIST_USED(state)      (trie->states[state].trans.list       \
                                     ? TRIE_LIST_CUR(state) - 1           \
                                     : 0)
-
-#ifdef DEBUGGING
-#  define TRIE_MARK_OCTET(octet)                                            \
-    STMT_START {                                                           \
-        TRIE_BITMAP_SET(trie, octet);                                       \
-    } STMT_END
-#else
-#  define TRIE_MARK_OCTET(octet) NOOP
-#endif
 
 #ifndef RE_PREFER_LONG_TRIE
 #  define RE_PREFER_LONG_TRIE 0
@@ -71,9 +63,6 @@ S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next)
 
 
 #ifdef DEBUGGING
-
-#define TRIE_DEBUG_OCTET_USED(trie, octet) \
-    BITMAP_TEST((trie)->bitmap, octet)
 
 static void
 S_dump_trie_char(pTHX_ const reg_trie_data *trie, U32 octet,
@@ -116,13 +105,34 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, U32 depth)
     U32 state;
     const int colwidth = 4;
     U32 word;
+    U8 debug_bitmap[ANYOF_BITMAP_SIZE];
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
+
+    /* Reconstruct the set of octets used by the executable trie for the
+     * diagnostic layout.  This is debug output only; the trie has no stored
+     * start bitmap. */
+    Zero(debug_bitmap, sizeof(debug_bitmap), U8);
+    for (state = trie->startstate; state < trie->statecount; state++) {
+        const U32 base = trie->states[state].trans.base;
+        U32 octet;
+
+        if (!base)
+            continue;
+        for (octet = 0; octet < TRIE_ALPHABET_SIZE; octet++) {
+            if (base + octet >= TRIE_ALPHABET_SIZE) {
+                const U32 slot = base + octet - TRIE_ALPHABET_SIZE;
+                if (slot < trie->lasttrans
+                        && trie->trans[slot].check == state)
+                    BITMAP_BYTE(debug_bitmap, octet) |= ANYOF_BIT((U8)octet);
+            }
+        }
+    }
 
     re_indentf("Char : %-6s%-6s%-4s ",
         depth+1, "Match","Base","Ofs" );
 
     for( state = 0 ; state < TRIE_ALPHABET_SIZE ; state++ ) {
-        if (!TRIE_DEBUG_OCTET_USED(trie, state))
+        if (!BITMAP_TEST(debug_bitmap, state))
             continue;
         S_dump_trie_char(aTHX_ trie, state, colwidth);
     }
@@ -130,7 +140,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, U32 depth)
     re_indentf("State|-----------------------", depth+1);
 
     for( state = 0 ; state < TRIE_ALPHABET_SIZE ; state++ )
-        if (TRIE_DEBUG_OCTET_USED(trie, state))
+        if (BITMAP_TEST(debug_bitmap, state))
             re_printf("%.*s", colwidth, "--------");
     re_printf("\n");
 
@@ -161,7 +171,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, U32 depth)
             re_printf("+%2" UVXf "[ ", (UV)ofs);
 
             for ( ofs = 0 ; ofs < TRIE_ALPHABET_SIZE ; ofs++ ) {
-                if (!TRIE_DEBUG_OCTET_USED(trie, ofs))
+                if (!BITMAP_TEST(debug_bitmap, ofs))
                     continue;
                 if ( ( base + ofs >= TRIE_ALPHABET_SIZE )
                         && ( base + ofs - TRIE_ALPHABET_SIZE
@@ -213,7 +223,9 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
             depth+1, "------:-----+-----------------\n" );
 
     for( state = 1; state < next_alloc; state++ ) {
-        U32 idx;
+        /* The first list element is the header; transition_index addresses
+         * the transitions. */
+        U32 transition_index;
 
         re_indentf(" %4" UVXf " :",
             depth+1, (UV)state  );
@@ -224,17 +236,19 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
                 trie->states[ state ].wordnum
             );
         }
-        for( idx = 1 ; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
-            const U32 forid = TRIE_LIST_ITEM(state, idx).forid;
-            if (forid <= U8_MAX && isPRINT_A((U8)forid)
-                    && forid != ' ' && forid != '\\' && forid != '\'') {
-                re_printf(" '%c'", (int)forid);
+        for (transition_index = 1;
+             transition_index <= TRIE_LIST_USED(state);
+             transition_index++) {
+            const U32 octet = TRIE_LIST_ITEM(state, transition_index).octet;
+            if (octet <= U8_MAX && isPRINT_A((U8)octet)
+                    && octet != ' ' && octet != '\\' && octet != '\'') {
+                re_printf(" '%c'", (int)octet);
             } else {
-                re_printf("%*.*X", colwidth, 2, (unsigned)forid);
+                re_printf("%*.*X", colwidth, 2, (unsigned)octet);
             }
             re_printf("=%4" UVXf " | ",
-                      (UV)TRIE_LIST_ITEM(state, idx).newstate);
-            if (!(idx % 10))
+                      (UV)TRIE_LIST_ITEM(state, transition_index).newstate);
+            if (!(transition_index % 10))
                 re_printf("\n%*s| ",
                     (int)((depth * 2) + 14), "");
         }
@@ -423,15 +437,15 @@ is the recommended Unicode-aware way of saying
         || OP(noper) == EXACTL || OP(noper) == EXACTFLU8)
 
 PERL_STATIC_INLINE void
-S_trie_list_push(reg_trie_data *trie, const U32 state, const U32 fid,
+S_trie_list_push(reg_trie_data *trie, const U32 state, const U32 octet,
                  const U32 newstate, const U32 position)
 {
-    /* Element zero is the list header, not a transition.  Its forid field
+    /* Element zero is the list header, not a transition.  Its octet field
      * stores the next insertion position (one past the last transition),
      * while newstate stores the allocated capacity.  Transition records
-     * occupy elements 1 through forid - 1 and remain sorted by forid. */
+     * occupy elements 1 through octet - 1 and remain sorted by octet. */
     reg_trie_trans_le *list = trie->states[state].trans.list;
-    const U32 used = list[0].forid;
+    const U32 used = list[0].octet;
 
     if (used >= list[0].newstate) {
         const U32 new_len = list[0].newstate * 2;
@@ -440,13 +454,14 @@ S_trie_list_push(reg_trie_data *trie, const U32 state, const U32 fid,
         list[0].newstate = new_len;
     }
 
-    /* An insertion at the end is the common fast path. */
+    /* Appending is the common fast path; an insertion before the end also
+     * has to move the later transition records out of the way. */
     if (position < used)
         Move(&list[position], &list[position + 1], used - position,
              reg_trie_trans_le);
-    list[position].forid = fid;
+    list[position].octet = octet;
     list[position].newstate = newstate;
-    list[0].forid++;
+    list[0].octet++;
 }
 
 PERL_STATIC_INLINE void
@@ -464,7 +479,7 @@ S_trie_list_new(reg_trie_data *trie, const U32 state)
      * states cheap to create. */
     const U32 initial_len = (state == 1) ? 16 : 4;
     Newx(trie->states[state].trans.list, initial_len, reg_trie_trans_le);
-    trie->states[state].trans.list[0].forid = 1;
+    trie->states[state].trans.list[0].octet = 1;
     trie->states[state].trans.list[0].newstate = initial_len;
 }
 
@@ -478,17 +493,16 @@ S_trie_list_transition(reg_trie_data *trie, U32 *state, const U32 octet,
     reg_trie_trans_le *list;
     const U32 current_state = *state;
 
-    TRIE_MARK_OCTET(octet);
     if (!trie->states[current_state].trans.list)
         S_trie_list_new(trie, current_state);
     list = trie->states[current_state].trans.list;
 
-    for (check = 1; check <= list[0].forid - 1; check++) {
-        if (list[check].forid == octet) {
+    for (check = 1; check <= list[0].octet - 1; check++) {
+        if (list[check].octet == octet) {
             newstate = list[check].newstate;
             break;
         }
-        if (list[check].forid > octet)
+        if (list[check].octet > octet)
             break;
     }
     if (!newstate) {
@@ -828,6 +842,11 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     if ( trie_needs_codepoint_processing ) {
                         const U8 *bp;
                         const U8 *ep;
+                        /* Extended codepoints may require more than the
+                         * four octets needed for Unicode scalar values, so
+                         * this must use UTF8_MAXBYTES rather than
+                         * MAX_UNICODE_UTF8_BYTES.  The extra octet is for
+                         * the terminating NUL expected by the encoder. */
                         U8 encoded[UTF8_MAXBYTES + 1];
 
                         if (!is_utf8 && FITS_IN_8_BITS(uvc)) {
@@ -948,9 +967,6 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         } /* end list construction */
 
         /* The list pass has also completed the source analysis. */
-#ifdef DEBUGGING
-        Zero(trie->bitmap, sizeof(trie->bitmap), U8);
-#endif
         trie->before_paren = OP(first) == BRANCH
                      ? ARG1a(first)
                      : ARG2a(first); /* BRANCHJ */
@@ -1012,17 +1028,18 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
                 if (trie->states[state].trans.list) {
                     const U32 used = TRIE_LIST_USED( state );
-                    const U32 minid = TRIE_LIST_ITEM( state, 1).forid;
-                    const U32 maxid = TRIE_LIST_ITEM( state, used).forid;
-                    const U32 frame_span = maxid - minid;
+                    const U32 min_octet = TRIE_LIST_ITEM( state, 1).octet;
+                    const U32 max_octet = TRIE_LIST_ITEM( state, used).octet;
+                    const U32 frame_span = max_octet - min_octet;
                     const U32 frame_width = frame_span + 1;
                     bool placed = false;
-                    U32 idx;
+                    U32 transition_index;
 
-                    /* A state's transitions form a frame from minid through
-                     * maxid.  Sparse frames may fit into holes left by earlier
-                     * frames.  Try the first available position.  The
-                     * frame may extend beyond table_highwater, provided it
+                    /* A state's transitions form a frame from min_octet
+                     * through max_octet.  Sparse frames may fit into holes
+                     * left by earlier frames.  Try the first available
+                     * position.  The frame may extend beyond table_highwater,
+                     * provided it
                      * fits in the allocation and its occupied slots do not
                      * clash. */
                     while (next_hole < table_highwater
@@ -1050,21 +1067,27 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                   transition_capacity - old_capacity,
                                   reg_trie_trans );
                         }
-                        for (idx = 1; idx <= used; idx++) {
+                        for (transition_index = 1;
+                             transition_index <= used;
+                             transition_index++) {
                             const U32 tid = next_hole
-                                           + TRIE_LIST_ITEM( state, idx ).forid
-                                           - minid;
+                                           + TRIE_LIST_ITEM(state,
+                                                            transition_index).octet
+                                           - min_octet;
                             if (trie->trans[ tid ].next)
                                 break;
                         }
-                        if (idx > used) {
-                            base = TRIE_ALPHABET_SIZE + next_hole - minid;
-                            for (idx = 1; idx <= used; idx++) {
+                        if (transition_index > used) {
+                            base = TRIE_ALPHABET_SIZE + next_hole - min_octet;
+                            for (transition_index = 1;
+                                 transition_index <= used;
+                                 transition_index++) {
                                 const U32 tid = base
                                                - TRIE_ALPHABET_SIZE
-                                               + TRIE_LIST_ITEM( state, idx ).forid;
+                                               + TRIE_LIST_ITEM(state,
+                                                                transition_index).octet;
                                 trie->trans[ tid ].next = TRIE_LIST_ITEM( state,
-                                                                    idx ).newstate;
+                                                                    transition_index ).newstate;
                                 trie->trans[ tid ].check = state;
                             }
                             if (candidate_end > table_highwater)
@@ -1094,15 +1117,15 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                               reg_trie_trans );
                     }
                     if (!placed) {
-                        base = TRIE_ALPHABET_SIZE + table_highwater - minid;
+                        base = TRIE_ALPHABET_SIZE + table_highwater - min_octet;
                     }
                     /* A one-transition frame can occupy one existing hole;
                      * it does not need its full frame width to be reserved. */
-                    if ( !placed && maxid == minid ) {
+                    if ( !placed && max_octet == min_octet ) {
                         U32 set = 0;
                         for ( ; next_hole < table_highwater ; next_hole++ ) {
                             if ( ! trie->trans[ next_hole ].next ) {
-                                base = TRIE_ALPHABET_SIZE + next_hole - minid;
+                                base = TRIE_ALPHABET_SIZE + next_hole - min_octet;
                                 trie->trans[ next_hole ].next = TRIE_LIST_ITEM( state,
                                                                    1).newstate;
                                 trie->trans[ next_hole ].check = state;
@@ -1122,12 +1145,15 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                 next_hole++;
                         }
                     } else if (!placed) {
-                        for ( idx = 1; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
+                        for (transition_index = 1;
+                             transition_index <= TRIE_LIST_USED(state);
+                             transition_index++) {
                             const U32 tid = base
                                            - TRIE_ALPHABET_SIZE
-                                           + TRIE_LIST_ITEM( state, idx ).forid;
+                                           + TRIE_LIST_ITEM(state,
+                                                            transition_index).octet;
                             trie->trans[ tid ].next = TRIE_LIST_ITEM( state,
-                                                                idx ).newstate;
+                                                                transition_index ).newstate;
                             trie->trans[ tid ].check = state;
                         }
                         table_highwater += frame_width;

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -22,7 +22,7 @@
 #define TRIE_LIST_CUR(state)  ( TRIE_LIST_ITEM( state, 0 ).forid )
 #define TRIE_LIST_LEN(state) ( TRIE_LIST_ITEM( state, 0 ).newstate )
 #define TRIE_LIST_USED(idx)  ( trie->states[state].trans.list         \
-                               ? (TRIE_LIST_CUR( idx ) - 1)           \
+                               ? (TRIE_LIST_CUR( idx ) - 1)            \
                                : 0 )
 
 #ifndef RE_PREFER_LONG_TRIE
@@ -200,7 +200,7 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
             depth+1, "------:-----+-----------------\n" );
 
     for( state = 1; state < next_alloc; state++ ) {
-        U16 charid;
+        U32 charid;
 
         re_indentf(" %4" UVXf " :",
             depth+1, (UV)state  );
@@ -249,7 +249,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
     PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE;
 
     U32 state;
-    U16 charid;
+    U32 charid;
     SV *sv = sv_newmortal();
     int colwidth = widecharmap ? 6 : 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -649,7 +649,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
     trie->startstate = 1;
     trie->wordcount = word_count;
     RExC_rxi->data->data[ data_slot ] = (void*)trie;
-    trie->charmap = (U16 *) PerlMemShared_calloc( 256, sizeof(U16) );
+    trie->charmap = (U32 *) PerlMemShared_calloc( 256, sizeof(U32) );
     if (flags == EXACT || flags == EXACT_REQ8 || flags == EXACTL)
         trie->bitmap = (char *) PerlMemShared_calloc( ANYOF_BITMAP_SIZE, 1 );
     trie->wordinfo = (reg_trie_wordinfo *) PerlMemShared_calloc(
@@ -952,7 +952,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
             regnode *noper   = REGNODE_AFTER( cur );
             U32 state        = 1;         /* required init */
-            U16 charid       = 0;         /* sanity init */
+            U32 charid       = 0;         /* sanity init */
             U32 wordlen      = 0;         /* required init */
 
             if (OP(noper) == NOTHING) {
@@ -987,14 +987,14 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         if ( !svpp ) {
                             charid = 0;
                         } else {
-                            charid = (U16)SvIV( *svpp );
+                            charid = (U32)SvIV( *svpp );
                         }
                     }
                     /* charid is now 0 if we dont know the char read, or
                      * nonzero if we do */
                     if ( charid ) {
 
-                        U16 check;
+                        U32 check;
                         U32 newstate = 0;
 
                         charid--;
@@ -1065,12 +1065,12 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 */
 
                 if (trie->states[state].trans.list) {
-                    U16 minid = TRIE_LIST_ITEM( state, 1).forid;
-                    U16 maxid = minid;
-                    U16 idx;
+                    U32 minid = TRIE_LIST_ITEM( state, 1).forid;
+                    U32 maxid = minid;
+                    U32 idx;
 
                     for( idx = 2 ; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
-                        const U16 forid = TRIE_LIST_ITEM( state, idx).forid;
+                        const U32 forid = TRIE_LIST_ITEM( state, idx).forid;
                         if ( forid < minid ) {
                             minid = forid;
                         } else if ( forid > maxid ) {
@@ -1184,7 +1184,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
             U32 state        = 1;         /* required init */
 
-            U16 charid       = 0;         /* sanity init */
+            U32 charid       = 0;         /* sanity init */
             U32 accept_state = 0;         /* sanity init */
 
             U32 wordlen      = 0;         /* required init */
@@ -1218,7 +1218,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                                            (char*)&uvc,
                                                            sizeof( UV ),
                                                            0);
-                        charid = svpp ? (U16)SvIV(*svpp) : 0;
+                        charid = svpp ? (U32)SvIV(*svpp) : 0;
                     }
                     if ( charid ) {
                         charid--;

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -96,7 +96,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
     U32 state;
     SV *sv = sv_newmortal();
     int colwidth = widecharmap ? 6 : 4;
-    U16 word;
+    U32 word;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     re_indentf("Char : %-6s%-6s%-4s ",
@@ -492,7 +492,7 @@ is the recommended Unicode-aware way of saying
 } STMT_END
 
 #define TRIE_HANDLE_WORD(state) STMT_START {                    \
-    U16 dupe = trie->states[ state ].wordnum;                    \
+    U32 dupe = trie->states[ state ].wordnum;                    \
     regnode * const noper_next = regnext( noper );              \
                                                                 \
     DEBUG_r({                                                   \
@@ -604,7 +604,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
     regnode *cur;
     STRLEN len = 0;
     UV uvc = 0;
-    U16 curword = 0;
+    U32 curword = 0;
     U32 next_alloc = 0;
     regnode *jumper = NULL;
     regnode *nextbranch = NULL;
@@ -1632,9 +1632,9 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
      *  already linked up earlier.
      */
     {
-        U16 word;
+        U32 word;
         U32 state;
-        U16 prev;
+        U32 prev;
 
         for (word = 1; word <= trie->wordcount; word++) {
             prev = 0;

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -18,12 +18,18 @@
 #include "unicode_constants.h"
 #include "regcomp_internal.h"
 
-#define TRIE_LIST_ITEM(state,idx) (trie->states[state].trans.list)[ idx ]
-#define TRIE_LIST_CUR(state)  ( TRIE_LIST_ITEM( state, 0 ).forid )
-#define TRIE_LIST_LEN(state) ( TRIE_LIST_ITEM( state, 0 ).newstate )
-#define TRIE_LIST_USED(idx)  ( trie->states[state].trans.list         \
-                               ? (TRIE_LIST_CUR( idx ) - 1)            \
-                               : 0 )
+/* During construction each state's transitions are kept in a sorted list.
+ * Element zero is a header, not a transition.  The header's octet field is
+ * the next insertion position, so transitions occupy elements 1 through
+ * octet - 1; its newstate field is the allocated capacity. */
+#define TRIE_LIST_HEAD(state)      (trie->states[state].trans.list[0])
+#define TRIE_LIST_ITEM(state, transition_index) \
+    (trie->states[state].trans.list[transition_index])
+#define TRIE_LIST_CUR(state)       (TRIE_LIST_HEAD(state).octet)
+#define TRIE_LIST_LEN(state)       (TRIE_LIST_HEAD(state).newstate)
+#define TRIE_LIST_USED(state)      (trie->states[state].trans.list       \
+                                    ? TRIE_LIST_CUR(state) - 1           \
+                                    : 0)
 
 #ifndef RE_PREFER_LONG_TRIE
 #  define RE_PREFER_LONG_TRIE 0
@@ -31,15 +37,11 @@
 
 
 static U8
-S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
-                 const bool want_charclass)
+S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next)
 {
     assert(needed_next <= U32_MAX);
 
     if (RE_PREFER_LONG_TRIE || needed_next > U16_MAX) {
-        if (want_charclass && trie_room >= sizeof(tregnode_LTRIEC)) {
-            return LTRIEC;
-        }
         if (trie_room >= sizeof(tregnode_LTRIE)) {
             return LTRIE;
         }
@@ -48,14 +50,8 @@ S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
         }
     }
     else {
-        if (want_charclass && trie_room >= sizeof(tregnode_TRIEC)) {
-            return TRIEC;
-        }
         if (trie_room >= sizeof(tregnode_TRIE)) {
             return TRIE;
-        }
-        if (want_charclass && trie_room >= sizeof(tregnode_LTRIEC)) {
-            return LTRIEC;
         }
         if (trie_room >= sizeof(tregnode_LTRIE)) {
             return LTRIE;
@@ -67,10 +63,24 @@ S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
 
 
 #ifdef DEBUGGING
+
+static void
+S_dump_trie_char(pTHX_ const reg_trie_data *trie, U32 octet,
+                 const int colwidth)
+{
+    octet = (U8)octet;
+
+    PERL_UNUSED_VAR(trie);
+    if (isPRINT_A(octet) && octet != ' ' && octet != '\\')
+        re_printf("%*c", colwidth, (int)octet);
+    else {
+        re_printf("%*.*X", colwidth, 2, (unsigned)octet);
+    }
+}
+
 /*
-   dump_trie(trie,widecharmap,revcharmap)
-   dump_trie_interim_list(trie,widecharmap,revcharmap,next_alloc)
-   dump_trie_interim_table(trie,widecharmap,revcharmap,next_alloc)
+   dump_trie(trie)
+   dump_trie_interim_list(trie,next_alloc)
 
    These routines dump out a trie in a somewhat readable format.
    The _interim_ variants are used for debugging the interim
@@ -88,41 +98,55 @@ S_select_trie_op(pTHX_ const Size_t trie_room, const U32 needed_next,
 */
 
 static void
-S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
-            AV *revcharmap, U32 depth)
+S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, U32 depth)
 {
     PERL_ARGS_ASSERT_DUMP_TRIE;
 
     U32 state;
-    SV *sv = sv_newmortal();
-    int colwidth = widecharmap ? 6 : 4;
+    const int colwidth = 4;
     U32 word;
+    U8 debug_bitmap[ANYOF_BITMAP_SIZE];
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
+
+    /* Reconstruct the set of octets used by the executable trie for the
+     * diagnostic layout.  This is debug output only; the trie has no stored
+     * start bitmap. */
+    Zero(debug_bitmap, sizeof(debug_bitmap), U8);
+    for (state = trie->startstate; state < trie->statecount; state++) {
+        const U32 base = trie->states[state].trans.base;
+        U32 octet;
+
+        if (!base)
+            continue;
+        for (octet = 0; octet < TRIE_ALPHABET_SIZE; octet++) {
+            if (base + octet >= TRIE_ALPHABET_SIZE) {
+                const U32 slot = base + octet - TRIE_ALPHABET_SIZE;
+                if (slot < trie->lasttrans
+                        && trie->trans[slot].check == state)
+                    BITMAP_BYTE(debug_bitmap, octet) |= ANYOF_BIT((U8)octet);
+            }
+        }
+    }
 
     re_indentf("Char : %-6s%-6s%-4s ",
         depth+1, "Match","Base","Ofs" );
 
-    for( state = 0 ; state < trie->uniquecharcount ; state++ ) {
-        SV ** const tmp = av_fetch_simple( revcharmap, state, 0);
-        if ( tmp ) {
-            re_printf("%*s",
-                colwidth,
-                pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), colwidth,
-                            PL_colors[0], PL_colors[1],
-                            (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0) |
-                            PERL_PV_ESCAPE_FIRSTCHAR
-                )
-            );
-        }
+    for( state = 0 ; state < TRIE_ALPHABET_SIZE ; state++ ) {
+        if (!BITMAP_TEST(debug_bitmap, state))
+            continue;
+        S_dump_trie_char(aTHX_ trie, state, colwidth);
     }
     re_printf("\n");
     re_indentf("State|-----------------------", depth+1);
 
-    for( state = 0 ; state < trie->uniquecharcount ; state++ )
-        re_printf("%.*s", colwidth, "--------");
+    for( state = 0 ; state < TRIE_ALPHABET_SIZE ; state++ )
+        if (BITMAP_TEST(debug_bitmap, state))
+            re_printf("%.*s", colwidth, "--------");
     re_printf("\n");
 
-    for( state = 1 ; state < trie->statecount ; state++ ) {
+    /* Prefix extraction leaves the old prefix states in the table, but the
+     * executable trie begins at startstate.  Dump only the executable part. */
+    for( state = trie->startstate ; state < trie->statecount ; state++ ) {
         const U32 base = trie->states[ state ].trans.base;
 
         re_indentf("#%4" UVXf "|", depth+1, (UV)state);
@@ -138,23 +162,25 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
         if ( base ) {
             U32 ofs = 0;
 
-            while( ( base + ofs  < trie->uniquecharcount ) ||
-                   ( base + ofs - trie->uniquecharcount < trie->lasttrans
-                     && trie->trans[ base + ofs - trie->uniquecharcount ].check
+            while( ( base + ofs  < TRIE_ALPHABET_SIZE ) ||
+                   ( base + ofs - TRIE_ALPHABET_SIZE < trie->lasttrans
+                     && trie->trans[ base + ofs - TRIE_ALPHABET_SIZE ].check
                                                                     != state))
                     ofs++;
 
             re_printf("+%2" UVXf "[ ", (UV)ofs);
 
-            for ( ofs = 0 ; ofs < trie->uniquecharcount ; ofs++ ) {
-                if ( ( base + ofs >= trie->uniquecharcount )
-                        && ( base + ofs - trie->uniquecharcount
+            for ( ofs = 0 ; ofs < TRIE_ALPHABET_SIZE ; ofs++ ) {
+                if (!BITMAP_TEST(debug_bitmap, ofs))
+                    continue;
+                if ( ( base + ofs >= TRIE_ALPHABET_SIZE )
+                        && ( base + ofs - TRIE_ALPHABET_SIZE
                                                         < trie->lasttrans )
                         && trie->trans[ base + ofs
-                                    - trie->uniquecharcount ].check == state )
+                                    - TRIE_ALPHABET_SIZE ].check == state )
                 {
                    re_printf("%*" UVXf, colwidth,
-                    (UV)trie->trans[ base + ofs - trie->uniquecharcount ].next
+                    (UV)trie->trans[ base + ofs - TRIE_ALPHABET_SIZE ].next
                    );
                 } else {
                     re_printf("%*s", colwidth,"   ." );
@@ -177,20 +203,17 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
 }
 /*
   Dumps a fully constructed but uncompressed trie in list form.
-  List tries normally only are used for construction when the number of
-  possible chars (trie->uniquecharcount) is very high.
+  List tries are used for construction with the fixed 256-octet alphabet.
   Used for debugging make_trie().
 */
 static void
 S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
-                         HV *widecharmap, AV *revcharmap, U32 next_alloc,
-                         U32 depth)
+                         U32 next_alloc, U32 depth)
 {
     PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_LIST;
 
     U32 state;
-    SV *sv = sv_newmortal();
-    int colwidth = widecharmap ? 6 : 4;
+    const int colwidth = 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     /* print out the table precompression.  */
@@ -200,7 +223,9 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
             depth+1, "------:-----+-----------------\n" );
 
     for( state = 1; state < next_alloc; state++ ) {
-        U32 charid;
+        /* The first list element is the header; transition_index addresses
+         * the transitions. */
+        U32 transition_index;
 
         re_indentf(" %4" UVXf " :",
             depth+1, (UV)state  );
@@ -211,101 +236,74 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
                 trie->states[ state ].wordnum
             );
         }
-        for( charid = 1 ; charid <= TRIE_LIST_USED( state ) ; charid++ ) {
-            SV ** const tmp = av_fetch_simple( revcharmap,
-                                        TRIE_LIST_ITEM(state, charid).forid, 0);
-            if ( tmp ) {
-                re_printf("%*s:%3X=%4" UVXf " | ",
-                    colwidth,
-                    pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp),
-                              colwidth,
-                              PL_colors[0], PL_colors[1],
-                              (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0)
-                              | PERL_PV_ESCAPE_FIRSTCHAR
-                    ) ,
-                    TRIE_LIST_ITEM(state, charid).forid,
-                    (UV)TRIE_LIST_ITEM(state, charid).newstate
-                );
-                if (!(charid % 10))
-                    re_printf("\n%*s| ",
-                        (int)((depth * 2) + 14), "");
+        for (transition_index = 1;
+             transition_index <= TRIE_LIST_USED(state);
+             transition_index++) {
+            const U32 octet = TRIE_LIST_ITEM(state, transition_index).octet;
+            if (octet <= U8_MAX && isPRINT_A((U8)octet)
+                    && octet != ' ' && octet != '\\' && octet != '\'') {
+                re_printf(" '%c'", (int)octet);
+            } else {
+                re_printf("%*.*X", colwidth, 2, (unsigned)octet);
             }
+            re_printf("=%4" UVXf " | ",
+                      (UV)TRIE_LIST_ITEM(state, transition_index).newstate);
+            if (!(transition_index % 10))
+                re_printf("\n%*s| ",
+                    (int)((depth * 2) + 14), "");
         }
         re_printf("\n");
     }
 }
 
-/*
-  Dumps a fully constructed but uncompressed trie in table form.
-  This is the normal DFA style state transition table, with a few
-  twists to facilitate compression later.
-  Used for debugging make_trie().
-*/
 static void
-S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
-                          HV *widecharmap, AV *revcharmap, U32 next_alloc,
-                          U32 depth)
+S_dump_trie_physical_char(pTHX_ U32 octet)
 {
-    PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE;
+    octet = (U8)octet;
 
-    U32 state;
-    U32 charid;
-    SV *sv = sv_newmortal();
-    int colwidth = widecharmap ? 6 : 4;
-    DECLARE_AND_GET_RE_DEBUG_FLAGS;
+    if (isPRINT_A(octet) && octet != ' ' && octet != '\\' && octet != '\'')
+        re_printf(" '%c'", (int)octet);
+    else
+        re_printf("  %02X", (unsigned)octet);
+}
 
-    /*
-       print out the table precompression so that we can do a visual check
-       that they are identical.
-     */
+static void
+S_dump_trie_physical(pTHX_ const struct reg_trie_data_ *trie,
+                     U32 physical, U32 depth)
+{
+    U32 slot;
+    PERL_ARGS_ASSERT_DUMP_TRIE_PHYSICAL;
 
-    re_indentf("Char : ", depth+1 );
-
-    for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
-        SV ** const tmp = av_fetch_simple( revcharmap, charid, 0);
-        if ( tmp ) {
-            STRLEN n;
-            const char *s = SvPV_const(*tmp, n);
-            re_printf("%*s",
-                colwidth,
-                pv_pretty(sv, s, n, colwidth,
-                            PL_colors[0], PL_colors[1],
-                            (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0) |
-                            PERL_PV_ESCAPE_FIRSTCHAR
-                )
-            );
-        }
-    }
-
-    re_printf("\n");
-    re_indentf("State+-", depth+1 );
-
-    for( charid = 0; charid < trie->uniquecharcount; charid++ ) {
-        re_printf("%.*s", colwidth,"--------");
-    }
-
-    re_printf("\n" );
-
-    for( state = 1; state < next_alloc; state += trie->uniquecharcount ) {
-
-        re_indentf("%4" UVXf " : ",
-            depth+1,
-            (UV)TRIE_NODENUM( state ) );
-
-        for( charid = 0 ; charid < trie->uniquecharcount ; charid++ ) {
-            UV v = (UV)SAFE_TRIE_NODENUM( trie->trans[ state + charid ].next );
-            if (v)
-                re_printf("%*" UVXf, colwidth, v );
+    re_indentf("Physical transitions:\n", depth+1);
+    re_indentf("Physical| State | Word  | Base  | Ofs | Char | Next\n", depth+1);
+    re_indentf("--------+-------+-------+-------+-----+------+-----\n", depth+1);
+    for (slot = 0; slot < physical; slot++) {
+        const reg_trie_trans * const trans = trie->trans + slot;
+        if (!trans->next)
+            continue;
+        {
+            const U32 state = trans->check;
+            const U32 octet = slot + TRIE_ALPHABET_SIZE
+                                     - trie->states[state].trans.base;
+            re_indentf("%8" UVXf "| #%4" UVXf " |",
+                       depth+1,
+                       (UV)slot,
+                       (UV)state);
+            if (trie->states[state].wordnum)
+                re_printf(" W%4" UVuf " |", (UV)trie->states[state].wordnum);
             else
-                re_printf("%*s", colwidth, "." );
-        }
-        if ( ! trie->states[ TRIE_NODENUM( state ) ].wordnum ) {
-            re_printf(" (%4" UVXf ")\n",
-                                            (UV)trie->trans[ state ].check );
-        } else {
-            re_printf(" (%4" UVXf ") W%4X\n",
-                                            (UV)trie->trans[ state ].check,
-            trie->states[ TRIE_NODENUM( state ) ].wordnum );
+                re_printf("       |");
+            re_printf(" @%4" UVXf " | +%02" UVXf " |",
+                      (UV)trie->states[state].trans.base,
+                      (UV)octet);
+            re_printf(" ");
+            S_dump_trie_physical_char(aTHX_ octet);
+            re_printf(" | %4" UVXf, (UV)trans->next);
+            if (!trie->states[trans->next].trans.base
+                    && trie->states[trans->next].wordnum)
+                re_printf(" (W%" UVuf ")",
+                          (UV)trie->states[trans->next].wordnum);
+            re_printf("\n");
         }
     }
 }
@@ -313,14 +311,14 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
 #endif
 
 
-/* make_trie(startbranch,first,last,tail,word_count,flags,depth)
+/* make_trie(startbranch,first,last,tail,word_count,octet_count,flags,depth)
   startbranch: the first branch in the whole branch sequence
   first      : start branch of sequence of branch-exact nodes.
                May be the same as startbranch
   last       : Thing following the last branch.
                May be the same as tail.
   tail       : item following the branch sequence
-  count      : words in the sequence
+  word_count : words in the sequence
   flags      : currently the OP() type we will be building one of /EXACT(|F|FA|FU|FU_SS|L|FLU8)/
   depth      : indent depth
 
@@ -430,204 +428,175 @@ is the recommended Unicode-aware way of saying
     *(d++) = uv;
 */
 
-#define TRIE_STORE_REVCHAR(val)                                            \
-    STMT_START {                                                           \
-        if (UTF) {                                                         \
-            SV *zlopp = newSV(UTF8_MAXBYTES);                              \
-            unsigned char *flrbbbbb = (unsigned char *) SvPVX(zlopp);      \
-            unsigned char *const kapow = uv_to_utf8(flrbbbbb, val);     \
-            *kapow = '\0';                                                 \
-            SvCUR_set(zlopp, kapow - flrbbbbb);                            \
-            SvPOK_on(zlopp);                                               \
-            SvUTF8_on(zlopp);                                              \
-            av_push_simple(revcharmap, zlopp);                                     \
-        } else {                                                           \
-            char ooooff = (char)val;                                           \
-            av_push_simple(revcharmap, newSVpvn(&ooooff, 1));                      \
-        }                                                                  \
-        } STMT_END
+/* These node types contain UTF-8 source octets even when the pattern itself
+ * is not marked UTF-8.  Ordinary non-UTF-8 nodes contain native octets; they
+ * must not be identified as UTF-8 merely because their octets happen to form
+ * a valid UTF-8 sequence. */
+#define TRIE_SOURCE_UTF8(noper)                                             \
+    (UTF || OP(noper) == EXACT_REQ8 || OP(noper) == EXACTFU_REQ8            \
+        || OP(noper) == EXACTL || OP(noper) == EXACTFLU8)
 
-/* This gets the next character from the input, folding it if not already
- * folded. */
-#define TRIE_READ_CHAR STMT_START {                                           \
-    wordlen++;                                                                \
-    if ( UTF ) {                                                              \
-        /* if it is UTF then it is either already folded, or does not need    \
-         * folding */                                                         \
-        uvc = valid_utf8_to_uv( (const U8*) uc, &len);                     \
-    }                                                                         \
-    else if (folder == PL_fold_latin1) {                                      \
-        /* This folder implies Unicode rules, which in the range expressible  \
-         *  by not UTF is the lower case, with the two exceptions, one of     \
-         *  which should have been taken care of before calling this */       \
-        assert(*uc != LATIN_SMALL_LETTER_SHARP_S);                            \
-        uvc = toLOWER_L1(*uc);                                                \
-        if (UNLIKELY(uvc == MICRO_SIGN)) uvc = GREEK_SMALL_LETTER_MU;         \
-        len = 1;                                                              \
-    } else {                                                                  \
-        /* raw data, will be folded later if needed */                        \
-        uvc = (U32)*uc;                                                       \
-        len = 1;                                                              \
-    }                                                                         \
-} STMT_END
-
-
-
-#define TRIE_LIST_PUSH(state,fid,ns) STMT_START {               \
-    if ( TRIE_LIST_CUR( state ) >=TRIE_LIST_LEN( state ) ) {    \
-        U32 ging = TRIE_LIST_LEN( state ) * 2;                  \
-        Renew( trie->states[ state ].trans.list, ging, reg_trie_trans_le ); \
-        TRIE_LIST_LEN( state ) = ging;                          \
-    }                                                           \
-    TRIE_LIST_ITEM( state, TRIE_LIST_CUR( state ) ).forid = fid;     \
-    TRIE_LIST_ITEM( state, TRIE_LIST_CUR( state ) ).newstate = ns;   \
-    TRIE_LIST_CUR( state )++;                                   \
-} STMT_END
-
-#define TRIE_LIST_NEW(state) STMT_START {                       \
-    Newx( trie->states[ state ].trans.list,                     \
-        4, reg_trie_trans_le );                                 \
-     TRIE_LIST_CUR( state ) = 1;                                \
-     TRIE_LIST_LEN( state ) = 4;                                \
-} STMT_END
-
-#define TRIE_HANDLE_WORD(state) STMT_START {                    \
-    U32 dupe = trie->states[ state ].wordnum;                    \
-    regnode * const noper_next = regnext( noper );              \
-                                                                \
-    DEBUG_r({                                                   \
-        /* store the word for dumping */                        \
-        SV* tmp;                                                \
-        if (OP(noper) != NOTHING)                               \
-            tmp = newSVpvn_utf8(STRING(noper), STR_LEN(noper), UTF);    \
-        else                                                    \
-            tmp = newSVpvn_utf8( "", 0, UTF );                  \
-        av_push_simple( trie_words, tmp );                      \
-    });                                                         \
-                                                                \
-    curword++;                                                  \
-    assert(curword <= word_count);                              \
-    trie->wordinfo[curword].prev   = 0;                         \
-    trie->wordinfo[curword].len    = wordlen;                   \
-    trie->wordinfo[curword].accept = state;                     \
-                                                                \
-    if ( noper_next < tail ) {                                  \
-        if (!trie->jump) {                                      \
-            trie->jump = (TRIE_JUMP_TYPE *) PerlMemShared_calloc( word_count + 1, sizeof(TRIE_JUMP_TYPE) ); \
-            trie->j_before_paren = (U16 *) PerlMemShared_calloc( word_count + 1, sizeof(U16) ); \
-            trie->j_after_paren = (U16 *) PerlMemShared_calloc( word_count + 1, sizeof(U16) );  \
-        }                                                       \
-        assert(noper_next > convert);                           \
-        assert(curword <= word_count);                          \
-        assert(!trie->jump[curword]);                           \
-        assert((noper_next - convert) >= 0);                    \
-        assert((noper_next - convert) <= TRIE_JUMP_TYPE_MAX);   \
-        trie->jump[curword] = noper_next - convert;             \
-        U16 set_before_paren;                                   \
-        U16 set_after_paren;                                    \
-        if (OP(cur) == BRANCH) {                                \
-            set_before_paren = ARG1a(cur);                      \
-            set_after_paren = ARG1b(cur);                       \
-        } else {                                                \
-            set_before_paren = ARG2a(cur);                      \
-            set_after_paren = ARG2b(cur);                       \
-        }                                                       \
-        trie->j_before_paren[curword] = set_before_paren;       \
-        trie->j_after_paren[curword] = set_after_paren;         \
-        if (!jumper)                                            \
-            jumper = noper_next;                                \
-        if (!nextbranch)                                        \
-            nextbranch = regnext(cur);                          \
-    }                                                           \
-                                                                \
-    if ( dupe ) {                                               \
-        /* It's a dupe. Pre-insert into the wordinfo[].prev   */\
-        /* chain, so that when the bits of chain are later    */\
-        /* linked together, the dups appear in the chain      */\
-        trie->wordinfo[curword].prev = trie->wordinfo[dupe].prev; \
-        trie->wordinfo[dupe].prev = curword;                    \
-    } else {                                                    \
-        /* we haven't inserted this word yet.                */ \
-        trie->states[ state ].wordnum = curword;                \
-    }                                                           \
-} STMT_END
-
-
-#define TRIE_TRANS_STATE(state,base,ucharcount,charid,special)          \
-     ( ( base + charid >=  ucharcount                                   \
-         && base + charid < ubound                                      \
-         && state == trie->trans[ base - ucharcount + charid ].check    \
-         && trie->trans[ base - ucharcount + charid ].next )            \
-           ? trie->trans[ base - ucharcount + charid ].next             \
-           : ( state == 1 ? special : 0 )                                 \
-      )
-
-/* Helper function for make_trie(): set a trie bit for both the character
- * and its folded variant, and for the first byte of a variant codepoint,
- * if any */
-
-static void
-S_trie_bitmap_set_folded(pTHX_ RExC_state_t *pRExC_state,
-    reg_trie_data *trie, U8 ch, const U8 * folder)
+PERL_STATIC_INLINE void
+S_trie_list_push(reg_trie_data *trie, const U32 state, const U32 octet,
+                 const U32 newstate, const U32 position)
 {
-    TRIE_BITMAP_SET(trie, ch);
-    /* store the folded codepoint */
-    if ( folder )
-        TRIE_BITMAP_SET(trie, folder[ch]);
+    /* Element zero is the list header, not a transition.  Its octet field
+     * stores the next insertion position (one past the last transition),
+     * while newstate stores the allocated capacity.  Transition records
+     * occupy elements 1 through octet - 1 and remain sorted by octet. */
+    reg_trie_trans_le *list = trie->states[state].trans.list;
+    const U32 used = list[0].octet;
 
-    if ( !UTF ) {
-        /* store first byte of utf8 representation of */
-        /* variant codepoints */
-        if (! UVCHR_IS_INVARIANT(ch)) {
-            U8 hi = UTF8_TWO_BYTE_HI(ch);
-            /* Note that hi will be either 0xc2 or 0xc3 (apart from EBCDIC
-             * systems), and TRIE_BITMAP_SET() will do >>3 to get the byte
-             * offset within the bit table, which is constant, and
-             * Coverity complained about this (CID 488118). */
-            TRIE_BITMAP_SET(trie, hi);
-        }
+    if (used >= list[0].newstate) {
+        const U32 new_len = list[0].newstate * 2;
+        Renew(list, new_len, reg_trie_trans_le);
+        trie->states[state].trans.list = list;
+        list[0].newstate = new_len;
     }
+
+    /* Appending is the common fast path; an insertion before the end also
+     * has to move the later transition records out of the way. */
+    if (position < used)
+        Move(&list[position], &list[position + 1], used - position,
+             reg_trie_trans_le);
+    list[position].octet = octet;
+    list[position].newstate = newstate;
+    list[0].octet++;
+}
+
+PERL_STATIC_INLINE void
+S_trie_list_new(reg_trie_data *trie, const U32 state)
+{
+    /* These lists exist only while the trie is being constructed.  They use
+     * the ordinary allocator and are released after the lists are packed
+     * into trie->trans; the persistent trie arrays use the shared allocator. */
+    /* Allocate initial storage for this state's transition list.  The
+     * length is measured in transitions, not octets: it is the number of
+     * transition records we can add before the list must be resized.  Most
+     * states in a trie have only one transition, and only a few states have
+     * several; when there is a branching state it is very often the first
+     * state.  Give that state more room up front, while keeping later sparse
+     * states cheap to create. */
+    const U32 initial_len = (state == 1) ? 16 : 4;
+    Newx(trie->states[state].trans.list, initial_len, reg_trie_trans_le);
+    trie->states[state].trans.list[0].octet = 1;
+    trie->states[state].trans.list[0].newstate = initial_len;
+}
+
+PERL_STATIC_INLINE void
+S_trie_list_transition(pTHX_ reg_trie_data *trie, U32 *state, const U32 octet,
+                       U32 *next_alloc, U32 *state_capacity,
+                       U32 **prev_states, STRLEN *transition_count)
+{
+    U32 check;
+    U32 newstate = 0;
+    reg_trie_trans_le *list;
+    const U32 current_state = *state;
+
+    if (!trie->states[current_state].trans.list)
+        S_trie_list_new(trie, current_state);
+    list = trie->states[current_state].trans.list;
+
+    for (check = 1; check <= list[0].octet - 1; check++) {
+        if (list[check].octet == octet) {
+            newstate = list[check].newstate;
+            break;
+        }
+        if (list[check].octet > octet)
+            break;
+    }
+    if (!newstate) {
+        if (*next_alloc >= *state_capacity) {
+            const U32 old_capacity = *state_capacity;
+            *state_capacity *= 2;
+            trie->states = (reg_trie_state *)
+                PerlMemShared_realloc(trie->states,
+                                      *state_capacity * sizeof(reg_trie_state));
+            Renew(*prev_states, *state_capacity, U32);
+            Zero(trie->states + old_capacity,
+                 *state_capacity - old_capacity, reg_trie_state);
+            Zero(*prev_states + old_capacity,
+                 *state_capacity - old_capacity, U32);
+        }
+        newstate = (*next_alloc)++;
+        (*prev_states)[newstate] = current_state;
+        if (!TRIE_LIST_USED(current_state)) {
+            trie->states[current_state].min_octet = (U8)octet;
+            trie->states[current_state].max_octet = (U8)octet;
+        }
+        else {
+            if (octet < trie->states[current_state].min_octet)
+                trie->states[current_state].min_octet = (U8)octet;
+            if (octet > trie->states[current_state].max_octet)
+                trie->states[current_state].max_octet = (U8)octet;
+        }
+        S_trie_list_push(trie, current_state, octet, newstate, check);
+        (*transition_count)++;
+    }
+    *state = newstate;
+}
+
+PERL_STATIC_INLINE U32
+S_trie_trans_state(const reg_trie_data *trie, const U32 state,
+                   const U32 base, const U32 ucharcount, const U32 octet,
+                   const U32 special, const U32 ubound)
+{
+    const U32 index = base - ucharcount + octet;
+
+    /* The packed table stores a transition at base - alphabet_size + octet.
+     * The check field confirms that the physical slot belongs to this state.
+     * During Aho-Corasick construction, special is the fallback transition
+     * used when the lookup is performed from the root state. */
+    return base + octet >= ucharcount
+        && base + octet < ubound
+        && state == trie->trans[index].check
+        && trie->trans[index].next
+        ? trie->trans[index].next
+        : state == 1 ? special : 0;
 }
 
 
 I32
 Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                   regnode *first, regnode *last, regnode *tail,
-                  U32 word_count, U32 flags, U32 depth)
+                  U32 word_count, STRLEN octet_count, U32 flags, U32 depth)
 {
     PERL_ARGS_ASSERT_MAKE_TRIE;
 
-    /* first pass, loop through and scan words */
+    /* Scan the source words and construct the trie in one pass. */
     reg_trie_data *trie;
-    HV *widecharmap = NULL;
-    AV *revcharmap = newAV();
     regnode *cur;
     STRLEN len = 0;
     UV uvc = 0;
     U32 curword = 0;
     U32 next_alloc = 0;
+    U32 state_capacity = 0;
     regnode *jumper = NULL;
     regnode *nextbranch = NULL;
     regnode *lastbranch = NULL;
     regnode *convert = NULL;
-    U32 *prev_states; /* temp array mapping each state to previous one */
-    /* we just use folder as a flag in utf8 */
+    /* Temporary predecessor links.  Once the list representation has been
+     * compressed, these links are used to reconstruct the wordinfo[].prev
+     * chains for words which end at the same or an earlier state. */
+    U32 *prev_states;
+    /* A non-NULL folder identifies a folded trie and also means that its
+     * transitions must use the processed UTF-8 representation. */
     const U8 * folder = NULL;
+    /* Every trie transition is an octet.  In raw mode, native source octets
+     * are used directly.  In processed mode, source codepoints are encoded
+     * as UTF-8 octets before entering the trie.  Invariant codepoints have
+     * the same representation in both modes; awkward and high codepoints
+     * require processed mode. */
+    bool trie_needs_codepoint_processing;
 
-    /* in the below reg_add_data call we are storing either 'tu' or 'tuaa'
-     * which stands for one trie structure, one hash, optionally followed
-     * by two arrays */
+    /* Store the trie and, in debugging builds, its word list. */
 #ifdef DEBUGGING
-    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("tuaa"));
+    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("ta"));
     AV *trie_words = NULL;
-    /* along with revcharmap, this only used during construction but both are
-     * useful during debugging so we store them in the struct when debugging.
-     */
 #else
-    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("tu"));
+    const U32 data_slot = reg_add_data( pRExC_state, STR_WITH_LEN("t"));
     STRLEN trie_charcount = 0;
 #endif
-    SV *re_trie_maxbuff;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
 #ifndef DEBUGGING
@@ -638,20 +607,34 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         case EXACTFAA:
         case EXACTFUP:
         case EXACTFU:
-        case EXACTFLU8: folder = PL_fold_latin1; break;
+        case EXACTFLU8:
+            folder = PL_fold_latin1;
+            break;
         case EXACTF:  folder = PL_fold; break;
         default: croak("panic! In trie construction, unknown node type %u %s", (unsigned) flags, REGNODE_NAME(flags) );
     }
 
-    /* create the trie struct, all zeroed */
+    /* Trie data is immutable after compilation and is shared by cloned
+     * regexes through refcounting.  Allocate the trie and its persistent
+     * storage from the shared allocator, and use PerlMemShared_realloc() and
+     * PerlMemShared_free() for it; pregfree() releases it only when the last
+     * regex reference disappears. */
     trie = (reg_trie_data *) PerlMemShared_calloc( 1, sizeof(reg_trie_data) );
     trie->refcount = 1;
     trie->startstate = 1;
     trie->wordcount = word_count;
+    trie->prop_flags = folder == NULL
+        ? 0
+        : folder == PL_fold
+            ? TRIE_FOLD_NATIVE
+            : TRIE_FOLD_UNICODE;
     RExC_rxi->data->data[ data_slot ] = (void*)trie;
-    trie->charmap = (U32 *) PerlMemShared_calloc( 256, sizeof(U32) );
-    if (flags == EXACT || flags == EXACT_REQ8 || flags == EXACTL)
-        trie->bitmap = (char *) PerlMemShared_calloc( ANYOF_BITMAP_SIZE, 1 );
+#ifdef DEBUGGING
+    /* The compiler can return early if no replacement node fits.  Install
+     * the optional word-list slot before that can happen, so regex cleanup
+     * never sees an uninitialised data pointer. */
+    RExC_rxi->data->data[ data_slot + TRIE_WORDS_OFFSET ] = NULL;
+#endif
     trie->wordinfo = (reg_trie_wordinfo *) PerlMemShared_calloc(
                        trie->wordcount+1, sizeof(reg_trie_wordinfo));
 
@@ -659,11 +642,6 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         trie_words = newAV();
     });
 
-    re_trie_maxbuff = get_sv(RE_TRIE_MAXBUF_NAME, GV_ADD);
-    assert(re_trie_maxbuff);
-    if (!SvIOK(re_trie_maxbuff)) {
-        sv_setiv(re_trie_maxbuff, RE_TRIE_MAXBUF_INIT);
-    }
     DEBUG_TRIE_COMPILE_r({
         re_indentf(
           "make_trie start == %d, first == %d, last == %d, tail == %d depth = %d\n",
@@ -680,255 +658,39 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         /* branch sub-chain */
         convert = REGNODE_AFTER( first );
     }
+    /* Jump offsets are recorded relative to this location.  Prefix
+     * extraction may move the trie, in which case jump_correction rebases
+     * them. */
+    regnode * const jump_base = convert;
 
-    /*  -- First loop and Setup --
-
-       We first traverse the branches and scan each word to determine if it
-       contains widechars, and how many unique chars there are, this is
-       important as we have to build a table with at least as many columns as we
-       have unique chars.
-
-       We use an array of integers to represent the character codes 0..255
-       (trie->charmap) and we use a an HV* to store Unicode characters. We use
-       the native representation of the character value as the key and IV's for
-       the coded index.
-
-       *TODO* If we keep track of how many times each character is used we can
-       remap the columns so that the table compression later on is more
-       efficient in terms of memory by ensuring the most common value is in the
-       middle and the least common are on the outside.  IMO this would be better
-       than a most to least common mapping as theres a decent chance the most
-       common letter will share a node with the least common, meaning the node
-       will not be compressible. With a middle is most common approach the worst
-       case is when we have the least common nodes twice.
-
-     */
-
-    for ( cur = first ; cur < last ; cur = regnext( cur ) ) {
-        regnode *noper = REGNODE_AFTER( cur );
-        const U8 *uc;
-        const U8 *e;
-        int foldlen = 0;
-        U32 wordlen      = 0;         /* required init */
-        STRLEN minchars = 0;
-        STRLEN maxchars = 0;
-        bool set_bit = trie->bitmap ? 1 : 0; /*store the first char in the
-                                               bitmap?*/
-
-        /* wordlen is needed for the TRIE_READ_CHAR() macro, but we don't use its
-           value in this scope, we only modify it.  clang 17 warns about this.
-           The later definitions of wordlen in this function do have their values
-           used.
-        */
-        PERL_UNUSED_VAR(wordlen);
-
-        lastbranch = cur;
-
-        if (OP(noper) == NOTHING) {
-            /* skip past a NOTHING at the start of an alternation
-             * eg, /(?:)a|(?:b)/ should be the same as /a|b/
-             *
-             * If the next node is not something we are supposed to process
-             * we will just ignore it due to the condition guarding the
-             * next block.
-             */
-
-            regnode *noper_next= regnext(noper);
-            if (noper_next < tail)
-                noper = noper_next;
-        }
-
-        if (    noper < tail
-            && (    OP(noper) == flags
-                || (flags == EXACT && OP(noper) == EXACT_REQ8)
-                || (flags == EXACTFU && (   OP(noper) == EXACTFU_REQ8
-                                         || OP(noper) == EXACTFUP))))
-        {
-            uc = (U8*)STRING(noper);
-            e = uc + STR_LEN(noper);
-        } else {
-            trie->minlen= 0;
-            continue;
-        }
-
-
-        if ( set_bit ) { /* bitmap only alloced when !(UTF && Folding) */
-            TRIE_BITMAP_SET(trie,*uc); /* store the raw first byte
-                                          regardless of encoding */
-            if (OP( noper ) == EXACTFUP) {
-                /* false positives are ok, so just set this */
-                TRIE_BITMAP_SET(trie, LATIN_SMALL_LETTER_SHARP_S);
-            }
-        }
-
-        for ( ; uc < e ; uc += len ) {  /* Look at each char in the current
-                                           branch */
-            TRIE_CHARCOUNT(trie)++;
-            TRIE_READ_CHAR;
-
-            /* TRIE_READ_CHAR returns the current character, or its fold if /i
-             * is in effect.  Under /i, this character can match itself, or
-             * anything that folds to it.  If not under /i, it can match just
-             * itself.  Most folds are 1-1, for example k, K, and KELVIN SIGN
-             * all fold to k, and all are single characters.   But some folds
-             * expand to more than one character, so for example LATIN SMALL
-             * LIGATURE FFI folds to the three character sequence 'ffi'.  If
-             * the string beginning at 'uc' is 'ffi', it could be matched by
-             * three characters, or just by the one ligature character. (It
-             * could also be matched by two characters: LATIN SMALL LIGATURE FF
-             * followed by 'i', or by 'f' followed by LATIN SMALL LIGATURE FI).
-             * (Of course 'I' and/or 'F' instead of 'i' and 'f' can also
-             * match.)  The trie needs to know the minimum and maximum number
-             * of characters that could match so that it can use size alone to
-             * quickly reject many match attempts.  The max is simple: it is
-             * the number of folded characters in this branch (since a fold is
-             * never shorter than what folds to it. */
-
-            maxchars++;
-
-            /* And the min is equal to the max if not under /i (indicated by
-             * 'folder' being NULL), or there are no multi-character folds.  If
-             * there is a multi-character fold, the min is incremented just
-             * once, for the character that folds to the sequence.  Each
-             * character in the sequence needs to be added to the list below of
-             * characters in the trie, but we count only the first towards the
-             * min number of characters needed.  This is done through the
-             * variable 'foldlen', which is returned by the macros that look
-             * for these sequences as the number of bytes the sequence
-             * occupies.  Each time through the loop, we decrement 'foldlen' by
-             * how many bytes the current char occupies.  Only when it reaches
-             * 0 do we increment 'minchars' or look for another multi-character
-             * sequence. */
-            if (folder == NULL) {
-                minchars++;
-            }
-            else if (foldlen > 0) {
-                foldlen -= (UTF) ? UTF8SKIP(uc) : 1;
-            }
-            else {
-                minchars++;
-
-                /* See if *uc is the beginning of a multi-character fold.  If
-                 * so, we decrement the length remaining to look at, to account
-                 * for the current character this iteration.  (We can use 'uc'
-                 * instead of the fold returned by TRIE_READ_CHAR because the
-                 * macro is smart enough to account for any unfolded
-                 * characters. */
-                if (UTF) {
-                    if ((foldlen = is_MULTI_CHAR_FOLD_utf8_safe(uc, e))) {
-                        foldlen -= UTF8SKIP(uc);
-                    }
-                }
-                else if ((foldlen = is_MULTI_CHAR_FOLD_latin1_safe(uc, e))) {
-                    foldlen--;
-                }
-            }
-
-            /* The current character (and any potential folds) should be added
-             * to the possible matching characters for this position in this
-             * branch */
-            if ( uvc < 256 ) {
-                if ( folder ) {
-                    U8 folded = folder[ (U8) uvc ];
-                    if ( !trie->charmap[ folded ] ) {
-                        trie->charmap[ folded ]=( ++trie->uniquecharcount );
-                        TRIE_STORE_REVCHAR( folded );
-                    }
-                }
-                if ( !trie->charmap[ uvc ] ) {
-                    trie->charmap[ uvc ]=( ++trie->uniquecharcount );
-                    TRIE_STORE_REVCHAR( uvc );
-                }
-                if ( set_bit ) {
-                    /* store the codepoint in the bitmap, and its folded
-                     * equivalent. */
-                    S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, uvc, folder);
-                    set_bit = 0; /* We've done our bit :-) */
-                }
-            } else {
-
-                /* XXX We could come up with the list of code points that fold
-                 * to this using PL_utf8_foldclosures, except not for
-                 * multi-char folds, as there may be multiple combinations
-                 * there that could work, which needs to wait until runtime to
-                 * resolve (The comment about LIGATURE FFI above is such an
-                 * example */
-
-                SV** svpp;
-                if ( !widecharmap )
-                    widecharmap = newHV();
-
-                svpp = hv_fetch( widecharmap, (char*)&uvc, sizeof( UV ), 1 );
-
-                if ( !svpp )
-                    croak("error creating/fetching widecharmap entry for 0x%" UVXf, uvc );
-
-                if ( !SvTRUE( *svpp ) ) {
-                    sv_setiv( *svpp, ++trie->uniquecharcount );
-                    TRIE_STORE_REVCHAR(uvc);
-                }
-            }
-        } /* end loop through characters in this branch of the trie */
-
-        /* We take the min and max for this branch and combine to find the min
-         * and max for all branches processed so far */
-        if( cur == first ) {
-            trie->minlen = minchars;
-            trie->maxlen = maxchars;
-        } else if (minchars < trie->minlen) {
-            trie->minlen = minchars;
-        } else if (maxchars > trie->maxlen) {
-            trie->maxlen = maxchars;
-        }
-    } /* end first pass */
-    trie->before_paren = OP(first) == BRANCH
-                 ? ARG1a(first)
-                 : ARG2a(first); /* BRANCHJ */
-
-    trie->after_paren = OP(lastbranch) == BRANCH
-                 ? ARG1b(lastbranch)
-                 : ARG2b(lastbranch); /* BRANCHJ */
-    DEBUG_TRIE_COMPILE_r(
-        re_indentf(
-                "TRIE(%s): W:%d C:%d Uq:%d Min:%d Max:%d\n",
-                depth+1,
-                ( widecharmap ? "UTF8" : "NATIVE" ), (int)word_count,
-                (int)TRIE_CHARCOUNT(trie), trie->uniquecharcount,
-                (int)trie->minlen, (int)trie->maxlen )
-    );
+    /* State zero is reserved as the sentinel; state one is the root, and
+     * next_alloc always names the next state to allocate. */
+    /* The list compiler performs source analysis and transition-list
+     * construction in one pass.  The larger of the word and octet counts is
+     * a useful initial estimate: common prefixes reduce the number of states,
+     * while UTF-8 expansion and folding can increase it.  State storage
+     * therefore grows on demand when the estimate is low. */
+    state_capacity = MAX(word_count, octet_count) + 2;
+    if (state_capacity < 16)
+        state_capacity = 16;
+    trie_needs_codepoint_processing = folder != NULL;
 
     /*
-        We now know what we are dealing with in terms of unique chars and
-        string sizes so we can calculate how much memory a naive
-        representation using a flat table  will take. If it's over a reasonable
-        limit (as specified by ${^RE_TRIE_MAXBUF}) we use a more memory
-        conservative but potentially much slower representation using an array
-        of lists.
-
-        At the end we convert both representations into the same compressed
-        form that will be used in regexec.c for matching with. The latter
-        is a form that cannot be used to construct with but has memory
-        properties similar to the list form and access properties similar
-        to the table form making it both suitable for fast searches and
-        small enough that its feasable to store for the duration of a program.
-
-        See the comment in the code where the compressed table is produced
-        inplace from the flat tabe representation for an explanation of how
-        the compression works.
+        We construct every trie using an array of transition lists.  Once
+        construction is complete, the list representation is converted into
+        the compressed transition form used by regexec.c.
 
     */
 
 
-    Newx(prev_states, TRIE_CHARCOUNT(trie) + 2, U32);
+    Newx(prev_states, state_capacity, U32);
     prev_states[1] = 0;
 
-    if ( (IV)( ( TRIE_CHARCOUNT(trie) + 1 ) * trie->uniquecharcount + 1)
-                                                    > SvIV(re_trie_maxbuff) )
     {
         /*
-            Second Pass -- Array Of Lists Representation
+            Array Of Lists Representation
 
-            Each state will be represented by a list of charid:state records
+            Each state will be represented by a list of octet:state records
             (reg_trie_trans_le) the first such element holds the CUR and LEN
             points of the allocated array. (See defines above).
 
@@ -937,23 +699,29 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
             (but cant be modified once converted).
         */
 
-        STRLEN transcount = 1;
+        /* TRIE_CHARCOUNT counts source characters for diagnostics.  This
+         * count is different from transition_count, which counts distinct
+         * list transitions and provides the initial packed-table estimate. */
+        STRLEN transition_count = 1;
 
         DEBUG_TRIE_COMPILE_MORE_r( re_indentf("Compiling trie using list compiler\n",
             depth+1));
 
         trie->states = (reg_trie_state *)
-            PerlMemShared_calloc( TRIE_CHARCOUNT(trie) + 2,
+            PerlMemShared_calloc( state_capacity,
                                   sizeof(reg_trie_state) );
-        TRIE_LIST_NEW(1);
+        S_trie_list_new(trie, 1);
         next_alloc = 2;
 
         for ( cur = first ; cur < last ; cur = regnext( cur ) ) {
 
             regnode *noper   = REGNODE_AFTER( cur );
             U32 state        = 1;         /* required init */
-            U32 charid       = 0;         /* sanity init */
             U32 wordlen      = 0;         /* required init */
+            int foldlen      = 0;
+            STRLEN minchars  = 0;
+            STRLEN maxchars  = 0;
+            lastbranch = cur;
 
             if (OP(noper) == NOTHING) {
                 regnode *noper_next= regnext(noper);
@@ -968,71 +736,247 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 && (    OP(noper) == flags
                     || (flags == EXACT && OP(noper) == EXACT_REQ8)
                     || (flags == EXACTFU && (   OP(noper) == EXACTFU_REQ8
-                                             || OP(noper) == EXACTFUP))))
+                                              || OP(noper) == EXACTFUP))))
             {
                 const U8 *uc= (U8*)STRING(noper);
                 const U8 *e= uc + STR_LEN(noper);
 
+                bool is_utf8 = TRIE_SOURCE_UTF8(noper);
+
                 for ( ; uc < e ; uc += len ) {
+                    if (is_utf8 && folder == NULL) {
+                        const U8 *bp;
+                        const U8 * const ep = uc + UTF8SKIP(uc);
 
-                    TRIE_READ_CHAR;
+                        /* An un-folded UTF-8 source word is already in the
+                         * representation used by the trie.  Avoid decoding
+                         * and re-encoding it; UTF8SKIP is sufficient here
+                         * because compiled pattern strings are well formed. */
+                        len = (STRLEN)(ep - uc);
+                        wordlen++;
+                        minchars++;
+                        maxchars++;
+                        TRIE_CHARCOUNT(trie)++;
 
-                    if ( uvc < 256 ) {
-                        charid = trie->charmap[ uvc ];
-                    } else {
-                        SV** const svpp = hv_fetch( widecharmap,
-                                                    (char*)&uvc,
-                                                    sizeof( UV ),
-                                                    0);
-                        if ( !svpp ) {
-                            charid = 0;
-                        } else {
-                            charid = (U32)SvIV( *svpp );
+                        if (len == 1) {
+                            trie->prop_flags |= TRIE_CP_INVARIANT;
                         }
+                        else if (UTF8_IS_ABOVE_LATIN1(*uc)) {
+                            trie->prop_flags |= TRIE_CP_HIGH;
+                            trie_needs_codepoint_processing = true;
+                        }
+                        else {
+                            trie->prop_flags |= TRIE_CP_AWKWARD;
+                            trie_needs_codepoint_processing = true;
+                        }
+
+                        for (bp = uc; bp < ep; bp++)
+                            S_trie_list_transition(aTHX_ trie, &state, *bp,
+                                                    &next_alloc, &state_capacity,
+                                                    &prev_states, &transition_count);
+                        continue;
                     }
-                    /* charid is now 0 if we dont know the char read, or
-                     * nonzero if we do */
-                    if ( charid ) {
 
-                        U32 check;
-                        U32 newstate = 0;
+                    wordlen++;
+                    if (is_utf8) {
+                        /* If it is UTF then it is either already folded, or
+                         * does not need folding. */
+                        uvc = valid_utf8_to_uv((const U8 *)uc, &len);
+                    }
+                    else if (folder == PL_fold_latin1) {
+                        /* This folder implies Unicode rules, which in the
+                         * range expressible by not UTF is the lower case,
+                         * with the two exceptions, one of which should have
+                         * been taken care of before calling this. */
+                        assert(*uc != LATIN_SMALL_LETTER_SHARP_S);
+                        uvc = toLOWER_L1(*uc);
+                        if (UNLIKELY(uvc == MICRO_SIGN))
+                            uvc = GREEK_SMALL_LETTER_MU;
+                        len = 1;
+                    }
+                    else {
+                        /* Raw data, will be folded later if needed. */
+                        uvc = (U32)*uc;
+                        len = 1;
+                    }
+                    TRIE_CHARCOUNT(trie)++;
 
-                        charid--;
-                        if ( !trie->states[ state ].trans.list ) {
-                            TRIE_LIST_NEW( state );
+                    /* YJO: KHW says that we dont need a NATIVE_TO_UNI() on uvc here */
+                    if (UVCHR_IS_INVARIANT(uvc))
+                        trie->prop_flags |= TRIE_CP_INVARIANT;
+                    else if (uvc < 256) {
+                        trie->prop_flags |= TRIE_CP_AWKWARD;
+                        trie_needs_codepoint_processing = true;
+                    }
+                    else {
+                        trie->prop_flags |= TRIE_CP_HIGH;
+                        trie_needs_codepoint_processing = true;
+                    }
+
+                    /* The trie contains every character in the folded
+                     * representation, so maxchars counts each character
+                     * visited here.  A multi-character fold can make the
+                     * actual match longer than the source word. */
+                    maxchars++;
+                    if (folder == NULL) {
+                        minchars++;
+                    }
+                    else if (foldlen > 0) {
+                        /* The remaining characters of a multi-character
+                         * fold are represented in the trie, but they do not
+                         * consume additional source characters. */
+                        foldlen -= (UTF) ? UTF8SKIP(uc) : 1;
+                    }
+                    else {
+                        minchars++;
+                        /* Count the first character of a fold normally, then
+                         * suppress the additional folded characters from the
+                         * minimum.  foldlen is measured in source octets. */
+                        if (UTF) {
+                            if ((foldlen = is_MULTI_CHAR_FOLD_utf8_safe(uc, e)))
+                                foldlen -= UTF8SKIP(uc);
                         }
-                        for ( check = 1;
-                              check <= TRIE_LIST_USED( state );
-                              check++ )
-                        {
-                            if ( TRIE_LIST_ITEM( state, check ).forid
-                                                                    == charid )
-                            {
-                                newstate = TRIE_LIST_ITEM( state, check ).newstate;
-                                break;
-                            }
+                        else if ((foldlen = is_MULTI_CHAR_FOLD_latin1_safe(uc, e)))
+                            foldlen--;
+                    }
+
+                    if ( trie_needs_codepoint_processing ) {
+                        const U8 *bp;
+                        const U8 *ep;
+                        /* Extended codepoints may require more than the
+                         * four octets needed for Unicode scalar values, so
+                         * this must use UTF8_MAXBYTES rather than
+                         * MAX_UNICODE_UTF8_BYTES.  The extra octet is for
+                         * the terminating NUL expected by the encoder. */
+                        U8 encoded[UTF8_MAXBYTES + 1];
+
+                        if (!is_utf8 && FITS_IN_8_BITS(uvc)) {
+                            const native_octet_utf8_t * const octet =
+                                &PL_native_octet_utf8[(U8)uvc];
+                            bp = octet->bytes;
+                            ep = bp + octet->len;
                         }
-                        if ( ! newstate ) {
-                            newstate = next_alloc++;
-                            prev_states[newstate] = state;
-                            TRIE_LIST_PUSH( state, charid, newstate );
-                            transcount++;
+                        else {
+                            /* YJO: KHW says this should not be NATIVE_TO_UNI(uvc) */
+                            ep = uv_to_utf8_flags(encoded, uvc, 0);
+                            bp = encoded;
                         }
-                        state = newstate;
+
+                        for ( ; bp < ep; bp++)
+                            S_trie_list_transition(aTHX_ trie, &state, *bp,
+                                                    &next_alloc, &state_capacity,
+                                                    &prev_states, &transition_count);
                     } else {
-                        croak("panic! In trie construction, no char mapping for %" IVdf, uvc );
+                        S_trie_list_transition(aTHX_ trie, &state, uvc,
+                                                &next_alloc, &state_capacity,
+                                                &prev_states, &transition_count);
                     }
                 }
             } else {
                 /* If we end up here it is because we skipped past a NOTHING, but did not end up
                  * on a trieable type. So we need to reset noper back to point at the first regop
-                 * in the branch before we call TRIE_HANDLE_WORD()
+                 * in the branch before we record the word
                 */
                 noper = REGNODE_AFTER(cur);
             }
-            TRIE_HANDLE_WORD(state);
+            if (cur == first) {
+                trie->minlen = minchars;
+                trie->maxlen = maxchars;
+            }
+            else if (minchars < trie->minlen) {
+                trie->minlen = minchars;
+            }
+            else if (maxchars > trie->maxlen) {
+                trie->maxlen = maxchars;
+            }
+            {
+                U32 dupe = trie->states[state].wordnum;
+                regnode * const noper_next = regnext(noper);
 
-        } /* end second pass */
+                DEBUG_r({
+                    /* Store the word for dumping. */
+                    SV *tmp;
+                    if (OP(noper) != NOTHING)
+                        tmp = newSVpvn_utf8(STRING(noper), STR_LEN(noper), UTF);
+                    else
+                        tmp = newSVpvn_utf8("", 0, UTF);
+                    av_push_simple(trie_words, tmp);
+                });
+
+                curword++;
+                assert(curword <= word_count);
+                trie->wordinfo[curword].prev = 0;
+                trie->wordinfo[curword].len = wordlen;
+                trie->wordinfo[curword].accept = state;
+
+                /* If this branch continues past its exact node, preserve the
+                 * continuation and the capture-state values associated with
+                 * the branch.  Replacing the branch chain with one trie node
+                 * would otherwise discard that control-flow information. */
+                if (noper_next < tail) {
+                    if (!trie->jump) {
+                        trie->jump = (TRIE_JUMP_TYPE *)
+                            PerlMemShared_calloc(word_count + 1,
+                                                 sizeof(TRIE_JUMP_TYPE));
+                        trie->j_before_paren = (U16 *)
+                            PerlMemShared_calloc(word_count + 1, sizeof(U16));
+                        trie->j_after_paren = (U16 *)
+                            PerlMemShared_calloc(word_count + 1, sizeof(U16));
+                    }
+                    assert(noper_next > convert);
+                    assert(curword <= word_count);
+                    assert(!trie->jump[curword]);
+                    assert((noper_next - convert) >= 0);
+                    assert((noper_next - convert) <= TRIE_JUMP_TYPE_MAX);
+                    trie->jump[curword] = noper_next - convert;
+                    U16 set_before_paren;
+                    U16 set_after_paren;
+                    if (OP(cur) == BRANCH) {
+                        set_before_paren = ARG1a(cur);
+                        set_after_paren = ARG1b(cur);
+                    }
+                    else {
+                        set_before_paren = ARG2a(cur);
+                        set_after_paren = ARG2b(cur);
+                    }
+                    trie->j_before_paren[curword] = set_before_paren;
+                    trie->j_after_paren[curword] = set_after_paren;
+                    if (!jumper)
+                        jumper = noper_next;
+                    if (!nextbranch)
+                        nextbranch = regnext(cur);
+                }
+
+                if (dupe) {
+                    /* It's a duplicate.  Pre-insert it into the
+                     * wordinfo[].prev chain so duplicate words appear in
+                     * the chain when it is linked below. */
+                    trie->wordinfo[curword].prev = trie->wordinfo[dupe].prev;
+                    trie->wordinfo[dupe].prev = curword;
+                }
+                else {
+                    trie->states[state].wordnum = curword;
+                }
+            }
+
+        } /* end list construction */
+
+        /* The list pass has also completed the source analysis. */
+        trie->before_paren = OP(first) == BRANCH
+                     ? ARG1a(first)
+                     : ARG2a(first); /* BRANCHJ */
+
+        trie->after_paren = OP(lastbranch) == BRANCH
+                     ? ARG1b(lastbranch)
+                     : ARG2b(lastbranch); /* BRANCHJ */
+        DEBUG_TRIE_COMPILE_r(
+            re_indentf(
+                    "TRIE(%s): W:%d C:%d Uq:%d Min:%d Max:%d\n",
+                    depth+1,
+                    ( trie_needs_codepoint_processing ? "PROCESSED" : "RAW" ), (int)word_count,
+                    (int)TRIE_CHARCOUNT(trie), TRIE_ALPHABET_SIZE,
+                    (int)trie->minlen, (int)trie->maxlen )
+        );
 
         /* next alloc is the NEXT state to be allocated */
         trie->statecount = next_alloc;
@@ -1042,17 +986,29 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                    * sizeof(reg_trie_state) );
 
         /* and now dump it out before we compress it */
-        DEBUG_TRIE_COMPILE_MORE_r(dump_trie_interim_list(trie, widecharmap,
-                                                         revcharmap, next_alloc,
+        DEBUG_TRIE_COMPILE_MORE_r(dump_trie_interim_list(trie, next_alloc,
                                                          depth+1)
         );
 
+        /* The list compiler has counted each distinct transition.  The flat
+         * table has an unused slot zero, so this is the ideal number of
+         * occupied entries.  The table itself may need more physical slots
+         * because a state's character-ID range can contain holes. */
+#ifdef DEBUGGING
+        const STRLEN ideal_transition_count = transition_count - 1;
+#endif
+        STRLEN transition_capacity = transition_count;
         trie->trans = (reg_trie_trans *)
-            PerlMemShared_calloc( transcount, sizeof(reg_trie_trans) );
+            PerlMemShared_calloc( transition_capacity,
+                                  sizeof(reg_trie_trans) );
         {
             U32 state;
-            U32 tp = 0;
-            U32 zp = 0;
+            /* table_highwater is one past the packed portion of trie->trans;
+             * next_hole is the first unused slot within that portion.  A
+             * non-zero next field marks an occupied slot, so holes can be
+             * reused without a separate occupancy map. */
+            U32 table_highwater = 0;
+            U32 next_hole = 0;
 
 
             for( state = 1; state < next_alloc; state ++ ) {
@@ -1060,63 +1016,145 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
                 /*
                 DEBUG_TRIE_COMPILE_MORE_r(
-                    re_printf("tp: %d zp: %d ",tp,zp)
+                    re_printf("table_highwater: %d next_hole: %d ",
+                              table_highwater, next_hole)
                 );
                 */
 
                 if (trie->states[state].trans.list) {
-                    U32 minid = TRIE_LIST_ITEM( state, 1).forid;
-                    U32 maxid = minid;
-                    U32 idx;
+                    const U32 used = TRIE_LIST_USED( state );
+                    const U32 min_octet = TRIE_LIST_ITEM( state, 1).octet;
+                    const U32 max_octet = TRIE_LIST_ITEM( state, used).octet;
+                    const U32 frame_span = max_octet - min_octet;
+                    const U32 frame_width = frame_span + 1;
+                    bool placed = false;
+                    U32 transition_index;
 
-                    for( idx = 2 ; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
-                        const U32 forid = TRIE_LIST_ITEM( state, idx).forid;
-                        if ( forid < minid ) {
-                            minid = forid;
-                        } else if ( forid > maxid ) {
-                            maxid = forid;
+                    /* A state's transitions form a frame from min_octet
+                     * through max_octet.  Sparse frames may fit into holes
+                     * left by earlier frames.  Try the first available
+                     * position.  The frame may extend beyond table_highwater,
+                     * provided it
+                     * fits in the allocation and its occupied slots do not
+                     * clash. */
+                    while (next_hole < table_highwater
+                            && trie->trans[next_hole].next)
+                        next_hole++;
+                    /* Only sparse frames benefit from hole searching.  Small
+                     * frames are cheap to try, while larger frames are tried
+                     * only when their span is much wider than their payload. */
+                    if (used > 1 && (used <= 4 || used * 8 < frame_span)
+                            && next_hole < table_highwater
+                            && next_hole + frame_width >= next_hole) {
+                        const U32 candidate_end = next_hole + frame_width;
+                        if (transition_capacity < candidate_end) {
+                            const U32 old_capacity = transition_capacity;
+                            const U32 needed = candidate_end;
+
+                            while (transition_capacity < needed)
+                                transition_capacity *= 2;
+                            trie->trans = (reg_trie_trans *)
+                                PerlMemShared_realloc(
+                                    trie->trans,
+                                    transition_capacity
+                                      * sizeof(reg_trie_trans) );
+                            Zero( trie->trans + old_capacity,
+                                  transition_capacity - old_capacity,
+                                  reg_trie_trans );
+                        }
+                        for (transition_index = 1;
+                             transition_index <= used;
+                             transition_index++) {
+                            const U32 tid = next_hole
+                                           + TRIE_LIST_ITEM(state,
+                                                            transition_index).octet
+                                           - min_octet;
+                            if (trie->trans[ tid ].next)
+                                break;
+                        }
+                        if (transition_index > used) {
+                            base = TRIE_ALPHABET_SIZE + next_hole - min_octet;
+                            for (transition_index = 1;
+                                 transition_index <= used;
+                                 transition_index++) {
+                                const U32 tid = base
+                                               - TRIE_ALPHABET_SIZE
+                                               + TRIE_LIST_ITEM(state,
+                                                                transition_index).octet;
+                                trie->trans[ tid ].next = TRIE_LIST_ITEM( state,
+                                                                    transition_index ).newstate;
+                                trie->trans[ tid ].check = state;
+                            }
+                            if (candidate_end > table_highwater)
+                                table_highwater = candidate_end;
+                            while (next_hole < table_highwater
+                                    && trie->trans[next_hole].next)
+                                next_hole++;
+                            placed = true;
                         }
                     }
-                    if ( transcount < tp + maxid - minid + 1) {
-                        transcount *= 2;
+
+                    /* Grow the physical table when the frame cannot fit at
+                     * the current high-water mark. */
+                    if (!placed
+                            && transition_capacity < table_highwater + frame_width) {
+                        const U32 old_capacity = transition_capacity;
+                        const U32 needed = table_highwater + frame_width;
+
+                        while (transition_capacity < needed)
+                            transition_capacity *= 2;
                         trie->trans = (reg_trie_trans *)
                             PerlMemShared_realloc( trie->trans,
-                                                     transcount
+                                                     transition_capacity
                                                      * sizeof(reg_trie_trans) );
-                        Zero( trie->trans + (transcount / 2),
-                              transcount / 2,
+                        Zero( trie->trans + old_capacity,
+                              transition_capacity - old_capacity,
                               reg_trie_trans );
                     }
-                    base = trie->uniquecharcount + tp - minid;
-                    if ( maxid == minid ) {
+                    if (!placed) {
+                        base = TRIE_ALPHABET_SIZE + table_highwater - min_octet;
+                    }
+                    /* A one-transition frame can occupy one existing hole;
+                     * it does not need its full frame width to be reserved. */
+                    if ( !placed && max_octet == min_octet ) {
                         U32 set = 0;
-                        for ( ; zp < tp ; zp++ ) {
-                            if ( ! trie->trans[ zp ].next ) {
-                                base = trie->uniquecharcount + zp - minid;
-                                trie->trans[ zp ].next = TRIE_LIST_ITEM( state,
+                        for ( ; next_hole < table_highwater ; next_hole++ ) {
+                            if ( ! trie->trans[ next_hole ].next ) {
+                                base = TRIE_ALPHABET_SIZE + next_hole - min_octet;
+                                trie->trans[ next_hole ].next = TRIE_LIST_ITEM( state,
                                                                    1).newstate;
-                                trie->trans[ zp ].check = state;
+                                trie->trans[ next_hole ].check = state;
                                 set = 1;
                                 break;
                             }
                         }
                         if ( !set ) {
-                            trie->trans[ tp ].next = TRIE_LIST_ITEM( state,
+                            trie->trans[ table_highwater ].next = TRIE_LIST_ITEM( state,
                                                                    1).newstate;
-                            trie->trans[ tp ].check = state;
-                            tp++;
-                            zp = tp;
+                            trie->trans[ table_highwater ].check = state;
+                            table_highwater++;
+                            next_hole = table_highwater;
+                        } else {
+                            while (next_hole < table_highwater
+                                    && trie->trans[next_hole].next)
+                                next_hole++;
                         }
-                    } else {
-                        for ( idx = 1; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
+                    } else if (!placed) {
+                        for (transition_index = 1;
+                             transition_index <= TRIE_LIST_USED(state);
+                             transition_index++) {
                             const U32 tid = base
-                                           - trie->uniquecharcount
-                                           + TRIE_LIST_ITEM( state, idx ).forid;
+                                           - TRIE_ALPHABET_SIZE
+                                           + TRIE_LIST_ITEM(state,
+                                                            transition_index).octet;
                             trie->trans[ tid ].next = TRIE_LIST_ITEM( state,
-                                                                idx ).newstate;
+                                                                transition_index ).newstate;
                             trie->trans[ tid ].check = state;
                         }
-                        tp += ( maxid - minid + 1 );
+                        table_highwater += frame_width;
+                        while (next_hole < table_highwater
+                                && trie->trans[next_hole].next)
+                            next_hole++;
                     }
                     Safefree(trie->states[ state ].trans.list);
                 }
@@ -1127,259 +1165,23 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 */
                 trie->states[ state ].trans.base = base;
             }
-            trie->lasttrans = tp + 1;
-        }
-    } else {
-        /*
-           Second Pass -- Flat Table Representation.
-
-           we dont use the 0 slot of either trans[] or states[] so we add 1 to
-           each.  We know that we will need Charcount+1 trans at most to store
-           the data (one row per char at worst case) So we preallocate both
-           structures assuming worst case.
-
-           We then construct the trie using only the .next slots of the entry
-           structs.
-
-           We use the .check field of the first entry of the node temporarily
-           to make compression both faster and easier by keeping track of how
-           many non zero fields are in the node.
-
-           Since trans are numbered from 1 any 0 pointer in the table is a FAIL
-           transition.
-
-           There are two terms at use here: state as a TRIE_NODEIDX() which is
-           a number representing the first entry of the node, and state as a
-           TRIE_NODENUM() which is the trans number. state 1 is TRIE_NODEIDX(1)
-           and TRIE_NODENUM(1), state 2 is TRIE_NODEIDX(2) and TRIE_NODENUM(3)
-           if there are 2 entrys per node. eg:
-
-             A B       A B
-          1. 2 4    1. 3 7
-          2. 0 3    3. 0 5
-          3. 0 0    5. 0 0
-          4. 0 0    7. 0 0
-
-           The table is internally in the right hand, idx form. However as we
-           also have to deal with the states array which is indexed by nodenum
-           we have to use TRIE_NODENUM() to convert.
-
-        */
-        DEBUG_TRIE_COMPILE_MORE_r( re_indentf("Compiling trie using table compiler\n",
-            depth+1));
-
-        trie->trans = (reg_trie_trans *)
-            PerlMemShared_calloc( ( TRIE_CHARCOUNT(trie) + 1 )
-                                  * trie->uniquecharcount + 1,
-                                  sizeof(reg_trie_trans) );
-        trie->states = (reg_trie_state *)
-            PerlMemShared_calloc( TRIE_CHARCOUNT(trie) + 2,
-                                  sizeof(reg_trie_state) );
-        next_alloc = trie->uniquecharcount + 1;
-
-
-        for ( cur = first ; cur < last ; cur = regnext( cur ) ) {
-
-            regnode *noper   = REGNODE_AFTER( cur );
-
-            U32 state        = 1;         /* required init */
-
-            U32 charid       = 0;         /* sanity init */
-            U32 accept_state = 0;         /* sanity init */
-
-            U32 wordlen      = 0;         /* required init */
-
-            if (OP(noper) == NOTHING) {
-                regnode *noper_next= regnext(noper);
-                if (noper_next < tail)
-                    noper = noper_next;
-                /* we will undo this assignment if noper does not
-                 * point at a trieable type in the else clause of
-                 * the following statement. */
-            }
-
-            if (    noper < tail
-                && (    OP(noper) == flags
-                    || (flags == EXACT && OP(noper) == EXACT_REQ8)
-                    || (flags == EXACTFU && (   OP(noper) == EXACTFU_REQ8
-                                             || OP(noper) == EXACTFUP))))
-            {
-                const U8 *uc= (U8*)STRING(noper);
-                const U8 *e= uc + STR_LEN(noper);
-
-                for ( ; uc < e ; uc += len ) {
-
-                    TRIE_READ_CHAR;
-
-                    if ( uvc < 256 ) {
-                        charid = trie->charmap[ uvc ];
-                    } else {
-                        SV* const * const svpp = hv_fetch( widecharmap,
-                                                           (char*)&uvc,
-                                                           sizeof( UV ),
-                                                           0);
-                        charid = svpp ? (U32)SvIV(*svpp) : 0;
-                    }
-                    if ( charid ) {
-                        charid--;
-                        if ( !trie->trans[ state + charid ].next ) {
-                            trie->trans[ state + charid ].next = next_alloc;
-                            trie->trans[ state ].check++;
-                            prev_states[TRIE_NODENUM(next_alloc)]
-                                    = TRIE_NODENUM(state);
-                            next_alloc += trie->uniquecharcount;
-                        }
-                        state = trie->trans[ state + charid ].next;
-                    } else {
-                        croak("panic! In trie construction, no char mapping for %" IVdf, uvc );
-                    }
-                    /* charid is now 0 if we dont know the char read, or
-                     * nonzero if we do */
-                }
-            } else {
-                /* If we end up here it is because we skipped past a NOTHING, but did not end up
-                 * on a trieable type. So we need to reset noper back to point at the first regop
-                 * in the branch before we call TRIE_HANDLE_WORD().
-                */
-                noper = REGNODE_AFTER(cur);
-            }
-            accept_state = TRIE_NODENUM( state );
-            TRIE_HANDLE_WORD(accept_state);
-
-        } /* end second pass */
-
-        /* and now dump it out before we compress it */
-        DEBUG_TRIE_COMPILE_MORE_r(dump_trie_interim_table(trie, widecharmap,
-                                                          revcharmap,
-                                                          next_alloc, depth+1));
-
-        {
-        /*
-           * Inplace compress the table.*
-
-           For sparse data sets the table constructed by the trie algorithm will
-           be mostly 0/FAIL transitions or to put it another way mostly empty.
-           (Note that leaf nodes will not contain any transitions.)
-
-           This algorithm compresses the tables by eliminating most such
-           transitions, at the cost of a modest bit of extra work during lookup:
-
-           - Each states[] entry contains a .base field which indicates the
-           index in the state[] array wheres its transition data is stored.
-
-           - If .base is 0 there are no valid transitions from that node.
-
-           - If .base is nonzero then charid is added to it to find an entry in
-           the trans array.
-
-           -If trans[states[state].base+charid].check!=state then the
-           transition is taken to be a 0/Fail transition. Thus if there are fail
-           transitions at the front of the node then the .base offset will point
-           somewhere inside the previous nodes data (or maybe even into a node
-           even earlier), but the .check field determines if the transition is
-           valid.
-
-           XXX - wrong maybe?
-           The following process inplace converts the table to the compressed
-           table: We first do not compress the root node 1,and mark all its
-           .check pointers as 1 and set its .base pointer as 1 as well. This
-           allows us to do a DFA construction from the compressed table later,
-           and ensures that any .base pointers we calculate later are greater
-           than 0.
-
-           - We set 'pos' to indicate the first entry of the second node.
-
-           - We then iterate over the columns of the node, finding the first and
-           last used entry at l and m. We then copy l..m into pos..(pos+m-l),
-           and set the .check pointers accordingly, and advance pos
-           appropriately and repreat for the next node. Note that when we copy
-           the next pointers we have to convert them from the original
-           NODEIDX form to NODENUM form as the former is not valid post
-           compression.
-
-           - If a node has no transitions used we mark its base as 0 and do not
-           advance the pos pointer.
-
-           - If a node only has one transition we use a second pointer into the
-           structure to fill in allocated fail transitions from other states.
-           This pointer is independent of the main pointer and scans forward
-           looking for null transitions that are allocated to a state. When it
-           finds one it writes the single transition into the "hole".  If the
-           pointer doesnt find one the single transition is appended as normal.
-
-           - Once compressed we can Renew/realloc the structures to release the
-           excess space.
-
-           See "Table-Compression Methods" in sec 3.9 of the Red Dragon,
-           specifically Fig 3.47 and the associated pseudocode.
-
-           demq
-        */
-        const U32 laststate = TRIE_NODENUM( next_alloc );
-        U32 state, charid;
-        U32 pos = 0, zp = 0;
-        trie->statecount = laststate;
-
-        for ( state = 1 ; state < laststate ; state++ ) {
-            U8 flag = 0;
-            const U32 stateidx = TRIE_NODEIDX( state );
-            const U32 o_used = trie->trans[ stateidx ].check;
-            U32 used = trie->trans[ stateidx ].check;
-            trie->trans[ stateidx ].check = 0;
-
-            for ( charid = 0;
-                  used && charid < trie->uniquecharcount;
-                  charid++ )
-            {
-                if ( flag || trie->trans[ stateidx + charid ].next ) {
-                    if ( trie->trans[ stateidx + charid ].next ) {
-                        if (o_used == 1) {
-                            for ( ; zp < pos ; zp++ ) {
-                                if ( ! trie->trans[ zp ].next ) {
-                                    break;
-                                }
-                            }
-                            trie->states[ state ].trans.base
-                                                    = zp
-                                                      + trie->uniquecharcount
-                                                      - charid ;
-                            trie->trans[ zp ].next
-                                = SAFE_TRIE_NODENUM( trie->trans[ stateidx
-                                                             + charid ].next );
-                            trie->trans[ zp ].check = state;
-                            if ( ++zp > pos ) pos = zp;
-                            break;
-                        }
-                        used--;
-                    }
-                    if ( !flag ) {
-                        flag = 1;
-                        trie->states[ state ].trans.base
-                                       = pos + trie->uniquecharcount - charid ;
-                    }
-                    trie->trans[ pos ].next
-                        = SAFE_TRIE_NODENUM(
-                                       trie->trans[ stateidx + charid ].next );
-                    trie->trans[ pos ].check = state;
-                    pos++;
-                }
-            }
-        }
-        trie->lasttrans = pos + 1;
-        trie->states = (reg_trie_state *)
-            PerlMemShared_realloc( trie->states, laststate
-                                   * sizeof(reg_trie_state) );
-        DEBUG_TRIE_COMPILE_MORE_r(
-            re_indentf("Alloc: %d Orig: %" IVdf " elements, Final:%" IVdf ". Savings of %%%5.2f\n",
-                depth+1,
-                (int)( ( TRIE_CHARCOUNT(trie) + 1 ) * trie->uniquecharcount
-                       + 1 ),
-                (IV)next_alloc,
-                (IV)pos,
-                ( ( next_alloc - pos ) * 100 ) / (double)next_alloc );
+            /* Slot zero is reserved by the packed-table representation; keep
+             * it in the recorded range even when table_highwater is zero. */
+            trie->lasttrans = table_highwater + 1;
+            assert(next_hole <= table_highwater);
+            assert(table_highwater <= transition_capacity);
+            DEBUG_TRIE_COMPILE_MORE_r(
+                re_indentf("Compressed table: physical=%" UVuf
+                           " ideal=%" UVuf " overhead=%" UVuf "\n",
+                    depth+1,
+                    (UV)table_highwater,
+                    (UV)ideal_transition_count,
+                    (UV)(table_highwater - ideal_transition_count))
             );
-
-        } /* end table compress */
+            DEBUG_TRIE_COMPILE_MORE_r(
+                dump_trie_physical(trie, table_highwater, depth+1)
+            );
+        }
     }
     DEBUG_TRIE_COMPILE_MORE_r(
             re_indentf("Statecount:%" UVxf " Lasttrans:%" UVxf "\n",
@@ -1396,10 +1198,20 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         U8 nodetype =(U8) flags;
         U8 trie_op = TRIE;
         char *str = NULL;
+        U8 original_len = 0;
+        U8 original_string[256];
+        U32 original_next = 0;
+        const U32 original_minlen = trie->minlen;
+        const U32 original_maxlen = trie->maxlen;
 
 #ifdef DEBUGGING
         regnode *optimize = NULL;
 #endif /* DEBUGGING */
+        if (trie->jump) {
+            original_len = STR_LEN(convert);
+            Copy(STRING(convert), original_string, original_len, U8);
+            original_next = TRIE_NEXT(convert);
+        }
         /* make sure we have enough room to inject the TRIE op */
         assert((!trie->jump) || !trie->jump[1] ||
                 (trie->jump[1] >= (sizeof(tregnode_TRIE)/sizeof(struct regnode))));
@@ -1419,62 +1231,180 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         }
         /* But first we check to see if there is a common prefix we can
            split out as an EXACT and put in front of the TRIE node.  */
-        trie->startstate= 1;
-        if ( trie->bitmap && !widecharmap && !trie->jump  ) {
+        trie->startstate = 1;
+        DEBUG_TRIE_COMPILE_MORE_r({
+            re_printf("Trie prefix probe: mode=%u ranges=%#x\n",
+                      (unsigned)(trie->prop_flags & TRIE_FOLD_MASK),
+                      (unsigned)(trie->prop_flags & (TRIE_CP_INVARIANT
+                                                     | TRIE_CP_AWKWARD
+                                                     | TRIE_CP_HIGH)));
+            if (trie_needs_codepoint_processing) {
+                U32 debug_state = 1;
+                U32 debug_octets = 0;
+                U32 debug_complete_octets = 0;
+                U32 debug_chars = 0;
+                U32 debug_need = 0;
+                U8 debug_prefix[256];
+
+                re_printf("Octet trie prefix probe:\n");
+                while (debug_state < trie->statecount - 1
+                       && debug_octets < sizeof(debug_prefix)) {
+                    U32 ofs;
+                    U32 count = trie->states[debug_state].wordnum ? 1 : 0;
+                    U32 transition = 0;
+                    const U32 min_octet =
+                        trie->states[debug_state].min_octet;
+                    const U32 max_octet =
+                        trie->states[debug_state].max_octet;
+
+                    for (ofs = min_octet; ofs <= max_octet; ofs++) {
+                        const U32 index = trie->states[debug_state].trans.base
+                                        + ofs - TRIE_ALPHABET_SIZE;
+                        if (trie->states[debug_state].trans.base + ofs
+                                >= TRIE_ALPHABET_SIZE
+                            && index < trie->lasttrans
+                            && trie->trans[index].check == debug_state) {
+                            count++;
+                            transition = ofs;
+                        }
+                    }
+                    if (count != 1)
+                        break;
+
+                    debug_prefix[debug_octets++] = (U8)transition;
+                    if (!debug_need) {
+                        /* The trie contains valid UTF-8 sequences, so use
+                         * Perl's encoding table rather than duplicating the
+                         * lead-octet length rules here. */
+                        debug_need = UTF8SKIP(
+                            &debug_prefix[debug_octets - 1]) - 1;
+                    }
+                    else
+                        debug_need--;
+                    if (!debug_need) {
+                        debug_complete_octets = debug_octets;
+                        debug_chars++;
+                    }
+                    debug_state++;
+                }
+                re_printf("  states=%u octets=%u complete_octets=%u chars=%u "
+                          "tail_octets=%u\n", (unsigned)debug_state,
+                          (unsigned)debug_octets, (unsigned)debug_complete_octets,
+                          (unsigned)debug_chars, (unsigned)debug_need);
+                re_printf("  raw prefix:");
+                for (debug_octets = 0; debug_octets < debug_complete_octets;
+                     debug_octets++)
+                    re_printf(" %02x", (unsigned)debug_prefix[debug_octets]);
+                re_printf("\n");
+            }
+        });
+        /* Extract a common prefix only when it is safe to remove complete
+         * characters from the trie.  Raw invariant tries consume one octet
+         * per character.  Processed tries must stop at UTF-8 codepoint
+         * boundaries; native processed tries also reject an awkward encoded
+         * transition (TRIE-PREFIX-XX) rather than treating its first octet as
+         * a complete character. */
+        if ( (!trie_needs_codepoint_processing || UTF) ) {
             /* we want to find the first state that has more than
              * one transition, if that state is not the first state
              * then we have a common prefix which we can remove.
              */
             U32 state;
+            U32 complete_state = 1;
+            /* prefixlen_octets and prefixlen_chars have different units in
+             * the processed path.  complete_state is the first trie state
+             * left after the complete prefix has been extracted. */
+            U32 complete_octets = 0;
+            U32 complete_chars = 0;
+            U8 utf8_prefix[256];
+
+            if (trie_needs_codepoint_processing) {
+                U32 octets = 0;
+                U32 chars = 0;
+                U32 need = 0;
+
+                state = 1;
+                /* The final state has no outgoing transition and is not a
+                 * prefix state, so stop before statecount - 1. */
+                while (state < trie->statecount - 1
+                       && octets < sizeof(utf8_prefix)) {
+                    U32 ofs;
+                    U32 count = trie->states[state].wordnum ? 1 : 0;
+                    U32 next_state = 0;
+                    const U32 base = trie->states[state].trans.base;
+                    const U32 min_octet = trie->states[state].min_octet;
+                    const U32 max_octet = trie->states[state].max_octet;
+
+                    for (ofs = min_octet; ofs <= max_octet; ofs++) {
+                        if (base + ofs >= TRIE_ALPHABET_SIZE
+                            && base + ofs - TRIE_ALPHABET_SIZE < trie->lasttrans
+                            && trie->trans[base + ofs - TRIE_ALPHABET_SIZE].check == state) {
+                            if (++count > 1)
+                                break;
+                            next_state = trie->trans[base + ofs
+                                                   - TRIE_ALPHABET_SIZE].next;
+                            utf8_prefix[octets] = (U8)ofs;
+                        }
+                    }
+                    if (count != 1)
+                        break;
+
+                    if (!need) {
+                        /* The trie contains only valid UTF-8 sequences, so
+                         * UTF8SKIP() gives the number of octets remaining in
+                         * this codepoint. */
+                        need = UTF8SKIP(&utf8_prefix[octets]) - 1;
+                    }
+                    else if (!UTF8_IS_CONTINUATION(utf8_prefix[octets]))
+                        break;
+                    else
+                        need--;
+
+                    octets++;
+                    state = next_state;
+                    if (!need) {
+                        complete_state = state;
+                        complete_octets = octets;
+                        complete_chars = ++chars;
+                    }
+                }
+                state = complete_state;
+                if (complete_octets) {
+                    OP(convert) = nodetype;
+                    str = STRING(convert);
+                    setSTR_LEN(convert, 0);
+                    /* The replacement EXACT node stores its string length in
+                     * an octet, so the extracted prefix must fit in 255. */
+                    assert(STR_LEN(convert) + complete_octets < 256);
+                    Copy(utf8_prefix, str, complete_octets, U8);
+                    str += complete_octets;
+                    setSTR_LEN(convert, (U8)complete_octets);
+                }
+            }
+            else {
+            /* The final state has no outgoing transition and is not a prefix
+             * state, so stop before statecount - 1. */
             for ( state = 1 ; state < trie->statecount-1 ; state++ ) {
                 U32 ofs = 0;
                 I32 first_ofs = -1; /* keeps track of the ofs of the first
                                        transition, -1 means none */
                 U32 count = 0;
                 const U32 base = trie->states[ state ].trans.base;
+                const U32 min_octet = trie->states[state].min_octet;
+                const U32 max_octet = trie->states[state].max_octet;
 
                 /* does this state terminate an alternation? */
                 if ( trie->states[state].wordnum )
                         count = 1;
 
-                for ( ofs = 0 ; ofs < trie->uniquecharcount ; ofs++ ) {
-                    if ( ( base + ofs >= trie->uniquecharcount ) &&
-                         ( base + ofs - trie->uniquecharcount < trie->lasttrans ) &&
-                         trie->trans[ base + ofs - trie->uniquecharcount ].check == state )
+                for ( ofs = min_octet ; ofs <= max_octet ; ofs++ ) {
+                    if ( ( base + ofs >= TRIE_ALPHABET_SIZE ) &&
+                         ( base + ofs - TRIE_ALPHABET_SIZE < trie->lasttrans ) &&
+                         trie->trans[ base + ofs - TRIE_ALPHABET_SIZE ].check == state )
                     {
                         if ( ++count > 1 ) {
-                            /* we have more than one transition */
-                            SV **tmp;
-                            U8 *ch;
-                            /* if this is the first state there is no common prefix
-                             * to extract, so we can exit */
-                            if ( state == 1 ) break;
-                            tmp = av_fetch_simple( revcharmap, ofs, 0);
-                            ch = (U8*)SvPV_nolen_const( *tmp );
-
-                            /* if we are on count 2 then we need to initialize the
-                             * bitmap, and store the previous char if there was one
-                             * in it*/
-                            if ( count == 2 ) {
-                                /* clear the bitmap */
-                                Zero(trie->bitmap, ANYOF_BITMAP_SIZE, char);
-                                DEBUG_OPTIMISE_r(
-                                    re_indentf("New Start State = %" UVuf " Class: [",
-                                        depth+1,
-                                        (UV)state));
-                                if (first_ofs >= 0) {
-                                    SV ** const tmp = av_fetch_simple( revcharmap, first_ofs, 0);
-                                    const U8 * const ch = (U8*)SvPV_nolen_const( *tmp );
-
-                                    S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, *ch, folder);
-                                    DEBUG_OPTIMISE_r(
-                                        re_printf("%s", (char*)ch)
-                                    );
-                                }
-                            }
-                            /* store the current firstchar in the bitmap */
-                            S_trie_bitmap_set_folded(aTHX_ pRExC_state, trie, *ch, folder);
-                            DEBUG_OPTIMISE_r(re_printf("%s", ch));
+                            /* more than one transition here, so we can exit the loop */
+                            break;
                         }
                         first_ofs = ofs;
                     }
@@ -1483,17 +1413,19 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     /* This state has only one transition, its transition is part
                      * of a common prefix - we need to concatenate the char it
                      * represents to what we have so far. */
-                    SV **tmp = av_fetch_simple( revcharmap, first_ofs, 0);
                     STRLEN len;
-                    char *ch = SvPV( *tmp, len );
+                    char *ch;
+                    U8 octet;
+                    octet = (U8)first_ofs;
+                    ch = (char *)&octet;
+                    len = 1;
                     DEBUG_OPTIMISE_r({
                         SV *sv = sv_newmortal();
                         re_indentf("Prefix State: %" UVuf " Ofs: %" UVuf " Char: '%s'\n",
                             depth+1,
                             (UV)state, (UV)first_ofs,
-                            pv_pretty(sv, SvPV_nolen_const(*tmp), SvCUR(*tmp), 6,
+                            pv_pretty(sv, ch, len, 6,
                                 PL_colors[0], PL_colors[1],
-                                (SvUTF8(*tmp) ? PERL_PV_ESCAPE_UNI : 0) |
                                 PERL_PV_ESCAPE_FIRSTCHAR
                             )
                         );
@@ -1503,6 +1435,8 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         str = STRING(convert);
                         setSTR_LEN(convert, 0);
                     }
+                    /* The replacement EXACT node stores its string length in
+                     * an octet, so the extracted prefix must fit in 255. */
                     assert( ( STR_LEN(convert) + len ) < 256 );
                     setSTR_LEN(convert, (U8)(STR_LEN(convert) + len));
                     while (len--)
@@ -1515,58 +1449,92 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                     break;
                 }
             }
-            trie->prefixlen = (state-1);
+            trie->prefixlen_octets = (state-1);
+            trie->prefixlen_chars = (state-1);
+            }
+            if (trie_needs_codepoint_processing) {
+                trie->prefixlen_octets = complete_octets;
+                trie->prefixlen_chars = complete_chars;
+            }
             if (str) {
+                /* A non-NULL str means that at least one common prefix
+                 * character was copied out of the trie and into convert. */
                 regnode *n = REGNODE_AFTER(convert);
-                TRIE_NEXT_set(convert, n - convert);
-                trie->startstate = state;
-                trie->minlen -= (state - 1);
-                trie->maxlen -= (state - 1);
+                if (trie->jump && trie->jump[1]
+                    && (SSize_t)trie->jump[1] - (n - jump_base)
+                         < (SSize_t)(sizeof(tregnode_TRIE)
+                                     / sizeof(struct regnode))) {
+                    /* The extracted prefix left too little room for a
+                     * jump-capable trie.  Restore the source node and leave
+                     * the trie at its original location. */
+                    Copy(original_string, STRING(convert), original_len, U8);
+                    setSTR_LEN(convert, original_len);
+                    TRIE_NEXT_set(convert, original_next);
+                    trie->startstate = 1;
+                    trie->minlen = original_minlen;
+                    trie->maxlen = original_maxlen;
+                    trie->prefixlen_octets = 0;
+                    trie->prefixlen_chars = 0;
+                    trie->jump_correction = 0;
+                    str = NULL;
+                }
+                if (str) {
+                    TRIE_NEXT_set(convert, n - convert);
+                    trie->startstate = state;
+                    /* The extracted prefix is now matched by convert, so remove
+                     * its character count from the length bounds that describe
+                     * the remaining trie.  In the processed path state - 1 counts
+                     * octet states, so use prefixlen_chars rather than state - 1. */
+                    trie->minlen -= trie->prefixlen_chars;
+                    trie->maxlen -= trie->prefixlen_chars;
 #ifdef DEBUGGING
-               /* At least the UNICOS C compiler choked on this
-                * being argument to DEBUG_r(), so let's just have
-                * it right here. */
-               if (
+                    /* At least the UNICOS C compiler choked on this
+                     * being argument to DEBUG_r(), so let's just have
+                     * it right here. */
+                    if (
 #ifdef PERL_EXT_RE_BUILD
-                   1
+                        1
 #else
-                   DEBUG_r_TEST
+                        DEBUG_r_TEST
 #endif
-                   ) {
-                   U32 word = trie->wordcount;
-                   while (word--) {
-                       SV ** const tmp = av_fetch_simple( trie_words, word, 0 );
-                       if (tmp) {
-                           if ( STR_LEN(convert) <= SvCUR(*tmp) )
-                               sv_chop(*tmp, SvPV_nolen(*tmp) + STR_LEN(convert));
-                           else
-                               sv_chop(*tmp, SvPV_nolen(*tmp) + SvCUR(*tmp));
-                       }
-                   }
-               }
+                    ) {
+                        U32 word = trie->wordcount;
+                        while (word--) {
+                            SV ** const tmp = av_fetch_simple( trie_words, word, 0 );
+                            if (tmp) {
+                                if ( STR_LEN(convert) <= SvCUR(*tmp) )
+                                    sv_chop(*tmp, SvPV_nolen(*tmp) + STR_LEN(convert));
+                                else
+                                    sv_chop(*tmp, SvPV_nolen(*tmp) + SvCUR(*tmp));
+                            }
+                        }
+                    }
 #endif
-                if (trie->maxlen) {
-                    convert = n;
-                } else {
-                    TRIE_NEXT_set(convert, tail - convert);
-                    DEBUG_r(optimize= n);
+                    if (trie->maxlen || (trie->jump && str)) {
+                        if (trie->jump)
+                            trie->jump_correction = n - jump_base;
+                        convert = n;
+                    } else {
+                        trie->jump_correction = 0;
+                        TRIE_NEXT_set(convert, tail - convert);
+                        DEBUG_r(optimize= n);
+                    }
                 }
             }
         }
         if (!jumper)
             jumper = last;
-        if ( trie->maxlen ) {
+        if ( trie->maxlen || (trie->jump && str) ) {
             const U32 needed_next = tail - convert;
-            const Size_t trie_room = (
-                (trie->jump && trie->jump[1])
-                    ? trie->jump[1] * sizeof(struct regnode)
-                    : (Size_t)((char *)jumper - (char *)convert)
-            );
-            const bool want_charclass = !trie->states[trie->startstate].wordnum
-                                        && trie->bitmap;
-
-            trie_op = S_select_trie_op(aTHX_ trie_room, needed_next,
-                                       want_charclass);
+            /* The replacement trie must fit in the program space being
+             * overwritten.  Jump tries reserve their first jump distance;
+             * otherwise jumper marks the end of the replaceable region. */
+            const SSize_t jump_room = trie->jump ? TRIE_JUMP_ROOM(trie) : 0;
+            const Size_t trie_room = trie->jump && trie->jump[1]
+                ? (Size_t)jump_room * sizeof(struct regnode)
+                : (Size_t)((char *)jumper - (char *)convert);
+            assert(!trie->jump || !trie->jump[1] || jump_room >= 0);
+            trie_op = S_select_trie_op(aTHX_ trie_room, needed_next);
 
             if (!trie_op) {
                 DEBUG_TRIE_COMPILE_r(
@@ -1591,13 +1559,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 assert(trie->jump[0] == 0);
                 assert(nextbranch <= tail);
 
-                trie->jump[0] = nextbranch - convert;
-            }
-
-            if (OP(convert) == TRIEC || OP(convert) == LTRIEC) {
-                Copy(trie->bitmap, ANYOF_BITMAP(convert), ANYOF_BITMAP_SIZE, char);
-                PerlMemShared_free(trie->bitmap);
-                trie->bitmap= NULL;
+                trie->jump[0] = nextbranch - jump_base;
             }
 
             /* store the type in the flags */
@@ -1623,9 +1585,10 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
         });
     } /* end node insert */
 
-    /*  Finish populating the prev field of the wordinfo array.  Walk back
-     *  from each accept state until we find another accept state, and if
-     *  so, point the first word's .prev field at the second word. If the
+    /*  Finish populating the prev field of the wordinfo array.  Starting at
+     *  each word's accept state, walk back through predecessor states until
+     *  we find the next earlier accepting state, and point the first word's
+     *  .prev field at that word. If the
      *  second already has a .prev field set, stop now. This will be the
      *  case either if we've already processed that word's accept state,
      *  or that state had multiple words, and the overspill words were
@@ -1656,14 +1619,9 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
 
     /* and now dump out the compressed format */
-    DEBUG_TRIE_COMPILE_r(dump_trie(trie, widecharmap, revcharmap, depth+1));
-
-    RExC_rxi->data->data[ data_slot + 1 ] = (void*)widecharmap;
+    DEBUG_TRIE_COMPILE_r(dump_trie(trie, depth+1));
 #ifdef DEBUGGING
     RExC_rxi->data->data[ data_slot + TRIE_WORDS_OFFSET ] = (void*)trie_words;
-    RExC_rxi->data->data[ data_slot + 3 ] = (void*)revcharmap;
-#else
-    SvREFCNT_dec_NN(revcharmap);
 #endif
     return trie->jump
            ? MADE_JUMP_TRIE
@@ -1703,12 +1661,12 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
     const U32 trie_offset = TRIE_DATA_SLOT(source);
     reg_trie_data *trie = (reg_trie_data *)RExC_rxi->data->data[trie_offset];
     U32 *q;
-    const U32 ucharcount = trie->uniquecharcount;
+    const U32 ucharcount = TRIE_ALPHABET_SIZE;
     const U32 numstates = trie->statecount;
     const U32 ubound = trie->lasttrans + ucharcount;
     U32 q_read = 0;
     U32 q_write = 0;
-    U32 charid;
+    U32 octet;
     U32 base = trie->states[ 1 ].trans.base;
     U32 *fail;
     reg_ac_data *aho;
@@ -1720,14 +1678,7 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
 #ifndef DEBUGGING
     PERL_UNUSED_ARG(depth);
 #endif
-    if (IS_ANYOF_TRIE(OP(source))) {
-        tregnode_AHOCORASICKC *op = (tregnode_AHOCORASICKC *)
-            PerlMemShared_calloc(1, sizeof(tregnode_AHOCORASICKC));
-        OP(op) = AHOCORASICKC;
-        FLAGS(op) = FLAGS(source);
-        Copy(ANYOF_BITMAP(source), ANYOF_BITMAP(op), ANYOF_BITMAP_SIZE, char);
-        stclass = (regnode *)op;
-    } else {
+    {
         tregnode_AHOCORASICK *op = (tregnode_AHOCORASICK *)
             PerlMemShared_calloc(1, sizeof(tregnode_AHOCORASICK));
         OP(op) = AHOCORASICK;
@@ -1735,7 +1686,7 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
         stclass = (regnode *)op;
     }
 
-    assert(OP(stclass)==AHOCORASICK || OP(stclass)==AHOCORASICKC);
+    assert(OP(stclass)==AHOCORASICK);
     /* AHOCORASICK nodes are short TRIE's, some compilers arn't smart
      * enough to know that the normal TRIE_DATA_SLOT_set() macro wont
      * ever access undefined memory because of the opcode guards. So we
@@ -1747,6 +1698,9 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
     aho->trie = trie_offset;
     aho->states = (reg_trie_state *)PerlMemShared_malloc( numstates * sizeof(reg_trie_state) );
     Copy( trie->states, aho->states, numstates, reg_trie_state );
+    /* The breadth-first work queue can contain each state at most once, so
+     * numstates entries suffice.  q_read and q_write address it as a
+     * circular queue while q_write advances monotonically. */
     Newx( q, numstates, U32);
     aho->fail = (U32 *) PerlMemShared_calloc( numstates, sizeof(U32) );
     aho->refcount = 1;
@@ -1755,35 +1709,50 @@ Perl_construct_ahocorasick_from_trie(pTHX_ RExC_state_t *pRExC_state, regnode *s
        a valid final fail state */
     fail[ 0 ] = fail[ 1 ] = 1;
 
-    for ( charid = 0; charid < ucharcount ; charid++ ) {
-        const U32 newstate = TRIE_TRANS_STATE( 1, base, ucharcount, charid, 0 );
-        if ( newstate ) {
-            q[ q_write ] = newstate;
-            /* set to point at the root */
-            fail[ q[ q_write++ ] ]=1;
+    /* Root transitions have no failure link to follow.  Seed the breadth-
+     * first traversal with them and make their failure state the root.
+     * Later lookups use special = 1 so a failed transition falls back to the
+     * root transition. */
+    if (base) {
+        for ( octet = trie->states[1].min_octet;
+              octet <= trie->states[1].max_octet; octet++ ) {
+            const U32 newstate = S_trie_trans_state(trie, 1, base, ucharcount,
+                                                    octet, 0, ubound);
+            if ( newstate ) {
+                q[ q_write ] = newstate;
+                /* set to point at the root */
+                fail[ q[ q_write++ ] ]=1;
+            }
         }
     }
     while ( q_read < q_write) {
         const U32 cur = q[ q_read++ % numstates ];
         base = trie->states[ cur ].trans.base;
 
-        for ( charid = 0 ; charid < ucharcount ; charid++ ) {
-            const U32 ch_state = TRIE_TRANS_STATE( cur, base, ucharcount, charid, 1 );
-            if (ch_state) {
-                U32 fail_state = cur;
-                U32 fail_base;
-                do {
-                    fail_state = fail[ fail_state ];
-                    fail_base = aho->states[ fail_state ].trans.base;
-                } while ( !TRIE_TRANS_STATE( fail_state, fail_base, ucharcount, charid, 1 ) );
+        if (base) {
+            for ( octet = aho->states[cur].min_octet;
+                  octet <= aho->states[cur].max_octet; octet++ ) {
+                const U32 ch_state = S_trie_trans_state(trie, cur, base,
+                                                        ucharcount, octet, 1,
+                                                        ubound);
+                if (ch_state) {
+                    U32 fail_state = cur;
+                    U32 fail_base;
+                    do {
+                        fail_state = fail[ fail_state ];
+                        fail_base = aho->states[ fail_state ].trans.base;
+                    } while ( !S_trie_trans_state(trie, fail_state, fail_base,
+                                                  ucharcount, octet, 1, ubound) );
 
-                fail_state = TRIE_TRANS_STATE( fail_state, fail_base, ucharcount, charid, 1 );
-                fail[ ch_state ] = fail_state;
-                if ( !aho->states[ ch_state ].wordnum && aho->states[ fail_state ].wordnum )
-                {
-                        aho->states[ ch_state ].wordnum =  aho->states[ fail_state ].wordnum;
+                    fail_state = S_trie_trans_state(trie, fail_state, fail_base,
+                                                ucharcount, octet, 1, ubound);
+                    fail[ ch_state ] = fail_state;
+                    if ( !aho->states[ ch_state ].wordnum && aho->states[ fail_state ].wordnum )
+                    {
+                            aho->states[ ch_state ].wordnum =  aho->states[ fail_state ].wordnum;
+                    }
+                    q[ q_write++ % numstates] = ch_state;
                 }
-                q[ q_write++ % numstates] = ch_state;
             }
         }
     }

--- a/regen/mk_invlists.pl
+++ b/regen/mk_invlists.pl
@@ -108,8 +108,8 @@ print $regexp_constants_fh <<'EOF';
  * important world scripts.  At 12 most of them are: including Arabic,
  * Cyrillic, Greek, Hebrew, Indian subcontinent, Latin, and Thai; but not Han,
  * Japanese, nor Korean.  The regnode sizing data structure in regnodes.h currently
- * uses a U8, and the trie types TRIEC and AHOCORASICKC are larger than U8 for
- * shift values above 12.)  Be sure to benchmark before changing, as larger sizes
+ * uses a U8 for its node sizing data above this point.)  Be sure to benchmark
+ * before changing, as larger sizes
  * do significantly slow down the test suite. */
 
 EOF

--- a/regexec.c
+++ b/regexec.c
@@ -1895,7 +1895,7 @@ STMT_START {                                                                \
             SV** const svpp = hv_fetch(widecharmap,                         \
                         (char*)&uvc, sizeof(UV), 0);                        \
             if (svpp)                                                       \
-                charid = (U16)SvIV(*svpp);                                  \
+                charid = (U32)SvIV(*svpp);                                  \
         }                                                                   \
     }                                                                       \
 } STMT_END
@@ -3337,7 +3337,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             while (s <= last_start) {
                 const U32 uniflags = UTF8_ALLOW_DEFAULT;
                 U8 *uc = (U8*)s;
-                U16 charid = 0;
+                U32 charid = 0;
                 U32 base = 1;
                 U32 state = 1;
                 UV uvc = 0;
@@ -7052,7 +7052,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                 while ( state && uc <= (U8*)(loceol) ) {
                     UV uvc = 0;
-                    U16 charid = 0;
+                    U32 charid = 0;
                     U32 base = trie->states[ state ].trans.base;
                     U16 wordnum = trie->states[ state ].wordnum;
                     PERL_DEB(U32 old_state = state);

--- a/regexec.c
+++ b/regexec.c
@@ -1815,11 +1815,21 @@ Perl_re_intuit_start(pTHX_
 
 /* 'uscan' is set to foldbuf, and incremented, so below the end of uscan is
  * 'foldbuf+sizeof(foldbuf)' */
-#define REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc, uc_end,      \
+#define REXEC_TRIE_READ_CHAR(trie_type, trie, uc, uc_end,                  \
                              uscan, len, uvc, charid, foldlen, foldbuf,     \
-                             uniflags)                                      \
+                             uniflags, octet_scan, octets_remaining,       \
+                             octet_buffer)                                 \
 STMT_START {                                                                \
     STRLEN skiplen;                                                         \
+    if (TRIE_RAW_INPUT_MODE(trie, utf8_target)) {                            \
+        uvc = (U8)*uc;                                                       \
+        charid = uvc + 1;                                                    \
+        len = 1;                                                             \
+    } else if (TRIE_CONTAINS_WIDE(trie) && octets_remaining > 0) {            \
+        charid = *octet_scan++ + 1;                                          \
+        octets_remaining--;                                                  \
+        len = 0;                                                             \
+    } else {                                                                 \
     U8 flags = FOLD_FLAGS_FULL;                                             \
     switch (trie_type) {                                                    \
     case trie_flu8:                                                         \
@@ -1886,18 +1896,27 @@ STMT_START {                                                                \
         uvc = (UV)*uc;                                                      \
         len = 1;                                                            \
     }                                                                       \
-    if (uvc < 256) {                                                        \
-        charid = trie->charmap[ uvc ];                                      \
-    }                                                                       \
+    if (TRIE_CONTAINS_WIDE(trie)) {                                         \
+        const native_octet_utf8_t *octet;                                   \
+        U8 *end;                                                            \
+        if (!utf8_target && FITS_IN_8_BITS(uvc)) {                          \
+            /* Non-UTF-8 input is a native octet.  Use its cached UTF-8     \
+             * representation when the trie needs UTF-8 transitions. */     \
+            octet = &PL_native_octet_utf8[(U8)uvc];                        \
+            charid = octet->bytes[0] + 1;                                   \
+            octet_scan = octet->bytes + 1;                                  \
+            octets_remaining = octet->len - 1;                              \
+        } else {                                                            \
+            end = uvchr_to_utf8(octet_buffer, uvc);                         \
+            charid = octet_buffer[0] + 1;                                   \
+            octet_scan = octet_buffer + 1;                                  \
+            octets_remaining = (STRLEN)(end - octet_buffer - 1);            \
+        }                                                                       \
+    }                                                                        \
     else {                                                                  \
-        charid = 0;                                                         \
-        if (widecharmap) {                                                  \
-            SV** const svpp = hv_fetch(widecharmap,                         \
-                        (char*)&uvc, sizeof(UV), 0);                        \
-            if (svpp)                                                       \
-                charid = (U32)SvIV(*svpp);                                  \
-        }                                                                   \
+        charid = uvc + 1;                                                    \
     }                                                                       \
+    }                                                                        \
 } STMT_END
 
 #define DUMP_EXEC_POS(li,s,doutf8,depth)                    \
@@ -3257,10 +3276,6 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
         }
         break;
 
-      case AHOCORASICKC_tb_pb:
-      case AHOCORASICKC_tb_p8:
-      case AHOCORASICKC_t8_pb:
-      case AHOCORASICKC_t8_p8:
       case AHOCORASICK_tb_pb:
       case AHOCORASICK_tb_p8:
       case AHOCORASICK_t8_pb:
@@ -3270,7 +3285,6 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             /* what trie are we using right now */
             reg_ac_data *aho = (reg_ac_data*)progi->data->data[ TRIE_DATA_SLOT(c) ];
             reg_trie_data *trie = (reg_trie_data*)progi->data->data[aho->trie];
-            HV *widecharmap = MUTABLE_HV(progi->data->data[ aho->trie + 1 ]);
 
             const char *last_start = strend - trie->minlen;
 #ifdef DEBUGGING
@@ -3294,7 +3308,9 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             bool used_heap = false;
 
             U8 foldbuf[ UTF8_MAXBYTES_CASE + 1 ];
-            U8 *bitmap = NULL;
+            U8 octet_buffer[ UTF8_MAXBYTES_CASE + 1 ];
+            const U8 *octet_scan = NULL;
+            STRLEN octets_remaining = 0;
             U8 **points_heap = NULL;
 
             DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -3311,14 +3327,8 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                 points = points_heap;
             }
 
-            if ( trie_type != trie_utf8_fold
-                 && (trie->bitmap || OP(c)==AHOCORASICKC) )
-            {
-                if (trie->bitmap)
-                    bitmap = (U8*)trie->bitmap;
-                else
-                    bitmap = (U8*)ANYOF_BITMAP(c);
-            }
+            /* Trie start-byte filtering is temporarily disabled while the
+             * post-prefix-extraction start state is being validated. */
             /* this is the Aho-Corasick algorithm modified a touch
                to include special handling for long "unknown char" sequences.
                The basic idea being that we use AC as long as we are dealing
@@ -3355,33 +3365,6 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                     U32 word = aho->states[ state ].wordnum;
 
                     if( state == 1 ) {
-                        if ( bitmap ) {
-                            DEBUG_TRIE_EXECUTE_r(
-                                if (  uc <= (U8*)last_start
-                                    && !BITMAP_TEST(bitmap,*uc) )
-                                {
-                                    dump_exec_pos( (char *)uc, c, strend,
-                                        real_start,
-                                        (char *)uc, utf8_target, 0 );
-                                    re_printf(
-                                        " Scanning for legal start char...\n");
-                                }
-                            );
-                            if (utf8_target) {
-                                while (  uc <= (U8*)last_start
-                                       && !BITMAP_TEST(bitmap,*uc) )
-                                {
-                                    uc += UTF8SKIP(uc);
-                                }
-                            } else {
-                                while (  uc <= (U8*)last_start
-                                       && ! BITMAP_TEST(bitmap,*uc) )
-                                {
-                                    uc++;
-                                }
-                            }
-                            s = (char *)uc;
-                        }
                         if (uc >(U8*)last_start) break;
                     }
 
@@ -3395,12 +3378,15 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         if (base == 0) break;
 
                     }
-                    points[pointpos++ % maxlen]= uc;
-                    if (foldlen || uc < (U8*)strend) {
-                        REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc,
+                    if (!octets_remaining \
+                            && (!utf8_target || !UTF8_IS_CONTINUATION(*uc)))
+                        points[pointpos++ % maxlen]= uc;
+                    if (foldlen || octets_remaining || uc < (U8*)strend) {
+                        REXEC_TRIE_READ_CHAR(trie_type, trie, uc,
                                              (U8 *) strend, uscan, len, uvc,
                                              charid, foldlen, foldbuf,
-                                             uniflags);
+                                             uniflags, octet_scan,
+                                             octets_remaining, octet_buffer);
                         DEBUG_TRIE_EXECUTE_r({
                             dump_exec_pos( (char *)uc, c, strend,
                                         real_start, s, utf8_target, 0);
@@ -3440,7 +3426,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             I32 offset;
                             if (charid &&
                                  ( ((offset = base + charid
-                                    - 1 - trie->uniquecharcount)) >= 0)
+                                    - 1 - TRIE_ALPHABET_SIZE)) >= 0)
                                  && ((U32)offset < trie->lasttrans)
                                  && trie->trans[offset].check == state
                                  && (tmp = trie->trans[offset].next))
@@ -6915,23 +6901,6 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
 #undef  ST
 #define ST st->u.trie
-        case LTRIEC:
-        case TRIEC: /* (ab|cd) with known charclass */
-            /* In this case the charclass data is available inline so
-               we can fail fast without a lot of extra overhead.
-             */
-            if ( !   NEXTCHR_IS_EOS
-                &&   locinput < loceol
-                && ! ANYOF_BITMAP_TEST(scan, nextbyte))
-            {
-                DEBUG_EXECUTE_r(
-                    re_exec_indentf("%sTRIE: failed to match trie start class...%s\n",
-                              depth, PL_colors[4], PL_colors[5])
-                );
-                sayNO_SILENT;
-                NOT_REACHED; /* NOTREACHED */
-            }
-            /* FALLTHROUGH */
         case LTRIE:
         case TRIE:  /* (ab|cd)  */
             /* the basic plan of execution of the trie is:
@@ -6990,7 +6959,6 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 assert(ST.before_paren <= rex->nparens);
                 assert(ST.after_paren <= rex->nparens);
 
-                HV * widecharmap = MUTABLE_HV(rexi->data->data[ TRIE_DATA_SLOT(scan) + 1 ]);
                 U32 state = trie->startstate;
 
                 if (FLAGS(scan) == EXACTL || FLAGS(scan) == EXACTFLU8) {
@@ -7007,26 +6975,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                                                                reginfo->strend);
                     }
                 }
-                if (   trie->bitmap
-                    && (     NEXTCHR_IS_EOS
-                        ||   locinput >= loceol
-                        || ! TRIE_BITMAP_TEST(trie, nextbyte)))
-                {
-                    if (trie->states[ state ].wordnum) {
-                         DEBUG_EXECUTE_r(
-                            re_exec_indentf("%sTRIE: matched empty string...%s\n",
-                                          depth, PL_colors[4], PL_colors[5])
-                        );
-                        if (!trie->jump)
-                            break;
-                    } else {
-                        DEBUG_EXECUTE_r(
-                            re_exec_indentf("%sTRIE: failed to match trie start class...%s\n",
-                                          depth, PL_colors[4], PL_colors[5])
-                        );
-                        sayNO_SILENT;
-                   }
-                }
+                /* Start-class filtering is disabled while trie prefix
+                 * extraction is being brought into alignment with the
+                 * executable start state. */
 
             {
                 U8 *uc = ( U8* )locinput;
@@ -7035,6 +6986,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 STRLEN foldlen = 0;
                 U8 *uscan = (U8*)NULL;
                 U8 foldbuf[ UTF8_MAXBYTES_CASE + 1 ];
+                U8 octet_buffer[ UTF8_MAXBYTES_CASE + 1 ];
+                const U8 *octet_scan = NULL;
+                STRLEN octets_remaining = 0;
                 U32 charcount = 0; /* how many input chars we have matched */
                 U32 accepted = 0; /* how many accepting states have we seen? */
 
@@ -7050,7 +7004,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                    shortest accept state and the wordnum of the longest
                    accept state */
 
-                while ( state && uc <= (U8*)(loceol) ) {
+                while ( state && (uc <= (U8*)(loceol) || octets_remaining) ) {
                     UV uvc = 0;
                     U32 charid = 0;
                     U32 base = trie->states[ state ].trans.base;
@@ -7076,18 +7030,22 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     }
 
                     /* read a char and goto next state */
-                    if ( base && (foldlen || uc < (U8*)(loceol))) {
+                    if ( base && (foldlen || octets_remaining || uc < (U8*)(loceol))) {
                         I32 offset;
-                        REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc,
+                        REXEC_TRIE_READ_CHAR(trie_type, trie, uc,
                                              (U8 *) loceol, uscan,
                                              len, uvc, charid, foldlen,
-                                             foldbuf, uniflags);
-                        charcount++;
+                                             foldbuf, uniflags, octet_scan,
+                                             octets_remaining, octet_buffer);
+                        if (TRIE_RAW_INPUT_MODE(trie, utf8_target) \
+                                ? (!utf8_target || !UTF8_IS_CONTINUATION(*uc)) \
+                                : len)
+                            charcount++;
                         if (foldlen > 0)
                             ST.longfold = true;
                         if (charid &&
                              ( ((offset =
-                              base + charid - 1 - trie->uniquecharcount)) >= 0)
+                              base + charid - 1 - TRIE_ALPHABET_SIZE)) >= 0)
 
                              && ((U32)offset < trie->lasttrans)
                              && trie->trans[offset].check == state)
@@ -7205,10 +7163,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 U32 chars; /* how many chars to skip */
                 reg_trie_data * const trie
                     = (reg_trie_data*)rexi->data->data[TRIE_DATA_SLOT(ST.me)];
-
-                assert((trie->wordinfo[ST.nextword].len - trie->prefixlen)
+                assert((trie->wordinfo[ST.nextword].len - trie->prefixlen_chars)
                             >=  ST.firstchars);
-                chars = (trie->wordinfo[ST.nextword].len - trie->prefixlen)
+                chars = (trie->wordinfo[ST.nextword].len - trie->prefixlen_chars)
                             - ST.firstchars;
                 uc = ST.firstpos;
 
@@ -7254,7 +7211,10 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 }
             }
             if (ST.jump && ST.jump[ST.nextword]) {
-                scan = ST.me + ST.jump[ST.nextword];
+                reg_trie_data * const trie
+                    = (reg_trie_data*)rexi->data->data[TRIE_DATA_SLOT(ST.me)];
+                scan = TRIE_JUMP_TARGET(ST.me, ST.jump, trie->jump_correction,
+                                        ST.nextword);
                 ST.before_paren = ST.j_before_paren[ST.nextword];
                 assert(ST.before_paren <= rex->nparens);
                 ST.after_paren = ST.j_after_paren[ST.nextword];

--- a/regexec.c
+++ b/regexec.c
@@ -7054,7 +7054,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     UV uvc = 0;
                     U32 charid = 0;
                     U32 base = trie->states[ state ].trans.base;
-                    U16 wordnum = trie->states[ state ].wordnum;
+                    U32 wordnum = trie->states[ state ].wordnum;
                     PERL_DEB(U32 old_state = state);
 
                     if (wordnum) { /* it's an accept state */
@@ -7126,7 +7126,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                 /* calculate total number of accept states */
                 {
-                    U16 w = ST.topword;
+                    U32 w = ST.topword;
                     accepted = 0;
                     while (w) {
                         w = trie->wordinfo[w].prev;
@@ -7176,9 +7176,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             {
                 /* Find next-highest word to process.  Note that this code
                  * is O(N^2) per trie run (O(N) per branch), so keep tight */
-                U16 min = 0;
-                U16 word;
-                U16 const nextword = ST.nextword;
+                U32 min = 0;
+                U32 word;
+                U32 const nextword = ST.nextword;
                 reg_trie_wordinfo * const wordinfo
                     = ((reg_trie_data*)rexi->data->data[TRIE_DATA_SLOT(ST.me)])->wordinfo;
                 for (word = ST.topword; word; word = wordinfo[word].prev) {

--- a/regexec.c
+++ b/regexec.c
@@ -1815,11 +1815,21 @@ Perl_re_intuit_start(pTHX_
 
 /* 'uscan' is set to foldbuf, and incremented, so below the end of uscan is
  * 'foldbuf+sizeof(foldbuf)' */
-#define REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc, uc_end,      \
+#define REXEC_TRIE_READ_CHAR(trie_type, trie, uc, uc_end,                  \
                              uscan, len, uvc, charid, foldlen, foldbuf,     \
-                             uniflags)                                      \
+                             uniflags, octet_scan, octets_remaining,       \
+                             octet_buffer)                                 \
 STMT_START {                                                                \
     STRLEN skiplen;                                                         \
+    if (TRIE_RAW_INPUT_MODE(trie, utf8_target)) {                            \
+        uvc = (U8)*uc;                                                       \
+        charid = uvc + 1;                                                    \
+        len = 1;                                                             \
+    } else if (TRIE_CONTAINS_WIDE(trie) && octets_remaining > 0) {            \
+        charid = *octet_scan++ + 1;                                          \
+        octets_remaining--;                                                  \
+        len = 0;                                                             \
+    } else {                                                                 \
     U8 flags = FOLD_FLAGS_FULL;                                             \
     switch (trie_type) {                                                    \
     case trie_flu8:                                                         \
@@ -1886,18 +1896,27 @@ STMT_START {                                                                \
         uvc = (UV)*uc;                                                      \
         len = 1;                                                            \
     }                                                                       \
-    if (uvc < 256) {                                                        \
-        charid = trie->charmap[ uvc ];                                      \
-    }                                                                       \
+    if (TRIE_CONTAINS_WIDE(trie)) {                                         \
+        const native_octet_utf8_t *octet;                                   \
+        U8 *end;                                                            \
+        if (!utf8_target && FITS_IN_8_BITS(uvc)) {                          \
+            /* Non-UTF-8 input is a native octet.  Use its cached UTF-8     \
+             * representation when the trie needs UTF-8 transitions. */     \
+            octet = &PL_native_octet_utf8[(U8)uvc];                        \
+            charid = octet->bytes[0] + 1;                                   \
+            octet_scan = octet->bytes + 1;                                  \
+            octets_remaining = octet->len - 1;                              \
+        } else {                                                            \
+            end = uvchr_to_utf8(octet_buffer, uvc);                         \
+            charid = octet_buffer[0] + 1;                                   \
+            octet_scan = octet_buffer + 1;                                  \
+            octets_remaining = (STRLEN)(end - octet_buffer - 1);            \
+        }                                                                       \
+    }                                                                        \
     else {                                                                  \
-        charid = 0;                                                         \
-        if (widecharmap) {                                                  \
-            SV** const svpp = hv_fetch(widecharmap,                         \
-                        (char*)&uvc, sizeof(UV), 0);                        \
-            if (svpp)                                                       \
-                charid = (U32)SvIV(*svpp);                                  \
-        }                                                                   \
+        charid = uvc + 1;                                                    \
     }                                                                       \
+    }                                                                        \
 } STMT_END
 
 #define DUMP_EXEC_POS(li,s,doutf8,depth)                    \
@@ -3257,10 +3276,6 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
         }
         break;
 
-      case AHOCORASICKC_tb_pb:
-      case AHOCORASICKC_tb_p8:
-      case AHOCORASICKC_t8_pb:
-      case AHOCORASICKC_t8_p8:
       case AHOCORASICK_tb_pb:
       case AHOCORASICK_tb_p8:
       case AHOCORASICK_t8_pb:
@@ -3270,7 +3285,6 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             /* what trie are we using right now */
             reg_ac_data *aho = (reg_ac_data*)progi->data->data[ TRIE_DATA_SLOT(c) ];
             reg_trie_data *trie = (reg_trie_data*)progi->data->data[aho->trie];
-            HV *widecharmap = MUTABLE_HV(progi->data->data[ aho->trie + 1 ]);
 
             const char *last_start = strend - trie->minlen;
 #ifdef DEBUGGING
@@ -3294,7 +3308,9 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             bool used_heap = false;
 
             U8 foldbuf[ UTF8_MAXBYTES_CASE + 1 ];
-            U8 *bitmap = NULL;
+            U8 octet_buffer[ UTF8_MAXBYTES_CASE + 1 ];
+            const U8 *octet_scan = NULL;
+            STRLEN octets_remaining = 0;
             U8 **points_heap = NULL;
 
             DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -3311,14 +3327,8 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                 points = points_heap;
             }
 
-            if ( trie_type != trie_utf8_fold
-                 && (trie->bitmap || OP(c)==AHOCORASICKC) )
-            {
-                if (trie->bitmap)
-                    bitmap = (U8*)trie->bitmap;
-                else
-                    bitmap = (U8*)ANYOF_BITMAP(c);
-            }
+            /* Trie start-byte filtering is temporarily disabled while the
+             * post-prefix-extraction start state is being validated. */
             /* this is the Aho-Corasick algorithm modified a touch
                to include special handling for long "unknown char" sequences.
                The basic idea being that we use AC as long as we are dealing
@@ -3355,33 +3365,6 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                     U32 word = aho->states[ state ].wordnum;
 
                     if( state == 1 ) {
-                        if ( bitmap ) {
-                            DEBUG_TRIE_EXECUTE_r(
-                                if (  uc <= (U8*)last_start
-                                    && !BITMAP_TEST(bitmap,*uc) )
-                                {
-                                    dump_exec_pos( (char *)uc, c, strend,
-                                        real_start,
-                                        (char *)uc, utf8_target, 0 );
-                                    re_printf(
-                                        " Scanning for legal start char...\n");
-                                }
-                            );
-                            if (utf8_target) {
-                                while (  uc <= (U8*)last_start
-                                       && !BITMAP_TEST(bitmap,*uc) )
-                                {
-                                    uc += UTF8SKIP(uc);
-                                }
-                            } else {
-                                while (  uc <= (U8*)last_start
-                                       && ! BITMAP_TEST(bitmap,*uc) )
-                                {
-                                    uc++;
-                                }
-                            }
-                            s = (char *)uc;
-                        }
                         if (uc >(U8*)last_start) break;
                     }
 
@@ -3395,12 +3378,15 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                         if (base == 0) break;
 
                     }
-                    points[pointpos++ % maxlen]= uc;
-                    if (foldlen || uc < (U8*)strend) {
-                        REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc,
+                    if (!octets_remaining \
+                            && (!utf8_target || !UTF8_IS_CONTINUATION(*uc)))
+                        points[pointpos++ % maxlen]= uc;
+                    if (foldlen || octets_remaining || uc < (U8*)strend) {
+                        REXEC_TRIE_READ_CHAR(trie_type, trie, uc,
                                              (U8 *) strend, uscan, len, uvc,
                                              charid, foldlen, foldbuf,
-                                             uniflags);
+                                             uniflags, octet_scan,
+                                             octets_remaining, octet_buffer);
                         DEBUG_TRIE_EXECUTE_r({
                             dump_exec_pos( (char *)uc, c, strend,
                                         real_start, s, utf8_target, 0);
@@ -3440,7 +3426,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
                             I32 offset;
                             if (charid &&
                                  ( ((offset = base + charid
-                                    - 1 - trie->uniquecharcount)) >= 0)
+                                    - 1 - TRIE_ALPHABET_SIZE)) >= 0)
                                  && ((U32)offset < trie->lasttrans)
                                  && trie->trans[offset].check == state
                                  && (tmp = trie->trans[offset].next))
@@ -6929,23 +6915,6 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
 #undef  ST
 #define ST st->u.trie
-        case LTRIEC:
-        case TRIEC: /* (ab|cd) with known charclass */
-            /* In this case the charclass data is available inline so
-               we can fail fast without a lot of extra overhead.
-             */
-            if ( !   NEXTCHR_IS_EOS
-                &&   locinput < loceol
-                && ! ANYOF_BITMAP_TEST(scan, nextbyte))
-            {
-                DEBUG_EXECUTE_r(
-                    re_exec_indentf("%sTRIE: failed to match trie start class...%s\n",
-                              depth, PL_colors[4], PL_colors[5])
-                );
-                sayNO_SILENT;
-                NOT_REACHED; /* NOTREACHED */
-            }
-            /* FALLTHROUGH */
         case LTRIE:
         case TRIE:  /* (ab|cd)  */
             /* the basic plan of execution of the trie is:
@@ -7004,7 +6973,6 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 assert(ST.before_paren <= rex->nparens);
                 assert(ST.after_paren <= rex->nparens);
 
-                HV * widecharmap = MUTABLE_HV(rexi->data->data[ TRIE_DATA_SLOT(scan) + 1 ]);
                 U32 state = trie->startstate;
 
                 if (FLAGS(scan) == EXACTL || FLAGS(scan) == EXACTFLU8) {
@@ -7021,26 +6989,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                                                                reginfo->strend);
                     }
                 }
-                if (   trie->bitmap
-                    && (     NEXTCHR_IS_EOS
-                        ||   locinput >= loceol
-                        || ! TRIE_BITMAP_TEST(trie, nextbyte)))
-                {
-                    if (trie->states[ state ].wordnum) {
-                         DEBUG_EXECUTE_r(
-                            re_exec_indentf("%sTRIE: matched empty string...%s\n",
-                                          depth, PL_colors[4], PL_colors[5])
-                        );
-                        if (!trie->jump)
-                            break;
-                    } else {
-                        DEBUG_EXECUTE_r(
-                            re_exec_indentf("%sTRIE: failed to match trie start class...%s\n",
-                                          depth, PL_colors[4], PL_colors[5])
-                        );
-                        sayNO_SILENT;
-                   }
-                }
+                /* Start-class filtering is disabled while trie prefix
+                 * extraction is being brought into alignment with the
+                 * executable start state. */
 
             {
                 U8 *uc = ( U8* )locinput;
@@ -7049,6 +7000,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 STRLEN foldlen = 0;
                 U8 *uscan = (U8*)NULL;
                 U8 foldbuf[ UTF8_MAXBYTES_CASE + 1 ];
+                U8 octet_buffer[ UTF8_MAXBYTES_CASE + 1 ];
+                const U8 *octet_scan = NULL;
+                STRLEN octets_remaining = 0;
                 U32 charcount = 0; /* how many input chars we have matched */
                 U32 accepted = 0; /* how many accepting states have we seen? */
 
@@ -7064,7 +7018,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                    shortest accept state and the wordnum of the longest
                    accept state */
 
-                while ( state && uc <= (U8*)(loceol) ) {
+                while ( state && (uc <= (U8*)(loceol) || octets_remaining) ) {
                     UV uvc = 0;
                     U32 charid = 0;
                     U32 base = trie->states[ state ].trans.base;
@@ -7090,18 +7044,22 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     }
 
                     /* read a char and goto next state */
-                    if ( base && (foldlen || uc < (U8*)(loceol))) {
+                    if ( base && (foldlen || octets_remaining || uc < (U8*)(loceol))) {
                         I32 offset;
-                        REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc,
+                        REXEC_TRIE_READ_CHAR(trie_type, trie, uc,
                                              (U8 *) loceol, uscan,
                                              len, uvc, charid, foldlen,
-                                             foldbuf, uniflags);
-                        charcount++;
+                                             foldbuf, uniflags, octet_scan,
+                                             octets_remaining, octet_buffer);
+                        if (TRIE_RAW_INPUT_MODE(trie, utf8_target) \
+                                ? (!utf8_target || !UTF8_IS_CONTINUATION(*uc)) \
+                                : len)
+                            charcount++;
                         if (foldlen > 0)
                             ST.longfold = true;
                         if (charid &&
                              ( ((offset =
-                              base + charid - 1 - trie->uniquecharcount)) >= 0)
+                              base + charid - 1 - TRIE_ALPHABET_SIZE)) >= 0)
 
                              && ((U32)offset < trie->lasttrans)
                              && trie->trans[offset].check == state)
@@ -7219,10 +7177,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 U32 chars; /* how many chars to skip */
                 reg_trie_data * const trie
                     = (reg_trie_data*)rexi->data->data[TRIE_DATA_SLOT(ST.me)];
-
-                assert((trie->wordinfo[ST.nextword].len - trie->prefixlen)
+                assert((trie->wordinfo[ST.nextword].len - trie->prefixlen_chars)
                             >=  ST.firstchars);
-                chars = (trie->wordinfo[ST.nextword].len - trie->prefixlen)
+                chars = (trie->wordinfo[ST.nextword].len - trie->prefixlen_chars)
                             - ST.firstchars;
                 uc = ST.firstpos;
 
@@ -7268,7 +7225,10 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                 }
             }
             if (ST.jump && ST.jump[ST.nextword]) {
-                scan = ST.me + ST.jump[ST.nextword];
+                reg_trie_data * const trie
+                    = (reg_trie_data*)rexi->data->data[TRIE_DATA_SLOT(ST.me)];
+                scan = TRIE_JUMP_TARGET(ST.me, ST.jump, trie->jump_correction,
+                                        ST.nextword);
                 ST.before_paren = ST.j_before_paren[ST.nextword];
                 assert(ST.before_paren <= rex->nparens);
                 ST.after_paren = ST.j_after_paren[ST.nextword];

--- a/regexp.h
+++ b/regexp.h
@@ -985,8 +985,8 @@ typedef struct regmatch_state {
             regnode     *me;        /* Which node am I - needed for jump tries*/
             U8          *firstpos;  /* pos in string of first trie match */
             U32         firstchars; /* len in chars of firstpos from start */
-            U16         nextword;   /* next word to try */
-            U16         topword;    /* longest accepted word */
+            U32         nextword;   /* next word to try */
+            U32         topword;    /* longest accepted word */
         } trie;
 
         /* special types - these members are used to store state for special

--- a/regexp_constants.h
+++ b/regexp_constants.h
@@ -14,8 +14,8 @@
  * important world scripts.  At 12 most of them are: including Arabic,
  * Cyrillic, Greek, Hebrew, Indian subcontinent, Latin, and Thai; but not Han,
  * Japanese, nor Korean.  The regnode sizing data structure in regnodes.h currently
- * uses a U8, and the trie types TRIEC and AHOCORASICKC are larger than U8 for
- * shift values above 12.)  Be sure to benchmark before changing, as larger sizes
+ * uses a U8 for its node sizing data above this point.)  Be sure to benchmark
+ * before changing, as larger sizes
  * do significantly slow down the test suite. */
 
 #define NUM_ANYOF_CODE_POINTS   (1 << 8)
@@ -83,5 +83,5 @@
  * 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * c4f76f4ba54f533e6b3c6197d2733a4f83f7bbf3c01e6d83b8950e291a3fe36a regen/mk_PL_charclass.pl
- * 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+ * 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
  * ex: set ro ft=c: */

--- a/regexp_constants.h
+++ b/regexp_constants.h
@@ -14,8 +14,8 @@
  * important world scripts.  At 12 most of them are: including Arabic,
  * Cyrillic, Greek, Hebrew, Indian subcontinent, Latin, and Thai; but not Han,
  * Japanese, nor Korean.  The regnode sizing data structure in regnodes.h currently
- * uses a U8, and the trie types TRIEC and AHOCORASICKC are larger than U8 for
- * shift values above 12.)  Be sure to benchmark before changing, as larger sizes
+ * uses a U8 for its node sizing data above this point.)  Be sure to benchmark
+ * before changing, as larger sizes
  * do significantly slow down the test suite. */
 
 #define NUM_ANYOF_CODE_POINTS   (1 << 8)
@@ -83,5 +83,5 @@
  * 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * 40a2020ba2420e15332d3855a26138f4391b9f49fbb53aafcb9560e1e288dd5a regen/mk_PL_charclass.pl
- * 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+ * 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
  * ex: set ro ft=c: */

--- a/regnodes.h
+++ b/regnodes.h
@@ -12,7 +12,6 @@
 
 typedef struct regnode_2                         tregnode_ACCEPT;
 typedef struct regnode_1                         tregnode_AHOCORASICK;
-typedef struct regnode_charclass                 tregnode_AHOCORASICKC;
 typedef struct regnode_charclass                 tregnode_ANYOF;
 typedef struct regnode_charclass                 tregnode_ANYOFD;
 typedef struct regnode_1                         tregnode_ANYOFH;
@@ -71,7 +70,6 @@ typedef struct regnode                           tregnode_LOGICAL;
 typedef struct regnode_1                         tregnode_LONGJMP;
 typedef struct regnode                           tregnode_LOOKBEHIND_END;
 typedef struct regnode_2                         tregnode_LTRIE;
-typedef struct regnode_charclass_trie            tregnode_LTRIEC;
 typedef struct regnode_1                         tregnode_MARKPOINT;
 typedef struct regnode                           tregnode_MBOL;
 typedef struct regnode                           tregnode_MEOL;
@@ -120,7 +118,6 @@ typedef struct regnode                           tregnode_SUCCEED;
 typedef struct regnode_1                         tregnode_SUSPEND;
 typedef struct regnode                           tregnode_TAIL;
 typedef struct regnode_1                         tregnode_TRIE;
-typedef struct regnode_charclass                 tregnode_TRIEC;
 typedef struct regnode_1                         tregnode_UNLESSM;
 typedef struct regnode_1                         tregnode_VERB;
 typedef struct regnode                           tregnode_WHILEM;
@@ -129,8 +126,8 @@ typedef struct regnode                           tregnode_WHILEM;
 
 /* Regops and State definitions */
 
-#define REGNODE_MAX           	113
-#define REGMATCH_STATE_MAX    	157
+#define REGNODE_MAX           	110
+#define REGMATCH_STATE_MAX    	154
 
 /* -- For regexec.c to switch on target being utf8 (t8) or not (tb, b='byte'); */
 #define with_t_UTF8ness(op, t_utf8) (((op) << 1) + (cBOOL(t_utf8)))
@@ -761,18 +758,8 @@ typedef struct regnode                           tregnode_WHILEM;
 #define TRIE_t8_p8                  ((TRIE) * 4 + 3)
 
 /* 0x3a :  58
-   TRIEC - Same as TRIE, but with embedded charclass data */
-#define TRIEC                       (TRIE + 1)
-#define TRIEC_tb                    ((TRIEC) * 2)
-#define TRIEC_t8                    ((TRIEC) * 2 + 1)
-#define TRIEC_tb_pb                 ((TRIEC) * 4)
-#define TRIEC_tb_p8                 ((TRIEC) * 4 + 1)
-#define TRIEC_t8_pb                 ((TRIEC) * 4 + 2)
-#define TRIEC_t8_p8                 ((TRIEC) * 4 + 3)
-
-/* 0x3b :  59
    AHOCORASICK - Aho Corasick stclass. flags==type */
-#define AHOCORASICK                 (TRIEC + 1)
+#define AHOCORASICK                 (TRIE + 1)
 #define AHOCORASICK_tb              ((AHOCORASICK) * 2)
 #define AHOCORASICK_t8              ((AHOCORASICK) * 2 + 1)
 #define AHOCORASICK_tb_pb           ((AHOCORASICK) * 4)
@@ -780,19 +767,9 @@ typedef struct regnode                           tregnode_WHILEM;
 #define AHOCORASICK_t8_pb           ((AHOCORASICK) * 4 + 2)
 #define AHOCORASICK_t8_p8           ((AHOCORASICK) * 4 + 3)
 
-/* 0x3c :  60
-   AHOCORASICKC - Same as AHOCORASICK, but with embedded charclass data */
-#define AHOCORASICKC                (AHOCORASICK + 1)
-#define AHOCORASICKC_tb             ((AHOCORASICKC) * 2)
-#define AHOCORASICKC_t8             ((AHOCORASICKC) * 2 + 1)
-#define AHOCORASICKC_tb_pb          ((AHOCORASICKC) * 4)
-#define AHOCORASICKC_tb_p8          ((AHOCORASICKC) * 4 + 1)
-#define AHOCORASICKC_t8_pb          ((AHOCORASICKC) * 4 + 2)
-#define AHOCORASICKC_t8_p8          ((AHOCORASICKC) * 4 + 3)
-
-/* 0x3d :  61
+/* 0x3b :  59
    LTRIE - Same as TRIE, but with longjump support */
-#define LTRIE                       (AHOCORASICKC + 1)
+#define LTRIE                       (AHOCORASICK + 1)
 #define LTRIE_tb                    ((LTRIE) * 2)
 #define LTRIE_t8                    ((LTRIE) * 2 + 1)
 #define LTRIE_tb_pb                 ((LTRIE) * 4)
@@ -800,19 +777,9 @@ typedef struct regnode                           tregnode_WHILEM;
 #define LTRIE_t8_pb                 ((LTRIE) * 4 + 2)
 #define LTRIE_t8_p8                 ((LTRIE) * 4 + 3)
 
-/* 0x3e :  62
-   LTRIEC - Same as TRIEC, but with longjump support */
-#define LTRIEC                      (LTRIE + 1)
-#define LTRIEC_tb                   ((LTRIEC) * 2)
-#define LTRIEC_t8                   ((LTRIEC) * 2 + 1)
-#define LTRIEC_tb_pb                ((LTRIEC) * 4)
-#define LTRIEC_tb_p8                ((LTRIEC) * 4 + 1)
-#define LTRIEC_t8_pb                ((LTRIEC) * 4 + 2)
-#define LTRIEC_t8_p8                ((LTRIEC) * 4 + 3)
-
-/* 0x3f :  63
+/* 0x3c :  60
    NOTHING - Match empty string. */
-#define NOTHING                     (LTRIEC + 1)
+#define NOTHING                     (LTRIE + 1)
 #define NOTHING_tb                  ((NOTHING) * 2)
 #define NOTHING_t8                  ((NOTHING) * 2 + 1)
 #define NOTHING_tb_pb               ((NOTHING) * 4)
@@ -820,7 +787,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define NOTHING_t8_pb               ((NOTHING) * 4 + 2)
 #define NOTHING_t8_p8               ((NOTHING) * 4 + 3)
 
-/* 0x40 :  64
+/* 0x3d :  61
    TAIL - Match empty string. Can jump here from outside. */
 #define TAIL                        (NOTHING + 1)
 #define TAIL_tb                     ((TAIL) * 2)
@@ -830,7 +797,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define TAIL_t8_pb                  ((TAIL) * 4 + 2)
 #define TAIL_t8_p8                  ((TAIL) * 4 + 3)
 
-/* 0x41 :  65
+/* 0x3e :  62
    OPTIMIZED - This is not really a node, but an optimized away piece of a
    "long" node.  To simplify debugging output, we mark it as if it were a node */
 #define OPTIMIZED                   (TAIL + 1)
@@ -841,7 +808,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define OPTIMIZED_t8_pb             ((OPTIMIZED) * 4 + 2)
 #define OPTIMIZED_t8_p8             ((OPTIMIZED) * 4 + 3)
 
-/* 0x42 :  66
+/* 0x3f :  63
    STAR - Match this (simple) thing 0 or more times: /A{0,}B/ where A is width
    1 char */
 #define STAR                        (OPTIMIZED + 1)
@@ -852,7 +819,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define STAR_t8_pb                  ((STAR) * 4 + 2)
 #define STAR_t8_p8                  ((STAR) * 4 + 3)
 
-/* 0x43 :  67
+/* 0x40 :  64
    PLUS - Match this (simple) thing 1 or more times: /A{1,}B/ where A is width
    1 char */
 #define PLUS                        (STAR + 1)
@@ -863,7 +830,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define PLUS_t8_pb                  ((PLUS) * 4 + 2)
 #define PLUS_t8_p8                  ((PLUS) * 4 + 3)
 
-/* 0x44 :  68
+/* 0x41 :  65
    CURLY - Match this (simple) thing {n,m} times: /A{m,n}B/ where A is width 1
    char */
 #define CURLY                       (PLUS + 1)
@@ -874,7 +841,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLY_t8_pb                 ((CURLY) * 4 + 2)
 #define CURLY_t8_p8                 ((CURLY) * 4 + 3)
 
-/* 0x45 :  69
+/* 0x42 :  66
    CURLYN - Capture next-after-this simple thing: /(A){m,n}B/ where A is width
    1 char */
 #define CURLYN                      (CURLY + 1)
@@ -885,7 +852,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYN_t8_pb                ((CURLYN) * 4 + 2)
 #define CURLYN_t8_p8                ((CURLYN) * 4 + 3)
 
-/* 0x46 :  70
+/* 0x43 :  67
    CURLYM - Capture this medium-complex thing {n,m} times: /(A){m,n}B/ where A
    is fixed-length */
 #define CURLYM                      (CURLYN + 1)
@@ -896,7 +863,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYM_t8_pb                ((CURLYM) * 4 + 2)
 #define CURLYM_t8_p8                ((CURLYM) * 4 + 3)
 
-/* 0x47 :  71
+/* 0x44 :  68
    CURLYX - Match/Capture this complex thing {n,m} times. */
 #define CURLYX                      (CURLYM + 1)
 #define CURLYX_tb                   ((CURLYX) * 2)
@@ -906,7 +873,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYX_t8_pb                ((CURLYX) * 4 + 2)
 #define CURLYX_t8_p8                ((CURLYX) * 4 + 3)
 
-/* 0x48 :  72
+/* 0x45 :  69
    WHILEM - Do curly processing and see if rest matches. */
 #define WHILEM                      (CURLYX + 1)
 #define WHILEM_tb                   ((WHILEM) * 2)
@@ -916,7 +883,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_t8_pb                ((WHILEM) * 4 + 2)
 #define WHILEM_t8_p8                ((WHILEM) * 4 + 3)
 
-/* 0x49 :  73
+/* 0x46 :  70
    OPEN - Mark this point in input as start of #n. */
 #define OPEN                        (WHILEM + 1)
 #define OPEN_tb                     ((OPEN) * 2)
@@ -926,7 +893,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define OPEN_t8_pb                  ((OPEN) * 4 + 2)
 #define OPEN_t8_p8                  ((OPEN) * 4 + 3)
 
-/* 0x4a :  74
+/* 0x47 :  71
    CLOSE - Close corresponding OPEN of #n. */
 #define CLOSE                       (OPEN + 1)
 #define CLOSE_tb                    ((CLOSE) * 2)
@@ -936,7 +903,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CLOSE_t8_pb                 ((CLOSE) * 4 + 2)
 #define CLOSE_t8_p8                 ((CLOSE) * 4 + 3)
 
-/* 0x4b :  75
+/* 0x48 :  72
    SROPEN - Start a script run */
 #define SROPEN                      (CLOSE + 1)
 #define SROPEN_tb                   ((SROPEN) * 2)
@@ -946,7 +913,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define SROPEN_t8_pb                ((SROPEN) * 4 + 2)
 #define SROPEN_t8_p8                ((SROPEN) * 4 + 3)
 
-/* 0x4c :  76
+/* 0x49 :  73
    SRCLOSE -  */
 #define SRCLOSE                     (SROPEN + 1)
 #define SRCLOSE_tb                  ((SRCLOSE) * 2)
@@ -956,7 +923,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define SRCLOSE_t8_pb               ((SRCLOSE) * 4 + 2)
 #define SRCLOSE_t8_p8               ((SRCLOSE) * 4 + 3)
 
-/* 0x4d :  77
+/* 0x4a :  74
    REF - Match some already matched string */
 #define REF                         (SRCLOSE + 1)
 #define REF_tb                      ((REF) * 2)
@@ -966,7 +933,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REF_t8_pb                   ((REF) * 4 + 2)
 #define REF_t8_p8                   ((REF) * 4 + 3)
 
-/* 0x4e :  78
+/* 0x4b :  75
    REFF - Match already matched string, using /di rules. */
 #define REFF                        (REF + 1)
 #define REFF_tb                     ((REFF) * 2)
@@ -976,7 +943,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFF_t8_pb                  ((REFF) * 4 + 2)
 #define REFF_t8_p8                  ((REFF) * 4 + 3)
 
-/* 0x4f :  79
+/* 0x4c :  76
    REFFL - Match already matched string, using /li rules. */
 #define REFFL                       (REFF + 1)
 #define REFFL_tb                    ((REFFL) * 2)
@@ -986,7 +953,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFL_t8_pb                 ((REFFL) * 4 + 2)
 #define REFFL_t8_p8                 ((REFFL) * 4 + 3)
 
-/* 0x50 :  80
+/* 0x4d :  77
    REFFU - Match already matched string, using /ui. */
 #define REFFU                       (REFFL + 1)
 #define REFFU_tb                    ((REFFU) * 2)
@@ -996,7 +963,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFU_t8_pb                 ((REFFU) * 4 + 2)
 #define REFFU_t8_p8                 ((REFFU) * 4 + 3)
 
-/* 0x51 :  81
+/* 0x4e :  78
    REFFA - Match already matched string, using /aai rules. */
 #define REFFA                       (REFFU + 1)
 #define REFFA_tb                    ((REFFA) * 2)
@@ -1006,7 +973,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFA_t8_pb                 ((REFFA) * 4 + 2)
 #define REFFA_t8_p8                 ((REFFA) * 4 + 3)
 
-/* 0x52 :  82
+/* 0x4f :  79
    REFN - Match some already matched string */
 #define REFN                        (REFFA + 1)
 #define REFN_tb                     ((REFN) * 2)
@@ -1016,7 +983,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFN_t8_pb                  ((REFN) * 4 + 2)
 #define REFN_t8_p8                  ((REFN) * 4 + 3)
 
-/* 0x53 :  83
+/* 0x50 :  80
    REFFN - Match already matched string, using /di rules. */
 #define REFFN                       (REFN + 1)
 #define REFFN_tb                    ((REFFN) * 2)
@@ -1026,7 +993,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFN_t8_pb                 ((REFFN) * 4 + 2)
 #define REFFN_t8_p8                 ((REFFN) * 4 + 3)
 
-/* 0x54 :  84
+/* 0x51 :  81
    REFFLN - Match already matched string, using /li rules. */
 #define REFFLN                      (REFFN + 1)
 #define REFFLN_tb                   ((REFFLN) * 2)
@@ -1036,7 +1003,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFLN_t8_pb                ((REFFLN) * 4 + 2)
 #define REFFLN_t8_p8                ((REFFLN) * 4 + 3)
 
-/* 0x55 :  85
+/* 0x52 :  82
    REFFUN - Match already matched string, using /ui rules. */
 #define REFFUN                      (REFFLN + 1)
 #define REFFUN_tb                   ((REFFUN) * 2)
@@ -1046,7 +1013,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFUN_t8_pb                ((REFFUN) * 4 + 2)
 #define REFFUN_t8_p8                ((REFFUN) * 4 + 3)
 
-/* 0x56 :  86
+/* 0x53 :  83
    REFFAN - Match already matched string, using /aai rules. */
 #define REFFAN                      (REFFUN + 1)
 #define REFFAN_tb                   ((REFFAN) * 2)
@@ -1056,7 +1023,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REFFAN_t8_pb                ((REFFAN) * 4 + 2)
 #define REFFAN_t8_p8                ((REFFAN) * 4 + 3)
 
-/* 0x57 :  87
+/* 0x54 :  84
    BRANCHJ - BRANCH with long offset. */
 #define BRANCHJ                     (REFFAN + 1)
 #define BRANCHJ_tb                  ((BRANCHJ) * 2)
@@ -1066,7 +1033,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define BRANCHJ_t8_pb               ((BRANCHJ) * 4 + 2)
 #define BRANCHJ_t8_p8               ((BRANCHJ) * 4 + 3)
 
-/* 0x58 :  88
+/* 0x55 :  85
    IFMATCH - Succeeds if the following matches; non-zero flags "f", next_off
    "o" means lookbehind assertion starting "f..(f-o)" characters before
    current */
@@ -1078,7 +1045,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define IFMATCH_t8_pb               ((IFMATCH) * 4 + 2)
 #define IFMATCH_t8_p8               ((IFMATCH) * 4 + 3)
 
-/* 0x59 :  89
+/* 0x56 :  86
    UNLESSM - Fails if the following matches; non-zero flags "f", next_off "o"
    means lookbehind assertion starting "f..(f-o)" characters before current */
 #define UNLESSM                     (IFMATCH + 1)
@@ -1089,7 +1056,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define UNLESSM_t8_pb               ((UNLESSM) * 4 + 2)
 #define UNLESSM_t8_p8               ((UNLESSM) * 4 + 3)
 
-/* 0x5a :  90
+/* 0x57 :  87
    SUSPEND - "Independent" sub-RE. */
 #define SUSPEND                     (UNLESSM + 1)
 #define SUSPEND_tb                  ((SUSPEND) * 2)
@@ -1099,7 +1066,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define SUSPEND_t8_pb               ((SUSPEND) * 4 + 2)
 #define SUSPEND_t8_p8               ((SUSPEND) * 4 + 3)
 
-/* 0x5b :  91
+/* 0x58 :  88
    IFTHEN - Switch, should be preceded by switcher. */
 #define IFTHEN                      (SUSPEND + 1)
 #define IFTHEN_tb                   ((IFTHEN) * 2)
@@ -1109,7 +1076,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define IFTHEN_t8_pb                ((IFTHEN) * 4 + 2)
 #define IFTHEN_t8_p8                ((IFTHEN) * 4 + 3)
 
-/* 0x5c :  92
+/* 0x59 :  89
    RENUM - Group with independently numbered parens. Not used yet. */
 #define RENUM                       (IFTHEN + 1)
 #define RENUM_tb                    ((RENUM) * 2)
@@ -1119,7 +1086,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define RENUM_t8_pb                 ((RENUM) * 4 + 2)
 #define RENUM_t8_p8                 ((RENUM) * 4 + 3)
 
-/* 0x5d :  93
+/* 0x5a :  90
    LONGJMP - Jump far away. */
 #define LONGJMP                     (RENUM + 1)
 #define LONGJMP_tb                  ((LONGJMP) * 2)
@@ -1129,7 +1096,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define LONGJMP_t8_pb               ((LONGJMP) * 4 + 2)
 #define LONGJMP_t8_p8               ((LONGJMP) * 4 + 3)
 
-/* 0x5e :  94
+/* 0x5b :  91
    MINMOD - Next operator is not greedy. */
 #define MINMOD                      (LONGJMP + 1)
 #define MINMOD_tb                   ((MINMOD) * 2)
@@ -1139,7 +1106,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define MINMOD_t8_pb                ((MINMOD) * 4 + 2)
 #define MINMOD_t8_p8                ((MINMOD) * 4 + 3)
 
-/* 0x5f :  95
+/* 0x5c :  92
    LOGICAL - Next opcode should set the flag only. */
 #define LOGICAL                     (MINMOD + 1)
 #define LOGICAL_tb                  ((LOGICAL) * 2)
@@ -1149,7 +1116,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define LOGICAL_t8_pb               ((LOGICAL) * 4 + 2)
 #define LOGICAL_t8_p8               ((LOGICAL) * 4 + 3)
 
-/* 0x60 :  96
+/* 0x5d :  93
    EVAL - Execute some Perl code. Used by other opcodes in some cases */
 #define EVAL                        (LOGICAL + 1)
 #define EVAL_tb                     ((EVAL) * 2)
@@ -1159,7 +1126,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define EVAL_t8_pb                  ((EVAL) * 4 + 2)
 #define EVAL_t8_p8                  ((EVAL) * 4 + 3)
 
-/* 0x61 :  97
+/* 0x5e :  94
    GOSUB - recurse to paren arg1 at (signed) ofs arg2 */
 #define GOSUB                       (EVAL + 1)
 #define GOSUB_tb                    ((GOSUB) * 2)
@@ -1169,7 +1136,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define GOSUB_t8_pb                 ((GOSUB) * 4 + 2)
 #define GOSUB_t8_p8                 ((GOSUB) * 4 + 3)
 
-/* 0x62 :  98
+/* 0x5f :  95
    GROUPP - Whether the group matched. */
 #define GROUPP                      (GOSUB + 1)
 #define GROUPP_tb                   ((GROUPP) * 2)
@@ -1179,7 +1146,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define GROUPP_t8_pb                ((GROUPP) * 4 + 2)
 #define GROUPP_t8_p8                ((GROUPP) * 4 + 3)
 
-/* 0x63 :  99
+/* 0x60 :  96
    GROUPPN - Whether the named group matched. */
 #define GROUPPN                     (GROUPP + 1)
 #define GROUPPN_tb                  ((GROUPPN) * 2)
@@ -1189,7 +1156,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define GROUPPN_t8_pb               ((GROUPPN) * 4 + 2)
 #define GROUPPN_t8_p8               ((GROUPPN) * 4 + 3)
 
-/* 0x64 : 100
+/* 0x61 :  97
    INSUBP - Whether we are in a specific recurse. */
 #define INSUBP                      (GROUPPN + 1)
 #define INSUBP_tb                   ((INSUBP) * 2)
@@ -1199,7 +1166,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define INSUBP_t8_pb                ((INSUBP) * 4 + 2)
 #define INSUBP_t8_p8                ((INSUBP) * 4 + 3)
 
-/* 0x65 : 101
+/* 0x62 :  98
    DEFINEP - Define regex subroutines. Contents never executed directly,
    disallows 'no' branch in conditional. */
 #define DEFINEP                     (INSUBP + 1)
@@ -1210,7 +1177,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define DEFINEP_t8_pb               ((DEFINEP) * 4 + 2)
 #define DEFINEP_t8_p8               ((DEFINEP) * 4 + 3)
 
-/* 0x66 : 102
+/* 0x63 :  99
    ENDLIKE - Used only for the type field of verbs */
 #define ENDLIKE                     (DEFINEP + 1)
 #define ENDLIKE_tb                  ((ENDLIKE) * 2)
@@ -1220,7 +1187,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define ENDLIKE_t8_pb               ((ENDLIKE) * 4 + 2)
 #define ENDLIKE_t8_p8               ((ENDLIKE) * 4 + 3)
 
-/* 0x67 : 103
+/* 0x64 : 100
    OPFAIL - Same as (?!), but with verb arg */
 #define OPFAIL                      (ENDLIKE + 1)
 #define OPFAIL_tb                   ((OPFAIL) * 2)
@@ -1230,7 +1197,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define OPFAIL_t8_pb                ((OPFAIL) * 4 + 2)
 #define OPFAIL_t8_p8                ((OPFAIL) * 4 + 3)
 
-/* 0x68 : 104
+/* 0x65 : 101
    ACCEPT - Accepts the current matched string, with verbar */
 #define ACCEPT                      (OPFAIL + 1)
 #define ACCEPT_tb                   ((ACCEPT) * 2)
@@ -1240,7 +1207,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define ACCEPT_t8_pb                ((ACCEPT) * 4 + 2)
 #define ACCEPT_t8_p8                ((ACCEPT) * 4 + 3)
 
-/* 0x69 : 105
+/* 0x66 : 102
    VERB - Used only for the type field of verbs */
 #define VERB                        (ACCEPT + 1)
 #define VERB_tb                     ((VERB) * 2)
@@ -1250,7 +1217,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define VERB_t8_pb                  ((VERB) * 4 + 2)
 #define VERB_t8_p8                  ((VERB) * 4 + 3)
 
-/* 0x6a : 106
+/* 0x67 : 103
    PRUNE - Pattern fails at this startpoint if no-backtracking through this */
 #define PRUNE                       (VERB + 1)
 #define PRUNE_tb                    ((PRUNE) * 2)
@@ -1260,7 +1227,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define PRUNE_t8_pb                 ((PRUNE) * 4 + 2)
 #define PRUNE_t8_p8                 ((PRUNE) * 4 + 3)
 
-/* 0x6b : 107
+/* 0x68 : 104
    MARKPOINT - Push the current location for rollback by cut. */
 #define MARKPOINT                   (PRUNE + 1)
 #define MARKPOINT_tb                ((MARKPOINT) * 2)
@@ -1270,7 +1237,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define MARKPOINT_t8_pb             ((MARKPOINT) * 4 + 2)
 #define MARKPOINT_t8_p8             ((MARKPOINT) * 4 + 3)
 
-/* 0x6c : 108
+/* 0x69 : 105
    SKIP - On failure skip forward (to the mark) before retrying */
 #define SKIP                        (MARKPOINT + 1)
 #define SKIP_tb                     ((SKIP) * 2)
@@ -1280,7 +1247,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define SKIP_t8_pb                  ((SKIP) * 4 + 2)
 #define SKIP_t8_p8                  ((SKIP) * 4 + 3)
 
-/* 0x6d : 109
+/* 0x6a : 106
    COMMIT - Pattern fails outright if backtracking through this */
 #define COMMIT                      (SKIP + 1)
 #define COMMIT_tb                   ((COMMIT) * 2)
@@ -1290,7 +1257,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define COMMIT_t8_pb                ((COMMIT) * 4 + 2)
 #define COMMIT_t8_p8                ((COMMIT) * 4 + 3)
 
-/* 0x6e : 110
+/* 0x6b : 107
    CUTGROUP - On failure go to the next alternation in the group */
 #define CUTGROUP                    (COMMIT + 1)
 #define CUTGROUP_tb                 ((CUTGROUP) * 2)
@@ -1300,7 +1267,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CUTGROUP_t8_pb              ((CUTGROUP) * 4 + 2)
 #define CUTGROUP_t8_p8              ((CUTGROUP) * 4 + 3)
 
-/* 0x6f : 111
+/* 0x6c : 108
    KEEPS - $& begins here. */
 #define KEEPS                       (CUTGROUP + 1)
 #define KEEPS_tb                    ((KEEPS) * 2)
@@ -1310,7 +1277,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define KEEPS_t8_pb                 ((KEEPS) * 4 + 2)
 #define KEEPS_t8_p8                 ((KEEPS) * 4 + 3)
 
-/* 0x70 : 112
+/* 0x6d : 109
    PSEUDO - Pseudo opcode for internal use. */
 #define PSEUDO                      (KEEPS + 1)
 #define PSEUDO_tb                   ((PSEUDO) * 2)
@@ -1320,7 +1287,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define PSEUDO_t8_pb                ((PSEUDO) * 4 + 2)
 #define PSEUDO_t8_p8                ((PSEUDO) * 4 + 3)
 
-/* 0x71 : 113
+/* 0x6e : 110
    REGEX_SET - Regex set, temporary node used in pre-optimization compilation */
 #define REGEX_SET                   (PSEUDO + 1)
 #define REGEX_SET_tb                ((REGEX_SET) * 2)
@@ -1331,7 +1298,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REGEX_SET_t8_p8             ((REGEX_SET) * 4 + 3)
 
 	/* ------------ States ------------- */
-/* 0x72 : 114
+/* 0x6f : 111
    TRIE_next - state for TRIE */
 #define TRIE_next                   (REGNODE_MAX + 1)
 #define TRIE_next_tb                ((TRIE_next) * 2)
@@ -1341,7 +1308,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define TRIE_next_t8_pb             ((TRIE_next) * 4 + 2)
 #define TRIE_next_t8_p8             ((TRIE_next) * 4 + 3)
 
-/* 0x73 : 115
+/* 0x70 : 112
    TRIE_next_fail - state for TRIE */
 #define TRIE_next_fail              (TRIE_next + 1)
 #define TRIE_next_fail_tb           ((TRIE_next_fail) * 2)
@@ -1351,7 +1318,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define TRIE_next_fail_t8_pb        ((TRIE_next_fail) * 4 + 2)
 #define TRIE_next_fail_t8_p8        ((TRIE_next_fail) * 4 + 3)
 
-/* 0x74 : 116
+/* 0x71 : 113
    EVAL_B - state for EVAL */
 #define EVAL_B                      (TRIE_next_fail + 1)
 #define EVAL_B_tb                   ((EVAL_B) * 2)
@@ -1361,7 +1328,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define EVAL_B_t8_pb                ((EVAL_B) * 4 + 2)
 #define EVAL_B_t8_p8                ((EVAL_B) * 4 + 3)
 
-/* 0x75 : 117
+/* 0x72 : 114
    EVAL_B_fail - state for EVAL */
 #define EVAL_B_fail                 (EVAL_B + 1)
 #define EVAL_B_fail_tb              ((EVAL_B_fail) * 2)
@@ -1371,7 +1338,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define EVAL_B_fail_t8_pb           ((EVAL_B_fail) * 4 + 2)
 #define EVAL_B_fail_t8_p8           ((EVAL_B_fail) * 4 + 3)
 
-/* 0x76 : 118
+/* 0x73 : 115
    EVAL_postponed_A - state for EVAL */
 #define EVAL_postponed_A            (EVAL_B_fail + 1)
 #define EVAL_postponed_A_tb         ((EVAL_postponed_A) * 2)
@@ -1381,7 +1348,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define EVAL_postponed_A_t8_pb      ((EVAL_postponed_A) * 4 + 2)
 #define EVAL_postponed_A_t8_p8      ((EVAL_postponed_A) * 4 + 3)
 
-/* 0x77 : 119
+/* 0x74 : 116
    EVAL_postponed_A_fail - state for EVAL */
 #define EVAL_postponed_A_fail       (EVAL_postponed_A + 1)
 #define EVAL_postponed_A_fail_tb    ((EVAL_postponed_A_fail) * 2)
@@ -1391,7 +1358,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define EVAL_postponed_A_fail_t8_pb ((EVAL_postponed_A_fail) * 4 + 2)
 #define EVAL_postponed_A_fail_t8_p8 ((EVAL_postponed_A_fail) * 4 + 3)
 
-/* 0x78 : 120
+/* 0x75 : 117
    EVAL_postponed_B - state for EVAL */
 #define EVAL_postponed_B            (EVAL_postponed_A_fail + 1)
 #define EVAL_postponed_B_tb         ((EVAL_postponed_B) * 2)
@@ -1401,7 +1368,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define EVAL_postponed_B_t8_pb      ((EVAL_postponed_B) * 4 + 2)
 #define EVAL_postponed_B_t8_p8      ((EVAL_postponed_B) * 4 + 3)
 
-/* 0x79 : 121
+/* 0x76 : 118
    EVAL_postponed_B_fail - state for EVAL */
 #define EVAL_postponed_B_fail       (EVAL_postponed_B + 1)
 #define EVAL_postponed_B_fail_tb    ((EVAL_postponed_B_fail) * 2)
@@ -1411,7 +1378,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define EVAL_postponed_B_fail_t8_pb ((EVAL_postponed_B_fail) * 4 + 2)
 #define EVAL_postponed_B_fail_t8_p8 ((EVAL_postponed_B_fail) * 4 + 3)
 
-/* 0x7a : 122
+/* 0x77 : 119
    CURLYX_end - state for CURLYX */
 #define CURLYX_end                  (EVAL_postponed_B_fail + 1)
 #define CURLYX_end_tb               ((CURLYX_end) * 2)
@@ -1421,7 +1388,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYX_end_t8_pb            ((CURLYX_end) * 4 + 2)
 #define CURLYX_end_t8_p8            ((CURLYX_end) * 4 + 3)
 
-/* 0x7b : 123
+/* 0x78 : 120
    CURLYX_end_fail - state for CURLYX */
 #define CURLYX_end_fail             (CURLYX_end + 1)
 #define CURLYX_end_fail_tb          ((CURLYX_end_fail) * 2)
@@ -1431,7 +1398,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYX_end_fail_t8_pb       ((CURLYX_end_fail) * 4 + 2)
 #define CURLYX_end_fail_t8_p8       ((CURLYX_end_fail) * 4 + 3)
 
-/* 0x7c : 124
+/* 0x79 : 121
    WHILEM_A_pre - state for WHILEM */
 #define WHILEM_A_pre                (CURLYX_end_fail + 1)
 #define WHILEM_A_pre_tb             ((WHILEM_A_pre) * 2)
@@ -1441,7 +1408,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_A_pre_t8_pb          ((WHILEM_A_pre) * 4 + 2)
 #define WHILEM_A_pre_t8_p8          ((WHILEM_A_pre) * 4 + 3)
 
-/* 0x7d : 125
+/* 0x7a : 122
    WHILEM_A_pre_fail - state for WHILEM */
 #define WHILEM_A_pre_fail           (WHILEM_A_pre + 1)
 #define WHILEM_A_pre_fail_tb        ((WHILEM_A_pre_fail) * 2)
@@ -1451,7 +1418,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_A_pre_fail_t8_pb     ((WHILEM_A_pre_fail) * 4 + 2)
 #define WHILEM_A_pre_fail_t8_p8     ((WHILEM_A_pre_fail) * 4 + 3)
 
-/* 0x7e : 126
+/* 0x7b : 123
    WHILEM_A_min - state for WHILEM */
 #define WHILEM_A_min                (WHILEM_A_pre_fail + 1)
 #define WHILEM_A_min_tb             ((WHILEM_A_min) * 2)
@@ -1461,7 +1428,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_A_min_t8_pb          ((WHILEM_A_min) * 4 + 2)
 #define WHILEM_A_min_t8_p8          ((WHILEM_A_min) * 4 + 3)
 
-/* 0x7f : 127
+/* 0x7c : 124
    WHILEM_A_min_fail - state for WHILEM */
 #define WHILEM_A_min_fail           (WHILEM_A_min + 1)
 #define WHILEM_A_min_fail_tb        ((WHILEM_A_min_fail) * 2)
@@ -1471,7 +1438,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_A_min_fail_t8_pb     ((WHILEM_A_min_fail) * 4 + 2)
 #define WHILEM_A_min_fail_t8_p8     ((WHILEM_A_min_fail) * 4 + 3)
 
-/* 0x80 : 128
+/* 0x7d : 125
    WHILEM_A_max - state for WHILEM */
 #define WHILEM_A_max                (WHILEM_A_min_fail + 1)
 #define WHILEM_A_max_tb             ((WHILEM_A_max) * 2)
@@ -1481,7 +1448,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_A_max_t8_pb          ((WHILEM_A_max) * 4 + 2)
 #define WHILEM_A_max_t8_p8          ((WHILEM_A_max) * 4 + 3)
 
-/* 0x81 : 129
+/* 0x7e : 126
    WHILEM_A_max_fail - state for WHILEM */
 #define WHILEM_A_max_fail           (WHILEM_A_max + 1)
 #define WHILEM_A_max_fail_tb        ((WHILEM_A_max_fail) * 2)
@@ -1491,7 +1458,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_A_max_fail_t8_pb     ((WHILEM_A_max_fail) * 4 + 2)
 #define WHILEM_A_max_fail_t8_p8     ((WHILEM_A_max_fail) * 4 + 3)
 
-/* 0x82 : 130
+/* 0x7f : 127
    WHILEM_B_min - state for WHILEM */
 #define WHILEM_B_min                (WHILEM_A_max_fail + 1)
 #define WHILEM_B_min_tb             ((WHILEM_B_min) * 2)
@@ -1501,7 +1468,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_B_min_t8_pb          ((WHILEM_B_min) * 4 + 2)
 #define WHILEM_B_min_t8_p8          ((WHILEM_B_min) * 4 + 3)
 
-/* 0x83 : 131
+/* 0x80 : 128
    WHILEM_B_min_fail - state for WHILEM */
 #define WHILEM_B_min_fail           (WHILEM_B_min + 1)
 #define WHILEM_B_min_fail_tb        ((WHILEM_B_min_fail) * 2)
@@ -1511,7 +1478,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_B_min_fail_t8_pb     ((WHILEM_B_min_fail) * 4 + 2)
 #define WHILEM_B_min_fail_t8_p8     ((WHILEM_B_min_fail) * 4 + 3)
 
-/* 0x84 : 132
+/* 0x81 : 129
    WHILEM_B_max - state for WHILEM */
 #define WHILEM_B_max                (WHILEM_B_min_fail + 1)
 #define WHILEM_B_max_tb             ((WHILEM_B_max) * 2)
@@ -1521,7 +1488,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_B_max_t8_pb          ((WHILEM_B_max) * 4 + 2)
 #define WHILEM_B_max_t8_p8          ((WHILEM_B_max) * 4 + 3)
 
-/* 0x85 : 133
+/* 0x82 : 130
    WHILEM_B_max_fail - state for WHILEM */
 #define WHILEM_B_max_fail           (WHILEM_B_max + 1)
 #define WHILEM_B_max_fail_tb        ((WHILEM_B_max_fail) * 2)
@@ -1531,7 +1498,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define WHILEM_B_max_fail_t8_pb     ((WHILEM_B_max_fail) * 4 + 2)
 #define WHILEM_B_max_fail_t8_p8     ((WHILEM_B_max_fail) * 4 + 3)
 
-/* 0x86 : 134
+/* 0x83 : 131
    BRANCH_next - state for BRANCH */
 #define BRANCH_next                 (WHILEM_B_max_fail + 1)
 #define BRANCH_next_tb              ((BRANCH_next) * 2)
@@ -1541,7 +1508,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define BRANCH_next_t8_pb           ((BRANCH_next) * 4 + 2)
 #define BRANCH_next_t8_p8           ((BRANCH_next) * 4 + 3)
 
-/* 0x87 : 135
+/* 0x84 : 132
    BRANCH_next_fail - state for BRANCH */
 #define BRANCH_next_fail            (BRANCH_next + 1)
 #define BRANCH_next_fail_tb         ((BRANCH_next_fail) * 2)
@@ -1551,7 +1518,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define BRANCH_next_fail_t8_pb      ((BRANCH_next_fail) * 4 + 2)
 #define BRANCH_next_fail_t8_p8      ((BRANCH_next_fail) * 4 + 3)
 
-/* 0x88 : 136
+/* 0x85 : 133
    CURLYM_A - state for CURLYM */
 #define CURLYM_A                    (BRANCH_next_fail + 1)
 #define CURLYM_A_tb                 ((CURLYM_A) * 2)
@@ -1561,7 +1528,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYM_A_t8_pb              ((CURLYM_A) * 4 + 2)
 #define CURLYM_A_t8_p8              ((CURLYM_A) * 4 + 3)
 
-/* 0x89 : 137
+/* 0x86 : 134
    CURLYM_A_fail - state for CURLYM */
 #define CURLYM_A_fail               (CURLYM_A + 1)
 #define CURLYM_A_fail_tb            ((CURLYM_A_fail) * 2)
@@ -1571,7 +1538,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYM_A_fail_t8_pb         ((CURLYM_A_fail) * 4 + 2)
 #define CURLYM_A_fail_t8_p8         ((CURLYM_A_fail) * 4 + 3)
 
-/* 0x8a : 138
+/* 0x87 : 135
    CURLYM_B - state for CURLYM */
 #define CURLYM_B                    (CURLYM_A_fail + 1)
 #define CURLYM_B_tb                 ((CURLYM_B) * 2)
@@ -1581,7 +1548,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYM_B_t8_pb              ((CURLYM_B) * 4 + 2)
 #define CURLYM_B_t8_p8              ((CURLYM_B) * 4 + 3)
 
-/* 0x8b : 139
+/* 0x88 : 136
    CURLYM_B_fail - state for CURLYM */
 #define CURLYM_B_fail               (CURLYM_B + 1)
 #define CURLYM_B_fail_tb            ((CURLYM_B_fail) * 2)
@@ -1591,7 +1558,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLYM_B_fail_t8_pb         ((CURLYM_B_fail) * 4 + 2)
 #define CURLYM_B_fail_t8_p8         ((CURLYM_B_fail) * 4 + 3)
 
-/* 0x8c : 140
+/* 0x89 : 137
    IFMATCH_A - state for IFMATCH */
 #define IFMATCH_A                   (CURLYM_B_fail + 1)
 #define IFMATCH_A_tb                ((IFMATCH_A) * 2)
@@ -1601,7 +1568,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define IFMATCH_A_t8_pb             ((IFMATCH_A) * 4 + 2)
 #define IFMATCH_A_t8_p8             ((IFMATCH_A) * 4 + 3)
 
-/* 0x8d : 141
+/* 0x8a : 138
    IFMATCH_A_fail - state for IFMATCH */
 #define IFMATCH_A_fail              (IFMATCH_A + 1)
 #define IFMATCH_A_fail_tb           ((IFMATCH_A_fail) * 2)
@@ -1611,7 +1578,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define IFMATCH_A_fail_t8_pb        ((IFMATCH_A_fail) * 4 + 2)
 #define IFMATCH_A_fail_t8_p8        ((IFMATCH_A_fail) * 4 + 3)
 
-/* 0x8e : 142
+/* 0x8b : 139
    CURLY_B_min - state for CURLY */
 #define CURLY_B_min                 (IFMATCH_A_fail + 1)
 #define CURLY_B_min_tb              ((CURLY_B_min) * 2)
@@ -1621,7 +1588,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLY_B_min_t8_pb           ((CURLY_B_min) * 4 + 2)
 #define CURLY_B_min_t8_p8           ((CURLY_B_min) * 4 + 3)
 
-/* 0x8f : 143
+/* 0x8c : 140
    CURLY_B_min_fail - state for CURLY */
 #define CURLY_B_min_fail            (CURLY_B_min + 1)
 #define CURLY_B_min_fail_tb         ((CURLY_B_min_fail) * 2)
@@ -1631,7 +1598,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLY_B_min_fail_t8_pb      ((CURLY_B_min_fail) * 4 + 2)
 #define CURLY_B_min_fail_t8_p8      ((CURLY_B_min_fail) * 4 + 3)
 
-/* 0x90 : 144
+/* 0x8d : 141
    CURLY_B_max - state for CURLY */
 #define CURLY_B_max                 (CURLY_B_min_fail + 1)
 #define CURLY_B_max_tb              ((CURLY_B_max) * 2)
@@ -1641,7 +1608,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLY_B_max_t8_pb           ((CURLY_B_max) * 4 + 2)
 #define CURLY_B_max_t8_p8           ((CURLY_B_max) * 4 + 3)
 
-/* 0x91 : 145
+/* 0x8e : 142
    CURLY_B_max_fail - state for CURLY */
 #define CURLY_B_max_fail            (CURLY_B_max + 1)
 #define CURLY_B_max_fail_tb         ((CURLY_B_max_fail) * 2)
@@ -1651,7 +1618,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CURLY_B_max_fail_t8_pb      ((CURLY_B_max_fail) * 4 + 2)
 #define CURLY_B_max_fail_t8_p8      ((CURLY_B_max_fail) * 4 + 3)
 
-/* 0x92 : 146
+/* 0x8f : 143
    COMMIT_next - state for COMMIT */
 #define COMMIT_next                 (CURLY_B_max_fail + 1)
 #define COMMIT_next_tb              ((COMMIT_next) * 2)
@@ -1661,7 +1628,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define COMMIT_next_t8_pb           ((COMMIT_next) * 4 + 2)
 #define COMMIT_next_t8_p8           ((COMMIT_next) * 4 + 3)
 
-/* 0x93 : 147
+/* 0x90 : 144
    COMMIT_next_fail - state for COMMIT */
 #define COMMIT_next_fail            (COMMIT_next + 1)
 #define COMMIT_next_fail_tb         ((COMMIT_next_fail) * 2)
@@ -1671,7 +1638,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define COMMIT_next_fail_t8_pb      ((COMMIT_next_fail) * 4 + 2)
 #define COMMIT_next_fail_t8_p8      ((COMMIT_next_fail) * 4 + 3)
 
-/* 0x94 : 148
+/* 0x91 : 145
    MARKPOINT_next - state for MARKPOINT */
 #define MARKPOINT_next              (COMMIT_next_fail + 1)
 #define MARKPOINT_next_tb           ((MARKPOINT_next) * 2)
@@ -1681,7 +1648,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define MARKPOINT_next_t8_pb        ((MARKPOINT_next) * 4 + 2)
 #define MARKPOINT_next_t8_p8        ((MARKPOINT_next) * 4 + 3)
 
-/* 0x95 : 149
+/* 0x92 : 146
    MARKPOINT_next_fail - state for MARKPOINT */
 #define MARKPOINT_next_fail         (MARKPOINT_next + 1)
 #define MARKPOINT_next_fail_tb      ((MARKPOINT_next_fail) * 2)
@@ -1691,7 +1658,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define MARKPOINT_next_fail_t8_pb   ((MARKPOINT_next_fail) * 4 + 2)
 #define MARKPOINT_next_fail_t8_p8   ((MARKPOINT_next_fail) * 4 + 3)
 
-/* 0x96 : 150
+/* 0x93 : 147
    SKIP_next - state for SKIP */
 #define SKIP_next                   (MARKPOINT_next_fail + 1)
 #define SKIP_next_tb                ((SKIP_next) * 2)
@@ -1701,7 +1668,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define SKIP_next_t8_pb             ((SKIP_next) * 4 + 2)
 #define SKIP_next_t8_p8             ((SKIP_next) * 4 + 3)
 
-/* 0x97 : 151
+/* 0x94 : 148
    SKIP_next_fail - state for SKIP */
 #define SKIP_next_fail              (SKIP_next + 1)
 #define SKIP_next_fail_tb           ((SKIP_next_fail) * 2)
@@ -1711,7 +1678,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define SKIP_next_fail_t8_pb        ((SKIP_next_fail) * 4 + 2)
 #define SKIP_next_fail_t8_p8        ((SKIP_next_fail) * 4 + 3)
 
-/* 0x98 : 152
+/* 0x95 : 149
    CUTGROUP_next - state for CUTGROUP */
 #define CUTGROUP_next               (SKIP_next_fail + 1)
 #define CUTGROUP_next_tb            ((CUTGROUP_next) * 2)
@@ -1721,7 +1688,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CUTGROUP_next_t8_pb         ((CUTGROUP_next) * 4 + 2)
 #define CUTGROUP_next_t8_p8         ((CUTGROUP_next) * 4 + 3)
 
-/* 0x99 : 153
+/* 0x96 : 150
    CUTGROUP_next_fail - state for CUTGROUP */
 #define CUTGROUP_next_fail          (CUTGROUP_next + 1)
 #define CUTGROUP_next_fail_tb       ((CUTGROUP_next_fail) * 2)
@@ -1731,7 +1698,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define CUTGROUP_next_fail_t8_pb    ((CUTGROUP_next_fail) * 4 + 2)
 #define CUTGROUP_next_fail_t8_p8    ((CUTGROUP_next_fail) * 4 + 3)
 
-/* 0x9a : 154
+/* 0x97 : 151
    KEEPS_next - state for KEEPS */
 #define KEEPS_next                  (CUTGROUP_next_fail + 1)
 #define KEEPS_next_tb               ((KEEPS_next) * 2)
@@ -1741,7 +1708,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define KEEPS_next_t8_pb            ((KEEPS_next) * 4 + 2)
 #define KEEPS_next_t8_p8            ((KEEPS_next) * 4 + 3)
 
-/* 0x9b : 155
+/* 0x98 : 152
    KEEPS_next_fail - state for KEEPS */
 #define KEEPS_next_fail             (KEEPS_next + 1)
 #define KEEPS_next_fail_tb          ((KEEPS_next_fail) * 2)
@@ -1751,7 +1718,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define KEEPS_next_fail_t8_pb       ((KEEPS_next_fail) * 4 + 2)
 #define KEEPS_next_fail_t8_p8       ((KEEPS_next_fail) * 4 + 3)
 
-/* 0x9c : 156
+/* 0x99 : 153
    REF_next - state for REF */
 #define REF_next                    (KEEPS_next_fail + 1)
 #define REF_next_tb                 ((REF_next) * 2)
@@ -1761,7 +1728,7 @@ typedef struct regnode                           tregnode_WHILEM;
 #define REF_next_t8_pb              ((REF_next) * 4 + 2)
 #define REF_next_t8_p8              ((REF_next) * 4 + 3)
 
-/* 0x9d : 157
+/* 0x9a : 154
    REF_next_fail - state for REF */
 #define REF_next_fail               (REF_next + 1)
 #define REF_next_fail_tb            ((REF_next_fail) * 2)
@@ -1833,62 +1800,59 @@ EXTCONST char * const PL_regnode_name[]  INIT( {
 	"EXACTFU_S_EDGE",        	/* 0x37 */
 	"LNBREAK",               	/* 0x38 */
 	"TRIE",                  	/* 0x39 */
-	"TRIEC",                 	/* 0x3a */
-	"AHOCORASICK",           	/* 0x3b */
-	"AHOCORASICKC",          	/* 0x3c */
-	"LTRIE",                 	/* 0x3d */
-	"LTRIEC",                	/* 0x3e */
-	"NOTHING",               	/* 0x3f */
-	"TAIL",                  	/* 0x40 */
-	"OPTIMIZED",             	/* 0x41 */
-	"STAR",                  	/* 0x42 */
-	"PLUS",                  	/* 0x43 */
-	"CURLY",                 	/* 0x44 */
-	"CURLYN",                	/* 0x45 */
-	"CURLYM",                	/* 0x46 */
-	"CURLYX",                	/* 0x47 */
-	"WHILEM",                	/* 0x48 */
-	"OPEN",                  	/* 0x49 */
-	"CLOSE",                 	/* 0x4a */
-	"SROPEN",                	/* 0x4b */
-	"SRCLOSE",               	/* 0x4c */
-	"REF",                   	/* 0x4d */
-	"REFF",                  	/* 0x4e */
-	"REFFL",                 	/* 0x4f */
-	"REFFU",                 	/* 0x50 */
-	"REFFA",                 	/* 0x51 */
-	"REFN",                  	/* 0x52 */
-	"REFFN",                 	/* 0x53 */
-	"REFFLN",                	/* 0x54 */
-	"REFFUN",                	/* 0x55 */
-	"REFFAN",                	/* 0x56 */
-	"BRANCHJ",               	/* 0x57 */
-	"IFMATCH",               	/* 0x58 */
-	"UNLESSM",               	/* 0x59 */
-	"SUSPEND",               	/* 0x5a */
-	"IFTHEN",                	/* 0x5b */
-	"RENUM",                 	/* 0x5c */
-	"LONGJMP",               	/* 0x5d */
-	"MINMOD",                	/* 0x5e */
-	"LOGICAL",               	/* 0x5f */
-	"EVAL",                  	/* 0x60 */
-	"GOSUB",                 	/* 0x61 */
-	"GROUPP",                	/* 0x62 */
-	"GROUPPN",               	/* 0x63 */
-	"INSUBP",                	/* 0x64 */
-	"DEFINEP",               	/* 0x65 */
-	"ENDLIKE",               	/* 0x66 */
-	"OPFAIL",                	/* 0x67 */
-	"ACCEPT",                	/* 0x68 */
-	"VERB",                  	/* 0x69 */
-	"PRUNE",                 	/* 0x6a */
-	"MARKPOINT",             	/* 0x6b */
-	"SKIP",                  	/* 0x6c */
-	"COMMIT",                	/* 0x6d */
-	"CUTGROUP",              	/* 0x6e */
-	"KEEPS",                 	/* 0x6f */
-	"PSEUDO",                	/* 0x70 */
-	"REGEX_SET",             	/* 0x71 */
+	"AHOCORASICK",           	/* 0x3a */
+	"LTRIE",                 	/* 0x3b */
+	"NOTHING",               	/* 0x3c */
+	"TAIL",                  	/* 0x3d */
+	"OPTIMIZED",             	/* 0x3e */
+	"STAR",                  	/* 0x3f */
+	"PLUS",                  	/* 0x40 */
+	"CURLY",                 	/* 0x41 */
+	"CURLYN",                	/* 0x42 */
+	"CURLYM",                	/* 0x43 */
+	"CURLYX",                	/* 0x44 */
+	"WHILEM",                	/* 0x45 */
+	"OPEN",                  	/* 0x46 */
+	"CLOSE",                 	/* 0x47 */
+	"SROPEN",                	/* 0x48 */
+	"SRCLOSE",               	/* 0x49 */
+	"REF",                   	/* 0x4a */
+	"REFF",                  	/* 0x4b */
+	"REFFL",                 	/* 0x4c */
+	"REFFU",                 	/* 0x4d */
+	"REFFA",                 	/* 0x4e */
+	"REFN",                  	/* 0x4f */
+	"REFFN",                 	/* 0x50 */
+	"REFFLN",                	/* 0x51 */
+	"REFFUN",                	/* 0x52 */
+	"REFFAN",                	/* 0x53 */
+	"BRANCHJ",               	/* 0x54 */
+	"IFMATCH",               	/* 0x55 */
+	"UNLESSM",               	/* 0x56 */
+	"SUSPEND",               	/* 0x57 */
+	"IFTHEN",                	/* 0x58 */
+	"RENUM",                 	/* 0x59 */
+	"LONGJMP",               	/* 0x5a */
+	"MINMOD",                	/* 0x5b */
+	"LOGICAL",               	/* 0x5c */
+	"EVAL",                  	/* 0x5d */
+	"GOSUB",                 	/* 0x5e */
+	"GROUPP",                	/* 0x5f */
+	"GROUPPN",               	/* 0x60 */
+	"INSUBP",                	/* 0x61 */
+	"DEFINEP",               	/* 0x62 */
+	"ENDLIKE",               	/* 0x63 */
+	"OPFAIL",                	/* 0x64 */
+	"ACCEPT",                	/* 0x65 */
+	"VERB",                  	/* 0x66 */
+	"PRUNE",                 	/* 0x67 */
+	"MARKPOINT",             	/* 0x68 */
+	"SKIP",                  	/* 0x69 */
+	"COMMIT",                	/* 0x6a */
+	"CUTGROUP",              	/* 0x6b */
+	"KEEPS",                 	/* 0x6c */
+	"PSEUDO",                	/* 0x6d */
+	"REGEX_SET",             	/* 0x6e */
 	/* ------------ States ------------- */
 	"TRIE_next",             	/* REGNODE_MAX +0x01 */
 	"TRIE_next_fail",        	/* REGNODE_MAX +0x02 */
@@ -2347,700 +2311,679 @@ EXTCONST struct regnode_meta PL_regnode_info[]  INIT( {
         .off_by_arg = 0
     },
     {
-        /* #58 op TRIEC */
-        .type = TRIE,
-        .arg_len = EXTRA_SIZE(tregnode_TRIEC),
-        .arg_len_varies = 0,
-        .off_by_arg = 0
-    },
-    {
-        /* #59 op AHOCORASICK */
+        /* #58 op AHOCORASICK */
         .type = TRIE,
         .arg_len = EXTRA_SIZE(tregnode_AHOCORASICK),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #60 op AHOCORASICKC */
-        .type = TRIE,
-        .arg_len = EXTRA_SIZE(tregnode_AHOCORASICKC),
-        .arg_len_varies = 0,
-        .off_by_arg = 0
-    },
-    {
-        /* #61 op LTRIE */
+        /* #59 op LTRIE */
         .type = TRIE,
         .arg_len = EXTRA_SIZE(tregnode_LTRIE),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #62 op LTRIEC */
-        .type = TRIE,
-        .arg_len = EXTRA_SIZE(tregnode_LTRIEC),
-        .arg_len_varies = 0,
-        .off_by_arg = 0
-    },
-    {
-        /* #63 op NOTHING */
+        /* #60 op NOTHING */
         .type = NOTHING,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #64 op TAIL */
+        /* #61 op TAIL */
         .type = NOTHING,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #65 op OPTIMIZED */
+        /* #62 op OPTIMIZED */
         .type = NOTHING,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #66 op STAR */
+        /* #63 op STAR */
         .type = STAR,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #67 op PLUS */
+        /* #64 op PLUS */
         .type = PLUS,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #68 op CURLY */
+        /* #65 op CURLY */
         .type = CURLY,
         .arg_len = EXTRA_SIZE(tregnode_CURLY),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #69 op CURLYN */
+        /* #66 op CURLYN */
         .type = CURLY,
         .arg_len = EXTRA_SIZE(tregnode_CURLYN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #70 op CURLYM */
+        /* #67 op CURLYM */
         .type = CURLY,
         .arg_len = EXTRA_SIZE(tregnode_CURLYM),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #71 op CURLYX */
+        /* #68 op CURLYX */
         .type = CURLY,
         .arg_len = EXTRA_SIZE(tregnode_CURLYX),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #72 op WHILEM */
+        /* #69 op WHILEM */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #73 op OPEN */
+        /* #70 op OPEN */
         .type = OPEN,
         .arg_len = EXTRA_SIZE(tregnode_OPEN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #74 op CLOSE */
+        /* #71 op CLOSE */
         .type = CLOSE,
         .arg_len = EXTRA_SIZE(tregnode_CLOSE),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #75 op SROPEN */
+        /* #72 op SROPEN */
         .type = SROPEN,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #76 op SRCLOSE */
+        /* #73 op SRCLOSE */
         .type = SRCLOSE,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #77 op REF */
+        /* #74 op REF */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REF),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #78 op REFF */
+        /* #75 op REFF */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFF),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #79 op REFFL */
+        /* #76 op REFFL */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFFL),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #80 op REFFU */
+        /* #77 op REFFU */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFFU),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #81 op REFFA */
+        /* #78 op REFFA */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFFA),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #82 op REFN */
+        /* #79 op REFN */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #83 op REFFN */
+        /* #80 op REFFN */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFFN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #84 op REFFLN */
+        /* #81 op REFFLN */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFFLN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #85 op REFFUN */
+        /* #82 op REFFUN */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFFUN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #86 op REFFAN */
+        /* #83 op REFFAN */
         .type = REF,
         .arg_len = EXTRA_SIZE(tregnode_REFFAN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #87 op BRANCHJ */
+        /* #84 op BRANCHJ */
         .type = BRANCHJ,
         .arg_len = EXTRA_SIZE(tregnode_BRANCHJ),
         .arg_len_varies = 0,
         .off_by_arg = 1
     },
     {
-        /* #88 op IFMATCH */
+        /* #85 op IFMATCH */
         .type = BRANCHJ,
         .arg_len = EXTRA_SIZE(tregnode_IFMATCH),
         .arg_len_varies = 0,
         .off_by_arg = 1
     },
     {
-        /* #89 op UNLESSM */
+        /* #86 op UNLESSM */
         .type = BRANCHJ,
         .arg_len = EXTRA_SIZE(tregnode_UNLESSM),
         .arg_len_varies = 0,
         .off_by_arg = 1
     },
     {
-        /* #90 op SUSPEND */
+        /* #87 op SUSPEND */
         .type = BRANCHJ,
         .arg_len = EXTRA_SIZE(tregnode_SUSPEND),
         .arg_len_varies = 0,
         .off_by_arg = 1
     },
     {
-        /* #91 op IFTHEN */
+        /* #88 op IFTHEN */
         .type = BRANCHJ,
         .arg_len = EXTRA_SIZE(tregnode_IFTHEN),
         .arg_len_varies = 0,
         .off_by_arg = 1
     },
     {
-        /* #92 op RENUM */
+        /* #89 op RENUM */
         .type = BRANCHJ,
         .arg_len = EXTRA_SIZE(tregnode_RENUM),
         .arg_len_varies = 0,
         .off_by_arg = 1
     },
     {
-        /* #93 op LONGJMP */
+        /* #90 op LONGJMP */
         .type = LONGJMP,
         .arg_len = EXTRA_SIZE(tregnode_LONGJMP),
         .arg_len_varies = 0,
         .off_by_arg = 1
     },
     {
-        /* #94 op MINMOD */
+        /* #91 op MINMOD */
         .type = MINMOD,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #95 op LOGICAL */
+        /* #92 op LOGICAL */
         .type = LOGICAL,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #96 op EVAL */
+        /* #93 op EVAL */
         .type = EVAL,
         .arg_len = EXTRA_SIZE(tregnode_EVAL),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #97 op GOSUB */
+        /* #94 op GOSUB */
         .type = GOSUB,
         .arg_len = EXTRA_SIZE(tregnode_GOSUB),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #98 op GROUPP */
+        /* #95 op GROUPP */
         .type = GROUPP,
         .arg_len = EXTRA_SIZE(tregnode_GROUPP),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #99 op GROUPPN */
+        /* #96 op GROUPPN */
         .type = GROUPPN,
         .arg_len = EXTRA_SIZE(tregnode_GROUPPN),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #100 op INSUBP */
+        /* #97 op INSUBP */
         .type = INSUBP,
         .arg_len = EXTRA_SIZE(tregnode_INSUBP),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #101 op DEFINEP */
+        /* #98 op DEFINEP */
         .type = DEFINEP,
         .arg_len = EXTRA_SIZE(tregnode_DEFINEP),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #102 op ENDLIKE */
+        /* #99 op ENDLIKE */
         .type = ENDLIKE,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #103 op OPFAIL */
+        /* #100 op OPFAIL */
         .type = ENDLIKE,
         .arg_len = EXTRA_SIZE(tregnode_OPFAIL),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #104 op ACCEPT */
+        /* #101 op ACCEPT */
         .type = ENDLIKE,
         .arg_len = EXTRA_SIZE(tregnode_ACCEPT),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #105 op VERB */
+        /* #102 op VERB */
         .type = VERB,
         .arg_len = EXTRA_SIZE(tregnode_VERB),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #106 op PRUNE */
+        /* #103 op PRUNE */
         .type = VERB,
         .arg_len = EXTRA_SIZE(tregnode_PRUNE),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #107 op MARKPOINT */
+        /* #104 op MARKPOINT */
         .type = VERB,
         .arg_len = EXTRA_SIZE(tregnode_MARKPOINT),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #108 op SKIP */
+        /* #105 op SKIP */
         .type = VERB,
         .arg_len = EXTRA_SIZE(tregnode_SKIP),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #109 op COMMIT */
+        /* #106 op COMMIT */
         .type = VERB,
         .arg_len = EXTRA_SIZE(tregnode_COMMIT),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #110 op CUTGROUP */
+        /* #107 op CUTGROUP */
         .type = VERB,
         .arg_len = EXTRA_SIZE(tregnode_CUTGROUP),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #111 op KEEPS */
+        /* #108 op KEEPS */
         .type = KEEPS,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #112 op PSEUDO */
+        /* #109 op PSEUDO */
         .type = PSEUDO,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #113 op REGEX_SET */
+        /* #110 op REGEX_SET */
         .type = REGEX_SET,
         .arg_len = EXTRA_SIZE(tregnode_REGEX_SET),
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #114 state TRIE_next */
+        /* #111 state TRIE_next */
         .type = TRIE,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #115 state TRIE_next_fail */
+        /* #112 state TRIE_next_fail */
         .type = TRIE,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #116 state EVAL_B */
+        /* #113 state EVAL_B */
         .type = EVAL,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #117 state EVAL_B_fail */
+        /* #114 state EVAL_B_fail */
         .type = EVAL,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #118 state EVAL_postponed_A */
+        /* #115 state EVAL_postponed_A */
         .type = EVAL,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #119 state EVAL_postponed_A_fail */
+        /* #116 state EVAL_postponed_A_fail */
         .type = EVAL,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #120 state EVAL_postponed_B */
+        /* #117 state EVAL_postponed_B */
         .type = EVAL,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #121 state EVAL_postponed_B_fail */
+        /* #118 state EVAL_postponed_B_fail */
         .type = EVAL,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #122 state CURLYX_end */
+        /* #119 state CURLYX_end */
         .type = CURLYX,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #123 state CURLYX_end_fail */
+        /* #120 state CURLYX_end_fail */
         .type = CURLYX,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #124 state WHILEM_A_pre */
+        /* #121 state WHILEM_A_pre */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #125 state WHILEM_A_pre_fail */
+        /* #122 state WHILEM_A_pre_fail */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #126 state WHILEM_A_min */
+        /* #123 state WHILEM_A_min */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #127 state WHILEM_A_min_fail */
+        /* #124 state WHILEM_A_min_fail */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #128 state WHILEM_A_max */
+        /* #125 state WHILEM_A_max */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #129 state WHILEM_A_max_fail */
+        /* #126 state WHILEM_A_max_fail */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #130 state WHILEM_B_min */
+        /* #127 state WHILEM_B_min */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #131 state WHILEM_B_min_fail */
+        /* #128 state WHILEM_B_min_fail */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #132 state WHILEM_B_max */
+        /* #129 state WHILEM_B_max */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #133 state WHILEM_B_max_fail */
+        /* #130 state WHILEM_B_max_fail */
         .type = WHILEM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #134 state BRANCH_next */
+        /* #131 state BRANCH_next */
         .type = BRANCH,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #135 state BRANCH_next_fail */
+        /* #132 state BRANCH_next_fail */
         .type = BRANCH,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #136 state CURLYM_A */
+        /* #133 state CURLYM_A */
         .type = CURLYM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #137 state CURLYM_A_fail */
+        /* #134 state CURLYM_A_fail */
         .type = CURLYM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #138 state CURLYM_B */
+        /* #135 state CURLYM_B */
         .type = CURLYM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #139 state CURLYM_B_fail */
+        /* #136 state CURLYM_B_fail */
         .type = CURLYM,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #140 state IFMATCH_A */
+        /* #137 state IFMATCH_A */
         .type = IFMATCH,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #141 state IFMATCH_A_fail */
+        /* #138 state IFMATCH_A_fail */
         .type = IFMATCH,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #142 state CURLY_B_min */
+        /* #139 state CURLY_B_min */
         .type = CURLY,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #143 state CURLY_B_min_fail */
+        /* #140 state CURLY_B_min_fail */
         .type = CURLY,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #144 state CURLY_B_max */
+        /* #141 state CURLY_B_max */
         .type = CURLY,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #145 state CURLY_B_max_fail */
+        /* #142 state CURLY_B_max_fail */
         .type = CURLY,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #146 state COMMIT_next */
+        /* #143 state COMMIT_next */
         .type = COMMIT,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #147 state COMMIT_next_fail */
+        /* #144 state COMMIT_next_fail */
         .type = COMMIT,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #148 state MARKPOINT_next */
+        /* #145 state MARKPOINT_next */
         .type = MARKPOINT,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #149 state MARKPOINT_next_fail */
+        /* #146 state MARKPOINT_next_fail */
         .type = MARKPOINT,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #150 state SKIP_next */
+        /* #147 state SKIP_next */
         .type = SKIP,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #151 state SKIP_next_fail */
+        /* #148 state SKIP_next_fail */
         .type = SKIP,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #152 state CUTGROUP_next */
+        /* #149 state CUTGROUP_next */
         .type = CUTGROUP,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #153 state CUTGROUP_next_fail */
+        /* #150 state CUTGROUP_next_fail */
         .type = CUTGROUP,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #154 state KEEPS_next */
+        /* #151 state KEEPS_next */
         .type = KEEPS,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #155 state KEEPS_next_fail */
+        /* #152 state KEEPS_next_fail */
         .type = KEEPS,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #156 state REF_next */
+        /* #153 state REF_next */
         .type = REF,
         .arg_len = 0,
         .arg_len_varies = 0,
         .off_by_arg = 0
     },
     {
-        /* #157 state REF_next_fail */
+        /* #154 state REF_next_fail */
         .type = REF,
         .arg_len = 0,
         .arg_len_varies = 0,
@@ -3123,8 +3066,8 @@ INIT({ CLUMP, BRANCH, STAR, PLUS, CURLY, CURLYN, CURLYM, CURLYX, WHILEM, REF,
     BRANCHJ, SUSPEND, IFTHEN,
     0 });
 
-/* varies: 000000000000000000000000000000000000000000000011000000000000000011111100111000011111111100001100000000000000000000000000 */
-EXTCONST U8 PL_varies_bitmask[] INIT({ 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0xFC, 0xE1, 0xFF, 0x0C, 0x00, 0x00, 0x00 });
+/* varies: 0000000000000000000000000000000000000000000000110000000010000000001111111111110010011111000000010000000000000000 */
+EXTCONST U8 PL_varies_bitmask[] INIT({ 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x80, 0x3F, 0xFC, 0x9F, 0x01, 0x00, 0x00 });
 
 /* The following always have a length of 1. U8 we can do strchr() on it. */
 /* (Note that length 1 means "one character" under UTF8, not "one octet".) */
@@ -3136,8 +3079,8 @@ INIT({ REG_ANY, SANY, ANYOF, ANYOFD, ANYOFL, ANYOFPOSIXL, ANYOFH, ANYOFHb,
     POSIXL, POSIXU, POSIXA, NPOSIXD, NPOSIXL, NPOSIXU, NPOSIXA, REGEX_SET,
     0 });
 
-/* simple: 000000000000000011111110111111111111111100000000000000000000000000000000000000000000000000000000000000000000000000000010 */
-EXTCONST U8 PL_simple_bitmask[] INIT({ 0x00, 0x00, 0xFE, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02 });
+/* simple: 0000000000000000111111101111111111111111000000000000000000000000000000000000000000000000000000000000000001000000 */
+EXTCONST U8 PL_simple_bitmask[] INIT({ 0x00, 0x00, 0xFE, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40 });
 
 /* Is 'op', known to be of type EXACT, folding? */
 #define isEXACTFish(op) (assert(REGNODE_TYPE(op) == EXACT), (PL_EXACTFish_bitmask & (1U << (op - EXACT))))

--- a/t/lib/warnings/regexec
+++ b/t/lib/warnings/regexec
@@ -137,16 +137,14 @@ setlocale(&POSIX::LC_CTYPE, "C");
 "\x{100}" =~ /[\x{100}\x{102}]/l;
 no warnings 'locale';
 EXPECT
-Wide character (U+100) in pattern match (m//) at - line 12.
-Wide character (U+100) in pattern match (m//) at - line 12.
-Wide character (U+100) in pattern match (m//) at - line 13.
-Wide character (U+100) in pattern match (m//) at - line 13.
-Wide character (U+100) in pattern match (m//) at - line 13.
-Wide character (U+100) in pattern match (m//) at - line 14.
-Wide character (U+100) in pattern match (m//) at - line 14.
-Wide character (U+100) in pattern match (m//) at - line 15.
-Wide character (U+100) in pattern match (m//) at - line 16.
-Wide character (U+100) in pattern match (m//) at - line 16.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 12.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 12.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 13.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 14.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 14.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 15.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 16.
+Wide character (U+100) in pattern match (m//) under a non-UTF-8 locale at - line 16.
 ########
 # NAME Wide character in UTF-8 locale
 require '../loc_tools.pl';

--- a/t/lib/warnings/utf8
+++ b/t/lib/warnings/utf8
@@ -704,11 +704,11 @@ $a = fc("\x{102}");
 $a = uc("\x{103}");
 $a = ucfirst("\x{104}");
 EXPECT
-Wide character (U+100) in lc at - line 14.
-Wide character (U+101) in lcfirst at - line 15.
-Wide character (U+102) in fc at - line 16.
-Wide character (U+103) in uc at - line 17.
-Wide character (U+104) in ucfirst at - line 18.
+Wide character (U+100) in lc under a non-UTF-8 locale at - line 14.
+Wide character (U+101) in lcfirst under a non-UTF-8 locale at - line 15.
+Wide character (U+102) in fc under a non-UTF-8 locale at - line 16.
+Wide character (U+103) in uc under a non-UTF-8 locale at - line 17.
+Wide character (U+104) in ucfirst under a non-UTF-8 locale at - line 18.
 ########
 # NAME Wide character in UTF-8 locale
 require '../loc_tools.pl';

--- a/t/re/opt.t
+++ b/t/re/opt.t
@@ -246,8 +246,8 @@ a[bB]c	3	0+abc	-	Tanchored
 (?=abc)	0	0+abc	-	Tanchored,Tminlen=3,minlenret=0
 abc|abc	3	0+abc	-	isall
 abcd|abce	4	0+abc	-	-
-acde|bcde	4	1+cde	-	Tanchored,stclass=~[ab]
-acdef|bcdeg	5	1+cde	-	Tanchored,stclass=~[ab]
+acde|bcde	4	1+cde	-	Tanchored,stclass=AHOCORASICK-EXACT
+acdef|bcdeg	5	1+cde	-	Tanchored,stclass=AHOCORASICK-EXACT
 
 # same as above, floating
 .?abc	3	-	0:1+abc	-

--- a/t/re/opt.t
+++ b/t/re/opt.t
@@ -246,8 +246,8 @@ a[bB]c	3	0+abc	-	Tanchored
 (?=abc)	0	0+abc	-	Tanchored,Tminlen=3,minlenret=0
 abc|abc	3	0+abc	-	isall
 abcd|abce	4	0+abc	-	-
-acde|bcde	4	1+cde	-	Tanchored,stclass=~[ab]
-acdef|bcdeg	5	1+cde	-	Tanchored,stclass=~[ab]
+acde|bcde	4	1+cde	-	Tanchored,stclass=AHOCORASICK-EXACT
+acdef|bcdeg	5	1+cde	-	Tanchored,stclass=AHOCORASICK-EXACT
 
 # same as above, floating
 .?abc	3	-	0:1+abc	-
@@ -278,7 +278,7 @@ abc(*ACCEPT)xyz	3	0+abc	-	-
 # Nested branches that should be flattened
 (?:mat3|mat4)|mat1|mat2	4	0+mat	-	-	flattened single nested branch
 ^(?:mat1|mat2|(?:mat3|mat4)|mat5|(?:mat6|mat7))$	4	0+mat	-	noscan,anchor SBOL	flattened multiple, simple branches
-(?:foo|bar|(?:baz|bop|bing)|zoop)	3	-	-	stclass=~AHOCORASICKC-EXACT\[bfz\]	flattened multiple branches
+(?:foo|bar|(?:baz|bop|bing)|zoop)	3	-	-	stclass=AHOCORASICK-EXACT	flattened multiple branches
 (?:(?:frog|fan)|fog)|(?:farce|(?:forge|flambe))	3	0+f	-	-	flattened multiple, deeper branches
 
 (?:(?:cat|dog|fish)|bird)x	4	-	3:4+x	-	flattened trie, trailing literal floats

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -2220,7 +2220,70 @@ ABCF|BCD[Ee]|C[Gg]	ABCDE	y	$&	BCDE	-	# GH 22892 - AHO-CORASICK bug
 # Nested branch flattening is not compatible with *THEN
 (?:zz|(?:a(*THEN)b|c)|d)	a	n	$&	a	-	(*THEN) stays nested (no match)
 (?:zz|(?:a(*THEN)b|c)|d)	d	y	$&	d	-	(*THEN) stays nested (match)
+
+# Prefixes extracted from jump tries must remain attached to those tries.
+# Otherwise an enclosing trie pass can discard the branch structure needed
+# by backtracking control verbs.  Keep both failing and successful paths here
+# to ensure that this protection does not disable prefix extraction itself.
 (?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	aab	n	-	-	-	(Don't) flatten *THEN
+(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	ab	y	$&	ab	-	extracted one-character prefix, successful SKIP path
+(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	ac	n	-	-	-	extracted one-character prefix, SKIP blocks alternatives
+(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	xy	y	$&	xy	-	sibling THEN path remains reachable
+
+x(*THEN)y|(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|a	aab	n	-	-	-	protected nested trie in middle
+x(*THEN)y|z|(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)	aab	n	-	-	-	protected nested trie last
+z|(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	aab	n	-	-	-	extra sibling before protected trie
+(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|z|x(*THEN)y|a	aab	n	-	-	-	extra sibling after protected trie
+
+(?:(?:ab(*SKIP)c|abd)|ab(*COMMIT)c)|x(*THEN)y|ab	ababc	n	-	-	-	extracted two-character prefix
+(?:(?:ab(*SKIP)c|abd)|ab(*COMMIT)c)|x(*THEN)y|ab	abc	y	$&	abc	-	two-character prefix successful path
+(?:(?:foo(*SKIP)x|fooy)|foo(*COMMIT)x)|z(*THEN)q|foo	foofoox	n	-	-	-	extracted three-character prefix
+(?:(?:foo(*SKIP)x|fooy)|foo(*COMMIT)x)|z(*THEN)q|foo	foox	y	$&	foox	-	three-character prefix successful path
+(?:(?:prefix(*SKIP)X|prefixY)|prefix(*COMMIT)X)|other(*THEN)Z|prefix	prefixprefixX	n	-	-	-	long extracted prefix
+(?:(?:prefix(*SKIP)X|prefixY)|prefix(*COMMIT)X)|other(*THEN)Z|prefix	prefixX	y	$&	prefixX	-	long prefix successful path
+
+(?:(?:\x{100}(*SKIP)b|\x{100}c)|\x{100}(*COMMIT)b)|x(*THEN)y|\x{100}	\x{100}\x{100}b	n	-	-	-	UTF-8 prefix
+(?:(?:\x{100}(*SKIP)b|\x{100}c)|\x{100}(*COMMIT)b)|x(*THEN)y|\x{100}	\x{100}b	y	$&	\x{100}b	-	UTF-8 prefix successful path
+(?:(?:\x{100}\x{101}(*SKIP)b|\x{100}\x{101}c)|\x{100}\x{101}(*COMMIT)b)|x(*THEN)y|\x{100}\x{101}	\x{100}\x{101}\x{100}\x{101}b	n	-	-	-	multi-character UTF-8 prefix
+(?:(?:\x{100}\x{101}(*SKIP)b|\x{100}\x{101}c)|\x{100}\x{101}(*COMMIT)b)|x(*THEN)y|\x{100}\x{101}	\x{100}\x{101}b	y	$&	\x{100}\x{101}b	-	multi-character UTF-8 prefix successful path
+(?:(?:a\x00(*SKIP)b|a\x00c)|a\x00(*COMMIT)b)|x(*THEN)y|a\x00	a\x00a\x00b	n	-	-	-	prefix containing NUL
+(?:(?:a\x00(*SKIP)b|a\x00c)|a\x00(*COMMIT)b)|x(*THEN)y|a\x00	a\x00b	y	$&	a\x00b	-	prefix containing NUL successful path
+
+(?u:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)	aab	n	-	-	-	extracted prefix under Unicode rules
+(?a:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)	aab	n	-	-	-	extracted prefix under ASCII rules
+(?aa:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)	aab	n	-	-	-	extracted prefix under strict ASCII rules
+(?l:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)	aab	n	-	-	-	extracted prefix under locale rules
+(?i:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)	AAB	n	-	-	-	folded trie adjacent case
+(?i:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)	AB	y	$&	AB	-	folded trie successful path
+(?ui:(?:(?:\x{100}(*SKIP)b|\x{100}c)|\x{100}(*COMMIT)b)|x(*THEN)y|\x{100})	\x{100}\x{100}b	n	-	-	-	folded UTF-8 prefix
+
+(?:(?:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|z)|q)|x(*THEN)y|a	aab	n	-	-	-	three nested alternation levels
+(?:(?:(?:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|z)|q)|r)|x(*THEN)y|a	aab	n	-	-	-	four nested alternation levels
+(?:(?:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|z)|q)|x(*THEN)y|a	z	y	$&	z	-	deeper nested sibling remains reachable
+
+(?:(?:a(*PRUNE)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	aab	n	-	-	-	PRUNE continuation after extracted prefix
+(?:(?:a(*THEN)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	aab	n	-	-	-	THEN continuation after extracted prefix
+(?:(?:a(*MARK:A)(*SKIP:A)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	aab	n	-	-	-	named SKIP continuation after extracted prefix
+(?:(?:a(*MARK:A)(*SKIP:A)b|ac)|a(*COMMIT)b)|x(*THEN)y|a	ab	y	$&	ab	-	named SKIP successful path
+
+((?:(?:a(*SKIP)b|ac)|a(*COMMIT)b))|x(*THEN)y|a	aab	n	-	-	-	outer capture around protected trie
+((?:(?:a(*SKIP)b|ac)|a(*COMMIT)b))|x(*THEN)y|a	ab	y	$1	ab	-	outer capture successful path
+(?:(?:(?<skip>a)(*SKIP)b|(?<cee>ac))|(?<commit>a)(*COMMIT)b)|(?<ex>x)(*THEN)y|(?<plain>a)	aab	n	-	-	-	named captures around protected trie
+
+(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|(?:(?:m(*PRUNE)n|mo)|m(*COMMIT)n)|x(*THEN)y|a	aab	n	-	-	-	first of two protected nested tries
+(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|(?:(?:m(*PRUNE)n|mo)|m(*COMMIT)n)|x(*THEN)y|a	mmn	n	-	-	-	second of two protected nested tries
+(?:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)Z)|x(*THEN)y|aZ	aabZ	n	-	-	-	protected nested trie with trailing literal
+
+\A(?:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)\z	aab	n	-	-	-	anchored protected nested trie
+\A(?:(?:(?:a(*SKIP)b|ac)|a(*COMMIT)b)|x(*THEN)y|a)\z	ab	y	$&	ab	-	anchored successful path
+
+# These do not require control-verb protection themselves, but exercise other
+# jump-trie continuations adjacent to the corrected optimizer boundary.
+(?:(?:ab(c)|ad(e))|af(g))|x(*THEN)y|a	abc	y	$1	c	-	capture continuation in first trie word
+(?:(?:ab(c)|ad(e))|af(g))|x(*THEN)y|a	ade	y	$2	e	-	capture continuation in second trie word
+(?:(?:ab(c)|ad(e))|af(g))|x(*THEN)y|a	afg	y	$3	g	-	capture continuation after nested trie
+(?:(?:ab(?=c)c|ad(?=e)e)|af)|x(*THEN)y|a	abc	y	$&	abc	-	lookahead continuation in first trie word
+(?:(?:ab(?=c)c|ad(?=e)e)|af)|x(*THEN)y|a	ade	y	$&	ade	-	lookahead continuation in second trie word
 
 # Keep these lines at the end of the file
 # pat	string	y/n/etc	expr	expected-expr	skip-reason	comment

--- a/t/re/trie_bench.pl
+++ b/t/re/trie_bench.pl
@@ -1,0 +1,534 @@
+#!./perl
+
+use strict;
+use warnings;
+use Cwd qw(abs_path);
+use File::Basename qw(dirname);
+use File::Spec;
+
+my $has_octet_trie;
+BEGIN {
+    my $internals_v = eval { join ' ', Internals::V() } // '';
+    $has_octet_trie = $internals_v =~ /\bPERL_REGEX_OCTET_TRIE\b/;
+    if (defined(my $mode = $ENV{TRIE_BENCH_MODE})) {
+        my %maxbuf = (default => undef, off => -1, list => 0,
+            table => 655360, trie => undef);
+        die "unknown TRIE_BENCH_MODE '$mode'\n"
+            unless exists $maxbuf{$mode};
+        my $effective_mode = $mode;
+        $effective_mode = 'trie'
+            if $mode eq 'list' && $has_octet_trie;
+        $effective_mode = 'list'
+            if $mode eq 'trie' && !$has_octet_trie;
+        my $value = $maxbuf{$effective_mode};
+        ${^RE_TRIE_MAXBUF} = $value if defined $value;
+    }
+}
+
+sub latin1 { pack 'C*', @_ }
+
+my $grinning = chr 0x1F600;
+my $han      = chr 0x4E2D;
+my $country  = chr 0x56FD;
+
+my $numeric_max = 100000;
+my @numeric_k = sort { $a <=> $b }
+    (10, 20, 40, 80, 160, 320, 640, 1280);
+my $numeric_common = $numeric_k[0];
+my @numeric_padding = (10, 20, 40, 80);
+
+sub numeric_case {
+    my ($max, $count, $common, $repeats, $padding) = @_;
+
+    my @pattern_words = ($max - $count) .. ($max - 1);
+    my @target_words = ($max - $common) .. ($max - 1);
+    my $pattern = join '|', @pattern_words;
+    my $re = qr/(?:$pattern)/;
+    # [name, regexp, target words, expected matches, compile divisor,
+    #  repeats, padding]
+    return ["numeric-$count-pad$padding", $re, \@target_words, $common,
+        $count, $repeats, $padding];
+}
+
+sub benchmark_case {
+    my ($name, $re, $inputs, $expected, $repeats) = @_;
+    return [$name, $re, $inputs, $expected, undef, $repeats];
+}
+
+my @cases = (
+    # Small ASCII alternatives with a four-byte common prefix.
+    benchmark_case('ascii-common-prefix', qr/(?:ABCP|ABCG|ABCE|ABCB|ABCA|ABCD)/,
+        [qw(ABCD ABCG ABCP XXXX)], 3, 10_000),
+    # ASCII alternatives with several shared prefixes and varied lengths.
+    benchmark_case('ascii-wide-alphabet', qr/(?:alpha|alpine|altar|algebra|almanac|aloe|alter|altruist)/,
+        [qw(alpine altar almanac alter absent)], 4, 10_000),
+    # Native, non-UTF-8 Latin-1 byte strings.
+    benchmark_case('latin1-native', qr/(?:caf\xE9|na\xEFve|r\xE9sum\xE9|touch\xE9|fa\xE7ade)/,
+        [latin1(0x63,0x61,0x66,0xE9), latin1(0x6E,0x61,0xEF,0x76,0x65),
+         latin1(0x6E,0x6F,0x70,0x65)], 2, 10_000),
+    # UTF-8 alternatives containing two-, three-, and four-byte codepoints.
+    benchmark_case('utf8-wide-codepoints', qr/(?:\x{3A9}mega|\x{3BC}icro|\Q$grinning\Eface|\Q$han$country\E|cafe)/,
+        ["\x{3A9}mega", "\x{3BC}icro", $grinning . 'face', 'nope'], 3, 10_000),
+    # One trie mixing ASCII, Latin-1, and codepoints above Latin-1.
+    benchmark_case('mixed-ascii-and-wide', qr/(?:abc|\x{E9}clair|\x{3A9}mega|abacus|\Q$han$country\E)/,
+        ['abc', 'abacus', "\x{E9}clair", "\x{3A9}mega", 'none'], 4, 10_000),
+    # Unicode case folding, including Greek mu, Kelvin, and sharp-s.
+    benchmark_case('unicode-folding', qr/(?:\x{39C}u|\x{3BC}u|\x{212A}elvin|kelvin|Stra\x{DF}e)/i,
+        ["\x{3BC}u", "\x{39C}u", 'KELVIN', 'strasse', 'nothing'], 4, 10_000),
+    # Latin-1 and Unicode fold equivalents for micro sign and Angstrom.
+    benchmark_case('latin1-folding', qr/(?:\x{B5}unit|\x{39C}unit|\x{C5}ngstrom|\x{212B}ngstrom)/i,
+        ["\x{B5}unit", "\x{39C}unit", "\x{C5}ngstrom", 'nothing'], 3, 10_000),
+    # Many accepting states, shared prefixes, and long continuations.  The
+    # common initial 'f' is extracted as a prefix, leaving the overlap-heavy
+    # part for the trie.
+    benchmark_case('overlap-prefixes', qr/(?:fe|fi|fo|fum|foo|foolish|foolishly|food|foal|foot|footfall|football|fodder)/,
+        [qw(fe fi fo fum foo foolish foolishly food foal foot footfall football fodder nope)],
+        13, 10_000),
+    # The same overlap pattern in the middle of a larger expression.  This
+    # uses an ordinary startclass instead of an Aho-Corasick startclass.
+    benchmark_case('overlap-middle', qr/[a-d](?:fe|fi|fo|fum|foo|foolish|foolishly|food|foal|foot|footfall|football|fodder)[g-m]/,
+        ['afeg', 'afig', 'afog', 'afoog', 'afooz'], 4, 10_000),
+    # Several jump continuations share the same trie word.
+    benchmark_case('jump-continuations', qr/(?:foo[ab]|foo[bc]|foo[de])/,
+        [qw(fooa foob fooc food foof)], 4, 10_000),
+    # An accepting state is also the prefix of multiple jump continuations.
+    benchmark_case('jump-accepting-prefix', qr/(?:foo|foo[ab]|foo[bc])/,
+        [qw(foo fooa foob fooc food fop)], 5, 10_000),
+    # Duplicate words and nested shared prefixes should not disturb the
+    # acceptance chains or the extracted prefix.
+    benchmark_case('duplicate-overlap', qr/(?:foo|foo|foob|fooba|foobar|fool)/,
+        [qw(foo foo foob fooba foobar fool fop)], 6, 10_000),
+);
+
+my @large_cases = (
+    # Numeric suffix alternatives. Every case tests the same target strings;
+    # only the number of items in the pattern varies.
+    map {
+        my $count = $_;
+        map {
+            numeric_case($numeric_max, $count, $numeric_common, 100, $_)
+        } @numeric_padding
+    } @numeric_k,
+);
+
+sub target_inputs {
+    my ($case) = @_;
+    if ($case->[0] =~ /^numeric-/) {
+        my $padding = $case->[6];
+        return map { (' ' x $padding) . $_ . (' ' x $padding) }
+            @{$case->[2]};
+    }
+    return @{$case->[2]};
+}
+
+sub filter_cases {
+    my ($source) = @_;
+    my @selected = @$source;
+    if (my $wanted = $ENV{TRIE_BENCH_CASES}) {
+        my %wanted = map { $_ => 1 } split /,/, $wanted;
+        @selected = grep { $wanted{$_->[0]} } @selected;
+    }
+    return @selected;
+}
+
+sub selected_cases {
+    return filter_cases([ @cases, @large_cases ]);
+}
+
+sub selected_bench_cases {
+    my ($phase) = @_;
+    # The large-alternation phase owns its complete K x padding matrix.
+    return @large_cases if $phase eq 'large-alternation';
+    return filter_cases(\@cases);
+}
+
+sub run_tests {
+    for my $case (selected_cases()) {
+        my ($name, $re, $inputs, $expected) = @$case;
+        my @targets = target_inputs($case);
+        for my $i (0 .. $#targets) {
+            my $want = $i < $expected;
+            my $got = $targets[$i] =~ $re;
+            main::ok(!!$got == $want, "$name input $i");
+        }
+    }
+}
+
+sub run_case {
+    my ($case, $iterations) = @_;
+    my ($name, $re, $inputs, $expected) = @$case;
+    my $matched = 0;
+    for (1 .. $iterations) {
+        $matched += ($_ =~ $re) for target_inputs($case);
+    }
+    die "unexpected match count for $name: $matched\n"
+        unless $matched == $iterations * $expected;
+}
+
+sub set_mode {
+    my ($mode) = @_;
+    my %maxbuf = (default => undef, off => -1, list => 0,
+        table => 655360, trie => undef);
+    die "unknown benchmark mode '$mode'\n" unless exists $maxbuf{$mode};
+    my $effective_mode = $mode;
+    $effective_mode = 'trie' if $mode eq 'list' && $has_octet_trie;
+    $effective_mode = 'list' if $mode eq 'trie' && !$has_octet_trie;
+    my $value = $maxbuf{$effective_mode};
+    ${^RE_TRIE_MAXBUF} = $value if defined $value;
+}
+
+sub effective_mode {
+    my ($mode) = @_;
+    return 'trie' if $mode eq 'list' && $has_octet_trie;
+    return 'list' if $mode eq 'trie' && !$has_octet_trie;
+    return $mode;
+}
+
+sub display_mode {
+    my ($mode) = @_;
+    return 'trie' if $has_octet_trie
+        && ($mode eq 'trie' || $mode eq 'list');
+    return 'list' if $mode eq 'trie' && !$has_octet_trie;
+    return $mode;
+}
+
+sub iterations_for_case {
+    my ($case) = @_;
+    my $multiplier = $ENV{TRIE_BENCH_MULTIPLIER} // 1;
+    die "TRIE_BENCH_MULTIPLIER must be a positive number\n"
+        unless $multiplier =~ /\A(?:\d+(?:\.\d*)?|\.\d+)\z/ && $multiplier > 0;
+    return int($case->[5] * $multiplier + 0.5) || 1;
+}
+
+sub compile_case {
+    my ($case, $serial) = @_;
+    my $source = "$case->[1]";
+    my $re = eval "qr/(?:$source)(?#trie-bench-$serial)/";
+    die "could not compile $case->[0]: $@\n" unless $re;
+    return $re;
+}
+
+sub run_phase {
+    my $phase = $ENV{TRIE_BENCH_PHASE} // 'match';
+    my $case_name = $ENV{TRIE_BENCH_CASE}
+        // (@ARGV > 1 && $ARGV[0] eq '--phase' ? $ARGV[1] : undef);
+    my ($case) = grep { $_->[0] eq $case_name }
+        selected_bench_cases($phase);
+    die "unknown benchmark case '$case_name'\n" unless $case;
+    my $iterations = iterations_for_case($case);
+    my $mode = $ENV{TRIE_BENCH_MODE} // ($has_octet_trie ? 'trie' : 'list');
+    if ($mode eq 'table' && $has_octet_trie) {
+        print "table mode not supported on this Perl; skipping\n";
+        return;
+    }
+    set_mode($mode);
+
+    my $serial = 0;
+    if ($phase eq 'compile') {
+        compile_case($case, ++$serial); # validate before timing
+        my $compile_iterations = $case->[4]
+            ? int(($iterations + $case->[4] - 1) / $case->[4]) || 1
+            : $iterations;
+        for (1 .. $compile_iterations) {
+            compile_case($case, ++$serial);
+        }
+    }
+    elsif ($phase eq 'match') {
+        my $re = compile_case($case, ++$serial);
+        for (1 .. $iterations) {
+            my $matched = 0;
+            $matched += ($_ =~ $re) for target_inputs($case);
+            die "unexpected match count\n"
+                unless $matched == $case->[3];
+        }
+    }
+    elsif ($phase eq 'large-alternation') {
+        my $re = compile_case($case, ++$serial);
+        for (1 .. $iterations) {
+            my $matched = 0;
+            $matched += ($_ =~ $re) for target_inputs($case);
+            die "unexpected match count\n"
+                unless $matched == $case->[3];
+        }
+    }
+    else {
+        die "unknown benchmark phase '$phase'\n";
+    }
+}
+
+sub run_profile {
+    my ($profile, $case_name, $iterations) = @ARGV[1 .. 3];
+    die "usage: $0 --profile compile|match CASE ITERATIONS\n"
+        unless defined $profile && defined $case_name && defined $iterations;
+    die "unknown profiling phase '$profile'\n"
+        unless $profile eq 'compile' || $profile eq 'match';
+    die "profiling iteration count must be a positive integer\n"
+        unless $iterations =~ /\A[1-9][0-9]*\z/;
+
+    my ($case) = grep { $_->[0] eq $case_name } @cases;
+    die "unknown benchmark case '$case_name'\n" unless $case;
+
+    my $mode = $ENV{TRIE_BENCH_MODE} // ($has_octet_trie ? 'trie' : 'list');
+    set_mode($mode);
+
+    if ($profile eq 'compile') {
+        my $serial = 0;
+        # The unique comment prevents the compiler from reusing a previous
+        # regexp while retaining the complete qr// compilation path.
+        for (1 .. $iterations) {
+            compile_case($case, ++$serial);
+        }
+    }
+    else {
+        my $re = compile_case($case, 1);
+        my @targets = target_inputs($case);
+        my $matched = 0;
+        for (1 .. $iterations) {
+            $matched += ($_ =~ $re) for @targets;
+        }
+        my $expected = $iterations * $case->[3];
+        die "unexpected match count for $case_name: $matched\n"
+            unless $matched == $expected;
+    }
+}
+
+sub find_dumbbench {
+    for my $dir (File::Spec->path) {
+        my $candidate = File::Spec->catfile($dir, 'dumbbench');
+        return $candidate if -x $candidate;
+    }
+    return;
+}
+
+sub run_with_dumbbench {
+    my $dumbbench = find_dumbbench();
+    unless ($dumbbench) {
+        print "dumbbench not found in PATH; skipping trie benchmarks\n",
+            "Install it with: cpanm Dumbbench\n";
+        return;
+    }
+
+    open my $help, '-|', $dumbbench, '--help'
+        or do {
+            print "dumbbench could not be executed; skipping trie benchmarks\n",
+                "Install it with: cpanm Dumbbench\n";
+            return;
+        };
+    local $/;
+    my $help_output = <$help> // '';
+    close $help;
+    if ($help_output !~ /Usage:/) {
+        print "dumbbench is not usable; skipping trie benchmarks\n",
+            "Install it with: cpanm Dumbbench\n";
+        return;
+    }
+
+    my $script = abs_path($0);
+    my $built  = abs_path('./perl');
+    my @requested_modes = $ENV{TRIE_BENCH_MODES}
+        ? split /,/, $ENV{TRIE_BENCH_MODES}
+        : ($has_octet_trie ? qw(off trie) : qw(off list));
+    my @modes;
+    my %seen_modes;
+    for my $mode (@requested_modes) {
+        my $effective = effective_mode($mode);
+        push @modes, $effective unless $seen_modes{$effective}++;
+    }
+    my @phases = $ENV{TRIE_BENCH_PHASES}
+        ? split /,/, $ENV{TRIE_BENCH_PHASES}
+        : qw(compile match);
+    my $multiplier = $ENV{TRIE_BENCH_MULTIPLIER} // 1;
+    my $precision = 0.03;
+    my $initial = 8;
+    my $maxiter = 40;
+    my $verbose = 1;
+    my %timings;
+
+    for my $mode (@modes) {
+        if ($mode eq 'table' && $has_octet_trie) {
+            print "table mode not supported on this Perl; skipping\n";
+            next;
+        }
+        set_mode($mode);
+        for my $phase (@phases) {
+            die "unknown benchmark phase '$phase'\n"
+                unless $phase eq 'compile' || $phase eq 'match'
+                    || $phase eq 'large-alternation';
+            for my $case (selected_bench_cases($phase)) {
+                my $child_iterations = iterations_for_case($case);
+                my $target_count = scalar @{$case->[2]};
+                my $display_mode = display_mode($mode);
+                print "=== $display_mode $phase $case->[0] ===\n";
+                print "    targets=$target_count child_iterations=$child_iterations",
+                    " multiplier=$multiplier",
+                    " precision=" . ($precision * 100) . "%",
+                    " initial_runs=$initial max_runs=$maxiter",
+                    " verbose=$verbose\n";
+                local $ENV{TRIE_BENCH_MODE} = $mode;
+                local $ENV{TRIE_BENCH_PHASE} = $phase;
+                local $ENV{TRIE_BENCH_CASE} = $case->[0];
+                my @command = (
+                    $dumbbench,
+                    '-p', $precision, '-i', $initial, '-m', $maxiter,
+                    ('-v') x $verbose, '--float', '--',
+                    $built, '-Ilib', $script, '--phase', $phase,
+                );
+                open my $bench, '-|', @command
+                    or die "could not run dumbbench: $!\n";
+                my $time;
+                while (my $line = <$bench>) {
+                    print $line;
+                    $time = $1
+                        if $line =~ /Rounded run time per iteration \(seconds\):\s+([0-9.]+)/;
+                }
+                close $bench;
+                die "dumbbench failed for $mode $phase $case->[0]\n"
+                    if $? != 0;
+                die "dumbbench produced no timing for $mode $phase $case->[0]\n"
+                    unless defined $time;
+                $timings{$phase}{$case->[0]}{$mode} = 0 + $time;
+            }
+        }
+    }
+
+    print "\n=== benchmark summary (seconds per child) ===\n";
+    my @display_modes = map { display_mode($_) } @modes;
+    my $have_speedup = $seen_modes{off} && $seen_modes{trie};
+    printf "%-18s %-20s", 'phase', 'case';
+    printf " %12s", $_ for @display_modes;
+    printf " %12s", 'trie/off' if $have_speedup;
+    print "\n";
+    for my $phase (@phases) {
+        for my $case (selected_bench_cases($phase)) {
+            my $name = $case->[0];
+            printf "%-18s %-20s", $phase, $name;
+            for my $mode (@modes) {
+                my $time = $timings{$phase}{$name}{$mode};
+                printf " %12s", defined $time ? sprintf('%.6f', $time) : '-';
+            }
+            if ($have_speedup) {
+                my $off = $timings{$phase}{$name}{off};
+                my $trie = $timings{$phase}{$name}{trie};
+                my $speedup = defined $off && defined $trie
+                    ? sprintf('%.2fx', $off / $trie) : '-';
+                printf " %12s", $speedup;
+            }
+            print "\n";
+        }
+    }
+
+    print_regression_report(\%timings, \@phases, \@modes);
+}
+
+sub load_statistics_regression {
+    return 1 if eval { require Statistics::Regression; 1 };
+
+    # The benchmark normally runs under ./perl, while optional analysis
+    # modules are installed for the Perl in PATH.  Ask that Perl where its
+    # module lives, then add the corresponding library root to this Perl's
+    # @INC. Statistics::Regression is pure Perl.
+    my $module = qx{perl -MStatistics::Regression -e 'print \$INC{"Statistics/Regression.pm"}' 2>/dev/null};
+    chomp $module;
+    return 0 unless $module && -f $module;
+
+    my $lib = dirname(dirname($module));
+    unshift @INC, $lib unless grep { $_ eq $lib } @INC;
+    return eval { require Statistics::Regression; 1 } ? 1 : 0;
+}
+
+sub print_regression_report {
+    my ($timings, $phases, $modes) = @_;
+    return unless grep { $_ eq 'large-alternation' } @$phases;
+
+    unless (load_statistics_regression()) {
+        print "\nRegression unavailable; install Statistics::Regression "
+            . "for a timing model (for example: cpanm Statistics::Regression)\n";
+        return;
+    }
+
+    my @cases = selected_bench_cases('large-alternation');
+    my %padding = map { $_->[6] => 1 } @cases;
+    my @predictors = keys(%padding) > 1
+        ? qw(const n_alt n_pad inter)
+        : qw(const n_alt);
+
+    print "\n=== timing regression (large-alternation) ===\n";
+    print "model: seconds/child = intercept plus coefficients for ",
+        join(', ', @predictors[1 .. $#predictors]), "\n";
+
+    for my $mode (@$modes) {
+        my $reg = Statistics::Regression->new(
+            "trie benchmark $mode", \@predictors
+        );
+        my $observations = 0;
+        for my $case (@cases) {
+            my $time = $timings->{'large-alternation'}{$case->[0]}{$mode};
+            next unless defined $time;
+            my $k = $case->[4];
+            my $p = $case->[6];
+            my @x = (1, $k);
+            push @x, ($p, $k * $p) if @predictors > 2;
+            $reg->include($time, \@x);
+            ++$observations;
+        }
+        my $required = scalar @predictors;
+        if ($observations <= $required) {
+            print "$mode: insufficient observations ($observations; need more than ",
+                $required - 1, ")\n";
+            next;
+        }
+        my @theta = $reg->theta();
+        my @stderr = $reg->standarderrors();
+        my @tstat = map {
+            $stderr[$_] && $stderr[$_] != 0
+                ? abs($theta[$_] / $stderr[$_]) : 0
+        } 0 .. $#theta;
+        print "\n--- ", display_mode($mode), " ---\n";
+        print "Variables: n_alt = number of alternations, "
+            . "n_pad = padding length, inter = (n_alt * n_pad)\n";
+        printf "Fitted model: time = %.9g", $theta[0];
+        printf " + (%+.9g * n_alt)", $theta[1];
+        if (@predictors > 2) {
+            printf " + (%+.9g * n_pad)", $theta[2];
+            printf " + (%+.9g * (n_alt * n_pad))", $theta[3];
+        }
+        print "\n";
+        $reg->print();
+
+        my $expected = $mode eq 'off' ? 3 : 0;
+        my $other_max = 0;
+        for my $i (0 .. $#tstat) {
+            next if $i == $expected;
+            $other_max = $tstat[$i] if $tstat[$i] > $other_max;
+        }
+        my $dominance = $other_max ? $tstat[$expected] / $other_max : 0;
+        my $shape_ok = $other_max == 0 || $dominance >= 5;
+        printf "Dominance check: %s (%s t-stat %.2f, next strongest %.2f, "
+            . "ratio %.2fx)\n",
+            $shape_ok ? 'PASS' : 'WARNING',
+            $predictors[$expected], $tstat[$expected], $other_max, $dominance;
+    }
+}
+
+sub run_benchmark {
+    if (@ARGV && $ARGV[0] eq '--with-dumbbench') {
+        run_with_dumbbench();
+        return;
+    }
+    if (@ARGV && $ARGV[0] eq '--phase') {
+        run_phase();
+        return;
+    }
+    if (@ARGV && $ARGV[0] eq '--profile') {
+        run_profile();
+        return;
+    }
+}
+
+if (caller) {
+    run_tests();
+} else {
+    run_benchmark();
+}
+
+1;

--- a/t/re/trie_bench.t
+++ b/t/re/trie_bench.t
@@ -1,0 +1,13 @@
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use strict;
+use warnings;
+
+plan tests => 387;
+require './re/trie_bench.pl';

--- a/t/re/trie_byte.t
+++ b/t/re/trie_byte.t
@@ -1,0 +1,142 @@
+#!./perl
+
+BEGIN {
+    ${^RE_TRIE_MAXBUF} = 65536;
+    chdir 't' if -d 't';
+    require './test.pl';
+    set_up_inc('../lib');
+}
+
+use strict;
+use warnings;
+
+plan tests => 35;
+
+my $trie = qr/(?:ab|ac|ad|ae)/;
+
+ok('ab' =~ $trie, 'ASCII trie matches a native target');
+ok('ac' =~ $trie, 'ASCII trie matches another native alternative');
+ok('ae' =~ $trie, 'ASCII trie matches the final native alternative');
+
+my $utf8 = 'ad';
+utf8::upgrade($utf8);
+ok($utf8 =~ $trie, 'ASCII trie matches an UTF-8 target');
+
+my $nonmatch = 'af';
+ok($nonmatch !~ $trie, 'ASCII trie rejects a non-matching native target');
+
+my $native_utf8_looking = pack('C*', 0xc3, 0xa9);
+my $native_utf8_looking_trie = qr/(?:\Q$native_utf8_looking\E|abc)/;
+ok($native_utf8_looking =~ $native_utf8_looking_trie,
+   'native octets that look like UTF-8 remain separate trie characters');
+
+my $unicode_trie = qr/(?:\x{e9}|\x{3a9}|abc)/;
+my $latin1 = pack('C', 0xe9);
+ok($latin1 =~ $unicode_trie, 'UTF-8 byte trie accepts a native Latin-1 byte');
+
+my $wide = "\x{3a9}";
+utf8::upgrade($wide);
+ok($wide =~ $unicode_trie, 'UTF-8 byte trie accepts a wide UTF-8 character');
+
+ok('abc' =~ $unicode_trie, 'UTF-8 byte trie retains ASCII alternatives');
+
+my $fold_trie = qr/(?:foo|bar|baz)/i;
+ok('BAR' =~ $fold_trie, 'folded ASCII trie matches a native target');
+my $fold_utf8 = "ω";
+utf8::upgrade($fold_utf8);
+ok($fold_utf8 =~ qr/(?:Ω|ω|abc)/i,
+   'folded UTF-8 trie matches a Unicode target');
+
+my $sharp_s = "\x{df}";
+utf8::upgrade($sharp_s);
+ok("ba$sharp_s" =~ qr/(?:foo|Ba$sharp_s|bar)/i,
+   'folded trie preserves multi-character sharp-s folds');
+
+ok('abd' =~ qr/(?:abc|abd|abe)/,
+   'ASCII-safe common prefixes remain valid in byte tries');
+
+# Keep several byte tries alive at once, then execute them repeatedly.  This
+# mirrors the benchmark workload and exercises trie ownership as well as the
+# transition path.
+my $wide_alphabet = qr/(?:alpha|alpine|altar|algebra|almanac|aloe|alter|altruist)/;
+my $omega = chr 0x3A9;
+my $mu = chr 0x3BC;
+my $capital_mu = chr 0x39C;
+my $grinning = chr 0x1F600;
+my $han = chr 0x4E2D;
+my $country = chr 0x56FD;
+my $micro_sign = chr 0xB5;
+my $angstrom = chr 0xC5;
+my $e_acute = chr 0xE9;
+my $kelvin = chr 0x212A;
+my $wide_sharp_s = chr 0xDF;
+my $utf8_prefix = qr/(?:\Q$omega\Ex|\Q$omega\Ey)/u;
+my $han_country = $han . $country;
+my $wide_codepoints = qr/(?:\Q$omega\Emega|\Q$mu\Eicro|\Q$grinning\Eface|\Q$han_country\E|cafe)/u;
+my $mixed = qr/(?:abc|\Q$e_acute\Eclair|\Q$omega\Emega|abacus|\Q$han_country\E)/u;
+my $unicode_fold = qr/(?:\Q$capital_mu\Eu|\Q$mu\Eu|\Q$kelvin\Eelvin|kelvin|Stra\Q$wide_sharp_s\Ee)/iu;
+my $latin1_fold = qr/(?:\Q$micro_sign\Eunit|\Q$capital_mu\Eunit|\Q$angstrom\Engstrom|\x{212B}ngstrom)/iu;
+
+ok(($omega . 'mega') =~ qr/\Q$omega\Emega/u,
+   'control exact matches a two-byte UTF-8 character');
+ok(($grinning . 'face') =~ qr/\Q$grinning\Eface/u,
+   'control exact matches a supplementary UTF-8 character');
+ok(($omega . 'x') =~ $utf8_prefix,
+   'UTF-8 prefix extraction matches its first alternative');
+ok(($omega . 'y') =~ $utf8_prefix,
+   'UTF-8 prefix extraction matches its second alternative');
+
+my $wide_hits = 0;
+my $mixed_hits = 0;
+my $unicode_fold_hits = 0;
+my $latin1_fold_hits = 0;
+for (1 .. 1000) {
+    $wide_hits += ($_ =~ $wide_alphabet) for qw(alpine altar almanac alter absent);
+    for my $s ($omega . 'mega', $mu . 'icro', $grinning . 'face', 'nope') {
+        $wide_hits += ($s =~ $wide_codepoints);
+    }
+    for my $s ('abc', 'abacus', $e_acute . 'clair', $omega . 'mega', 'none') {
+        $mixed_hits += ($s =~ $mixed);
+    }
+    for my $s ($mu . 'u', $capital_mu . 'u', 'KELVIN', 'strasse', 'nothing') {
+        $unicode_fold_hits += ($s =~ $unicode_fold);
+    }
+    for my $s ($micro_sign . 'unit', $capital_mu . 'unit', $angstrom . 'ngstrom', 'nothing') {
+        $latin1_fold_hits += ($s =~ $latin1_fold);
+    }
+}
+
+ok($wide_hits == 7000, 'wide trie survives repeated execution');
+ok($mixed_hits == 4000, 'mixed byte trie survives repeated execution');
+ok($unicode_fold_hits == 4000, 'Unicode folded trie survives repeated execution');
+ok($latin1_fold_hits == 3000, 'Latin-1 folded trie survives repeated execution');
+
+ok(($omega . 'mega') =~ $wide_codepoints,
+   'wide-codepoint trie matches after other tries execute');
+ok('strasse' =~ $unicode_fold,
+   'Unicode folded trie matches after repeated execution');
+ok(($angstrom . 'ngstrom') =~ $latin1_fold,
+   'Latin-1 folded trie matches after repeated execution');
+ok('altruist' =~ $wide_alphabet,
+   'wide ASCII trie retains its final alternative');
+ok('abacus' =~ $mixed,
+   'mixed trie retains its ASCII alternative');
+ok(($grinning . 'face') =~ $wide_codepoints,
+   'wide trie retains its supplementary-plane alternative');
+
+ok(($omega . 'mega') =~ $wide_codepoints,
+   'wide trie matches the Greek capital omega alternative');
+ok(($mu . 'icro') =~ $wide_codepoints,
+   'wide trie matches the Greek small mu alternative');
+ok(($e_acute . 'clair') =~ $mixed,
+   'mixed trie matches the Latin-1 alternative');
+ok(($omega . 'mega') =~ $mixed,
+   'mixed trie matches the Greek alternative');
+ok(($mu . 'u') =~ $unicode_fold,
+   'Unicode fold trie matches the small-mu alternative');
+ok(($capital_mu . 'u') =~ $unicode_fold,
+   'Unicode fold trie matches the capital-mu alternative');
+ok('KELVIN' =~ $unicode_fold,
+   'Unicode fold trie matches the Kelvin alternative');
+ok('strasse' =~ $unicode_fold,
+   'Unicode fold trie matches the sharp-s expansion alternative');

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -8176,6 +8176,6 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
  * 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * c4f76f4ba54f533e6b3c6197d2733a4f83f7bbf3c01e6d83b8950e291a3fe36a regen/mk_PL_charclass.pl
- * 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+ * 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
  * a6ce8aefad005c081d4e04523e1f1f1a5a1bed5414ca4a421b5b16b73bfce6a4 regen/mph.pl
  * ex: set ro ft=c: */

--- a/uni_keywords.h
+++ b/uni_keywords.h
@@ -8176,6 +8176,6 @@ match_uniprop( const unsigned char * const key, const U16 key_len ) {
  * 8c30575264b2772c7a69c5bb6069a28f0e0a7a0df735871bde2d99ee674316ac lib/unicore/version
  * 0a6b5ab33bb1026531f816efe81aea1a8ffcd34a27cbea37dd6a70a63d73c844 regen/charset_translations.pl
  * 40a2020ba2420e15332d3855a26138f4391b9f49fbb53aafcb9560e1e288dd5a regen/mk_PL_charclass.pl
- * 20a6e3d507a66f4594586485568134873485b08e23383f3dc4e6b3047569267b regen/mk_invlists.pl
+ * 96b3ff442d0c9122f1bce72b7bc46c2ead13c3028c250f65aca689cd5e142d58 regen/mk_invlists.pl
  * a6ce8aefad005c081d4e04523e1f1f1a5a1bed5414ca4a421b5b16b73bfce6a4 regen/mph.pl
  * ex: set ro ft=c: */

--- a/utf8.h
+++ b/utf8.h
@@ -460,6 +460,14 @@ C<cp> is Unicode if above 255; otherwise is platform-native.
  */
 #define UVCHR_IS_INVARIANT(cp)  (OFFUNI_IS_INVARIANT(NATIVE_TO_UNI(cp)))
 
+/* UTF-8 representations of native octets.  Every native octet represents a
+ * Unicode code point no greater than U+00FF, so its representation is at most
+ * two octets on both UTF-8 and UTF-EBCDIC platforms. */
+typedef struct {
+    U8 len;
+    U8 bytes[2];
+} native_octet_utf8_t;
+
 /* This defines the 1-bits that are to be in the first byte of a multi-byte
  * UTF-8 encoded character that mark it as a start byte and give the number of
  * bytes that comprise the character. 'len' is that number.


### PR DESCRIPTION
The trie compiler now builds trie transitions from the octets of the                                                                                                                          
UTF-8 representation of the pattern. This gives every trie the same                                                                                                                           
256-octet alphabet and removes the need to represent Unicode codepoints                                                                                                                       
as entries in a potentially very large transition alphabet.                                                                                                                                   
                                                                                                                                                                                              
There is a special case for patterns whose codepoints are all ASCII: the                                                                                                                      
ASCII and UTF-8 representations use the same octets, so they naturally                                                                                                                        
share the same trie representation. Other low-page and native-string                                                                                                                          
cases are handled as encoding details around this common UTF-8-byte                                                                                                                           
representation, rather than as different trie formats.                                                                                                                                        
                                                                                                                                                                                              
Encoding-specific matching rules, including native versus UTF-8 behavior                                                                                                                      
and case folding, are handled independently of the fact that trie                                                                                                                             
transitions are stored as UTF-8 octets. This keeps the representation                                                                                                                         
uniform while preserving the existing matching semantics.                                                                                                                                     

Trie construction now uses the list representation throughout and
converts it directly to the compressed transition form used by the
executor. The old flat table construction path, character maps, reverse
character map, wide character map, and inline-charclass trie op variants
are removed. This eliminates a substantial amount of special handling
for Unicode transitions and makes the implementation easier to maintain
and prove correct.

Trie indexes and related counters are widened to U32 where required,
while the debug bitmap is kept as U8 data. Prefix extraction tracks
encoded-byte and source-codepoint lengths so that UTF-8 prefixes are not
split in the middle of a codepoint. Debug trie dumps now describe the
octet alphabet and omit columns that are not present in the pattern.

The regular expression internals version now identifies the octet-trie
implementation, and the perldelta and regex internals documentation
describe the new representation. Tests cover native and UTF-8 byte
tries, updated diagnostics, and benchmark the scaling of large
alternations with different amounts of padding. 

* This set of changes requires a perldelta entry, and it is included.
