### PR TITLE
Rename struct REENTR to PERL_REENTR

### DIFF
--- a/intrpvar.h
+++ b/intrpvar.h
@@ -916,7 +916,7 @@ PERLVARI(I, veto_switch_non_tTHX_context, int, FALSE)
 #endif
 
 #ifdef USE_REENTRANT_API
-PERLVAR(I, reentrant_buffer, REENTR *)	/* here we store the _r buffers */
+PERLVAR(I, reentrant_buffer, PERL_REENTR *)  /* here we store the _r buffers */
 #endif
 
 PERLVAR(I, custom_op_names, HV *)	/* Names of user defined ops */

--- a/reentr.c
+++ b/reentr.c
@@ -179,7 +179,7 @@ Perl_reentrant_init(pTHX) {
 
 #ifdef USE_REENTRANT_API
 
-        Newx(PL_reentrant_buffer, 1, REENTR);
+        Newx(PL_reentrant_buffer, 1, PERL_REENTR);
         Perl_reentrant_size(aTHX);
 
 #  ifdef HAS_ASCTIME_R

--- a/reentr.h
+++ b/reentr.h
@@ -875,7 +875,7 @@ typedef struct {
 
 
     int dummy; /* cannot have empty structs */
-} REENTR;
+} PERL_REENTR;
 
 /* The wrappers. */
 

--- a/regen/reentr.pl
+++ b/regen/reentr.pl
@@ -360,7 +360,7 @@ close DATA;
     }
 }
 
-my @struct; # REENTR struct members
+my @struct; # PERL_REENTR struct members
 my @size;   # struct member buffer size initialization code
 my @init;   # struct member buffer initialization (malloc) code
 my @free;   # struct member buffer release (free) code
@@ -799,7 +799,7 @@ typedef struct {
 
 @struct
     int dummy; /* cannot have empty structs */
-} REENTR;
+} PERL_REENTR;
 
 /* The wrappers. */
 
@@ -878,7 +878,7 @@ Perl_reentrant_init(pTHX) {
 
 #ifdef USE_REENTRANT_API
 
-        Newx(PL_reentrant_buffer, 1, REENTR);
+        Newx(PL_reentrant_buffer, 1, PERL_REENTR);
         Perl_reentrant_size(aTHX);
 
 @init


### PR DESCRIPTION
This struct is visible to all code.  I noticed in grepping metacpan that some modules use this spelling to refer to other things, so there is a potential clash.  Since this is used only in generated code, it is easy to rename it to use a spelling reserved for Perl's use.


* This set of changes does not require a perldelta entry.
