### PR TITLE
PERL_UNUSED_VAR should be PERL_UNUSED_ARG in places

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -463,7 +463,7 @@ Perl_XS_builtin_indexed(pTHX_ CV *cv)
     PERL_ARGS_ASSERT_XS_BUILTIN_INDEXED;
 
     dXSARGS;
-    PERL_UNUSED_VAR(cv);
+    PERL_UNUSED_ARG(cv);
 
     switch(GIMME_V) {
         case G_VOID:

--- a/doio.c
+++ b/doio.c
@@ -1273,9 +1273,9 @@ S_argvout_free(pTHX_ SV *io, MAGIC *mg)
 static void
 S_argvout_clone(pTHX_ SV *sv, MAGIC *mg, SV *osv, MAGIC *omg, CLONE_PARAMS *param)
 {
-    PERL_UNUSED_VAR(sv);
-    PERL_UNUSED_VAR(osv);
-    PERL_UNUSED_VAR(omg);
+    PERL_UNUSED_ARG(sv);
+    PERL_UNUSED_ARG(osv);
+    PERL_UNUSED_ARG(omg);
     PERL_UNUSED_ARG(param);
 
     /* ideally we could just remove the magic from the SV but we don't get the SV here */

--- a/gv.c
+++ b/gv.c
@@ -3464,7 +3464,7 @@ bool
 Perl_amagic_applies(pTHX_ SV *sv, int method, int flags)
 {
     PERL_ARGS_ASSERT_AMAGIC_APPLIES;
-    PERL_UNUSED_VAR(flags);
+    PERL_UNUSED_ARG(flags);
 
     assert(method >= 0 && method < NofAMmeth);
 

--- a/pp_hot.c
+++ b/pp_hot.c
@@ -209,10 +209,10 @@ Perl_rpp_free_2_(pTHX_ SV *const sv1,  SV *const sv2,
     else
         Perl_sv_free2(aTHX_ sv2, rc2);
 #else
-    PERL_UNUSED_VAR(sv1);
-    PERL_UNUSED_VAR(sv2);
-    PERL_UNUSED_VAR(rc1);
-    PERL_UNUSED_VAR(rc2);
+    PERL_UNUSED_ARG(sv1);
+    PERL_UNUSED_ARG(sv2);
+    PERL_UNUSED_ARG(rc1);
+    PERL_UNUSED_ARG(rc2);
 #endif
 }
 

--- a/util.c
+++ b/util.c
@@ -5328,7 +5328,7 @@ Perl_my_snprintf(char *buffer, const Size_t len, const char *format, ...)
     dTHX;
 
 #ifndef HAS_VSNPRINTF
-    PERL_UNUSED_VAR(len);
+    PERL_UNUSED_ARG(len);
 #endif
     va_start(ap, format);
 #ifdef USE_QUADMATH


### PR DESCRIPTION
The changed lines are arguments not variables, so call the semantically correct macro, even if both currently expand to the same thing


* This set of changes does not require a perldelta entry.
