### PR TITLE
Re-enable LeakSanitizer runs

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -734,9 +734,8 @@ jobs:
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -V
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests
-        # LeakSanitizer is disabled because it randomly crashes, see [gh #19189]
         run: |
-          ASAN_OPTIONS=detect_leaks=0 PERL_DESTRUCT_LEVEL=2 TEST_JOBS=2 ./perl t/harness
+          PERL_DESTRUCT_LEVEL=2 TEST_JOBS=2 ./perl t/harness
 
   #  ____  _____ ____  _        _   _ _   _ ___ ____ ___  ____  _____
   # |  _ \| ____|  _ \| |      | | | | \ | |_ _/ ___/ _ \|  _ \| ____|
@@ -784,9 +783,8 @@ jobs:
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -V
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests
-        # LeakSanitizer is disabled because it randomly crashes, see [gh #19189]
         run: |
-          ASAN_OPTIONS=detect_leaks=0 PERL_DESTRUCT_LEVEL=2 LC_ALL=en_US.UTF-8 PERL_UNICODE="" TEST_JOBS=2 ./perl t/harness
+          PERL_DESTRUCT_LEVEL=2 LC_ALL=en_US.UTF-8 PERL_UNICODE="" TEST_JOBS=2 ./perl t/harness
 
   #      _ _     _                            _       _
   #   __| (_)___| |_      _ __ ___   ___   __| |_   _| | ___  ___


### PR DESCRIPTION
It's been almost 6 years since the feature was disabled due to instability running GDBM tests in commit 229e23b64687900359b531b3aeaae7fa90eaca86. The original intent in the commit which introduced the ASAN CI job was described in commit 4e4a36d25ad28cea817290e458e48b3b749e88ce "Whilst this *will* detect various dangerous mistakes involving bad memory accesses, it's far more likely to spot if changes create memory leaks." I think it is time to revisit to see after many tooling releases if LeakSanitizer is choking. If so, perhaps it would be better to remove GDBM install as part of this job until whatever triggers failures can be identified and fixed rather than limiting ASAN features in an ASAN CI job.

* This set of changes does not require a perldelta entry.