### PR TITLE
skip leading _ in default :param/:reader/:writer names

### DIFF
--- a/class.c
+++ b/class.c
@@ -1134,11 +1134,28 @@ S_pad_import_field(pTHX_ PADNAME *fieldpn)
 }
 
 static void
+padname_skip_underscore(const PADNAME *pn, const char **pname, STRLEN *plen) {
+    /* skip sigil */
+    const char *name = PadnamePV(pn) + 1;
+    STRLEN len = PadnameLEN(pn) - 1;
+    if (len > 0 && *name == '_') {
+        name++;
+        len--;
+    }
+    *pname = name;
+    *plen = len;
+}
+
+static void
 apply_field_attribute_param(pTHX_ PADNAME *pn, SV *value)
 {
-    if(!value)
-        /* Default to name minus the sigil */
-        value = newSVpvn_utf8(PadnamePV(pn) + 1, PadnameLEN(pn) - 1, PadnameUTF8(pn));
+    if(!value) {
+        /* Default to name minus the sigil (and one underscore if present) */
+        const char *name;
+        STRLEN len;
+        padname_skip_underscore(pn, &name, &len);
+        value = newSVpvn_utf8(name, len, PadnameUTF8(pn));
+    }
 
     if(PadnamePV(pn)[0] != '$')
         croak("Only scalar fields can take a :param attribute");
@@ -1168,9 +1185,13 @@ apply_field_attribute_reader(pTHX_ PADNAME *pn, SV *value)
 {
     if(value)
         SvREFCNT_inc(value);
-    else
-        /* Default to name minus the sigil */
-        value = newSVpvn_utf8(PadnamePV(pn) + 1, PadnameLEN(pn) - 1, PadnameUTF8(pn));
+    else {
+        /* Default to name minus the sigil (and one underscore if present) */
+        const char *name;
+        STRLEN len;
+        padname_skip_underscore(pn, &name, &len);
+        value = newSVpvn_utf8(name, len, PadnameUTF8(pn));
+    }
 
     if(!valid_identifier_sv(value))
         croak("%" SVf_QUOTEDPREFIX " is not a valid name for a generated method", value);
@@ -1234,10 +1255,12 @@ apply_field_attribute_writer(pTHX_ PADNAME *pn, SV *value)
     if(value)
         SvREFCNT_inc(value);
     else {
-        /* Default to "set_" . name minus the sigil */
+        /* Default to "set_" . name minus the sigil (and one underscore if present) */
+        const char *name;
+        STRLEN len;
+        padname_skip_underscore(pn, &name, &len);
         value = newSVpvs("set_");
-        sv_catpvn_flags(value, PadnamePV(pn) + 1, PadnameLEN(pn) - 1,
-                PadnameUTF8(pn) ? SV_CATUTF8 : 0);
+        sv_catpvn_flags(value, name, len, PadnameUTF8(pn) ? SV_CATUTF8 : 0);
     }
 
     if(!valid_identifier_sv(value))

--- a/pod/perlclass.pod
+++ b/pod/perlclass.pod
@@ -248,6 +248,12 @@ can be specified in the attribute.
     field $x :param;
     field $y :param(the_y_value);
 
+If the field name starts with an underscore, one underscore will be removed
+from the default parameter name:
+
+    field $_foo :param;   # equivalent to :param(foo)
+    field $__bar :param;  # equivalent to :param(_bar)
+
 If there is no defaulting expression, then the parameter is required by the
 constructor; the caller must pass it or an exception is thrown. With a
 defaulting expression this becomes optional.
@@ -271,6 +277,12 @@ leading sigil), but a different name can be specified in the attribute's value.
 
     # Generates a method
     method get_x () { return $x; }
+
+As with C<:param>, if the field name starts with an underscore, one underscore
+will be removed from the default method name:
+
+    field $_foo :reader;   # equivalent to :reader(foo)
+    field $__bar :reader;  # equivalent to :reader(_bar)
 
 Reader methods can be applied to non-scalar fields. When invoked in list
 context, they yield the contents of the field; in scalar context they yield
@@ -303,6 +315,12 @@ can be specified in the attribute's value.
 
     # Generates a method
     method write_x ($new) { ... }
+
+As with C<:reader>, if the field name starts with an underscore, one underscore
+will be removed from the default method name:
+
+    field $_foo :writer;   # equivalent to :writer(set_foo)
+    field $__bar :writer;  # equivalent to :writer(set__bar)
 
 Currently, writer accessors can only be applied to scalar fields.  Attempts
 to apply this attribute to a non-scalar field will result in a fatal exception

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -61,6 +61,24 @@ XXX For a release on a stable branch, this section aspires to be:
 
 [ List each incompatible change as a =head2 entry ]
 
+=head2 Names derived from class fields skip a leading underscore
+
+If the name of a class field starts with an underscore, any derived constructor
+parameters (C<:param>) or methods (C<:reader>, C<:writer>) will skip that
+underscore:
+
+    class Foo {
+        field $_bar :param :reader :writer;
+        # Equivalent to:
+        #   field $_bar :param(bar) :reader(bar) :writer(set_bar);
+    }
+
+This is how L<Object::Pad> works, too.
+
+In previous versions of Perl, the underscore was retained, making the above
+declaration equivalent to C<< field $_bar :param(_bar) :reader(_bar)
+:writer(set__bar); >>.
+
 =head1 Deprecations
 
 XXX Any deprecated features, syntax, modules etc. should be listed here.

--- a/t/class/accessor.t
+++ b/t/class/accessor.t
@@ -23,6 +23,9 @@ no warnings 'experimental::class';
         field %h :reader() = qw( the hash );
 
         field $empty :reader;
+
+        field $_alpha :reader = 'A';
+        field $__beta :reader = 'B';
     }
 
     my $o = Testcase1->new;
