### PR TITLE
t/op/glob.t fails on -DEBUGGING build

### DIFF
--- a/t/op/glob.t
+++ b/t/op/glob.t
@@ -7,7 +7,7 @@ BEGIN {
 }
 
 use Config;
-my $is_debugging_build = $Config{config_args} =~ /\bDDEBUGGING\b(*nla:=none)/;
+my $is_debugging_build = $Config{ccflags} =~ /(?<!\S)-DDEBUGGING(?!\S)/;
 
 @oops = @ops = <op/*>;
 

--- a/t/run/todo.t
+++ b/t/run/todo.t
@@ -103,7 +103,7 @@ use warnings;
 
 my $switches = "";
 
-my $is_debugging_build = $Config{config_args} =~ /\bDDEBUGGING\b(*nla:=none)/;
+my $is_debugging_build = $Config{ccflags} =~ /(?<!\S)-DDEBUGGING(?!\S)/;
 
 our $TODO;
 


### PR DESCRIPTION
I have found that in v5.45.2 `t/op/glob.t` fails when configured with `-DEBUGGING`.

This seems to be because `t/op/glob.t` only searches `DDEBUGGING` in Configure argument to determine whether the build is a debugging build, so a test intended to be skipped in debugging builds is inadvertently not skipped if a debugging build is specified by `-DEBUGGING` (which is described in INSTALL as an alias for `-DDEBUGGING`).

This PR will address this problem, but IMHO it would be nice if an unified interface such as `is_debugging_build` (like `is_miniperl`) is eventually provided in `test.pl`.

-------------------------------------------------------------------------------

This set of changes is a trivial test fix, so I  think:

* This set of changes does not require a perldelta entry.
