### PR TITLE
Net-Ping: Permit tests in 3 files to run on FreeBSD

### DIFF
--- a/dist/Net-Ping/t/010_pingecho.t
+++ b/dist/Net-Ping/t/010_pingecho.t
@@ -20,7 +20,6 @@ BEGIN {use_ok('Net::Ping')};
 TODO: {
     local $TODO = "Not working on os390 smoker; may be a permissions problem"
       if $^O eq 'os390';
-    $TODO = "Not working on freebsd" if $^O eq 'freebsd';
     my $result = pingecho("127.0.0.1");
     is($result, 1, "pingecho 127.0.0.1 works");
 }

--- a/dist/Net-Ping/t/450_service.t
+++ b/dist/Net-Ping/t/450_service.t
@@ -78,7 +78,7 @@ is($p->ping("127.0.0.1"), 1, 'first port is reachable');
 $p->{port_num} = $port2;
 
 {
-    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390|cygwin|freebsd)$/;
+    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|MSWin32|os390|cygwin)$/;
     is($p->ping("127.0.0.1"), 1, 'second port is reachable');
 }
 
@@ -133,7 +133,7 @@ SKIP: {
 
   {
     local $TODO = "Believed not to work on $^O"
-      if $^O =~ /^(?:hpux|MSWin32|os390|cygwin|freebsd)$/;
+      if $^O =~ /^(?:hpux|MSWin32|os390|cygwin)$/;
     is($p->ack(), '127.0.0.1', 'IP should be reachable');
   }
 }

--- a/dist/Net-Ping/t/510_ping_udp.t
+++ b/dist/Net-Ping/t/510_ping_udp.t
@@ -20,7 +20,7 @@ SKIP: {
     skip "No udp echo port", 2 unless getservbyname('echo', 'udp');
     skip "udp ping blocked by Window's default settings", 2 if isWindowsVista();
     skip "No getprotobyname", 2 unless $Config{d_getpbyname};
-    skip "Not allowed on $^O", 2 if $^O =~ /^(hpux|irix|aix|freebsd)$/;
+    skip "Not allowed on $^O", 2 if $^O =~ /^(hpux|irix|aix)$/;
     my $p = new Net::Ping "udp";
     # message_type can't be used
     eval {


### PR DESCRIPTION
Several tests in 3 files in dist/Net-Ping/t/ were TODO-ed or SKIP-ped but now appear to be safe to run and are PASS-ing.

As discussed in the past few days in https://github.com/Perl/perl5/pull/24710, we should narrow the scope of such exclusions where possible.  Early in the annual dev cycle is a good time to do so.

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