@@ -49,6 +52,9 @@ no warnings 'experimental::class';
     is($o->s, "the scalar", ':reader does not expose internal SVs');
     ok(eq_array([$o->a], [qw( the array )]), ':reader does not expose internal AVs');
     ok(eq_hash({$o->h}, {qw( the hash )}), ':reader does not expose internal HVs');
+
+    is($o->alpha, 'A', ':reader strips a leading underscore');
+    is($o->_beta, 'B', ':reader strips one leading underscore only');
 }
 
 # writer accessors on scalars
@@ -56,6 +62,9 @@ no warnings 'experimental::class';
     class Testcase2 {
         field $s :reader :writer = "initial";
         field $xno :param :reader = "Eh-ehhh";
+        field $_alpha :reader :writer;
+        field $__beta :reader :writer;
+        field $_42 :reader(get_42) :writer;
     }
 
     my $o = Testcase2->new;
@@ -78,6 +87,13 @@ no warnings 'experimental::class';
         'Cannot write without :writer attribute');
     like($@, qr/^Can\'t locate object method \"set_xno\" via package \"Testcase2\"/,
         'Failure from writing without :writer');
+
+    $o->set_alpha('AA');
+    is($o->alpha, 'AA', ':writer strips a leading underscore');
+    $o->set__beta('BB');
+    is($o->_beta, 'BB', ':writer strips one leading underscore only');
+    $o->set_42('answer');
+    is($o->get_42, 'answer', ':writer accepts numeric field names');
 }
 
 # Alternative names

--- a/t/class/field.t
+++ b/t/class/field.t
@@ -329,6 +329,24 @@ no warnings 'experimental::class';
     ok(eq_hash({$obj->hash}, {}), 'Hash field can have redundant initialiser');
 }
 
+{
+    class Testcase16 {
+        field $_alpha :param;
+        field $__beta :param;
+        field $gamma_ :param;
+
+        method values() { $_alpha, $__beta, $gamma_ }
+    }
+
+    my $obj = Testcase16->new(
+        alpha  => 'A',
+        _beta  => 'B',
+        gamma_ => 'G',
+    );
+
+    ok(eq_array([$obj->values], [qw(A B G)]), ':param strips one leading underscore');
+}
+
 SKIP: {
     eval { require XS::APItest; 1 }
         or skip "XS::APItest not available", 1;

--- a/t/lib/croak/class
+++ b/t/lib/croak/class
@@ -298,3 +298,12 @@ class Foo {
 }
 EXPECT
 Can't use global $_ in "field" at - line 4, near "field $_"
+########
+# NAME :reader name must be valid identifier after stripping _
+use v5.44;
+use experimental 'class';
+class Foo {
+    field $_42 :reader;
+}
+EXPECT
+"42" is not a valid name for a generated method at - line 4.

--- a/t/porting/known_pod_issues.dat
+++ b/t/porting/known_pod_issues.dat
@@ -249,6 +249,7 @@ nl_langinfo(3)
 Number::Format
 Object::Accessor
 Object::InsideOut
+Object::Pad
 open(2)
 OS2::Proc
 OS2::WinObject


### PR DESCRIPTION
Previously,

    field $_foo :param :reader :writer;

was equivalent to

    field $_foo :param(_foo) :reader(_foo) :writer(set__foo);

Now it means

    field $_foo :param(foo) :reader(foo) :writer(set_foo);

That is, the constructor parameter and reader/writer methods skip over a single leading underscore in the field name if present.

It is often convenient to visually mark a field as "internal" to a class by giving it a name that starts with an underscore. But constructor arguments are part of the public interface of a class, so it would be weird to have a leading _ there. (The same argument applies to generated accessor methods.)

Object::Pad does the same thing:

> A single prefix character "_" will be removed if present.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and it is included.

