### PR TITLE
Devel-PPPort: add Size_t_MAX, SSize_t_MAX and STRLEN_MAX

### DIFF
--- a/dist/Devel-PPPort/Changes
+++ b/dist/Devel-PPPort/Changes
@@ -1,5 +1,29 @@
 Revision history for Devel-PPPort
 
+3.74
+
+ * add SSize_t_MAX, Size_t_MAX, STRLEN_MAX
+
+3.73
+
+ * Note: the version wasn't increased here between perl releases
+   when it probably should have been.
+ * Add PERL_STACK_REALIGN, SvREFCNT_dec(), newSVbool(), mXPUSHpvs(),
+   SvVSTRING(), SvREFCNT_dec_NN(),
+
+3.72
+
+ * Add Stack_off_t
+ * fix PERL_VERSION_xx comparison macros
+
+3.71
+
+ * fix handling of signed klen in check_HeUTF8()
+
+3.70
+
+ * silence some maybe-uninitialized warnings
+
 3.68 - 2022-03-18
 
  * fix newSVsv_flags: rename variable to fix C++ compilation issue

--- a/dist/Devel-PPPort/PPPort_pm.PL
+++ b/dist/Devel-PPPort/PPPort_pm.PL
@@ -756,7 +756,7 @@ package Devel::PPPort;
 use strict;
 use vars qw($VERSION $data);
 
-$VERSION = '3.73';
+$VERSION = '3.74';
 
 sub _init_data
 {

--- a/dist/Devel-PPPort/parts/apidoc.fnc
+++ b/dist/Devel-PPPort/parts/apidoc.fnc
@@ -807,8 +807,10 @@ Amd|void|seedDrand01|Rand_seed_t x
 md|void|SETERRNO|int errcode|int vmserrcode
 Amd|void|Siglongjmp|jmp_buf env|int val
 Amd|int|Sigsetjmp|jmp_buf env|int savesigs
+Amn||Size_t_MAX
 AmnUd||SP
 Amnsd||SPAGAIN
+Amn||SSize_t_MAX
 Amd|SV*|ST|int ix
 Amnud||START_EXTERN_C
 Amnhd||START_MY_CXT
@@ -822,6 +824,7 @@ Amd|bool|strGE|char* s1|char* s2
 Amd|bool|strGT|char* s1|char* s2
 Amud|string|STRINGIFY|token x
 Amd|bool|strLE|char* s1|char* s2
+Amn||STRLEN_MAX
 Amd|bool|strLT|char* s1|char* s2
 Amd|bool|strNE|char* s1|char* s2
 Amd|bool|strnEQ|char* s1|char* s2|STRLEN len

--- a/dist/Devel-PPPort/parts/inc/limits
+++ b/dist/Devel-PPPort/parts/inc/limits
@@ -33,6 +33,9 @@ IVSIZE
 UVSIZE
 IVTYPE
 UVTYPE
+Size_t_MAX
+SSize_t_MAX
+STRLEN_MAX
 
 =implementation
 
@@ -288,6 +291,10 @@ UVTYPE
 __UNDEFINED__ UVTYPE unsigned IVTYPE
 __UNDEFINED__ UVSIZE IVSIZE
 
+__UNDEFINED__ Size_t_MAX  (~(Size_t)0)
+__UNDEFINED__ SSize_t_MAX (SSize_t)(~(Size_t)0 >> 1)
+__UNDEFINED__ STRLEN_MAX  (~(STRLEN)0)
+
 =xsubs
 
 IV
@@ -318,9 +325,36 @@ uv_type()
         OUTPUT:
                 RETVAL
 
-=tests plan => 4
+UV
+size_t_max()
+        CODE:
+                RETVAL = Size_t_MAX;
+        OUTPUT:
+                RETVAL
+
+UV
+ssize_t_max()
+        CODE:
+                RETVAL = SSize_t_MAX;
+        OUTPUT:
+                RETVAL
+
+UV
+strlen_max()
+        CODE:
+                RETVAL = STRLEN_MAX;
+        OUTPUT:
+                RETVAL
+
+
+=tests plan => 9
 
 ok(&Devel::PPPort::iv_size());
 ok(&Devel::PPPort::uv_size());
 ok(&Devel::PPPort::iv_type());
 ok(&Devel::PPPort::uv_type());
+ok(&Devel::PPPort::size_t_max());
+ok(&Devel::PPPort::ssize_t_max());
+ok(&Devel::PPPort::strlen_max());
+is((&Devel::PPPort::size_t_max()-1)/2, &Devel::PPPort::ssize_t_max());
+is(&Devel::PPPort::size_t_max(), &Devel::PPPort::strlen_max());


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
If this addresses an open issue, please reference it in this format: GH #12345
so that GitHub adds a link in that issue to this new pull request.
-->
 The types Size_t and SSize_t were introduced in 5.000.

STRLEN was introduced in 3.0.

Also did a rough update to Changes.

Going to look at making porting/cmp_version stricter here.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
