### PR TITLE
hints/darwin.sh: Fix building on macOS 26 with Xcode 27 cctools

### DIFF
--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -540,7 +540,7 @@ case "$osvers" in
     *) d_readdir_r=undef ;;
 esac
 
-# dup3() and pipe2() are marked as available in Golden Gate onwards (27.0 / darwin 26)
+# dup3() and pipe2() are marked as available in Golden Gate onwards (27.0 / darwin 27)
 case "$osvers" in
     [0-9].*|1[0-9].*|2[0-5].*)
         d_dup3=undef

--- a/hints/darwin.sh
+++ b/hints/darwin.sh
@@ -539,3 +539,11 @@ case "$osvers" in
     [0-9].*|1[0-8].*) ;;
     *) d_readdir_r=undef ;;
 esac
+
+# dup3() and pipe2() are marked as available in Golden Gate onwards (27.0 / darwin 26)
+case "$osvers" in
+    [0-9].*|1[0-9].*|2[0-5].*)
+        d_dup3=undef
+        d_pipe2=undef
+        ;;
+esac

--- a/pod/perldelta.pod
+++ b/pod/perldelta.pod
@@ -375,6 +375,10 @@ source tree.
 
 XXX
 
+=item MacOS (Darwin)
+
+Add support for building with Command Line Tools for Xcode 27.0
+
 =back
 
 =head2 Discontinued Platforms


### PR DESCRIPTION
`'dup3' has been marked as being introduced in macOS 27.0 here, but the deployment target is macOS 26.0.0`
likewise for `pipe2`, and miniperl fails to build.

Fixes issue #24804

* This set of changes requires a perldelta entry, and it is included.
