### PR TITLE
Replace character literals used as a sigil with constant

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -314,7 +314,7 @@ XS(XS_builtin_export_lexically)
                     bad = "a SCALAR";
                 break;
 
-            case '@':
+            case Perl_Sigil_Array:
                 if(SvTYPE(rv) != SVt_PVAV)
                     bad = "an ARRAY";
                 break;

--- a/builtin.c
+++ b/builtin.c
@@ -306,7 +306,7 @@ XS(XS_builtin_export_lexically)
                     bad = "a CODE";
                 break;
 
-            case '$':
+            case Perl_Sigil_Scalar:
                 /* Permit any of SVt_NULL to SVt_PVMG. Technically this also
                  * includes SVt_INVLIST but it isn't thought possible for pureperl
                  * code to ever manage to see one of those. */

--- a/builtin.c
+++ b/builtin.c
@@ -319,7 +319,7 @@ XS(XS_builtin_export_lexically)
                     bad = "an ARRAY";
                 break;
 
-            case '%':
+            case Perl_Sigil_Hash:
                 if(SvTYPE(rv) != SVt_PVHV)
                     bad = "a HASH";
                 break;

--- a/dump.c
+++ b/dump.c
@@ -3562,7 +3562,7 @@ S_append_padvar(pTHX_ PADOFFSET off, CV *cv, SV *out, int n,
                                  UTF8fARG(1, PadnameLEN(sv) - 1,
                                           PadnamePV(sv) + 1));
             if (is_scalar)
-                SvPVX(out)[cur] = '$';
+                SvPVX(out)[cur] = Perl_Sigil_Scalar;
         }
         else
             sv_catpvf(out, "[%" UVuf "]", (UV)(off+i));

--- a/gv.c
+++ b/gv.c
@@ -2017,7 +2017,7 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len,
                     ck_warner_d(
                         packWARN(WARN_MISC),
                         "Variable \"%c%" UTF8f "\" is not imported",
-                        sv_type == SVt_PVAV ? '@' :
+                        sv_type == SVt_PVAV ? Perl_Sigil_Array :
                         sv_type == SVt_PVHV ? '%' : Perl_Sigil_Scalar,
                         UTF8fARG(is_utf8, len, name));
                     if (GvCVu(*gvp))

