### PR TITLE
Silence build warning on 32-bit DEBUGGING build

### DIFF
--- a/perl.h
+++ b/perl.h
@@ -8488,13 +8488,14 @@ cannot have changed since the precalculation.
         STMT_START {                                                        \
             DEBUG_Lv(PerlIO_printf(Perl_debug_log,                          \
                                "%s: %" LINE_Tf ": lc_numeric standard=%d\n",\
-                                __FILE__, __LINE__, PL_numeric_standard));  \
+                               __FILE__, (line_t)__LINE__,                  \
+                               PL_numeric_standard));                       \
             if (UNLIKELY(NOT_IN_NUMERIC_STANDARD_)) {                       \
                 Perl_set_numeric_standard(aTHX_ __FILE__, __LINE__);        \
             }                                                               \
             DEBUG_Lv(PerlIO_printf(Perl_debug_log,                          \
                      "%s: %" LINE_Tf ": lc_numeric standard=%d\n",          \
-                     __FILE__, __LINE__, PL_numeric_standard));             \
+                     __FILE__, (line_t)__LINE__, PL_numeric_standard));     \
         } STMT_END
 
 #  define SET_NUMERIC_UNDERLYING()                                          \


### PR DESCRIPTION
On 32-bit host (where `LINE_Tf` is defined as `"lu"`), building DEBUGGING perl used to produce -Wformat warnings:
```
perl.h:8487:32: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 4 has type ‘int’ [-Wformat=]
 8487 |                                "%s: %" LINE_Tf ": lc_numeric standard=%d\n",\
      |                                ^~~~~~~
perl.h:5262:33: note: in definition of macro ‘DEBUG__’
 5262 |                 DEBUG_PRE_STMTS a; DEBUG_POST_STMTS                     \
      |                                 ^
perl.h:8486:13: note: in expansion of macro ‘DEBUG_Lv’
 8486 |             DEBUG_Lv(PerlIO_printf(Perl_debug_log,                          \
      |             ^~~~~~~~
numeric.c:1709:17: note: in expansion of macro ‘SET_NUMERIC_STANDARD’
 1709 |                 SET_NUMERIC_STANDARD();
      |                 ^~~~~~~~~~~~~~~~~~~~
...
```
This patch will fix this warning by adding explicit casts to `__LINE__` arguments.

-------------------------------------------------------------------------------

* This set of changes does not require a perldelta entry.
