### PR TITLE
Add quotes to install paths in win32 Makefile

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -491,6 +491,7 @@ Firas Khalil Khana             <firasuke@gmail.com>
 Florent Guillaume
 Florian Ragwitz                <rafl@debian.org>
 Florian Weimer                 <fweimer@redhat.com>
+Frank                          <46161394+BraveChicken1@users.noreply.github.com>
 Frank Crawford
 Frank Ridderbusch              <Frank.Ridderbusch@pdb.siemens.de>
 Frank Tobin                    <ftobin@uiuc.edu>

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1310,17 +1310,17 @@ install : all installbare installhtml
 
 installbare : utils ..\pod\perltoc.pod
 	$(PERLEXE) ..\installperl
-	if exist $(WPERLEXE) $(XCOPY) $(WPERLEXE) $(INST_BIN)\*.*
-	if exist $(PERLEXESTATIC) $(XCOPY) $(PERLEXESTATIC) $(INST_BIN)\*.*
-	$(XCOPY) $(GLOBEXE) $(INST_BIN)\*.*
-	if exist ..\perl*.pdb $(XCOPY) ..\perl*.pdb $(INST_BIN)\*.*
-	$(XCOPY) bin\*.bat $(INST_SCRIPT)\*.*
+	if exist $(WPERLEXE) $(XCOPY) $(WPERLEXE) "$(INST_BIN)\*.*"
+	if exist $(PERLEXESTATIC) $(XCOPY) $(PERLEXESTATIC) "$(INST_BIN)\*.*"
+	$(XCOPY) $(GLOBEXE) "$(INST_BIN)\*.*"
+	if exist ..\perl*.pdb $(XCOPY) ..\perl*.pdb "$(INST_BIN)\*.*"
+	$(XCOPY) bin\*.bat "$(INST_SCRIPT)\*.*"
 
 installhtml : doc
-	$(RCOPY) $(HTMLDIR)\*.* $(INST_HTML)\*.*
+	$(RCOPY) $(HTMLDIR)\*.* "$(INST_HTML)\*.*"
 
 inst_lib : $(CONFIGPM)
-	$(RCOPY) ..\lib $(INST_LIB)\*.*
+	$(RCOPY) ..\lib "$(INST_LIB)\*.*"
 
 $(UNIDATAFILES) ..\pod\perluniprops.pod : $(MINIPERL) $(CONFIGPM) ..\lib\unicore\mktables Extensions_nonxs
 	cd ..\lib\unicore && \


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
This PR adds support for a `INST_TOP` with spaces in its file path in the win32 Makefile.

Currently using a file path with spaces results in the part after the space being ignored. By adding quotes when passing these paths to commands, this issue is fixed.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
