### PR TITLE
perlfunc: fix perlop links for tr, y, qx

### DIFF
--- a/pod/perlfunc.pod
+++ b/pod/perlfunc.pod
@@ -6512,7 +6512,7 @@ removed as of Perl 5.24.
 
 =for Pod::Functions backquote quote a string
 
-Generalized quotes.  See L<perlop/"Quote-Like Operators">.
+Generalized quotes.  See L<perlop/Simpler Quote-Like Operators>.
 
 =item qr/STRING/
 
@@ -9989,7 +9989,7 @@ Portability issues: L<perlport/times>.
 
 The transliteration operator.  Same as
 L<C<yE<sol>E<sol>E<sol>>|/yE<sol>E<sol>E<sol>>.  See
-L<perlop/"Quote-Like Operators">.
+L<perlop/Transliteration Quote-Like Operators>.
 
 =item truncate FILEHANDLE,LENGTH
 X<truncate>
@@ -11009,7 +11009,7 @@ L<C<read>|/read FILEHANDLE,SCALAR,LENGTH,OFFSET>.  Unfortunately.
 
 The transliteration operator.  Same as
 L<C<trE<sol>E<sol>E<sol>>|/trE<sol>E<sol>E<sol>>.  See
-L<perlop/"Quote-Like Operators">.
+L<perlop/Transliteration Quote-Like Operators>.
 
 =back
 

--- a/pod/perlop.pod
+++ b/pod/perlop.pod
@@ -3970,11 +3970,11 @@ only to prevent breaking any pre-existing links to it from outside.
 
 =head2 Quote-Like Operators
 
-This section has been replaced by L</Simpler Quote-Like Operators>
+This section has been replaced by L</Simpler Quote-Like Operators>.
 
 =head2 Indented Here-docs
 
-This section has been merged into L</Here-docs>
+This section has been merged into L</Here-docs>.
 
 =head1 APPENDIX
 


### PR DESCRIPTION
Nowadays "Quote-Like Operators" is just a stub section redirecting to "Simpler Quote-Like Operators", which describes q, qq, qx, qw, but not tr.

Follow-up to e729bd4f1145.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
