### PR TITLE
Remove extra tokens warning introduced by 1cda553

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -3329,7 +3329,7 @@ PP(pp_i_postdec)
     }
 }
 
-#undef SvIsSimpleIV(sv)
+#undef SvIsSimpleIV
 
 /* High falutin' math. */
 


### PR DESCRIPTION
Removes this warning introduced during commit squashing.
```
pp.c:3332:20: warning: extra tokens at end of #undef directive
 3332 | #undef SvIsSimpleIV(sv)
```

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
