### PR TITLE
Suppress 'subroutine redefined' warning

### DIFF
--- a/lib/overload.pm
+++ b/lib/overload.pm
@@ -46,6 +46,7 @@ sub OVERLOAD {
                 $sub = \&nil;
             }
             #print STDERR "Setting '$ {'package'}::\cO$_' to \\&'$sub'.\n";
+            no warnings 'redefine';
             *{$package . "::(" . $_} = \&{ $sub };
         }
     }


### PR DESCRIPTION
... which was triggered by introduction of 'use v5.42;'

Fixes: GH #24774

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
