### PR TITLE
Make Windows pull from the OS CSPRNG for the Perl seed

### DIFF
--- a/pod/perl5452delta.pod
+++ b/pod/perl5452delta.pod
@@ -263,6 +263,14 @@ F<t/porting/customized.dat> that no longer need to be there.
 Use of mkostemp(3) enabled on macOS 10.12 Sierra (Darwin 16) and newer,
 where it is available.
 
+=item Windows
+
+Perl's PRNG seeding (used by C<rand>, C<srand>, hash seed initialization
+and per-thread C<drand48> state) now queries the Windows OS CSPRNG
+(C<RtlGenRandom>, exported as C<SystemFunction036> from F<advapi32.dll>)
+on native Windows builds. There is no F</dev/urandom> or C<getentropy()>
+on Windows, so this avoids the weak time/PID/pointer fallback
+
 =back
 
 =head1 Internal Changes

--- a/util.c
+++ b/util.c
@@ -4716,6 +4716,9 @@ Perl_parse_unicode_opts(pTHX_ const char **popt)
 #ifdef VMS
 #  include <starlet.h>
 #endif
+#ifdef WIN32
+BOOLEAN NTAPI SystemFunction036(PVOID RandomBuffer, ULONG RandomBufferLength);
+#endif
 
 /* Splitmix64 is a simple PRNG and integer hashing function. It was
  * introduced in 2015: https://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
@@ -4737,10 +4740,14 @@ Perl_seed(pTHX)
     PERL_ARGS_ASSERT_SEED;
 
    /*
-    * Attempt to read from /dev/urandom to generate a pseudo-random number.
-    * If that does not work, or it is unavailable, we fall back to gathering
+    * Attempt to read from the OS CSPRNG to generate a pseudo-random number.
+    * On Windows this is RtlGenRandom (SystemFunction036 from advapi32.dll);
+    * on Unix-like systems we try getentropy() and then /dev/urandom. If
+    * none of those are available or they fail, we fall back to gathering
     * several state variables and hashing them into a seed value.
     */
+
+    U64 seed;
 
 /* This test is an escape hatch, this symbol isn't set by Configure. */
 #ifndef PERL_NO_DEV_RANDOM
@@ -4756,7 +4763,6 @@ Perl_seed(pTHX)
 #    define PERL_RANDOM_DEVICE "/dev/urandom"
 #  endif
 #endif
-    U64 seed;
 
 #ifdef HAS_GETENTROPY
     U8 ok = (getentropy(&seed, sizeof(seed)) == 0);
@@ -4777,6 +4783,14 @@ Perl_seed(pTHX)
         if (seed) {
             return seed;
         }
+    }
+#endif
+
+#ifdef WIN32
+    /* Ask the Windows OS CSPRNG (available since XP, already linked via
+     * advapi32) for seed material. */
+    if (SystemFunction036((PVOID)&seed, (ULONG)sizeof(seed))) {
+        return seed;
     }
 #endif
 


### PR DESCRIPTION
This PR makes our Windows builds pull from the OS CSPRNG instead of hashing state variables. This should provide better entropy for seeding our `rand()` stuff.

This brings Windows up to parity with Linux/MacOS/BSD which already reads from the OS CSPRNG.