### PR TITLE
bodies_by_type: SVt_PVFM bodies use an arena, just like all other bodies

### DIFF
--- a/sv.c
+++ b/sv.c
@@ -16120,15 +16120,13 @@ S_sv_dup_common(pTHX_ const SV *const ssv, CLONE_PARAMS *const param)
             case SVt_PV:
                 assert(sv_type_details->body_size);
 #ifndef PURIFY
-                if (sv_type_details->arena) {
-                    new_body = S_new_body(aTHX_ sv_type);
-                    new_body
-                        = (void*)((char*)new_body - sv_type_details->offset);
-                } else
+                assert(sv_type_details->arena);
+                new_body = S_new_body(aTHX_ sv_type);
+                new_body
+                    = (void*)((char*)new_body - sv_type_details->offset);
+#else
+                new_body = new_NOARENA(sv_type_details);
 #endif
-                {
-                    new_body = new_NOARENA(sv_type_details);
-                }
             }
         have_body:
             assert(new_body);

--- a/sv.c
+++ b/sv.c
@@ -7749,8 +7749,16 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
              * efficient than stepping through the general logic.
              */
 
-            if (SvROK(sv))
-                goto free_rv;
+            if (SvROK(sv)) {
+                /* This duplicates the same code used for RV-in-PV, but
+                 * duplication will help (some) compilers to produce
+                 * better code layout. */
+                SV * const target = SvRV(sv);
+                if (SvWEAKREF(sv))
+                    sv_del_backref(target, sv);
+                else
+                    next_sv = target;
+            }
             SvFLAGS(sv) &= SVf_BREAK;
             SvFLAGS(sv) |= SVTYPEMASK;
             goto free_head;
@@ -7958,7 +7966,6 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
                 /* Don't even bother with turning off the OOK flag.  */
             }
             if (SvROK(sv)) {
-            free_rv:
                 {
                     SV * const target = SvRV(sv);
                     if (SvWEAKREF(sv))
@@ -8030,13 +8037,13 @@ Perl_sv_clear(pTHX_ SV *const orig_sv)
             SvFLAGS(sv) &= SVf_BREAK;
             SvFLAGS(sv) |= SVTYPEMASK;
 
-            if (sv_type_details->arena) {
-                del_body(((char *)SvANY(sv) + sv_type_details->offset),
-                         &PL_body_roots[arena_index]);
-            }
-            else if (sv_type_details->body_size) {
-                safefree(SvANY(sv));
-            }
+#ifndef PURIFY
+            assert(sv_type_details->arena);
+            del_body(((char *)SvANY(sv) + sv_type_details->offset),
+                     &PL_body_roots[arena_index]);
+#else
+            safefree(SvANY(sv));
+#endif
         }
 
       free_head:

--- a/sv.c
+++ b/sv.c
@@ -1134,7 +1134,7 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
         assert(new_type_details->arena_size);
         /* This points to the start of the allocated area.  */
         new_body = S_new_body(aTHX_ new_type);
-        /* xpvav and xpvhv have no offset, so no need to adjust new_body */
+        /* xpvav, xpvhv, xobject have no offset, no need to adjust new_body */
         assert(!(new_type_details->offset));
 #else
         /* We always allocated the full length item with PURIFY. To do this
@@ -1227,16 +1227,14 @@ Perl_sv_upgrade(pTHX_ SV *const sv, svtype new_type)
         /* We always allocated the full length item with PURIFY. To do this
            we fake things so that arena is false for all 16 types..  */
 #ifndef PURIFY
-        if(new_type_details->arena) {
-            /* This points to the start of the allocated area.  */
-            new_body = S_new_body(aTHX_ new_type);
-            Zero(new_body, new_type_details->body_size, char);
-            new_body = ((char *)new_body) - new_type_details->offset;
-        } else
+        assert(new_type_details->arena);
+        /* This points to the start of the allocated area.  */
+        new_body = S_new_body(aTHX_ new_type);
+        Zero(new_body, new_type_details->body_size, char);
+        new_body = ((char *)new_body) - new_type_details->offset;
+#else
+        new_body = new_NOARENAZ(new_type_details);
 #endif
-        {
-            new_body = new_NOARENAZ(new_type_details);
-        }
         SvANY(sv) = new_body;
 
         if (old_type_details->copy) {

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -463,36 +463,21 @@ Perl_newSV_type(pTHX_ const svtype type)
     case SVt_PVMG:
     case SVt_PVNV:
     case SVt_PV:
-        /* For a type known at compile time, it should be possible for the
-         * compiler to deduce the value of (type_details->arena), resolve
-         * that branch below, and inline the relevant values from
-         * bodies_by_type. Except, at least for gcc, it seems not to do that.
-         * We help it out here with two deviations from sv_upgrade:
-         * (1) Minor rearrangement here, so that PVFM - the only type at this
-         *     point not to be allocated from an array appears last, not PV.
-         * (2) The ASSUME() statement here for everything that isn't PVFM.
-         * Obviously this all only holds as long as it's a true reflection of
-         * the bodies_by_type lookup table. */
-#ifndef PURIFY
-         ASSUME(type_details->arena);
-#endif
-         /* FALLTHROUGH */
     case SVt_PVFM:
-
         assert(type_details->body_size);
         /* We always allocated the full length item with PURIFY. To do this
            we fake things so that arena is false for all 16 types..  */
 #ifndef PURIFY
-        if(type_details->arena) {
-            /* This points to the start of the allocated area.  */
-            new_body = S_new_body(aTHX_ type);
-            Zero(new_body, type_details->body_size, char);
-            new_body = ((char *)new_body) - type_details->offset;
-        } else
+        assert(type_details->arena);
+        assert(type_details->arena_size);
+
+        /* This points to the start of the allocated area.  */
+        new_body = S_new_body(aTHX_ type);
+        Zero(new_body, type_details->body_size, char);
+        new_body = ((char *)new_body) - type_details->offset;
+#else
+        new_body = new_NOARENAZ(type_details);
 #endif
-        {
-            new_body = new_NOARENAZ(type_details);
-        }
         SvANY(sv) = new_body;
 
         if (UNLIKELY(type == SVt_PVIO)) {

--- a/sv_inline.h
+++ b/sv_inline.h
@@ -281,7 +281,7 @@ static const struct body_details bodies_by_type[] = {
     { sizeof(ALIGNED_TYPE_NAME(XPVFM)),
       sizeof(XPVFM),
       0,
-      SVt_PVFM, TRUE, NONV, NOARENA,
+      SVt_PVFM, TRUE, NONV, HASARENA,
       FIT_ARENA(20, sizeof(ALIGNED_TYPE_NAME(XPVFM))) },
 
     { sizeof(ALIGNED_TYPE_NAME(XPVIO)),


### PR DESCRIPTION
On a build that uses SV arenas, only the `SVt_PVFM` body is allocated,
with all other types being bodiless (e.g. `SVt_IV`) or using arenas.

Hot functions that add or remove bodies therefore have to perform a
check - which is effectively for a rare type - every time and contain
code to deal with both arenas & allocations.

The first commit in this PR makes `SVt_PVFM` bodies also use an arena.
This enables simplification of any core function that adds or removes a body.

The subsequent PRs make such changes to:
* `Perl_newSV_type`
* `Perl_sv_upgrade`
* `S_sv_dup_common`
* `Perl_sv_clear`

-------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.