### PR TITLE
perlsub: delete reference to removed attrs.pm

### DIFF
--- a/pod/perlsub.pod
+++ b/pod/perlsub.pod
@@ -2163,9 +2163,6 @@ associated with it.  If such an attribute list is present, it is
 broken up at space or colon boundaries and treated as though a
 C<use attributes> had been seen.  See L<attributes> for details
 about what attributes are currently supported.
-Unlike the limitation with the obsolescent C<use attrs>, the
-C<sub : ATTRLIST> syntax works to associate the attributes with
-a pre-declaration, and not just with a subroutine definition.
 
 The attributes must be valid as simple identifier names (without any
 punctuation other than the '_' character).  They may have a parameter


### PR DESCRIPTION
Fixes #24792.

Backstory:

- 1997-09-09: attrs.pm is added to core, providing locked and method attributes; 77a005ab9f9f
- 1999-09-05: attrs.pm gains an lvalue attribute; cd06dffe59d6
- 1999-08-28: current attribute syntax is implemented and documented; `use attrs` reference added to perlsub; attrs.pm marked obsolescent; 09bef84370e9
- 1999-10-02: attrs.pm is formally deprecated; lvalue support removed again; a98df9627d19
- 2009-04-12: attrs.pm is removed after 10 years of deprecation; d62c72f64114



-------------------------------------------------------------------------------
<!--
Significant or noteworthy changes to Perl must be documented in pod/perldelta.pod.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
* This set of changes does not require a perldelta entry.
