### PR TITLE
vdeb can take a NULL context parameter

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -2790,7 +2790,7 @@ p	|void	|peep		|NULLOK OP *o
 ATdo	|PerlInterpreter *|perl_alloc
 ATdo	|void	|perl_construct |NN PerlInterpreter *my_perl
 
-t: The reason for the 'u' flag is that this passes "aTHX_ x" to its callee: not
+: The reason for the 'u' flag is that this passes "aTHX_ x" to its callee: not
 : a legal C parameter
 Admu	|const XOP *|Perl_custom_op_xop 				\
 				|NN const OP *o

--- a/embed.fnc
+++ b/embed.fnc
@@ -4216,7 +4216,7 @@ Adp	|int	|vcmp		|NN SV *lhv				\
 				|NN SV *rhv
 Adprt	|void	|vcroak 	|NULLOK const char *pat 		\
 				|NULLOK va_list *args
-Adp	|void	|vdeb		|NN const char *pat			\
+Adpt	|void	|vdeb		|NN const char *pat			\
 				|NULLOK va_list *args
 Adpt	|void	|vfatal_warner	|U32 err				\
 				|NN const char *pat			\

--- a/proto.h
+++ b/proto.h
@@ -8416,10 +8416,9 @@ Perl_vcroak(pTHX_ const char *pat, va_list *args)
 
 PERL_CALLCONV void
 Perl_vdeb(pTHX_ const char *pat, va_list *args)
-        Perl_attribute_nonnull_aTHX
         Perl_attribute_nonnull(pTHX_1);
 #define PERL_ARGS_ASSERT_VDEB                   \
-        Perl_assert_aTHX; assert(pat)
+        assert(pat)
 
 PERL_CALLCONV void
 Perl_vfatal_warner(pTHX_ U32 err, const char *pat, va_list *args)


### PR DESCRIPTION
In f06f49a, I neglected to add the 't' flag to the vdeb entry, unlike all the other functions in that commit.
That can cause an assert failure, which we're seeing in, e.g., SUSE smokes

* This set of changes does not require a perldelta entry.
