### PR TITLE
smartmatch is discouraged, no longer deprecated

### DIFF
--- a/lib/overload.t
+++ b/lib/overload.t
@@ -3243,8 +3243,7 @@ package GH21477 {
 
     my $o = bless ['cat'];
 
-    # smartmatch is deprecated and will be removed in 5.042
-    no warnings 'deprecated';
+    # smartmatch is officially discouraged as of perl-5.42
 
     my @result = ($o ~~ 'cat');
     ::is(scalar(@result), 1, "GH #21477: return one result");

--- a/t/op/svleak.t
+++ b/t/op/svleak.t
@@ -647,8 +647,7 @@ PERL
 }
 
 {
-    # smartmatch is deprecated and will be removed in 5.042
-    no warnings 'deprecated';
+    # smartmatch is officially discouraged as of perl-5.42
     my $one = 1;
     leak 2, 0, sub { 1 ~~ sub { 1 + $one } }, 'Smartmatch doesn\'t leak';
 }


### PR DESCRIPTION
Update 2 inline comments to reflect that.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
