### PR TITLE
Sync Socket-2.042 into blead

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1043,7 +1043,7 @@ our %Modules = (
         'DISTRIBUTION' => 'PEVANS/Socket-2.041.tar.gz',
         'SYNCINFO'     => 'leo on Mon May  4 16:10:37 2026',
         'FILES'        => q[cpan/Socket],
-        'EXCLUDED'     => ['.editorconfig'],
+        'EXCLUDED'     => ['.editorconfig', 'distrolint.ini'],
     },
 
     'Storable' => {

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1040,8 +1040,8 @@ our %Modules = (
     },
 
     'Socket' => {
-        'DISTRIBUTION' => 'PEVANS/Socket-2.041.tar.gz',
-        'SYNCINFO'     => 'leo on Mon May  4 16:10:37 2026',
+        'DISTRIBUTION' => 'PEVANS/Socket-2.042.tar.gz',
+        'SYNCINFO'     => 'jkeenan on Mon Aug 17 14:13:31 2026',
         'FILES'        => q[cpan/Socket],
         'EXCLUDED'     => ['.editorconfig', 'distrolint.ini'],
     },

--- a/cpan/Socket/Socket.pm
+++ b/cpan/Socket/Socket.pm
@@ -3,7 +3,7 @@ package Socket;
 use v5.6.1;
 use strict;
 
-our $VERSION = '2.041';
+our $VERSION = '2.042';
 
 =head1 NAME
 
@@ -59,8 +59,8 @@ C<:crlf> export tag:
     $sock->print("GET / HTTP/1.0$CRLF");
 
 The entire getaddrinfo() subsystem can be exported using the tag C<:addrinfo>;
-this exports the getaddrinfo() and getnameinfo() functions, and all the
-C<AI_*>, C<NI_*>, C<NIx_*> and C<EAI_*> constants.
+this exports the gai_strerror(), getaddrinfo() and getnameinfo() functions,
+and all the C<AI_*>, C<NI_*>, C<NIx_*> and C<EAI_*> constants.
 
 =cut
 
@@ -393,6 +393,17 @@ C<d.d.d.d> form for C<AF_INET> or C<hhhh:hhhh::hhhh> form for C<AF_INET6>.
 
 See also getnameinfo() for a more powerful and flexible function to turn
 socket addresses into human-readable textual representations.
+
+=head2 gai_strerror
+
+    $errstr = gai_strerror $err;
+
+I<Since version 2.042.>
+
+Converts a numerical C<getaddrinfo> or C<getnameinfo> error constant into its
+human-readable string message. Normally this function is not required, as the
+error value returned by those functions is a dualvar containing both numerical
+and stringy parts already.
 
 =head2 getaddrinfo
 
@@ -854,7 +865,7 @@ our @EXPORT_OK = qw(
 
     inet_pton inet_ntop
 
-    getaddrinfo getnameinfo
+    gai_strerror getaddrinfo getnameinfo
 
     AI_ADDRCONFIG AI_ALL AI_CANONIDN AI_CANONNAME AI_IDN
     AI_IDN_ALLOW_UNASSIGNED AI_IDN_USE_STD3_ASCII_RULES AI_NUMERICHOST
@@ -871,7 +882,7 @@ our @EXPORT_OK = qw(
 
 our %EXPORT_TAGS = (
     crlf     => [qw(CR LF CRLF $CR $LF $CRLF)],
-    addrinfo => [qw(getaddrinfo getnameinfo), grep m/^(?:AI|NI|NIx|EAI)_/, @EXPORT_OK],
+    addrinfo => [qw(gai_strerror getaddrinfo getnameinfo), grep m/^(?:AI|NI|NIx|EAI)_/, @EXPORT_OK],
     all      => [@EXPORT, @EXPORT_OK],
 );
 
@@ -941,13 +952,15 @@ my %errstr;
 if( defined &getaddrinfo ) {
     # These are not part of the API, nothing uses them, and deleting them
     # reduces the size of %Socket:: by about 12K
+    delete $Socket::{fake_gai_strerror};
     delete $Socket::{fake_getaddrinfo};
     delete $Socket::{fake_getnameinfo};
 } else {
     require Scalar::Util;
 
-    *getaddrinfo = \&fake_getaddrinfo;
-    *getnameinfo = \&fake_getnameinfo;
+    *gai_strerror = \&fake_gai_strerror;
+    *getaddrinfo  = \&fake_getaddrinfo;
+    *getnameinfo  = \&fake_getnameinfo;
 
     # These numbers borrowed from GNU libc's implementation, but since
     # they're only used by our emulation, it doesn't matter if the real
@@ -1018,6 +1031,12 @@ sub fake_makeerr
     my ( $errno ) = @_;
     my $errstr = $errno == 0 ? "" : ( $errstr{$errno} || $errno );
     return Scalar::Util::dualvar( $errno, $errstr );
+}
+
+sub fake_gai_strerror
+{
+    my ( $errno ) = @_;
+    return $errno == 0 ? "" : $errstr{$errno + 0};
 }
 
 sub fake_getaddrinfo

--- a/cpan/Socket/Socket.xs
+++ b/cpan/Socket/Socket.xs
@@ -580,6 +580,24 @@ static SV *err_to_SV(pTHX_ int err)
     return ret;
 }
 
+static void xs_gai_strerror(pTHX_ CV *cv)
+{
+    dXSARGS;
+
+    SV *ret;
+
+    PERL_UNUSED_ARG(cv);
+    if(items < 1 || items > 3)
+        croak("Usage: Socket::gai_strerror(errno)");
+
+    SP -= items;
+
+    ret = err_to_SV(aTHX_ SvIV(ST(0)));
+
+    PUSHs(ret);
+    XSRETURN(1);
+}
+
 static void xs_getaddrinfo(pTHX_ CV *cv)
 {
     dXSARGS;
@@ -768,7 +786,8 @@ INCLUDE: const-xs.inc
 
 BOOT:
 #ifdef HAS_GETADDRINFO
-        newXS("Socket::getaddrinfo", xs_getaddrinfo, __FILE__);
+        newXS("Socket::gai_strerror", xs_gai_strerror, __FILE__);
+        newXS("Socket::getaddrinfo",  xs_getaddrinfo,  __FILE__);
 #endif
 #ifdef HAS_GETNAMEINFO
         newXS("Socket::getnameinfo", xs_getnameinfo, __FILE__);

--- a/cpan/Socket/t/getaddrinfo.t
+++ b/cpan/Socket/t/getaddrinfo.t
@@ -1,7 +1,7 @@
 use v5.6.1;
 use strict;
 use warnings;
-use Test::More tests => 31;
+use Test::More tests => 32;
 
 use Socket qw(:addrinfo AF_INET SOCK_STREAM IPPROTO_TCP unpack_sockaddr_in inet_aton);
 
@@ -71,7 +71,8 @@ ok( $res[0]->{protocol} == 0 || $res[0]->{protocol} == IPPROTO_TCP,
 my $goodhost = "cpan.perl.org";
 
 SKIP: {
-    skip "Resolver has no answer for $goodhost", 2 unless gethostbyname( $goodhost );
+    skip "Resolver has no answer for host=$goodhost", 2 unless gethostbyname( $goodhost );
+    skip "Resolver has no answer for service=ftp", 2 unless getservbyname( "ftp", IPPROTO_TCP );
 
     ( $err, @res ) = getaddrinfo( "cpan.perl.org", "ftp", { socktype => SOCK_STREAM } );
     cmp_ok( $err, "==", 0, '$err == 0 for host=cpan.perl.org/service=ftp/socktype=STREAM' );
@@ -129,6 +130,10 @@ SKIP: {
 
     ( $err, @res ) = getaddrinfo( $goodhost, "ftp", { flags => AI_NUMERICHOST, socktype => SOCK_STREAM } );
     ok( $err != 0, "\$err != 0 for host=$goodhost/service=ftp/flags=AI_NUMERICHOST/socktype=SOCK_STREAM" );
+
+    # Here's a good time to check gai_strerror matches
+    cmp_ok( gai_strerror( $err ), 'eq', "$err",
+        'gai_strerror() yields same result as stringified $err' );
 }
 
 # Some sanity checking on the hints hash


### PR DESCRIPTION
cpan/Socket - Update to version 2.042
    
2.042   2026-08-17
CHANGES
             * Provide also a `gai_strerror` to go with `getaddrinfo` and
               `getnameinfo`
    
BUGFIXES
             * Skip `getaddrinfo` test on "ftp" service if legacy resolver does
               not have an answer for that service name

Committer:  Added `distrolint.ini` to `EXCLUDED` kvp in `%Maintainers::Modules`.