### PR TITLE
PADNAME: restore C99 compatibility

### DIFF
--- a/pad.c
+++ b/pad.c
@@ -2951,7 +2951,7 @@ Perl_padname_upgrade_sv(pTHX_ PADNAME *pn)
     SvUTF8_on(sv);
     SvREADONLY_on(sv);
 
-    pn->xpadn_sv = sv;
+    pn->xpadn_name_u.xpadn_sv = sv;
 
     PadnameFLAGS(pn) |= PADNAMEf_FULLSV;
     return pn;
@@ -2995,8 +2995,8 @@ Perl_padname_dup(pTHX_ PADNAME *src, CLONE_PARAMS *param)
 
         if(PadnameIsFULLSV(src)) {
             char *pnpv = PadnamePV(dst);
-            dst->xpadn_sv = sv_dup_inc(src->xpadn_sv, param);
-            SvPVX(dst->xpadn_sv) = pnpv;
+            dst->xpadn_name_u.xpadn_sv = sv_dup_inc(src->xpadn_name_u.xpadn_sv, param);
+            SvPVX(dst->xpadn_name_u.xpadn_sv) = pnpv;
         }
     }
     ptr_table_store(PL_ptr_table, src, dst);

--- a/pad.h
+++ b/pad.h
@@ -61,7 +61,7 @@ struct padname_fieldinfo;
     union {                             \
         char *	xpadn_pv;		\
         SV *    xpadn_sv;               \
-    };                                  \
+    } xpadn_name_u;                     \
     HV *	xpadn_ourstash;		\
     union {				\
         HV *	xpadn_typestash;	\
@@ -345,11 +345,11 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PadARRAY(pad)		AvARRAY(pad)
 #define PadMAX(pad)		AvFILLp(pad)
 
-#define PadnamePV(pn)		(PadnameIsFULLSV(pn) ? SvPVX((pn)->xpadn_sv) : (pn)->xpadn_pv)
-#define PadnameLEN(pn)		(PadnameIsFULLSV(pn) ? SvCUR((pn)->xpadn_sv) : (pn)->xpadn_len)
+#define PadnamePV(pn)		(PadnameIsFULLSV(pn) ? SvPVX((pn)->xpadn_name_u.xpadn_sv) : (pn)->xpadn_name_u.xpadn_pv)
+#define PadnameLEN(pn)		(PadnameIsFULLSV(pn) ? SvCUR((pn)->xpadn_name_u.xpadn_sv) : (pn)->xpadn_len)
 #define PadnameUTF8(pn)		1
 #define PadnameSV(pn) \
-        (PadnameIsFULLSV(pn) ? (pn)->xpadn_sv : newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8|SVf_READONLY|SVf_PROTECT))
+        (PadnameIsFULLSV(pn) ? (pn)->xpadn_name_u.xpadn_sv : newSVpvn_flags(PadnamePV(pn), PadnameLEN(pn), SVs_TEMP|SVf_UTF8|SVf_READONLY|SVf_PROTECT))
 #define PadnameFLAGS(pn)	(pn)->xpadn_flags
 #define PadnameIsOUR(pn)	cBOOL((pn)->xpadn_ourstash)
 #define PadnameOURSTASH(pn)	(pn)->xpadn_ourstash
@@ -380,7 +380,7 @@ Restore the old pad saved into the local variable C<opad> by C<PAD_SAVE_LOCAL()>
 #define PADNAMEf_FULLSV     0x80    /* padname stored in SVt_PV in xpadn_sv */
 
 #ifdef PERL_CORE
-#  define PadnamePV_set(pn, pv)     (assert(!PadnameIsFULLSV(pn)), (pn)->xpadn_pv = (pv))
+#  define PadnamePV_set(pn, pv)     (assert(!PadnameIsFULLSV(pn)), (pn)->xpadn_name_u.xpadn_pv = (pv))
 #  define PadnameLEN_set(pn, len)   (assert(!PadnameIsFULLSV(pn)), (pn)->xpadn_len = (len))
 #endif
 


### PR DESCRIPTION
Commit aca7b5cadb25 inadvertently introduced a C11-only feature (unnamed structure/union members) in struct padname. Give the union a name so we can build cleanly on C99-only compilers.

Fixes #24740.

-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes requires a perldelta entry, and I need help writing it.
* This set of changes does not require a perldelta entry.
