### PR TITLE
lib/B/Deparse-core.t: Suppress 'equ/new' experimental warnings

### DIFF
--- a/lib/B/Deparse-core.t
+++ b/lib/B/Deparse-core.t
@@ -35,6 +35,7 @@ BEGIN {
 }
 
 use warnings;
+no warnings 'experimental::equ';
 use strict;
 use Test::More;
 


### PR DESCRIPTION
We test that we get those warnings in `lib/warnings.t` (source in `t/lib/warnings/toke` lines 1860-1869).  But they just crowd up the screen when we run `lib/B/Deparse-core.t`.  For an example, see https://perl.develop-help.com/dblog/5538297.

Ideally, we would apply the "no warnings 'experimental::equ'" pragma in a narrowly scoped block.  That proved difficult, so this should suffice.


-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
