### PR TITLE
document the regex engine's super-linear cache

### DIFF
--- a/Porting/todo.pod
+++ b/Porting/todo.pod
@@ -1187,8 +1187,10 @@ much of the work.  However, that code has bit-rotted a little; some patterns
 don't make as much use of it as they should.  The proposal is to analyse
 where the current cache code has problems, and extend it to cover those cases.
 
-See also
-L<http://www.xray.mpe.mpg.de/mailing-lists/perl5-porters/2013-01/msg00339.html>
+See L<perlreguts/The super-linear cache> for a detailed explanation of the
+cache. See also
+L<https://www.nntp.perl.org/group/perl.perl5.porters/2013/01/msg197378.html>
+for a discussion about the cache's limitations.
 
 =head1 Big projects
 

--- a/pod/perlreguts.pod
+++ b/pod/perlreguts.pod
@@ -1048,9 +1048,21 @@ regop. An even more aggressive form of this is that a branch
 sequence of the form C<EXACT BRANCH ... EXACT> can be converted into a
 C<TRIE-EXACT> regop.
 
-All of this occurs in the routine C<study_chunk()> which uses a special
-structure C<scan_data_t> to store the analysis that it has performed, and
-does the "peep-hole" optimisations as it goes.
+=head4 study_chunk()
+
+All of the optimisations described above occur in the routine
+C<study_chunk()>, which is called from C<Perl_re_op_compile()> after
+C<reg()> is done. It uses a special structure C<scan_data_t> to store the
+analysis that it has performed, and does the "peep-hole" optimisations as
+it goes, in-place.
+
+The basic structure of C<study_chunk()> is recursive. By default it will
+linearly process all nodes until it reaches the node specified by the
+C<last> parameter, or an C<END> node if earlier. But when it encounters a
+sub-pattern such the 'A' in quantifiers like C<(A)+> or C<(A){1,5}>, it
+will recurse into that sub-pattern, with C<last> set to the end of that
+sub-pattern. Similarly for a branch such as C<A|B|C>, it will recurse for
+each sub-pattern A,B and C.
 
 The code involved in C<study_chunk()> is extremely cryptic. Be careful. :-)
 

--- a/pod/perlreguts.pod
+++ b/pod/perlreguts.pod
@@ -1122,6 +1122,224 @@ the possible states are the regops themselves, plus a number of additional
 intermediate and failure states. A few of the states are implemented as
 subroutines but the bulk are inline code.
 
