### PR TITLE
Make the trie engine use 32 bit values throughout (more or less).

### DIFF
--- a/regcomp.h
+++ b/regcomp.h
@@ -1235,7 +1235,7 @@ typedef struct reg_trie_trans_list_elem_ reg_trie_trans_le;
   the state has no children (and will be accepting)
 */
 struct reg_trie_state_ {
-  U16 wordnum;
+  U32 wordnum;
   union {
     U32                base;
     reg_trie_trans_le* list;
@@ -1244,7 +1244,7 @@ struct reg_trie_state_ {
 
 /* info per word; indexed by wordnum */
 typedef struct {
-    U16  prev;	/* previous word in acceptance chain; eg in
+    U32  prev;	/* previous word in acceptance chain; eg in
                  * zzz|abc|ab/ after matching the chars abc, the
                  * accepted word is #2, and the previous accepted
                  * word is #3 */

--- a/regcomp.h
+++ b/regcomp.h
@@ -1224,7 +1224,7 @@ struct reg_trie_trans_ {
 
 /* a transition list element for the list based representation */
 struct reg_trie_trans_list_elem_ {
-    U16 forid;
+    U32 forid;
     U32 newstate;
 };
 typedef struct reg_trie_trans_list_elem_ reg_trie_trans_le;
@@ -1264,7 +1264,7 @@ typedef struct reg_trie_trans_    reg_trie_trans;
 struct reg_trie_data_ {
     U32             refcount;        /* number of times this trie is referenced */
     U32             lasttrans;       /* last valid transition element */
-    U16             *charmap;        /* byte to charid lookup array */
+    U32             *charmap;        /* byte to charid lookup array */
     reg_trie_state  *states;         /* state data */
     reg_trie_trans  *trans;          /* array of transition elements */
     char            *bitmap;         /* stclass bitmap */
@@ -1276,7 +1276,7 @@ struct reg_trie_data_ {
                                         for the given jump. */
 
     reg_trie_wordinfo *wordinfo;     /* array of info per word */
-    U16             uniquecharcount; /* unique chars in trie (width of trans table) */
+    U32             uniquecharcount; /* unique chars in trie (width of trans table) */
     U32             startstate;      /* initial state - used for common prefix optimisation */
     STRLEN          minlen;          /* minimum length of words in trie - build/opt only? */
     STRLEN          maxlen;          /* maximum length of words in trie - build/opt only? */

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -22,7 +22,7 @@
 #define TRIE_LIST_CUR(state)  ( TRIE_LIST_ITEM( state, 0 ).forid )
 #define TRIE_LIST_LEN(state) ( TRIE_LIST_ITEM( state, 0 ).newstate )
 #define TRIE_LIST_USED(idx)  ( trie->states[state].trans.list         \
-                               ? (TRIE_LIST_CUR( idx ) - 1)           \
+                               ? (TRIE_LIST_CUR( idx ) - 1)            \
                                : 0 )
 
 #ifndef RE_PREFER_LONG_TRIE
@@ -200,7 +200,7 @@ S_dump_trie_interim_list(pTHX_ const struct reg_trie_data_ *trie,
             depth+1, "------:-----+-----------------\n" );
 
     for( state = 1; state < next_alloc; state++ ) {
-        U16 charid;
+        U32 charid;
 
         re_indentf(" %4" UVXf " :",
             depth+1, (UV)state  );
@@ -249,7 +249,7 @@ S_dump_trie_interim_table(pTHX_ const struct reg_trie_data_ *trie,
     PERL_ARGS_ASSERT_DUMP_TRIE_INTERIM_TABLE;
 
     U32 state;
-    U16 charid;
+    U32 charid;
     SV *sv = sv_newmortal();
     int colwidth = widecharmap ? 6 : 4;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
@@ -649,7 +649,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
     trie->startstate = 1;
     trie->wordcount = word_count;
     RExC_rxi->data->data[ data_slot ] = (void*)trie;
-    trie->charmap = (U16 *) PerlMemShared_calloc( 256, sizeof(U16) );
+    trie->charmap = (U32 *) PerlMemShared_calloc( 256, sizeof(U32) );
     if (flags == EXACT || flags == EXACT_REQ8 || flags == EXACTL)
         trie->bitmap = (char *) PerlMemShared_calloc( ANYOF_BITMAP_SIZE, 1 );
     trie->wordinfo = (reg_trie_wordinfo *) PerlMemShared_calloc(
@@ -952,7 +952,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
             regnode *noper   = REGNODE_AFTER( cur );
             U32 state        = 1;         /* required init */
-            U16 charid       = 0;         /* sanity init */
+            U32 charid       = 0;         /* sanity init */
             U32 wordlen      = 0;         /* required init */
 
             if (OP(noper) == NOTHING) {
@@ -987,14 +987,14 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                         if ( !svpp ) {
                             charid = 0;
                         } else {
-                            charid = (U16)SvIV( *svpp );
+                            charid = (U32)SvIV( *svpp );
                         }
                     }
                     /* charid is now 0 if we dont know the char read, or
                      * nonzero if we do */
                     if ( charid ) {
 
-                        U16 check;
+                        U32 check;
                         U32 newstate = 0;
 
                         charid--;
@@ -1065,12 +1065,12 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                 */
 
                 if (trie->states[state].trans.list) {
-                    U16 minid = TRIE_LIST_ITEM( state, 1).forid;
-                    U16 maxid = minid;
-                    U16 idx;
+                    U32 minid = TRIE_LIST_ITEM( state, 1).forid;
+                    U32 maxid = minid;
+                    U32 idx;
 
                     for( idx = 2 ; idx <= TRIE_LIST_USED( state ) ; idx++ ) {
-                        const U16 forid = TRIE_LIST_ITEM( state, idx).forid;
+                        const U32 forid = TRIE_LIST_ITEM( state, idx).forid;
                         if ( forid < minid ) {
                             minid = forid;
                         } else if ( forid > maxid ) {
@@ -1184,7 +1184,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
 
             U32 state        = 1;         /* required init */
 
-            U16 charid       = 0;         /* sanity init */
+            U32 charid       = 0;         /* sanity init */
             U32 accept_state = 0;         /* sanity init */
 
             U32 wordlen      = 0;         /* required init */
@@ -1218,7 +1218,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
                                                            (char*)&uvc,
                                                            sizeof( UV ),
                                                            0);
-                        charid = svpp ? (U16)SvIV(*svpp) : 0;
+                        charid = svpp ? (U32)SvIV(*svpp) : 0;
                     }
                     if ( charid ) {
                         charid--;

--- a/regcomp_trie.c
+++ b/regcomp_trie.c
@@ -96,7 +96,7 @@ S_dump_trie(pTHX_ const struct reg_trie_data_ *trie, HV *widecharmap,
     U32 state;
     SV *sv = sv_newmortal();
     int colwidth = widecharmap ? 6 : 4;
-    U16 word;
+    U32 word;
     DECLARE_AND_GET_RE_DEBUG_FLAGS;
 
     re_indentf("Char : %-6s%-6s%-4s ",
@@ -492,7 +492,7 @@ is the recommended Unicode-aware way of saying
 } STMT_END
 
 #define TRIE_HANDLE_WORD(state) STMT_START {                    \
-    U16 dupe = trie->states[ state ].wordnum;                    \
+    U32 dupe = trie->states[ state ].wordnum;                    \
     regnode * const noper_next = regnext( noper );              \
                                                                 \
     DEBUG_r({                                                   \
@@ -604,7 +604,7 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
     regnode *cur;
     STRLEN len = 0;
     UV uvc = 0;
-    U16 curword = 0;
+    U32 curword = 0;
     U32 next_alloc = 0;
     regnode *jumper = NULL;
     regnode *nextbranch = NULL;
@@ -1632,9 +1632,9 @@ Perl_make_trie(pTHX_ RExC_state_t *pRExC_state, regnode *startbranch,
      *  already linked up earlier.
      */
     {
-        U16 word;
+        U32 word;
         U32 state;
-        U16 prev;
+        U32 prev;
 
         for (word = 1; word <= trie->wordcount; word++) {
             prev = 0;

--- a/regexec.c
+++ b/regexec.c
@@ -7053,7 +7053,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
                     UV uvc = 0;
                     U32 charid = 0;
                     U32 base = trie->states[ state ].trans.base;
-                    U16 wordnum = trie->states[ state ].wordnum;
+                    U32 wordnum = trie->states[ state ].wordnum;
                     PERL_DEB(U32 old_state = state);
 
                     if (wordnum) { /* it's an accept state */
@@ -7125,7 +7125,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                 /* calculate total number of accept states */
                 {
-                    U16 w = ST.topword;
+                    U32 w = ST.topword;
                     accepted = 0;
                     while (w) {
                         w = trie->wordinfo[w].prev;
@@ -7175,9 +7175,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
             {
                 /* Find next-highest word to process.  Note that this code
                  * is O(N^2) per trie run (O(N) per branch), so keep tight */
-                U16 min = 0;
-                U16 word;
-                U16 const nextword = ST.nextword;
+                U32 min = 0;
+                U32 word;
+                U32 const nextword = ST.nextword;
                 reg_trie_wordinfo * const wordinfo
                     = ((reg_trie_data*)rexi->data->data[TRIE_DATA_SLOT(ST.me)])->wordinfo;
                 for (word = ST.topword; word; word = wordinfo[word].prev) {

--- a/regexec.c
+++ b/regexec.c
@@ -1895,7 +1895,7 @@ STMT_START {                                                                \
             SV** const svpp = hv_fetch(widecharmap,                         \
                         (char*)&uvc, sizeof(UV), 0);                        \
             if (svpp)                                                       \
-                charid = (U16)SvIV(*svpp);                                  \
+                charid = (U32)SvIV(*svpp);                                  \
         }                                                                   \
     }                                                                       \
 } STMT_END
@@ -3337,7 +3337,7 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
             while (s <= last_start) {
                 const U32 uniflags = UTF8_ALLOW_DEFAULT;
                 U8 *uc = (U8*)s;
-                U16 charid = 0;
+                U32 charid = 0;
                 U32 base = 1;
                 U32 state = 1;
                 UV uvc = 0;
@@ -7051,7 +7051,7 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
 
                 while ( state && uc <= (U8*)(loceol) ) {
                     UV uvc = 0;
-                    U16 charid = 0;
+                    U32 charid = 0;
                     U32 base = trie->states[ state ].trans.base;
                     U16 wordnum = trie->states[ state ].wordnum;
                     PERL_DEB(U32 old_state = state);

--- a/regexp.h
+++ b/regexp.h
@@ -985,8 +985,8 @@ typedef struct regmatch_state {
             regnode     *me;        /* Which node am I - needed for jump tries*/
             U8          *firstpos;  /* pos in string of first trie match */
             U32         firstchars; /* len in chars of firstpos from start */
-            U16         nextword;   /* next word to try */
-            U16         topword;    /* longest accepted word */
+            U32         nextword;   /* next word to try */
+            U32         topword;    /* longest accepted word */
         } trie;
 
         /* special types - these members are used to store state for special


### PR DESCRIPTION
Make the trie engine use 32 bit values throughout. Simplify things, less room for error. 

* This set of changes may require a perldelta entry, and it is not included.
