### PR TITLE
Verify whether a shared KEY came from PL_strtab before bumping refcount

### DIFF
--- a/hv.c
+++ b/hv.c
@@ -1015,8 +1015,34 @@ Perl_hv_common(pTHX_ HV *hv, SV *keysv, const char *key, STRLEN klen,
     if (LIKELY(HvSHAREKEYS(hv))) {
         entry = new_HE();
         if (keysv_hek) {
-            HeKEY_hek(entry) = share_hek_hek(keysv_hek);
+            /* In threaded builds, keysv_hek will almost always be
+             * present in the PL_strtab of the *current* interpreter
+             * instance. It's safe in that scenario to just do:
+             *     HeKEY_hek(entry) = share_hek_hek(keysv_hek);
+             *
+             * However, XS code that is not thread safe might pass in a
+             * HEK that lives in a foreign instance of PL_strtab.
+             *
+             * share_hek_flags() handles this by doing a full HEK
+             * comparison and inserting a fresh HEK into the current
+             * PL_strtab if necessary.
+             *
+             * We attempt a cheaper check here first. */
+             const unsigned char keysv_flags = HEK_FLAGS(keysv_hek);
+             HE *sentry = (HvARRAY(PL_strtab))[hash & (I32)HvMAX(PL_strtab)];
+             for (;sentry; sentry = HeNEXT(sentry)) {
+                 HEK *candidate = HeKEY_hek(sentry);
+                 if (candidate == keysv_hek &&
+                     HEK_FLAGS(candidate) == keysv_flags) {
+                     /* Found it */
+                     HeKEY_hek(entry) = share_hek_hek(keysv_hek);
+                     break;
+                 }
+             }
+             if (UNLIKELY(!sentry)) /* keysv_hek not in this PL_strtab */
+                 goto safe_share;
         } else {
+          safe_share:
             HeKEY_hek(entry) = share_hek_flags(key, klen, hash, flags);
         }
     }


### PR DESCRIPTION
https://github.com/Perl/perl5/commit/823fa88ebd51f2c7d55e978d5881cf33e1e64508 attempted to avoid a seemingly-unnecessary call to `share_hek_flags()` when inserting a shared HEK into a hash. (Bumping the refcount instead.)

The underlying assumption was that the shared HEK - being a shared HEK - must already be in the current interpreter's `PL_strtab`.

However, thread-unsafe XS code may pass a HEK, shared in one thread's `PL_strtab`, to a different thread. `share_hek_flags()` covers over any unsafe/lack of thread context handling, but directly bumping the underlying refcount acts on the originating thread's `PL_strtab`, not the receiving thread's version.

This commit adds a pointer-comparison walk of the relevant bucket in the _current_ `PL_strtab` to check if the shared HEK is present and falls back to `share_hek_flags()` if not.

Fixes #24600 

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
