### PR TITLE
Re-enable LeakSanitizer runs on Ubuntu 26.04

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -731,7 +731,7 @@ jobs:
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests
         run: |
-          PERL_DESTRUCT_LEVEL=2 TEST_JOBS=2 ./perl t/harness
+          LSAN_OPTIONS=verbosity=1:log_threads=1 PERL_DESTRUCT_LEVEL=2 TEST_JOBS=2 ./perl t/harness
 
   #  ____  _____ ____  _        _   _ _   _ ___ ____ ___  ____  _____
   # |  _ \| ____|  _ \| |      | | | | \ | |_ _/ ___/ _ \|  _ \| ____|
@@ -776,7 +776,7 @@ jobs:
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests
         run: |
-          PERL_DESTRUCT_LEVEL=2 LC_ALL=en_US.UTF-8 PERL_UNICODE="" TEST_JOBS=2 ./perl t/harness
+          LSAN_OPTIONS=verbosity=1:log_threads=1 PERL_DESTRUCT_LEVEL=2 LC_ALL=en_US.UTF-8 PERL_UNICODE="" TEST_JOBS=2 ./perl t/harness
 
   #      _ _     _                            _       _
   #   __| (_)___| |_      _ __ ___   ___   __| |_   _| | ___  ___

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -699,7 +699,7 @@ jobs:
 
   ASAN:
     name: "ASAN"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 120
     needs: sanity_check
     if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_asan == 'true'))
@@ -734,9 +734,8 @@ jobs:
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -V
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests
-        # LeakSanitizer is disabled because it randomly crashes, see [gh #19189]
         run: |
-          ASAN_OPTIONS=detect_leaks=0 PERL_DESTRUCT_LEVEL=2 TEST_JOBS=2 ./perl t/harness
+          PERL_DESTRUCT_LEVEL=2 TEST_JOBS=2 ./perl t/harness
 
   #  ____  _____ ____  _        _   _ _   _ ___ ____ ___  ____  _____
   # |  _ \| ____|  _ \| |      | | | | \ | |_ _/ ___/ _ \|  _ \| ____|
@@ -749,7 +748,7 @@ jobs:
 
   PERL_UNICODE:
     name: "PERL_UNICODE"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 120
     needs: sanity_check
     if: (! cancelled() && (needs.sanity_check.outputs.run_all_jobs == 'true' || needs.sanity_check.outputs.ci_force_perl_unicode == 'true'))
@@ -784,9 +783,8 @@ jobs:
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -V
           ASAN_OPTIONS=detect_leaks=0 ./perl -Ilib -e 'use Config; print Config::config_sh'
       - name: Run Tests
-        # LeakSanitizer is disabled because it randomly crashes, see [gh #19189]
         run: |
-          ASAN_OPTIONS=detect_leaks=0 PERL_DESTRUCT_LEVEL=2 LC_ALL=en_US.UTF-8 PERL_UNICODE="" TEST_JOBS=2 ./perl t/harness
+          PERL_DESTRUCT_LEVEL=2 LC_ALL=en_US.UTF-8 PERL_UNICODE="" TEST_JOBS=2 ./perl t/harness
 
   #      _ _     _                            _       _
   #   __| (_)___| |_      _ __ ___   ___   __| |_   _| | ___  ___

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -715,10 +715,6 @@ jobs:
           - "-Dusethreads"
 
     steps:
-      - name: Install System dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v6
       - name: git cfg
         run: |
@@ -762,10 +758,6 @@ jobs:
           - "-Dusethreads -Accflags=-DPURIFY -Dcc='gcc -fsanitize=address' -Dld='gcc -fsanitize=address'"
 
     steps:
-      - name: Install System dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgdbm-dev libdb-dev
       - uses: actions/checkout@v6
       - name: git cfg
         run: |


### PR DESCRIPTION
ubuntu-latest target currently means Ubuntu 24.04, whilst the latest actual release of Ubuntu is 26.04.
Target 26.04 to see if LeakSanitzer still struggles when GDBM support is included.
Part of PR #24765

* This set of changes does not require a perldelta entry.
