### PR TITLE
Add and use bitcount32 & bitcount64 inline functions

### DIFF
--- a/embed.fnc
+++ b/embed.fnc
@@ -987,6 +987,8 @@ Adp	|void	|av_unshift	|NN AV *av				\
 Rp	|OP *	|bind_match	|I32 type				\
 				|NN OP *left				\
 				|NN OP *right
+ATdip	|unsigned|bitcount32	|uint32_t v
+ATdip	|unsigned|bitcount64	|uint64_t v
 : Used in perly.y
 ARdp	|OP *	|block_end	|I32 floor				\
 				|NULLOK OP *seq

--- a/embed.h
+++ b/embed.h
@@ -387,6 +387,8 @@
 # define av_store_simple(a,b,c)                 Perl_av_store_simple(aTHX_ a,b,c)
 # define av_undef(a)                            Perl_av_undef(aTHX_ a)
 # define av_unshift(a,b)                        Perl_av_unshift(aTHX_ a,b)
+# define bitcount32                             Perl_bitcount32
+# define bitcount64                             Perl_bitcount64
 # define block_end(a,b)                         Perl_block_end(aTHX_ a,b)
 # define block_gimme()                          Perl_block_gimme(aTHX)
 # define block_start(a)                         Perl_block_start(aTHX_ a)

--- a/inline.h
+++ b/inline.h
@@ -5258,5 +5258,43 @@ Perl_my_strlcpy(char *dst, const char *src, Size_t size)
 #endif
 
 /*
+=for apidoc bitcount64
+=for apidoc_item bitcount32
+
+Functions for finding the number of set bits in a C<uint64_t> or
+C<uint32_t>. The exact implementation may vary depending upon
+compiler, architecture level, and CPU.
+
+For now, both are implemented as recognisably standard SWAR
+functions. A capable compiler may optimize these to C<popcnt>
+or equivalent instructions.
+
+(e.g. A recent gcc/clang building at the x86-64-v2 architecture
+or above is expected recognise this code and swap in popcnt.)
+
+=cut
+
+*/
+
+PERL_STATIC_INLINE unsigned
+Perl_bitcount64(uint64_t v) {
+    PERL_ARGS_ASSERT_BITCOUNT64;
+    v = v - ((v >> 1) & 0x5555555555555555ULL);
+    v = (v & 0x3333333333333333ULL) + ((v >> 2) & 0x3333333333333333ULL);
+    v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0FULL;
+    return (unsigned)((v * 0x0101010101010101ULL) >> 56);
+}
+
+
+PERL_STATIC_INLINE unsigned
+Perl_bitcount32(uint32_t v) {
+    PERL_ARGS_ASSERT_BITCOUNT32;
+    v = v - ((v >> 1) & 0x55555555U);
+    v = (v & 0x33333333U) + ((v >> 2) & 0x33333333U);
+    v = (v + (v >> 4)) & 0x0F0F0F0FU;
+    return (unsigned)((v * 0x01010101U) >> 24);
+}
+
+/*
  * ex: set ts=8 sts=4 sw=4 et:
  */

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2532,13 +2532,7 @@ PP(pp_caller)
 
         if (!has_arg) {
             int f = (subscripts & (OPpCALLER_SUB|OPpCALLER_HINTS|OPpCALLER_BITS|OPpCALLER_HINTH));
-
-            /* Compilers may recognise this loop and substitute popcnt */
-            int cnt = 0;
-            while(f != 0) {
-                f &= f - 1;
-                cnt++;
-            }
+            unsigned cnt = bitcount32( (uint32_t)f );
 
             while (cnt) {
                 rpp_push_IMM(&PL_sv_undef);

--- a/proto.h
+++ b/proto.h
@@ -14595,6 +14595,14 @@ Perl_av_store_simple(pTHX_ AV *av, SSize_t key, SV *val)
 # define PERL_ARGS_ASSERT_AV_STORE_SIMPLE       \
         Perl_assert_aTHX; assert(av); assert(SvTYPE(av) == SVt_PVAV)
 
+PERL_STATIC_INLINE unsigned
+Perl_bitcount32(uint32_t v);
+# define PERL_ARGS_ASSERT_BITCOUNT32
+
+PERL_STATIC_INLINE unsigned
+Perl_bitcount64(uint64_t v);
+# define PERL_ARGS_ASSERT_BITCOUNT64
+
 PERL_STATIC_INLINE U8 *
 Perl_bytes_to_utf8(pTHX_ const U8 *s, STRLEN *lenp)
         Perl_attribute_nonnull_aTHX


### PR DESCRIPTION
For counting the number of bits set in a `uint32_t` or `unit64_t`.

The initial implementations are recognised by compilers, such as
modern versions of clang & ggc, which will replace them with
`popcnt` instructions where the build conditions/architecture
permit.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
