### PR TITLE
Add missing trailing quotes in perlootut

### DIFF
--- a/pod/perlootut.pod
+++ b/pod/perlootut.pod
@@ -43,7 +43,7 @@ should also read the L<perlsyn>, L<perlop>, and L<perlsub> documents.
 =head1 OBJECT-ORIENTED FUNDAMENTALS
 
 Most object systems share a number of common concepts. You've probably
-heard terms like "class", "object, "method", and "attribute" before.
+heard terms like "class", "object", "method", and "attribute" before.
 Understanding the concepts will make it much easier to read and write
 object-oriented code. If you're already familiar with these terms, you
 should still skim this section, since it explains each concept in terms


### PR DESCRIPTION
A small punctuation correction.

In perlootut. the word "objects" had a starting quote, but not an ending one.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
