### PR TITLE
multiconcat: empty target didn't clear NIOK flags

### DIFF
--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -434,7 +434,32 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+Since 5.28.0, the numeric value of a string would sometimes not get reset
+after the string was assigned to as part of a string concatenation. It
+required the following circumstances to all be present for the bug to
+manifest:
+
+=over
+
+=item *
+
+the string variable must be zero length and have just been used in numeric
+context, e.g. C<$s = ""; $n = $s + 1;>
+
+=item *
+
+then the variable must be the target of a string concatenation and also
+be used on the RHS, e.g.C<$s = "9$s";>
+
+=item *
+
+then if the string is used in numeric context again, the bug caused the
+old numeric value of 0 to be returned, rather than numifying the new
+string value and returning 9.
+
+=back
+
+[GH #24763]
 
 =item *
 

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -854,6 +854,7 @@ PP(pp_multiconcat)
             U32 targ_utf8;
           stringify_targ:
             SvPV_force_nomg_nolen(targ);
+            SvNIOK_off(targ);
             targ_utf8 = SvFLAGS(targ) & SVf_UTF8;
             if (UNLIKELY(dst_utf8 & ~targ_utf8)) {
                  if (LIKELY(!IN_BYTES))

--- a/t/opbasic/concat.t
+++ b/t/opbasic/concat.t
@@ -39,7 +39,7 @@ sub is {
     return $ok;
 }
 
-print "1..254\n";
+print "1..259\n";
 
 ($a, $b, $c) = qw(foo bar);
 
@@ -860,4 +860,41 @@ package RT132595 {
     my ($a, $b)  = qw(a b);
     ($a = 'A'.$b) .= 'c';
     is($a, "Abc", "RT #133441");
+}
+
+# GH #24763
+#
+# string vars which also had SvIOK etc set, sometimes didn't have those
+# flags turned off when the var was modified in a multiconcat
+{
+    # IOK
+
+    my $x;
+    my $i = "";
+    $i .= "";       # ensure its not COW
+
+    $x = $i + 0; # make $i IOK
+    $i = "7$i";
+    ok($i + 0 == 7, " GH #24763: 7");
+
+    $x = $i + 0; # make $i IOK
+    $i .= "8$i";
+    ok($i + 0 == 787, " GH #24763: 787");
+
+    $x = $i + 0; # make $i IOK
+    $i .= "9";
+    ok($i + 0 == 7879, " GH #24763: 7879");
+
+    # NOK
+
+    $i = "";
+    $i .= "";       # ensure its not COW
+
+    $x = $i + 0.1; # make $i NOK
+    $i = "1.5$i";
+    ok($i + 0.0 == 1.5, " GH #24763: 1.5");
+
+    $x = $i + 0.1; # make $i nOK
+    $i .= "0";
+    ok($i + 0.0 == 1.5, " GH #24763: 1.50");
 }


### PR DESCRIPTION
GH #24763
    
In something like
    
    $s = "-$s"
    
i.e. where the variable is both assigned to and its old value used on
the RHS, then in the specific case that length($s) == 0, the IOK and
NOK flags on $s weren't getting reset.

* This set of changes requires a perldelta entry, and it is included.