+=head3 The super-linear cache
+
+"Insanity is doing the same thing over and over again and expecting
+different results."
+
+Under some circumstances with quantifiers, it is possible for an NFA
+engine to encounter a combinatorial explosion of backtracking. The
+super-linear cache (SLC) is intended to avoid this happening under some
+circumstances.
+
+Consider this simple example:
+
+    ("a" x 20) =~ /^ ( (aa?) ){5,100} [b] /x;
+
+(This example works just the same using C<*> rather than C<{5,100}>, but
+the latter form is used here as it will shortly help illuminate an issue
+with non-infinite ranges.)
+
+This pattern will eventually fail, since the string doesn't include a 'b'
+character (which for this example is in a character class to stop intuit
+rejecting it immediately). But early on in execution the quantifier will
+have iterated 10 times, each time consuming 'aa'. So at that point the
+entire input string can be thought of as having been consumed in this
+fashion:
+
+    (aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)
+
+Then the 'b' isn't found and the pattern starts backtracking. The last
+C<aa?> is retried, this time consuming a single character, and an 11th
+iteration can proceed, resulting in:
+
+    (aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(a)(a)
+
+before again failing to find the 'b'. The backtracking continues until
+every possible permutation of 'a' and 'aa' in each iteration is tried,
+which may take a long time.
+
+Staying with this example, consider that after much iterating and
+backtracking, the engine may have reached this state:
+
+    (aa)(a)(a)
+
+where it has consumed four characters using three iterations. The rest of
+the match at this point can be thought of as the equivalent of:
+
+    ("a" x 16) =~ /^ ( (aa?) ){2,97} [b] /x;
+
+Running this will eventually fail, and after backtracking to the
+C<(aa)(a)(a)> state, it backtracks further and tries further permutations,
+after which it will eventually reach this state:
+
+    (a)(aa)(a)
+
+In a similar fashion to the previous state, the rest of the match at this
+point is equivalent to:
+
+    ("a" x 16) =~ /^ ( (aa?) ){2,97} [b] /x;
+
+But hold on: we know that this particular sub-match failed earlier on; so
+running the exact same match again must also fail. So, in principle, after
+the first set of backtracking back to the C<(aa)(a)(a)> state, we could
+record in a cache somewhere that the match failed for that particular
+quantifier when starting from string position 4 and with between 2 and 97
+iterations left. Then the next time the same quantifier finds itself at
+the same string position and with the same number of iterations left, it
+knows that it can fail itself immediately and backtrack, rather than
+pushing on and (eventually) failing again.
+
+This is the essence of the SLC.
+
+There are several caveats to to this in order to make a system which is
+both practical and logically correct (i.e. without false cache failures).
+
+=over
+
+=item *
+
+The obvious objection at this point is that recording a whole bunch of
+(quantifier-id, current string position, min iterations left, max
+iterations left) tuples will be extremely expensive in memory.
+
+We can reduce this complexity by using the SLC only on quantifiers which
+have a maximum of infinity (such as C<*>, C<+>, C<({5,}>), and make the
+quantifiers only use the cache after the minimum number of iterations has
+already been satisfied. Under these two conditions, the remaining number
+of iterations will always have a min of 0 and a max of infinity, so we
+don't need to record the min and max values any more.
+
+With this simplification, we just need to record a single bit of
+information ("failed already") for every (quantifier-id, current string
+position) tuple. We can achieve this by allocating a single bit array
+whose size is equal to the string length multiplied by the number of
+candidate quantifiers in the pattern. So for example when matching a 1
+Mbyte string against a pattern like C</(...)*(...)*/> which has two
+quantifiers, 2 million bits must be allocated.
+
+To avoid a potentially large malloc() for every match that has been marked
+as suitable for SLC, a countdown is initiated the first time a candidate
+C<WHILEM> node is reached; only after (string length) multiplied by
+(number of participating C<WHILEM> nodes) iterations is the cache actually
+allocated and initialised. This crude heuristic is an indication that the
+match has gone super-linear.
+
+=item *
+
+It is only used for quantifiers on I<variable-length> sub-patterns, i.e.
+those which are compiled to a C<CURLYX>/C<WHILEM> node pair. Quantifiers
+with simpler sub-patterns are less likely to exhibit exponential
+behaviour.
+
+=item *
+
+Non-regular pattern items such as backreferences (C<\g{1}>) and evals
+(C<(??{...})/>) break the assumption that running the same rest-of-pattern
+from the same position will give the same result each time. If these occur
+in the rest-of-pattern, the cache is reset. This is currently done at
+runtime.
+
+=item *
+
+Nested quantifiers can sometimes the break the assumption that running the
+rest-of-pattern from the same string position will always give the same
+result. To understand this issue, first consider a non-nested quantifier
+pattern, such as
+
+    / A (B)+ C /x
+
+where each capital letter represents an entire sub-pattern: for example,
+'A' might represent C<(pq)?rs>.
+
+During execution, A will have consumed some characters, then a number of
+iterations of the quantified sub-pattern B will have consumed some more
+characters, then the rest-of-pattern (in this case C) will be attempted,
+starting at string position p say. If C subsequently fails, then the
+engine backtracks to the quantifier, which marks in the cache that running
+the rest-of-pattern from position p will always fail. Subsequent attempts
+might see A consuming a different number of characters and the quantifier
+might iterate a different number of times, but if the quantifier is
+ever about to run the rest-of-pattern again from position p, the cache can
+be used to fail immediately, rather than running and failing C again.
+
+Now consider a nested pattern such as
+
+    / A ((B)+){2,5} C /x
+
+Here, the inner quantifier doesn't know how many times the outer
+quantifier has already iterated, nor that what's to the right of it can
+now vary depending on that iteration count. The rest-of-pattern after an
+inner quantifier run (from the viewpoint of that inner quantifier), rather
+than always being just C as in the non-nested example above, is now
+instead equivalent to
+
+    / ... ((B)+){1,4} C /x   # after the first  outer iteration
+    / ... ((B)+){0,3} C /x   # after the second outer iteration
+    / ... ((B)+){0,2} C /x   # after the third  outer iteration
+    etc
+
+This violates the assumption that the rest-of-pattern is always the same
+sub-pattern and that what's to the right will always pass or fail in the
+same way from the same string position.
+
+For it to be safe to use the cache in a nested quantifier, the rule is
+that the outer quantifier's still-to-go minimum and maximum values must
+both remain constant on the second, third, etc., iterations. Since such
+values normally count down until they reach zero or remain at infinity,
+This means that a minimum can only be be 0 or 1, and a maximum must be 0,
+1 or infinity. This effectively means that any outer quantifier other than
+C<?,*,+> disqualifies nested quantifiers from participating in the cache.
+
+[DAPM 2026: I suspect that this restriction is too severe, and that an
+outer quantifier like C<{1,5}> is safe. But I have neither been able to
+prove this to my satisfaction, nor able to find a counter-example. But my
+strong suspicion is that the outer must iterate at least twice (so is at
+minimum C<{2,...}>) so that the first iteration can fail and mark the
+cache, then the second incorrectly fail due to the cache.]
+
+There are some tests for nested quantifiers in F<t/re/re_tests> under the
+heading 'RT #79152'.
+
+=item *
+
+The number of cache-participating C<WHILEM> nodes is stored in the upper 4
+bits of each C<WHILEM>'s C<FLAGS()> field, while the identity of the
+particular C<WHILEM> (used as part of the index into the bit cache) is
+stored in the lower 4 bits. This means that a pattern can have a maximum
+of 16 participating C<WHILEM>s. If the flags field is zero, it indicates
+that this C<WHILEM> node won't participate in the cache mechanism.
+
+=back
+
+The runtime state of the SLC is mainly stored in various fields of the
+C<reginfo> struct, which is initialised at the start of a match.
+
+A pointer to the cache is stored in C<< reginfo->info_aux.poscache >>,
+which will be freed when matching ends (the aux structure is guaranteed to
+be freed even on abnormal termination), and its size is recorded in
+C<< reginfo->poscache_size >>.
+
+If zero, C<< reginfo->poscache_maxiter >> indicates that the SLC countdown
+has not yet been triggered (i.e. no candidate C<WHILEM> node has been
+executed yet), or that it has been subsequently disabled again. Otherwise,
+its (positive) value is used for two different purposes: what value to
+start an initial (or reset) countdown from; and the size to C<alloc()> the
+cache, in bits. Currently these values are the same, but in principle they
+needn't be.
+
+C<< reginfo->poscache_iter >> only has meaning if C<poscache_maxiter> is
+non-zero. In that case, it represents a countdown initialised from
+C<poscache_maxiter>. If it reaches 1, the cache is malloced/realloced if
+necessary, and then zeroed. When it reaches 0, the cache is used.
+
+The C<CACHEsayNO> macro is used at runtime in various places as a
+replacement for C<sayNO> to set a fail bit in the cache while popping the
+current state. The C<ST.cache_offset> and C<ST.cache_mask> fields are set
+by the current C<WHILEM> to the address in the cache of the byte and bit
+corresponding to the current match state. These are used by C<CACHEsayNO>
+to mark the cache during a subsequent unwinding.
+
 =head1 MISCELLANEOUS
 
 =head2 Unicode and Localisation Support

--- a/regcomp_internal.h
+++ b/regcomp_internal.h
@@ -709,7 +709,15 @@ static const scan_data_t zero_scan_data = {
     0, 0, NULL, NULL, NULL
 };
 
-/* study flags */
+
+/* Flags for studying.
+ *
+ * The SF_  (scan)        flags are for the scan_data_t->data field.
+ * The SCF_ (study_chunk) flags are mainly for the flags parameter
+ *                        to Perl_study_chunk(), but some can also be used
+ *                        in scan_data_t->data, which is why they share a
+ *                        common bit space.
+ */
 
 #define SF_BEFORE_SEOL          0x0001
 #define SF_BEFORE_MEOL          0x0002
@@ -736,6 +744,12 @@ static const scan_data_t zero_scan_data = {
 #define SCF_DO_STCLASS_AND      0x0800
 #define SCF_DO_STCLASS_OR       0x1000
 #define SCF_DO_STCLASS          (SCF_DO_STCLASS_AND|SCF_DO_STCLASS_OR)
+
+/* SCF_WHILEM_VISITED_POS indicates to study_chunk() that either its
+ * caller is a CURLYX/WHILEM of a type which allows inner CURLYX/WHILEMs
+ * to partake in the super-linear cache, or that there is no enclosing
+ * CURLYX. See L<perlreguts/The super-linear cache> for more details.
+ */
 #define SCF_WHILEM_VISITED_POS  0x2000
 
 #define SCF_TRIE_RESTUDY        0x4000 /* Need to do restudy in study_chunk()?

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -2514,7 +2514,7 @@ Perl_study_chunk(pTHX_
                  * L<perlreguts/The super-linear cache> for the criteria
                  * on when its safe.
                  */
-               if ((mincount > 1) || (maxcount > 1 && maxcount != REG_INFTY))
+                if ((mincount > 1) || (maxcount > 1 && maxcount != REG_INFTY))
                     f &= ~SCF_WHILEM_VISITED_POS;
 
                 /* This will finish on WHILEM, setting scan, or on NULL: */

--- a/regcomp_study.c
+++ b/regcomp_study.c
@@ -2503,15 +2503,17 @@ Perl_study_chunk(pTHX_
                     f |= SCF_DO_STCLASS_AND;
                     f &= ~SCF_DO_STCLASS_OR;
                 }
-                /* Exclude from super-linear cache processing any {n,m}
-                   regops for which the combination of input pos and regex
-                   pos is not enough information to determine if a match
-                   will be possible.
 
-                   For example, in the regex /foo(bar\s*){4,8}baz/ with the
-                   regex pos at the \s*, the prospects for a match depend not
-                   only on the input position but also on how many (bar\s*)
-                   repeats into the {4,8} we are. */
+                /* Exclude from super-linear cache processing any nested
+                 * {n,m} regops for which the combination of input pos and
+                 * regex pos is not enough information to determine if a
+                 * match will be possible, due to the circumstances of
+                 * the outer quantifier (i.e. this node).
+
+                 * See the section on nested quantifiers in
+                 * L<perlreguts/The super-linear cache> for the criteria
+                 * on when its safe.
+                 */
                if ((mincount > 1) || (maxcount > 1 && maxcount != REG_INFTY))
                     f &= ~SCF_WHILEM_VISITED_POS;
 
@@ -2731,13 +2733,19 @@ Perl_study_chunk(pTHX_
                         FLAGS(oscan) = 0;
                 }
                 else if ((OP(oscan) == CURLYX)
+                        /* Possibly mark the corresponding WHILEM node as
+                         * being allowed to use the super-linear cache.
+                         *
+                         * Unless this quantifier has been disallowed
+                         * from using the super-linear cache by an outer
+                         * qualifier: */
                          && (flags & SCF_WHILEM_VISITED_POS)
-                         /* See the comment on a similar expression above.
-                            However, this time it's not a subexpression
-                            we care about, but the expression itself. */
+                         /* Or is non-infinite. See
+                          * L<perlreguts/The super-linear cache>
+                          * for why only inf quantifiers qualify */
                          && (maxcount == REG_INFTY)
-                         && data) {
-                    /* This stays as CURLYX, we can put the count/of pair. */
+                         && data)
+                {
                     /* Find WHILEM (as in regexec.c) */
                     regnode *nxt = oscan + NEXT_OFF(oscan);
 

--- a/regexec.c
+++ b/regexec.c
@@ -9166,62 +9166,19 @@ NULL
                 goto do_whilem_B_max;
             }
 
-            /* super-linear cache processing.
-             *
-             * The idea here is that for certain types of CURLYX/WHILEM -
-             * principally those whose upper bound is infinity (and
-             * excluding regexes that have things like \1 and other very
-             * non-regular expressiony things), then if a pattern like
-             * /....A*.../ fails and we backtrack to the WHILEM, then we
-             * make a note that this particular WHILEM op was at string
-             * position 47 (say) when the rest of pattern failed. Then, if
-             * we ever find ourselves back at that WHILEM, and at string
-             * position 47 again, we can just fail immediately rather than
-             * running the rest of the pattern again.
-             *
-             * This is very handy when patterns start to go
-             * 'super-linear', like in (a+)*(a+)*(a+)*, where you end up
-             * with a combinatorial explosion of backtracking.
-             *
-             * The cache is implemented as a bit array, with one bit per
-             * string byte position per WHILEM op (up to 16) - so its
-             * between 0.25 and 2x the string size.
-             *
-             * To avoid allocating a poscache buffer every time, we do an
-             * initially countdown; only after we have  executed a WHILEM
-             * op (string-length x #WHILEMs) times do we allocate the
-             * cache.
-             *
-             * The top 4 bits of FLAGS(scan) byte say how many different
-             * relevant CURLLYX/WHILEM op pairs there are, while the
-             * bottom 4-bits is the identifying index number of this
-             * WHILEM.
-             *
-             * The main variables associated with the SLC are:
-             *
-             * reginfo->poscache_maxiter
-             *     If zero, indicates that the SLC has not yet been
-             *     triggered, or that it has been subsequently disabled
-             *     again.
-             *     Otherwise, its (positive) value is used for two
-             *     different purposes:
-             *       - what value to start an initial (or reset)
-             *         countdown from;
-             *       - the size to alloc() the cache in bits.
-             *     Currently these values are the same, but they needn't
-             *     be in principle.
-             *
-             * reginfo->poscache_iter
-             *    Only has meaning if poscache_maxiter is non-zero. In
-             *    that case, it represents a countdown initialised
-             *    from poscache_maxiter.
-             *    If it reaches 1, the cache is malloced/realloced if
-             *    necessary, and then zeroed. When it reaches 0, the cache
-             *    is used.
-             */
-
             if (FLAGS(scan)) {
-
+                /* Super-linear cache processing.
+                 *
+                 * See L<perlreguts/The super-linear cache> for a detailed
+                 * background on how this works.
+                 *
+                 * For WHILEM nodes which can participate in the cache
+                 * (FLAGS() is non-zero), the processing at this point is to
+                 * first initiate a countdown. Then when on subsequent
+                 * iterations that reaches zero, the match has likely gone
+                 * super-linear and the cache is allocated and starts to be
+                 * used.
+                 */
 #ifdef DEBUGGING
                 if (reginfo->poscache_maxiter) {
                     DEBUG_OPTIMISE_MORE_r(re_exec_indentf(

--- a/regexec.c
+++ b/regexec.c
@@ -6561,12 +6561,17 @@ S_backup_one_WB_but_over_Extend_FO(pTHX_ WB_enum * previous,
     st->resume_state = state;                               \
     goto push_yes_state;
 
-#define DEBUG_STATE_pp(pp)                                      \
+/* output a 'push #N' (push==1) or 'pop #N' (push==0) message */
+
+#define DEBUG_STATE_pp(push, extra_text)                        \
     DEBUG_STATE_r({                                             \
         DUMP_EXEC_POS(locinput, scan, utf8_target,depth);       \
-        re_printf(\
-            "%*s" pp " %s%s%s%s%s\n",                           \
+        re_printf(                                              \
+            "%*s%s #%u %s %s%s%s%s%s\n",                        \
             INDENT_CHARS(depth), "",                            \
+            push ? "push" : "pop",                              \
+            (unsigned int)(depth -1 + push),                    \
+            extra_text,                                         \
             REGNODE_NAME(st->resume_state),                     \
             ((st == yes_state || st == mark_state) ? "[" : ""), \
             ((st == yes_state) ? "Y" : ""),                     \
@@ -10323,7 +10328,7 @@ NULL
                         curyes = cur->u.yes.prev_yes_state;
                 }
             } else {
-                DEBUG_STATE_pp("push")
+                DEBUG_STATE_pp(1, "")
             });
             depth++;
             st->locinput = locinput;
@@ -10365,13 +10370,7 @@ NULL
                 PL_regmatch_slab = PL_regmatch_slab->prev;
                 st = SLAB_LAST(PL_regmatch_slab);
             }
-            DEBUG_STATE_r({
-                if (no_final) {
-                    DEBUG_STATE_pp("pop (no final)");
-                } else {
-                    DEBUG_STATE_pp("pop (yes)");
-                }
-            });
+            DEBUG_STATE_pp(0, no_final ? "(no final)" : "(yes)");
             depth--;
         }
 #else
@@ -10447,7 +10446,7 @@ NULL
         loceol = st->loceol;
         script_run_begin = st->sr0;
 
-        DEBUG_STATE_pp("pop");
+        DEBUG_STATE_pp(0, "");
         depth--;
         if (yes_state == st)
             yes_state = st->u.yes.prev_yes_state;

--- a/regexec.c
+++ b/regexec.c
@@ -6506,8 +6506,17 @@ S_backup_one_WB_but_over_Extend_FO(pTHX_ WB_enum * previous,
 /* we don't use STMT_START/END here because it leads to
    "unreachable code" warnings, which are bogus, but distracting. */
 #define CACHEsayNO \
-    if (ST.cache_mask) \
-       reginfo->info_aux->poscache[ST.cache_offset] |= ST.cache_mask; \
+    if (ST.cache_mask) {                                               \
+        DEBUG_EXECUTE_r({                                              \
+            regnode *whilem =                                          \
+                REGNODE_BEFORE(regnext(cur_curlyx->u.curlyx.me));      \
+            re_exec_indentf(                                           \
+                "WHILEM[%d/%d]: (cache) marking failure at pos %" UVuf "\n",  \
+                depth, (FLAGS(whilem) & 0xf), (FLAGS(whilem)>>4),      \
+                (UV)(locinput - reginfo->strbeg));                     \
+        });                                                            \
+       reginfo->info_aux->poscache[ST.cache_offset] |= ST.cache_mask;  \
+    }                                                                  \
     sayNO
 
 #define EVAL_CLOSE_PAREN_IS(st,expr)                        \
@@ -9229,7 +9238,7 @@ NULL
                         Newxz(aux->poscache, size, char);
                     }
                     DEBUG_EXECUTE_r( re_exec_indentf(
-      "%sWHILEM: Detected a super-linear match, switching on caching%s...\n",
+      "%sWHILEM: Detected a super-linear match, enabling cache%s...\n",
                               depth, PL_colors[4], PL_colors[5])
                     );
                 }
@@ -9244,8 +9253,10 @@ NULL
                     mask    = 1 << (offset % 8);
                     offset /= 8;
                     if (reginfo->info_aux->poscache[offset] & mask) {
-                        DEBUG_EXECUTE_r( re_exec_indentf("WHILEM: (cache) already tried at this position...\n",
-                            depth)
+                        DEBUG_EXECUTE_r( re_exec_indentf(
+                            "WHILEM[%d/%d]: (cache) already failed at pos %" UVuf "\n",
+                            depth, (FLAGS(scan) & 0xf), (FLAGS(scan)>>4),
+                            (UV)(locinput - reginfo->strbeg));
                         );
                         cur_curlyx->u.curlyx.count--;
                         sayNO; /* cache records failure */

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -1636,6 +1636,10 @@ a(.)\4294967298	ab\o{42}94967298	ya	$1	b	\d not converted to native; \o{} is
 [\_]	_	y	$&	_
 
 # RT #79152
+# Test the super-linear cache against nested quantifiers.
+# Note that the first half of each of these patterns is there purely
+# to soak up the initial cache countdown; the guts of the test is the
+# second half.
 (q1|.)*(q2|.)*(x(a|bc)*y){2,}	xayxay	y	$&	xayxay
 (q1|.)*(q2|.)*(x(a|bc)*y){2,3}	xayxay	y	$&	xayxay
 (q1|z)*(q2|z)*z{15}-.*?(x(a|bc)*y){2,3}Z	zzzzzzzzzzzzzzzz-xayxayxayxayZ	y	$&	zzzzzzzzzzzzzzzz-xayxayxayxayZ


### PR DESCRIPTION
This set of commits adds a section on the super-linear cache (SLC) to perlreguts.pod. It also updates various code comments, and improves some debugging output relating to the SLC. It also adds some brief info about study_chunk(), since I learned a bit about that function that along the way.

This new documentation contains a lot of original research, since I had no idea how nodes are decided as being suitable for the SLC at regex compile time, and none of the original commits from 25 years ago, nor the p5p list, included any discussion about the theoretical background.

* This set of changes does not require a perldelta entry.
