### PR TITLE
Fix croak message in newSV_type()

### DIFF
--- a/sv_inline.h
+++ b/sv_inline.h
@@ -512,8 +512,7 @@ Perl_newSV_type(pTHX_ const svtype type)
         sv->sv_u.svu_rv = NULL;
         break;
     default:
-        Perl_croak(aTHX_ "panic: sv_upgrade to unknown type %lu",
-                   (unsigned long)type);
+        croak("panic: newSV_type() unknown type %lu", (unsigned long)type);
     }
 
     return sv;


### PR DESCRIPTION
It was very confusing as it referred to a different function name. I suspect a result of some copypaste from elsewhere.

Also it might as well use the `croak()` macro rather than the direct call to `Perl_croak()` function.

* This set of changes does not require a perldelta entry.