### PR TITLE
regen_perly.y: Slight modernisation

### DIFF
--- a/perly.act
+++ b/perly.act
@@ -2320,5 +2320,5 @@ case 2: /* @1: %empty  */
 
 /* Generated from:
  * 783af8ff7ff42fd7313d85df8bbde58d7480e4964bb41ce7b92a5039a7286074 perly.y
- * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
+ * 1a4cfc5b32006b09aba17cc80cd31ade3503ab1e829681adfe337d9c26e19fe0 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.h
+++ b/perly.h
@@ -199,8 +199,7 @@ extern int yydebug;
 /* Value type.  */
 #ifdef PERL_IN_TOKE_C
 static bool
-S_is_opval_token(int type)
-{
+S_is_opval_token(int type) {
     switch (type) {
     case ATTRLIST:
     case BAREWORD:
@@ -250,5 +249,5 @@ int yyparse (void);
 
 /* Generated from:
  * 783af8ff7ff42fd7313d85df8bbde58d7480e4964bb41ce7b92a5039a7286074 perly.y
- * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
+ * 1a4cfc5b32006b09aba17cc80cd31ade3503ab1e829681adfe337d9c26e19fe0 regen_perly.pl
  * ex: set ro ft=c: */

--- a/perly.tab
+++ b/perly.tab
@@ -1698,5 +1698,5 @@ static const toketypes yy_type_tab[] =
 
 /* Generated from:
  * 783af8ff7ff42fd7313d85df8bbde58d7480e4964bb41ce7b92a5039a7286074 perly.y
- * f13e9c08cea6302f0c1d1f467405bd0e0880d0ea92d0669901017a7f7e94ab28 regen_perly.pl
+ * 1a4cfc5b32006b09aba17cc80cd31ade3503ab1e829681adfe337d9c26e19fe0 regen_perly.pl
  * ex: set ro ft=c: */

--- a/regen_perly.pl
+++ b/regen_perly.pl
@@ -29,21 +29,20 @@
 # it may work elsewhere but no specific attempt has been made to make it
 # portable.
 
-use 5.006;
-sub usage { die "usage: $0 [ -b bison_executable ] [ file.y ]\n" }
-
+use v5.12;
 use warnings;
-use strict;
+sub usage { die "usage: $0 [ -b bison_executable ] [ -Wfoo ... ] [ file.y ]\n" }
 
 our $Verbose;
 BEGIN { require './regen/regen_lib.pl'; }
 
-my $bison = 'bison';
+use Getopt::Long;
+Getopt::Long::Configure(qw( bundling_values no_ignore_case ));
 
-if (@ARGV >= 2 and $ARGV[0] eq '-b') {
-    shift;
-    $bison = shift;
-}
+GetOptions(
+    'b|bison=s' => \(my $bison = 'bison'),
+    'W=s'       => \my @bison_warnings,
+) or usage;
 
 my $y_file = shift || 'perly.y';
 
@@ -90,7 +89,8 @@ EOF
 $version = $1;
 
 # creates $tmpc_file and $tmph_file
-my_system("$bison -d -o $tmpc_file $y_file");
+my_system("$bison -d -o $tmpc_file $y_file " .
+    join(" ", map { "-W$_" } @bison_warnings));
 
 open my $ctmp_fh, '<', $tmpc_file or die "Can't open $tmpc_file: $!\n";
 my $clines;


### PR DESCRIPTION
A couple of prereqs useful for debugging during development of #24304 

 * use `Getopt::Long`
 * support `-Wfoo` passthrough to bison

There's no semantic change in the generated `perly.*` files, but they embed the SHA256 hash of the files that generated them.