--- a/gv.c
+++ b/gv.c
@@ -1556,7 +1556,7 @@ S_require_tie_mod(pTHX_ GV *gv, const char varname, const char * name,
        || ! GET_HV_FETCH_TIE_FUNC)
       {
         SV * const module = newSVpvn(name, len);
-        const char type = varname == '[' ? Perl_Sigil_Scalar : '%';
+        const char type = varname == '[' ? Perl_Sigil_Scalar : Perl_Sigil_Hash;
         if ( flags & 1 )
             save_scalar(gv);
         load_module(PERL_LOADMOD_NOIMPORT, module, NULL);
@@ -2018,7 +2018,7 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len,
                         packWARN(WARN_MISC),
                         "Variable \"%c%" UTF8f "\" is not imported",
                         sv_type == SVt_PVAV ? Perl_Sigil_Array :
-                        sv_type == SVt_PVHV ? '%' : Perl_Sigil_Scalar,
+                        sv_type == SVt_PVHV ? Perl_Sigil_Hash : Perl_Sigil_Scalar,
                         UTF8fARG(is_utf8, len, name));
                     if (GvCVu(*gvp))
                         ck_warner_d(

--- a/gv.c
+++ b/gv.c
@@ -1556,7 +1556,7 @@ S_require_tie_mod(pTHX_ GV *gv, const char varname, const char * name,
        || ! GET_HV_FETCH_TIE_FUNC)
       {
         SV * const module = newSVpvn(name, len);
-        const char type = varname == '[' ? '$' : '%';
+        const char type = varname == '[' ? Perl_Sigil_Scalar : '%';
         if ( flags & 1 )
             save_scalar(gv);
         load_module(PERL_LOADMOD_NOIMPORT, module, NULL);
@@ -2018,7 +2018,7 @@ S_find_default_stash(pTHX_ HV **stash, const char *name, STRLEN len,
                         packWARN(WARN_MISC),
                         "Variable \"%c%" UTF8f "\" is not imported",
                         sv_type == SVt_PVAV ? '@' :
-                        sv_type == SVt_PVHV ? '%' : '$',
+                        sv_type == SVt_PVHV ? '%' : Perl_Sigil_Scalar,
                         UTF8fARG(is_utf8, len, name));
                     if (GvCVu(*gvp))
                         ck_warner_d(

--- a/op.c
+++ b/op.c
@@ -1946,7 +1946,7 @@ S_op_varname_subscript(pTHX_ const OP *o, int subscript_type)
            o->op_type == OP_PADHV || o->op_type == OP_RV2HV);
     {
         const char funny  = o->op_type == OP_PADAV
-                         || o->op_type == OP_RV2AV ? '@' : '%';
+                         || o->op_type == OP_RV2AV ? Perl_Sigil_Array : '%';
         if (o->op_type == OP_RV2AV || o->op_type == OP_RV2HV) {
             GV *gv;
             if (cUNOPo->op_first->op_type != OP_GV

--- a/op.c
+++ b/op.c
@@ -1946,7 +1946,7 @@ S_op_varname_subscript(pTHX_ const OP *o, int subscript_type)
            o->op_type == OP_PADHV || o->op_type == OP_RV2HV);
     {
         const char funny  = o->op_type == OP_PADAV
-                         || o->op_type == OP_RV2AV ? Perl_Sigil_Array : '%';
+                         || o->op_type == OP_RV2AV ? Perl_Sigil_Array : Perl_Sigil_Hash;
         if (o->op_type == OP_RV2AV || o->op_type == OP_RV2HV) {
             GV *gv;
             if (cUNOPo->op_first->op_type != OP_GV

--- a/op.c
+++ b/op.c
@@ -14246,7 +14246,7 @@ Perl_ck_fun(pTHX_ OP *o)
                                 SV *namesv;
                                 targ = pad_alloc(OP_RV2GV, SVf_READONLY);
                                 namesv = PAD_SVl(targ);
-                                if (want_dollar && *name != '$')
+                                if (want_dollar && *name != Perl_Sigil_Scalar)
                                     sv_setpvs(namesv, "$");
                                 else
                                     SvPVCLEAR(namesv);

--- a/sv.c
+++ b/sv.c
@@ -18384,7 +18384,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
         if (match && subscript_type == FUV_SUBSCRIPT_WITHIN)
             break;
 
-        return varname(gv, (char)(hash ? '%' : '@'), obase->op_targ,
+        return varname(gv, (char)(hash ? '%' : Perl_Sigil_Array), obase->op_targ,
                                     keysv, index, subscript_type);
       }
 
@@ -18538,7 +18538,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 return varname(gv, '%', o->op_targ,
                             kidsv, 0, FUV_SUBSCRIPT_HASH);
             else
-                return varname(gv, '@', o->op_targ, NULL,
+                return varname(gv, Perl_Sigil_Array, o->op_targ, NULL,
                     negate ? - SvIV(cSVOPx_sv(kid)) : SvIV(cSVOPx_sv(kid)),
                     FUV_SUBSCRIPT_ARRAY);
         }
@@ -18555,14 +18555,14 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 const SSize_t index
                     = find_array_subscript((const AV *)sv, uninit_sv);
                 if (index >= 0)
-                    return varname(gv, '@', o->op_targ,
+                    return varname(gv, Perl_Sigil_Array, o->op_targ,
                                         NULL, index, FUV_SUBSCRIPT_ARRAY);
             }
             if (match)
                 break;
             return varname(gv,
                 (char)((o->op_type == OP_PADAV || o->op_type == OP_RV2AV)
-                ? '@' : '%'),
+                ? Perl_Sigil_Array : '%'),
                 o->op_targ, NULL, 0, FUV_SUBSCRIPT_WITHIN);
         }
         NOT_REACHED; /* NOTREACHED */
@@ -18751,7 +18751,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             return is_hv
                 ? varname(agg_gv, '%', agg_targ,
                                 index_const_sv, 0,    FUV_SUBSCRIPT_HASH)
-                : varname(agg_gv, '@', agg_targ,
+                : varname(agg_gv, Perl_Sigil_Array, agg_targ,
                                 NULL, index_const_iv, FUV_SUBSCRIPT_ARRAY);
         }
         else {
@@ -18766,7 +18766,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 const SSize_t index
                     = find_array_subscript((const AV *)sv, uninit_sv);
                 if (index >= 0)
-                    return varname(agg_gv, '@', agg_targ,
+                    return varname(agg_gv, Perl_Sigil_Array, agg_targ,
                                         NULL, index, FUV_SUBSCRIPT_ARRAY);
             }
             /* look for an element not found */
@@ -18792,7 +18792,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                         SV * const * const svp =
                             av_fetch(MUTABLE_AV(sv), index, FALSE);
                         if (!svp) {
-                            return varname(agg_gv, '@', agg_targ,
+                            return varname(agg_gv, Perl_Sigil_Array, agg_targ,
                                            NULL, index, FUV_SUBSCRIPT_ARRAY);
                         }
                     }
@@ -18801,7 +18801,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             if (match)
                 break;
             return varname(agg_gv,
-                is_hv ? '%' : '@',
+                is_hv ? '%' : Perl_Sigil_Array,
                 agg_targ, NULL, 0, FUV_SUBSCRIPT_WITHIN);
         }
         NOT_REACHED; /* NOTREACHED */
@@ -19001,7 +19001,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             else {
                 break;
             }
-            sv = varname(gv, '@', o->op_targ, NULL, 0, FUV_SUBSCRIPT_NONE);
+            sv = varname(gv, Perl_Sigil_Array, o->op_targ, NULL, 0, FUV_SUBSCRIPT_NONE);
         }
         if (sv) {
             const char *name = OP_NAME(obase);

--- a/sv.c
+++ b/sv.c
@@ -18254,14 +18254,14 @@ Perl_varname(pTHX_ const GV *const gv, const char gvtype, PADOFFSET targ,
         STRLEN len;
         const char * const pv = SvPV_nomg_const((SV*)keyname, len);
 
-        *SvPVX(name) = '$';
+        *SvPVX(name) = Perl_Sigil_Scalar;
         sv_catpvf(name, "{%s}",
             pv_pretty(sv, pv, len, 32, NULL, NULL,
                     PERL_PV_PRETTY_DUMP | PERL_PV_ESCAPE_UNI_DETECT ));
         SvREFCNT_dec_NN(sv);
     }
     else if (subscript_type == FUV_SUBSCRIPT_ARRAY) {
-        *SvPVX(name) = '$';
+        *SvPVX(name) = Perl_Sigil_Scalar;
         sv_catpvf(name, "[%" IVdf "]", (IV)aindex);
     }
     else if (subscript_type == FUV_SUBSCRIPT_WITHIN) {
@@ -18327,7 +18327,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             (obase->op_private & (OPpTARGET_MY | OPpUNDEF_KEEP_PV)) == (OPpTARGET_MY | OPpUNDEF_KEEP_PV)
             && (!match || PAD_SVl(obase->op_targ) == uninit_sv)
         ) {
-            return varname(NULL, '$', obase->op_targ, NULL, 0, FUV_SUBSCRIPT_NONE);
+            return varname(NULL, Perl_Sigil_Scalar, obase->op_targ, NULL, 0, FUV_SUBSCRIPT_NONE);
         }
         break;
 
@@ -18396,7 +18396,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 break;
             if (match && (GvSV(gv) != uninit_sv))
                 break;
-            return varname(gv, '$', 0, NULL, 0, FUV_SUBSCRIPT_NONE);
+            return varname(gv, Perl_Sigil_Scalar, 0, NULL, 0, FUV_SUBSCRIPT_NONE);
         }
         /* ${expr} */
         return find_uninit_var(cUNOPx(obase)->op_first, uninit_sv, 1, desc_p);
@@ -18404,20 +18404,20 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
     case OP_PADSV:
         if (match && PAD_SVl(obase->op_targ) != uninit_sv)
             break;
-        return varname(NULL, '$', obase->op_targ,
+        return varname(NULL, Perl_Sigil_Scalar, obase->op_targ,
                                     NULL, 0, FUV_SUBSCRIPT_NONE);
 
     case OP_PADSV_STORE:
         if (match && PAD_SVl(obase->op_targ) != uninit_sv)
             goto do_op;
-        return varname(NULL, '$', obase->op_targ,
+        return varname(NULL, Perl_Sigil_Scalar, obase->op_targ,
                                     NULL, 0, FUV_SUBSCRIPT_NONE);
 
     case OP_GVSV:
         gv = cGVOPx_gv(obase);
         if (!gv || (match && GvSV(gv) != uninit_sv) || !GvSTASH(gv))
             break;
-        return varname(gv, '$', 0, NULL, 0, FUV_SUBSCRIPT_NONE);
+        return varname(gv, Perl_Sigil_Scalar, 0, NULL, 0, FUV_SUBSCRIPT_NONE);
 
     case OP_AELEMFAST_LEX:
         if (match) {
@@ -18429,7 +18429,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             if (!svp || *svp != uninit_sv)
                 break;
         }
-        return varname(NULL, '$', obase->op_targ,
+        return varname(NULL, Perl_Sigil_Scalar, obase->op_targ,
                        NULL, (I8)obase->op_private, FUV_SUBSCRIPT_ARRAY);
 
     case OP_AELEMFASTLEX_STORE:
@@ -18442,7 +18442,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             if (!svp || *svp != uninit_sv)
                 goto do_op;
         }
-        return varname(NULL, '$', obase->op_targ,
+        return varname(NULL, Perl_Sigil_Scalar, obase->op_targ,
                        NULL, (I8)obase->op_private, FUV_SUBSCRIPT_ARRAY);
 
     case OP_AELEMFAST:
@@ -18459,7 +18459,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 if (!svp || *svp != uninit_sv)
                     break;
             }
-            return varname(gv, '$', 0,
+            return varname(gv, Perl_Sigil_Scalar, 0,
                     NULL, (I8)obase->op_private, FUV_SUBSCRIPT_ARRAY);
         }
         NOT_REACHED; /* NOTREACHED */
@@ -18700,14 +18700,14 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             assert(index_type != MDEREF_INDEX_none);
             if (index_gv) {
                 if (GvSV(index_gv) == uninit_sv)
-                    return varname(index_gv, '$', 0, NULL, 0,
+                    return varname(index_gv, Perl_Sigil_Scalar, 0, NULL, 0,
                                                     FUV_SUBSCRIPT_NONE);
                 else
                     return NULL;
             }
             if (index_targ) {
                 if (PL_curpad[index_targ] == uninit_sv)
-                    return varname(NULL, '$', index_targ,
+                    return varname(NULL, Perl_Sigil_Scalar, index_targ,
                                     NULL, 0, FUV_SUBSCRIPT_NONE);
                 else
                     return NULL;
@@ -18826,7 +18826,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 gv = cGVOPx_gv(o);
                 if (match && GvSV(gv) != uninit_sv)
                     break;
-                return varname(gv, '$', 0,
+                return varname(gv, Perl_Sigil_Scalar, 0,
                             NULL, 0, FUV_SUBSCRIPT_NONE);
             }
             /* other possibilities not handled are:
@@ -18848,7 +18848,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 return newSVpvs_flags("$_", SVs_TEMP);
             else if (obase->op_targ
                   && uninit_sv == PAD_SVl(obase->op_targ))
-                return varname(NULL, '$', obase->op_targ, NULL, 0,
+                return varname(NULL, Perl_Sigil_Scalar, obase->op_targ, NULL, 0,
                                FUV_SUBSCRIPT_NONE);
         }
         goto do_op;

--- a/sv.c
+++ b/sv.c
@@ -18384,7 +18384,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
         if (match && subscript_type == FUV_SUBSCRIPT_WITHIN)
             break;
 
-        return varname(gv, (char)(hash ? '%' : Perl_Sigil_Array), obase->op_targ,
+        return varname(gv, (char)(hash ? Perl_Sigil_Hash : Perl_Sigil_Array), obase->op_targ,
                                     keysv, index, subscript_type);
       }
 
@@ -18535,7 +18535,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 }
             }
             if (obase->op_type == OP_HELEM)
-                return varname(gv, '%', o->op_targ,
+                return varname(gv, Perl_Sigil_Hash, o->op_targ,
                             kidsv, 0, FUV_SUBSCRIPT_HASH);
             else
                 return varname(gv, Perl_Sigil_Array, o->op_targ, NULL,
@@ -18548,7 +18548,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             if (obase->op_type == OP_HELEM) {
                 SV * const keysv = find_hash_subscript((const HV*)sv, uninit_sv);
                 if (keysv)
-                    return varname(gv, '%', o->op_targ,
+                    return varname(gv, Perl_Sigil_Hash, o->op_targ,
                                                 keysv, 0, FUV_SUBSCRIPT_HASH);
             }
             else {
@@ -18562,7 +18562,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 break;
             return varname(gv,
                 (char)((o->op_type == OP_PADAV || o->op_type == OP_RV2AV)
-                ? Perl_Sigil_Array : '%'),
+                ? Perl_Sigil_Array : Perl_Sigil_Hash),
                 o->op_targ, NULL, 0, FUV_SUBSCRIPT_WITHIN);
         }
         NOT_REACHED; /* NOTREACHED */
@@ -18749,7 +18749,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                 }
             }
             return is_hv
-                ? varname(agg_gv, '%', agg_targ,
+                ? varname(agg_gv, Perl_Sigil_Hash, agg_targ,
                                 index_const_sv, 0,    FUV_SUBSCRIPT_HASH)
                 : varname(agg_gv, Perl_Sigil_Array, agg_targ,
                                 NULL, index_const_iv, FUV_SUBSCRIPT_ARRAY);
@@ -18759,7 +18759,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             if (is_hv) {
                 SV * const keysv = find_hash_subscript((const HV*)sv, uninit_sv);
                 if (keysv)
-                    return varname(agg_gv, '%', agg_targ,
+                    return varname(agg_gv, Perl_Sigil_Hash, agg_targ,
                                                 keysv, 0, FUV_SUBSCRIPT_HASH);
             }
             else {
@@ -18783,7 +18783,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
                         SV *report_index_sv = SvOK(index_sv) ? index_sv : &PL_sv_no;
                         HE *he = hv_fetch_ent(MUTABLE_HV(sv), report_index_sv, 0, 0);
                         if (!he) {
-                            return varname(agg_gv, '%', agg_targ,
+                            return varname(agg_gv, Perl_Sigil_Hash, agg_targ,
                                            report_index_sv, 0, FUV_SUBSCRIPT_HASH);
                         }
                     }
@@ -18801,7 +18801,7 @@ S_find_uninit_var(pTHX_ const OP *const obase, const SV *const uninit_sv,
             if (match)
                 break;
             return varname(agg_gv,
-                is_hv ? '%' : Perl_Sigil_Array,
+                is_hv ? Perl_Sigil_Hash : Perl_Sigil_Array,
                 agg_targ, NULL, 0, FUV_SUBSCRIPT_WITHIN);
         }
         NOT_REACHED; /* NOTREACHED */

--- a/sv.h
+++ b/sv.h
@@ -2997,6 +2997,24 @@ typedef struct {
 } sv_reftype_entry;
 #define PL_sv_reftype_lookup_MAX 14
 extern const sv_reftype_entry PL_sv_reftype_lookup[PL_sv_reftype_lookup_MAX];
+
+/*
+=for apidoc      Ay||Perl_Sigil
+=for apidoc_item Perl_Sigil_Array
+=for apidoc_item Perl_Sigil_Code
+=for apidoc_item Perl_Sigil_Hash
+=for apidoc_item Perl_Sigil_Scalar
+
+Identifies character literal used as a sigil - character used in the Perl code.
+
+=cut
+*/
+
+#define Perl_Sigil_Array  '@'
+#define Perl_Sigil_Code   '&'
+#define Perl_Sigil_Hash   '%'
+#define Perl_Sigil_Scalar '$'
+
 #endif
 
 /*


### PR DESCRIPTION
Some character literals, used in code base, have different meaning depending on context they are used in.

For example `$` can represents:
- scalar variable in pad
- scalar sigil
- prototype
- ...

This pull request identifies where character literals are used as sigils and replaces them with named constants, making code easier to read (in my humble opinion)

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
