### PR TITLE
sbox32_hash.h - remove the default fallback to zaphod32

### DIFF
--- a/sbox32_hash.h
+++ b/sbox32_hash.h
@@ -1461,7 +1461,6 @@ SBOX32_STATIC_INLINE U32 sbox32_hash_with_state(
     const U32 *state= (const U32 *)state_ch;
     U32 hash = *state;
     switch (key_len) {
-        default: return zaphod32_hash_with_state(state_ch, key, key_len);
         case_256_SBOX32(hash,state,key)
         case_255_SBOX32(hash,state,key)
         case_254_SBOX32(hash,state,key)


### PR DESCRIPTION
@bulk88 was tell us how this default is a problem. I had thought the compiler would just compile this away, but apparently not. And since setting  SBOX32_MAX_LEN to a value larger than >=256 will throw an error there really is no reason for this default clause.

The defaults presence was intended to handle if someone foolishly set SBOX32_MAX_LEN to >=256 then zaphod would handle the tail. However since this code is never reached and apparently not all compilers are smart enough to notice we drag in a lot of stuff.

* This set of changes does not require a perldelta entry.
