### PR TITLE
update my e-mail adress

### DIFF
--- a/Porting/core-team.json
+++ b/Porting/core-team.json
@@ -8,7 +8,7 @@
     "xdg@xdg.me"
   ],
   "active": [
-    "andk@cpan.org",
+    "andreas.j.koenig@gmail.com",
     "chris@bingosnet.co.uk",
     "cpan@corion.net",
     "craigberry@mac.com",


### PR DESCRIPTION
After I was recently added as a new member to the Core Team, my address @cpan.org was disabled. So this commit picks a gmail address as a replacement. Thank you.