### PR TITLE
pp_ctl.c: remove redundant double assignment to lcop

### DIFF
--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -2327,9 +2327,9 @@ S_caller_push_pkg(pTHX_ const HEK *stash_hek)
 static void
 S_caller_push_line(pTHX_ const PERL_CONTEXT *cx)
 {
-    const COP *lcop = lcop = closest_cop(cx->blk_oldcop,
-                                         OpSIBLING(cx->blk_oldcop),
-                                         cx->blk_sub.retop, TRUE);
+    const COP *lcop = closest_cop(cx->blk_oldcop,
+                                  OpSIBLING(cx->blk_oldcop),
+                                  cx->blk_sub.retop, TRUE);
     if (!lcop)
         lcop = cx->blk_oldcop;
     rpp_push_1_norc( newSVuv( (UV)(CopLINE(lcop)) ) );


### PR DESCRIPTION
Follow-up to the OP_CALLER slice optimization in 1f866fac6f55.


-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
